### PR TITLE
Matrix optimizations

### DIFF
--- a/core/src/tile/mapTile.h
+++ b/core/src/tile/mapTile.h
@@ -82,7 +82,10 @@ private:
 
     glm::dvec2 m_tileOrigin; // Center of the tile in 2D projection space in meters (e.g. mercator meters)
 
-    glm::dmat4 m_modelMatrix; // Translation matrix from world origin to tile origin
+    glm::mat4 m_modelMatrix; // Matrix relating tile-local coordinates to global projection space coordinates;
+    // Note that this matrix does not contain the relative translation from the global origin to the tile origin.
+    // Distances from the global origin are too large to represent precisely in 32-bit floats, so we only apply the
+    // relative translation from the view origin to the model origin immediately before drawing the tile. 
 
     std::unordered_map<std::string, std::unique_ptr<VboMesh>> m_geometry; // Map of <Style>s and their associated <VboMesh>es
 };

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -144,7 +144,7 @@ void View::updateMatrices() {
     m_width = m_height * m_aspect;
     
     // set vertical field-of-view
-    double fovy = PI * 0.5;
+    float fovy = PI * 0.5;
     
     // we assume portrait orientation by default, so in landscape
     // mode we scale the vertical FOV such that the wider dimension
@@ -158,11 +158,11 @@ void View::updateMatrices() {
     
     // set near clipping distance as a function of camera z
     // TODO: this is a simple heuristic that deserves more thought
-    double near = m_pos.z / 50.0;
+    float near = m_pos.z / 50.0;
     
     // update view and projection matrices
-    m_view = glm::lookAt(m_pos, m_pos + glm::dvec3(0, 0, -1), glm::dvec3(0, 1, 0));
-    m_proj = glm::perspective(fovy, double(m_aspect), near, m_pos.z + 1.0);
+    m_view = glm::lookAt(glm::vec3(0.0, 0.0, 0.0), glm::vec3(0.0, 0.0, -1.0), glm::vec3(0.0, 1.0, 0.0));
+    m_proj = glm::perspective(fovy, m_aspect, near, (float)m_pos.z + 1.0f);
     m_viewProj = m_proj * m_view;
     
 }

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -1,7 +1,9 @@
 #include "view.h"
+
+#include <cmath>
+
 #include "util/tileID.h"
 #include "platform.h"
-#include "glm/gtx/string_cast.hpp"
 #include "glm/gtc/matrix_transform.hpp"
 
 constexpr float View::s_maxZoom; // Create a stack reference to the static member variable

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -67,9 +67,9 @@ public:
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
     const glm::dvec3& getPosition() const { return m_pos; }
     
-    const glm::dmat4& getViewMatrix() const { return m_view; }
-    const glm::dmat4& getProjectionMatrix() const { return m_proj; }
-    const glm::dmat4 getViewProjectionMatrix() const { return m_viewProj; }
+    const glm::mat4& getViewMatrix() const { return m_view; }
+    const glm::mat4& getProjectionMatrix() const { return m_proj; }
+    const glm::mat4 getViewProjectionMatrix() const { return m_viewProj; }
 
     /* Returns a rectangle of the current view range as [[x_min, y_min], [x_max, y_max]] */
     glm::dmat2 getBoundsRect() const;
@@ -102,9 +102,9 @@ protected:
     bool m_changed;
     std::set<TileID> m_visibleTiles;
     glm::dvec3 m_pos;
-    glm::dmat4 m_view;
-    glm::dmat4 m_proj;
-    glm::dmat4 m_viewProj;
+    glm::mat4 m_view;
+    glm::mat4 m_proj;
+    glm::mat4 m_viewProj;
     float m_zoom;
     float m_initZoom = 16.0;
     bool m_isZoomIn = false;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -2,7 +2,6 @@
 
 #include <vector>
 #include <set>
-#include <cmath>
 #include <memory>
 
 #include "glm/mat4x4.hpp"
@@ -67,8 +66,14 @@ public:
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
     const glm::dvec3& getPosition() const { return m_pos; }
     
+    /* Gets the transformation from global space into view (camera) space; Due to precision limits, this 
+       does not contain the translation of the view from the global origin (you must apply that separately) */
     const glm::mat4& getViewMatrix() const { return m_view; }
+
+    /* Gets the transformation from view space into screen space */
     const glm::mat4& getProjectionMatrix() const { return m_proj; }
+
+    /* Gets the combined view and projection transformation */
     const glm::mat4 getViewProjectionMatrix() const { return m_viewProj; }
 
     /* Returns a rectangle of the current view range as [[x_min, y_min], [x_max, y_max]] */
@@ -78,6 +83,7 @@ public:
     
     float getHeight() const { return m_vpHeight; }
     
+    /* Calculate the distance in map projection units represented by the given distance in screen space */
     float toWorldDistance(float _screenDistance) const;
     
     /* Returns the set of all tiles visible at the current position and zoom */
@@ -98,23 +104,29 @@ protected:
     void updateTiles();
 
     std::unique_ptr<MapProjection> m_projection;
-    bool m_dirty;
-    bool m_changed;
     std::set<TileID> m_visibleTiles;
+
     glm::dvec3 m_pos;
+
     glm::mat4 m_view;
     glm::mat4 m_proj;
     glm::mat4 m_viewProj;
+    
     float m_zoom;
     float m_initZoom = 16.0;
     bool m_isZoomIn = false;
-    int m_vpWidth;
-    int m_vpHeight;
+
     float m_width;
     float m_height;
+    
+    int m_vpWidth;
+    int m_vpHeight;
     float m_aspect;
     float m_pixelScale = 1.0f;
     float m_pixelsPerTile = 256.0;
+
+    bool m_dirty;
+    bool m_changed;
     
 };
 


### PR DESCRIPTION
By separating the global translations from the model and view matrices, we can store these matrices in single precision values instead of double precision (and prevent looping through matrices and casting like we currently do). This also adds some comments to clarify the usage of the relevant matrices. 