### PR TITLE
Fix a crash occurring when the application exits

### DIFF
--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -16,13 +16,13 @@
 
 namespace Tangram {
 
-std::unique_ptr<TileManager> m_tileManager;    
+std::unique_ptr<TileManager> m_tileManager;
 std::shared_ptr<Scene> m_scene;
 std::shared_ptr<View> m_view;
-
+    
 void initialize() {
     
-    logMsg("%s\n", "initialize");
+    logMsg("initialize\n");
 
     // Create view
     if (!m_view) {
@@ -80,7 +80,7 @@ void initialize() {
 
     while (Error::hadGlError("Tangram::initialize()")) {}
 
-    logMsg("%s\n", "finish initialize");
+    logMsg("finish initialize\n");
 
 }
 
@@ -185,10 +185,16 @@ void handlePinchGesture(float _posX, float _posY, float _scale) {
 }
 
 void teardown() {
-    // TODO: Release resources!
+    // Release resources!
+    logMsg("teardown\n");
+    m_tileManager.reset();
+    m_scene.reset();
+    m_view.reset();
 }
 
 void onContextDestroyed() {
+    
+    logMsg("context destroyed\n");
     
     // The OpenGL context has been destroyed since the last time resources were created,
     // so we invalidate all data that depends on OpenGL object handles.
@@ -198,6 +204,7 @@ void onContextDestroyed() {
 
     // Buffer objects are invalidated and re-uploaded the next time they are used
     VboMesh::invalidateAllVBOs();
+    
     
 }
     

--- a/core/src/util/shaderProgram.h
+++ b/core/src/util/shaderProgram.h
@@ -4,7 +4,6 @@
 #include "gl.h"
 #include <string>
 #include <vector>
-#include <unordered_set>
 #include <unordered_map>
 
 /*
@@ -52,7 +51,7 @@ public:
     /* 
      * Binds the program in openGL if it is not already bound
      */
-    void use() const;
+    void use();
 
     /* 
      * Ensures the program is bound and then sets the named uniform to the given value(s)
@@ -108,8 +107,9 @@ private:
 
     static GLuint s_activeGlProgram;
     
-    static std::unordered_set<ShaderProgram*> s_managedPrograms;
-
+    static int s_validGeneration; // Incremented when GL context is invalidated
+    int m_generation;
+    
     GLuint m_glProgram;
     GLuint m_glFragmentShader;
     GLuint m_glVertexShader;
@@ -117,7 +117,8 @@ private:
     std::unordered_map<std::string, ShaderLocation> m_uniformMap;
     std::string m_fragmentShaderSource;
     std::string m_vertexShaderSource;
-
+    
+    void checkValidity();
     GLuint makeLinkedShaderProgram(GLint _fragShader, GLint _vertShader);
     GLuint makeCompiledShader(const std::string& _src, GLenum _type);
 

--- a/core/src/util/vboMesh.h
+++ b/core/src/util/vboMesh.h
@@ -2,7 +2,6 @@
 
 #include <vector>
 #include <memory>
-#include <unordered_set>
 
 #include "gl.h"
 #include "vertexLayout.h"
@@ -83,8 +82,9 @@ public:
     static void invalidateAllVBOs();
 
 private:
-
-    static std::unordered_set<VboMesh*> s_managedVBOs;
+    
+    static int s_validGeneration; // Incremented when the GL context is invalidated
+    int m_generation;
     
     std::shared_ptr<VertexLayout> m_vertexLayout;
     
@@ -99,5 +99,7 @@ private:
     GLenum m_drawMode;
 
     bool m_isUploaded;
+    
+    void checkValidity();
 
 };


### PR DESCRIPTION
Currently, running Tangram from GLFW and closing the app will produce a segmentation fault during the exit process. The same (bad) behavior occurs on every platform, but errors get suppressed on Android and iOS. The reasons for this error are somewhat nuanced, but have been found and resolved (so feel free to skip the following description). 

In order to recover from GL context loss, classes that contain handles to OpenGL objects (`ShaderProgram` and `VboMesh`) previously tracked all instances of themselves in static `std::set`s so that they can be efficiently invalidated when context loss occurs. Instances of these classes add themselves to these `set`s in their constructor and remove themselves from it in their destructor. In typical program operation this works as expected, but it fails when exiting the program. On exit, the main resource containers (tileManager, scene) are automatically destructed, further destructing all of their members all the way down to `ShaderProgram`s and `VboMesh`es. When these destructors are called, we find that the static `set`s for these classes have already been destructed! As it turns out, our main resource containers are globally scoped in the program, meaning that they have static storage duration. All objects with static storage duration persist for the entire main function, but the order of destruction of these objects is undefined between different compilation units (source files). The result is that these instances of `ShaderProgram` and `VboMesh` weren't getting destructed until after other parts of static memory (namely, the static `set`s in their classes). 

The simplest solution was to modify our context-loss-recovery strategy to not require tracking all instances of those classes. I modified both classes to instead statically track the number of times the GL context has been invalidated and check with each use whether they are 'up to date'. 