### PR TITLE
Make styling functions const to forbid potential concurrent modification

### DIFF
--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -35,11 +35,11 @@ void PolygonStyle::setupFrame() {
     m_shaderProgram->setUniformf("u_lightDirection", -1.0, -1.0, 1.0);
 }
 
-void PolygonStyle::buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) {
+void PolygonStyle::buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) const {
     // No-op
 }
 
-void PolygonStyle::buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) {
+void PolygonStyle::buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) const {
     std::vector<PosNormColVertex> vertices;
     std::vector<GLushort> indices;
     std::vector<glm::vec3> points;
@@ -67,7 +67,7 @@ void PolygonStyle::buildLine(Line& _line, std::string& _layer, Properties& _prop
     _mesh.addIndices(indices.data(), indices.size());
 }
 
-void PolygonStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) {
+void PolygonStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) const {
     
     std::vector<PosNormColVertex> vertices;
     std::vector<GLushort> indices;

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -24,9 +24,9 @@ protected:
     
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) override;
-    virtual void buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) override;
-    virtual void buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) override;
+    virtual void buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) const override;
     
 public:
     

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -38,11 +38,11 @@ void PolylineStyle::setupFrame() {
     m_shaderProgram->setUniformf("u_time", ((float)t)/CLOCKS_PER_SEC);
 }
 
-void PolylineStyle::buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) {
+void PolylineStyle::buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) const {
     // No-op
 }
 
-void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) {
+void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) const {
     std::vector<PosNormEnormColVertex> vertices;
     std::vector<GLushort> indices;
     std::vector<glm::vec3> points;
@@ -83,6 +83,6 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     _mesh.addIndices(indices.data(), indices.size());
 }
 
-void PolylineStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) {
+void PolylineStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) const {
     // No-op
 }

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -24,9 +24,9 @@ protected:
     
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) override;
-    virtual void buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) override;
-    virtual void buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) override;
+    virtual void buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) const override;
     
 public:
     

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -15,7 +15,7 @@ void Style::addLayers(std::vector<std::string> _layers) {
     m_layers.insert(_layers.cbegin(), _layers.cend());
 }
 
-void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) {
+void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) const {
     
     VboMesh* mesh = new VboMesh(m_vertexLayout, m_drawMode);
     

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -48,10 +48,10 @@ protected:
     virtual void constructShaderProgram() = 0;
     
     /* Build styled vertex data for point geometry and add it to the given <VboMesh> */
-    virtual void buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) = 0;
+    virtual void buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) const = 0;
     
     /* Build styled vertex data for line geometry and add it to the given <VboMesh> */
-    virtual void buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) = 0;
+    virtual void buildLine(Line& _line, std::string& _layer, Properties& _props, VboMesh& _mesh) const = 0;
     
     /* Build styled vertex data for polygon geometry and add it to the given <VboMesh> 
      * 
@@ -60,7 +60,7 @@ protected:
      * simple polygon (in the mathematical sense), _sizes will have one element which is
      * the number of points in the first vector.
      */
-    virtual void buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) = 0;
+    virtual void buildPolygon(Polygon& _polygon, std::string& _layer, Properties& _props, VboMesh& _mesh) const = 0;
 
 public:
 
@@ -71,7 +71,7 @@ public:
     virtual void addLayers(std::vector<std::string> _layers);
     
     /* Add styled geometry from the given Json object to the given <MapTile> */
-    virtual void addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection);
+    virtual void addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) const;
     
     /* Perform any setup needed before drawing each frame */
     virtual void setupFrame();

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -140,7 +140,7 @@ void TileManager::addTile(const TileID& _tileID) {
                 
                 auto tileData = dataSource->getTileData(_id);
                 
-                for (auto& style : m_scene->getStyles()) {
+                for (const auto& style : m_scene->getStyles()) {
                     if (tileData) {
                         style->addData(*tileData, *tile, m_view->getMapProjection());
                     }


### PR DESCRIPTION
This may become irrelevant after future revisions to the tile building process; I expect that when we have a pool of workers, each worker can hold a copy of any data needed for the building process so concurrent access won't be a problem. However, for now this enforces that Style members won't be modified inside functions that are called from multiple threads. 