### PR TITLE
Build system improvements

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -17,6 +17,7 @@ foreach(_headerFile ${FOUND_HEADERS})
     get_filename_component(_dir ${_headerFile} PATH)
     list(APPEND INCLUDE_DIRS ${_dir})
 endforeach()
+set(CORE_INCLUDE_DIRS ${INCLUDE_DIRS} CACHE INTERNAL "core include directories" FORCE)
 list(APPEND INCLUDE_DIRS "${DEPENDENCIES_DIR}/tess2/libtess2/Include")
 list(APPEND INCLUDE_DIRS "${DEPENDENCIES_DIR}/jsoncpp")
 list(REMOVE_DUPLICATES INCLUDE_DIRS)
@@ -30,7 +31,7 @@ if(NOT DEFINED CORE_LIB_NAME)
     set(CORE_LIB_NAME core)
 endif()
 
-add_library(${CORE_LIB_NAME} ${CORE_LIB_TYPE} ${FOUND_SOURCES})
+add_library(${CORE_LIB_NAME} ${CORE_LIB_TYPE} ${FOUND_SOURCES} ${FOUND_HEADERS})
 target_link_libraries(${CORE_LIB_NAME} json libtess2 ${CORE_LIB_DEPS})
 
 # post build commands

--- a/tests/unit/curlTests.cpp
+++ b/tests/unit/curlTests.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN 
-#include "catch/catch.hpp"
+#include "catch.hpp"
 
 #include <iostream>
 

--- a/tests/unit/fileTests.cpp
+++ b/tests/unit/fileTests.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN 
-#include "catch/catch.hpp"
+#include "catch.hpp"
 
 #include <iostream>
 #include <sys/stat.h>

--- a/tests/unit/mercProjTests.cpp
+++ b/tests/unit/mercProjTests.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN 
-#include "catch/catch.hpp"
+#include "catch.hpp"
 
 #include <iostream>
 #include <iomanip>

--- a/toolchains/android.cmake
+++ b/toolchains/android.cmake
@@ -31,9 +31,8 @@ set(CORE_INSTALLATION_PATH ${CMAKE_SOURCE_DIR}/android/libs/${ANDROID_ABI})
 set(CORE_LIB_DEPS GLESv2 ${LIBCURL_PRECOMPILED_LIB})
 set(CORE_LIB_NAME tangram) # in order to have libtangram.so
 
-include_directories(${PROJECT_SOURCE_DIR}/core/include/)
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
-include_recursive_dirs(${PROJECT_SOURCE_DIR}/core/*.h)
+include_directories(${CORE_INCLUDE_DIRS})
 
 # link and build functions
 function(link_libraries)

--- a/toolchains/darwin.cmake
+++ b/toolchains/darwin.cmake
@@ -9,10 +9,8 @@ add_definitions(-DPLATFORM_OSX)
 include_directories(/usr/local/include)
 
 # load core library
-include_directories(${PROJECT_SOURCE_DIR}/core/include/)
-include_directories(${PROJECT_SOURCE_DIR}/core/include/jsoncpp/)
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
-include_recursive_dirs(${PROJECT_SOURCE_DIR}/core/src/*.h)
+include_directories(${CORE_INCLUDE_DIRS})
 
 # add sources and include headers
 set(OSX_EXTENSIONS_FILES *.mm *.cpp)

--- a/toolchains/iOS.cmake
+++ b/toolchains/iOS.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}
     -std=gnu++11 
     -stdlib=libc++ 
     -isysroot ${CMAKE_IOS_SDK_ROOT}")
-set(CXX_FLAGS_DEBUG "-g -O0")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} 
     -fobjc-abi-version=2 

--- a/toolchains/iOS.cmake
+++ b/toolchains/iOS.cmake
@@ -38,10 +38,8 @@ file(GLOB_RECURSE CORE_RESOURCES ${PROJECT_SOURCE_DIR}/core/resources/**)
 list(APPEND RESOURCES ${CORE_RESOURCES})
 
 # load core library
-include_directories(${PROJECT_SOURCE_DIR}/core/include/)
-include_directories(${PROJECT_SOURCE_DIR}/core/include/jsoncpp)
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
-include_recursive_dirs(${PROJECT_SOURCE_DIR}/core/*.h)
+include_directories(${CORE_INCLUDE_DIRS})
 
 find_package(ZLIB REQUIRED)
 if (ZLIB_FOUND)

--- a/toolchains/raspberrypi.cmake
+++ b/toolchains/raspberrypi.cmake
@@ -12,10 +12,8 @@ include_directories(/opt/vc/include/interface/vcos/pthreads)
 include_directories(/opt/vc/include/interface/vmcs_host/linux)
 
 # load core library
-include_directories(${PROJECT_SOURCE_DIR}/core/include/)
-include_directories(${PROJECT_SOURCE_DIR}/core/include/jsoncpp/)
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
-include_recursive_dirs(${PROJECT_SOURCE_DIR}/core/src/*.h)
+include_directories(${CORE_INCLUDE_DIRS})
 
 # add sources and include headers
 find_sources_and_include_directories(

--- a/toolchains/unitTests.cmake
+++ b/toolchains/unitTests.cmake
@@ -11,6 +11,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/core)
 include_directories(${CORE_INCLUDE_DIRS})
 
 # for testing purposes include those folders
+include_directories(${PROJECT_SOURCE_DIR}/core/include/)
 include_directories(${PROJECT_SOURCE_DIR}/core/include/catch/)
 include_directories(${PROJECT_SOURCE_DIR}/core/include/jsoncpp/)
 

--- a/toolchains/unitTests.cmake
+++ b/toolchains/unitTests.cmake
@@ -7,10 +7,12 @@ add_definitions(-DPLATFORM_OSX)
 include_directories(/usr/local/include)
 
 # load core library
-include_directories(${PROJECT_SOURCE_DIR}/core/include/)
-include_directories(${PROJECT_SOURCE_DIR}/core/include/jsoncpp/)
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
-include_recursive_dirs(${PROJECT_SOURCE_DIR}/core/src/*.h)
+include_directories(${CORE_INCLUDE_DIRS})
+
+# for testing purposes include those folders
+include_directories(${PROJECT_SOURCE_DIR}/core/include/catch/)
+include_directories(${PROJECT_SOURCE_DIR}/core/include/jsoncpp/)
 
 set(OSX_PLATFORM_SRC ${PROJECT_SOURCE_DIR}/osx/src/platform_osx.mm)
 


### PR DESCRIPTION
For more consistency reduced the numbers of header files included from the dependent platform cmake files. This is done by outputing a variable after calling the core cmake file. Also, fixed the arrangement of header files inside xcode, and debugging for iOS.