### PR TITLE
Configure libtess2 allocator

### DIFF
--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -4,8 +4,31 @@
 #include "rectangle.h"
 #include "geom.h"
 
+#include <memory>
+
 static auto& NO_TEXCOORDS = *(new std::vector<glm::vec2>); // denotes that texture coordinates should not be used
 static auto& NO_SCALING_VECS = *(new std::vector<glm::vec2>); // denotes that scaling vectors should not be used
+
+void* alloc(void* _userData, unsigned int _size) {
+    return malloc(_size);
+}
+
+void* realloc(void* _userData, void* _ptr, unsigned int _size) {
+    return realloc(_ptr, _size);
+}
+
+void free(void* _userData, void* _ptr) {
+    free(_ptr);
+}
+
+static TESSalloc allocator = {&alloc, &realloc, &free, nullptr,
+                              128, // meshEdgeBucketSize
+                              128, // meshVertexBucketSize
+                              64,  // meshFaceBucketSize
+                              128, // dictNodeBucketSize
+                              64,  // regionBucketSize
+                              128  // extraVertices
+                             };
 
 void Builders::buildPolygon(const Polygon& _polygon, std::vector<glm::vec3>& _pointsOut, std::vector<glm::vec3>& _normalOut, std::vector<ushort>& _indicesOut) {
     
@@ -15,7 +38,7 @@ void Builders::buildPolygon(const Polygon& _polygon, std::vector<glm::vec3>& _po
 
 void Builders::buildPolygon(const Polygon& _polygon, std::vector<glm::vec3>& _pointsOut, std::vector<glm::vec3>& _normalOut, std::vector<ushort>& _indicesOut, std::vector<glm::vec2>& _texcoordOut) {
     
-    TESStesselator* tesselator = tessNewTess(nullptr);
+    TESStesselator* tesselator = tessNewTess(&allocator);
     
     bool useTexCoords = &_texcoordOut != &NO_TEXCOORDS;
     

--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -22,12 +22,12 @@ void free(void* _userData, void* _ptr) {
 }
 
 static TESSalloc allocator = {&alloc, &realloc, &free, nullptr,
-                              128, // meshEdgeBucketSize
-                              128, // meshVertexBucketSize
-                              64,  // meshFaceBucketSize
-                              128, // dictNodeBucketSize
-                              64,  // regionBucketSize
-                              128  // extraVertices
+                              64, // meshEdgeBucketSize
+                              64, // meshVertexBucketSize
+                              16,  // meshFaceBucketSize
+                              64, // dictNodeBucketSize
+                              16,  // regionBucketSize
+                              64  // extraVertices
                              };
 
 void Builders::buildPolygon(const Polygon& _polygon, std::vector<glm::vec3>& _pointsOut, std::vector<glm::vec3>& _normalOut, std::vector<ushort>& _indicesOut) {


### PR DESCRIPTION
By providing more sensible values for allocation sizes in libtess2, polygon tesselation is made roughly 2 times faster (in a city scene). 

Further optimization would include:
1. Extended experimentation with these values
2. Changing the allocation functions to use pooled memory