### PR TITLE
Checking for geometry for a specific style

### DIFF
--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -124,7 +124,7 @@ void render() {
         // Loop over all tiles in m_tileSet
         for (const auto& mapIDandTile : m_tileManager->getVisibleTiles()) {
             const std::shared_ptr<MapTile>& tile = mapIDandTile.second;
-            if (tile->hasGeometry()) {
+            if (tile->hasGeometry(style->getName())) {
                 // Draw tile!
                 style->setupTile(tile);
                 tile->draw(*style, *m_view);

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -39,33 +39,29 @@ void MapTile::addGeometry(const Style& _style, std::unique_ptr<VboMesh> _mesh) {
 }
 
 void MapTile::draw(const Style& _style, const View& _view) {
-    
 
     const std::unique_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
 
-    if (styleMesh) {
+    std::shared_ptr<ShaderProgram> shader = _style.getShaderProgram();
 
-        std::shared_ptr<ShaderProgram> shader = _style.getShaderProgram();
+    glm::dmat4 modelViewProjMatrix = _view.getViewProjectionMatrix() * m_modelMatrix;
 
-        glm::dmat4 modelViewProjMatrix = _view.getViewProjectionMatrix() * m_modelMatrix;
+    // NOTE : casting to float, but loop over the matrix values
+    double* first = &modelViewProjMatrix[0][0];
+    std::vector<float> fmvp(first, first + 16);
 
-        // NOTE : casting to float, but loop over the matrix values
-        double* first = &modelViewProjMatrix[0][0];
-        std::vector<float> fmvp(first, first + 16);
+    shader->setUniformMatrix4f("u_modelViewProj", &fmvp[0]);
 
-        shader->setUniformMatrix4f("u_modelViewProj", &fmvp[0]);
-
-        // Set tile offset for proxy tiles
-        float offset = 0;
-        if (m_proxyCounter > 0) {
-            offset = 1.0f + log((_view.s_maxZoom + 1) / (_view.s_maxZoom + 1 - m_id.z));
-        } else {
-            offset = 1.0f + log(_view.s_maxZoom + 2);
-        }
-        shader->setUniformf("u_tileDepthOffset", offset);
-
-        styleMesh->draw(shader);
+    // Set tile offset for proxy tiles
+    float offset = 0;
+    if (m_proxyCounter > 0) {
+        offset = 1.0f + log((_view.s_maxZoom + 1) / (_view.s_maxZoom + 1 - m_id.z));
+    } else {
+        offset = 1.0f + log(_view.s_maxZoom + 2);
     }
+    shader->setUniformf("u_tileDepthOffset", offset);
+
+    styleMesh->draw(shader);
 }
 
 bool MapTile::hasGeometry() {

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -71,3 +71,8 @@ void MapTile::draw(const Style& _style, const View& _view) {
 bool MapTile::hasGeometry() {
     return (m_geometry.size() != 0);
 }
+
+bool MapTile::hasGeometry(std::string _styleName) {
+    return (m_geometry.find(_styleName) != m_geometry.end()) ? true : false;
+}
+

--- a/core/src/tile/mapTile.h
+++ b/core/src/tile/mapTile.h
@@ -53,6 +53,11 @@ public:
      * Method to check if this tile's vboMesh(s) are loaded and ready to be drawn
      */
     bool hasGeometry();
+    
+    /*
+     * Overloaded function to check if geometry exists for a specific style
+     */
+    bool hasGeometry(std::string _styleName);
 
     /* Draws the geometry associated with the provided <Style> and view-projection matrix */
     void draw(const Style& _style, const View& _view);


### PR DESCRIPTION
- change for more readibility. tile->draw should not be called for styles for which there is no geometry/vbo in the
tile.