### PR TITLE
Travis android osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
           env: PLATFORM=osx
           compiler: clang
         - os: osx
+          env: PLATFORM=ios
+          compiler: clang
+        - os: osx
           env: PLATFORM=android
           compiler: gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ language: cpp
 matrix:
     include:
         - os: osx
+          env: PLATFORM=osx
           compiler: clang
-        - os: linux
+        - os: osx
+          env: PLATFORM=android
           compiler: gcc
 
 before_install:

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -3,40 +3,43 @@
 set -e
 set -o pipefail
 
-if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
-    ANDROID_SDK_VERSION="r24.0.2"
-    ANDROID_NDK_VERSION="r10d"
-    ANDROID_BUILD_TOOL_VERSION="21.1.2"
-    ANDROID_PLATFORM_VERSION="19"
-fi
-
 if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
     brew update
+fi
+
+if [[ ${PLATFORM} == "osx" ]]; then
     brew tap homebrew/versions
     brew install glfw3
 fi
 
+if [[ ${PLATFORM} == "android" ]]; then
 
-if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
+    ANDROID_SDK_VERSION="r24.0.2"
+    ANDROID_NDK_VERSION="r10d"
+    ANDROID_BUILD_TOOL_VERSION="21.1.2"
+    ANDROID_PLATFORM_VERSION="19"
+
     # gcc-4.8 should be default in travis ci now (https://github.com/travis-ci/travis-cookbooks/pull/215), but for safety
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    sudo apt-get update -qq
+    #sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+    #sudo apt-get update -qq
     # No linux specific build right now, for android builds, gcc bundled with ndk is used
     # if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
     # if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
     # install other required packages
-    sudo apt-get -y install git build-essential automake gdb libtool make cmake pkg-config 
+    #sudo apt-get -y install git build-essential automake gdb libtool make cmake pkg-config 
 
     # not installing mesa and opengl right now, will need with linux builds though
 
     # install jdk, ant and 32bit dependencies for android sdk
-    sudo apt-get -qq -y install openjdk-7-jdk ant lib32z1-dev lib32stdc++6
+    #sudo apt-get -qq -y install openjdk-7-jdk ant lib32z1-dev lib32stdc++6
+    brew install ant
 
     # install android sdk
-    wget https://dl-ssl.google.com/android/android-sdk_${ANDROID_SDK_VERSION}-linux.tgz
-    tar -zxf android-sdk_${ANDROID_SDK_VERSION}-linux.tgz
-    export ANDROID_HOME=$PWD/android-sdk-linux
+    wget https://dl-ssl.google.com/android/android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
+    tar -zxf android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
+    export ANDROID_HOME=$PWD/android-sdk-mac_x86
+    
     # install android ndk
     # only binary link avaiable for r10d, no download links available for r10b
     wget http://dl.google.com/android/ndk/android-ndk-r10d-linux-x86_64.bin

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -42,9 +42,10 @@ if [[ ${PLATFORM} == "android" ]]; then
     
     # install android ndk
     # only binary link avaiable for r10d, no download links available for r10b
-    wget http://dl.google.com/android/ndk/android-ndk-r10d-linux-x86_64.bin
-    chmod +x android-ndk-r10d-linux-x86_64.bin
-    ./android-ndk-r10d-linux-x86_64.bin | egrep -v ^Extracting
+    ANDROID_NDK_NAME="android-ndk-${ANDROID_NDK_VERSION}-darwin-x86_64.bin"
+    wget http://dl.google.com/android/ndk/${ANDROID_NDK_NAME}
+    chmod a+x ${ANDROID_NDK_NAME}
+    ./android-ndk-r10d-darwin-x86_64.bin | egrep -v ^Extracting
     export ANDROID_NDK=$PWD/android-ndk-${ANDROID_NDK_VERSION}
 
     # Update PATH

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
-    brew update
+    brew update >/dev/null
 fi
 
 if [[ ${PLATFORM} == "osx" ]]; then
@@ -38,7 +38,7 @@ if [[ ${PLATFORM} == "android" ]]; then
     # install android sdk
     wget https://dl-ssl.google.com/android/android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
     tar -zxf android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
-    export ANDROID_HOME=$PWD/android-sdk-mac_x86
+    export ANDROID_HOME=$PWD/android-sdk-macosx
     
     # install android ndk
     # only binary link avaiable for r10d, no download links available for r10b
@@ -49,7 +49,7 @@ if [[ ${PLATFORM} == "android" ]]; then
     export ANDROID_NDK=$PWD/android-ndk-${ANDROID_NDK_VERSION}
 
     # Update PATH
-    export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_NDK}
+    export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_NDK}
 
     # Install required Android components.
     # automatically accept the license prompt

--- a/travis/script_build.sh
+++ b/travis/script_build.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
+if [[ ${PLATFORM} == "osx" ]]; then
     # Build osx project
     echo "Building osx project"
     make osx
@@ -13,8 +13,9 @@ if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
     make ios
 fi
 
-if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
+if [[ ${PLATFORM} == "android" ]]; then
     # Build android project
+    echo "Building android project"
     make android
 fi
 

--- a/travis/script_build.sh
+++ b/travis/script_build.sh
@@ -7,7 +7,9 @@ if [[ ${PLATFORM} == "osx" ]]; then
     # Build osx project
     echo "Building osx project"
     make osx
+fi
 
+if [[ ${PLATFORM} == "ios" ]]; then
     # Build ios project
     echo "Building ios project (simulator)"
     make ios

--- a/travis/script_build_tests.sh
+++ b/travis/script_build_tests.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
+if [[ ${PLATFORM} == "osx" ]]; then
     # Build unit tests
     make tests
 fi

--- a/travis/script_run_tests.sh
+++ b/travis/script_run_tests.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
+if [[ ${PLATFORM} == "osx" ]]; then
     # Run unit tests
     echo "Running Unit Tests"
     for file in ./build/tests/unit/bin/*


### PR DESCRIPTION
Building Android on an OS X machine seems to resolve the issue we've been having where Travis fails when extracting the NDK archive (extraction has been successful all 3 times it's run). 