### PR TITLE
Preallocation in geometry building

### DIFF
--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -237,10 +237,9 @@ void buildGeneralPolyLine(const Line& _line, float _halfWidth, std::vector<glm::
     
     normCurrNext = glm::normalize(normCurrNext);
     
-    _pointsOut.push_back(nextCoord);
-    _pointsOut.push_back(nextCoord);
-    
     if (useScalingVecs) {
+        _pointsOut.push_back(nextCoord);
+        _pointsOut.push_back(nextCoord);
         _scalingVecsOut.push_back(rightNorm);
         _scalingVecsOut.push_back(-rightNorm);
     } else {


### PR DESCRIPTION
I spent a little time trying to pre-allocate std::vectors in our geometry construction process (since there are many case where we know their final size ahead of time). Turns out this can have a big impact on performance for phones!

Testing on our iPhone 5s, we see the following metrics:

```
                       Avg. Time Baseline:    Avg. Time Prealloc:    Delta:
buildPolygon:          185ms                  180ms                  -2.7%
buildPolygonExtrusion: 90ms                   50ms                   -44%
buildGeneralPolyline:  11ms                   4ms                    -64%
```

The tessellation step still dominates the overall cost, but building many geometries can be made twice as fast simply by preallocating vectors with `std::vector::reserve()`
