### PR TITLE
Minimal NDK for Travis

### DIFF
--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -15,7 +15,6 @@ fi
 if [[ ${PLATFORM} == "android" ]]; then
 
     ANDROID_SDK_VERSION="r24.0.2"
-    ANDROID_NDK_VERSION="r10d"
     ANDROID_BUILD_TOOL_VERSION="21.1.2"
     ANDROID_PLATFORM_VERSION="19"
 
@@ -41,12 +40,8 @@ if [[ ${PLATFORM} == "android" ]]; then
     export ANDROID_HOME=$PWD/android-sdk-macosx
     
     # install android ndk
-    # only binary link avaiable for r10d, no download links available for r10b
-    ANDROID_NDK_NAME="android-ndk-${ANDROID_NDK_VERSION}-darwin-x86_64.bin"
-    wget http://dl.google.com/android/ndk/${ANDROID_NDK_NAME}
-    chmod a+x ${ANDROID_NDK_NAME}
-    ./android-ndk-r10d-darwin-x86_64.bin | egrep -v ^Extracting
-    export ANDROID_NDK=$PWD/android-ndk-${ANDROID_NDK_VERSION}
+    git clone --quiet --depth 1 https://github.com/tangrams/mindk.git
+    export ANDROID_NDK=$PWD/mindk/android-ndk-r10d
 
     # Update PATH
     export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_NDK}

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -18,37 +18,28 @@ if [[ ${PLATFORM} == "android" ]]; then
     ANDROID_BUILD_TOOL_VERSION="21.1.2"
     ANDROID_PLATFORM_VERSION="19"
 
-    # gcc-4.8 should be default in travis ci now (https://github.com/travis-ci/travis-cookbooks/pull/215), but for safety
-    #sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    #sudo apt-get update -qq
-    # No linux specific build right now, for android builds, gcc bundled with ndk is used
-    # if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
-    # if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-
-    # install other required packages
-    #sudo apt-get -y install git build-essential automake gdb libtool make cmake pkg-config 
-
-    # not installing mesa and opengl right now, will need with linux builds though
-
-    # install jdk, ant and 32bit dependencies for android sdk
-    #sudo apt-get -qq -y install openjdk-7-jdk ant lib32z1-dev lib32stdc++6
+    # Install ant
     brew install ant
 
-    # install android sdk
+    # Install android sdk
     wget https://dl-ssl.google.com/android/android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
     tar -zxf android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
     export ANDROID_HOME=$PWD/android-sdk-macosx
-    
-    # install android ndk
+
+    # Install required Android components; automatically accept the license prompt
+    echo "Updating Android SDK..."
+    echo "y" | android update sdk --filter platform-tools,build-tools-${ANDROID_BUILD_TOOL_VERSION},android-${ANDROID_PLATFORM_VERSION},extra-android-support --no-ui --force >/dev/null
+    echo "Done."
+
+    # Install android ndk
+    echo "Cloning mindk..."
     git clone --quiet --depth 1 https://github.com/tangrams/mindk.git
     export ANDROID_NDK=$PWD/mindk/android-ndk-r10d
+    echo "Done."
 
     # Update PATH
+    echo "Updating PATH..."
     export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_NDK}
-
-    # Install required Android components.
-    # automatically accept the license prompt
-    echo "y" | android update sdk --filter platform-tools,build-tools-${ANDROID_BUILD_TOOL_VERSION},android-${ANDROID_PLATFORM_VERSION},extra-android-support --no-ui --force >/dev/null
-
     echo $PATH
+    echo "Done."
 fi

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -26,11 +26,6 @@ if [[ ${PLATFORM} == "android" ]]; then
     tar -zxf android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
     export ANDROID_HOME=$PWD/android-sdk-macosx
 
-    # Install required Android components; automatically accept the license prompt
-    echo "Updating Android SDK..."
-    echo "y" | android update sdk --filter platform-tools,build-tools-${ANDROID_BUILD_TOOL_VERSION},android-${ANDROID_PLATFORM_VERSION},extra-android-support --no-ui --force >/dev/null
-    echo "Done."
-
     # Install android ndk
     echo "Cloning mindk..."
     git clone --quiet --depth 1 https://github.com/tangrams/mindk.git
@@ -41,5 +36,10 @@ if [[ ${PLATFORM} == "android" ]]; then
     echo "Updating PATH..."
     export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_NDK}
     echo $PATH
+    echo "Done."
+
+    # Install required Android components; automatically accept the license prompt
+    echo "Updating Android SDK..."
+    echo "y" | android update sdk --filter platform-tools,build-tools-${ANDROID_BUILD_TOOL_VERSION},android-${ANDROID_PLATFORM_VERSION},extra-android-support --no-ui --force >/dev/null
     echo "Done."
 fi

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -48,7 +48,7 @@ if [[ ${PLATFORM} == "android" ]]; then
 
     # Install required Android components.
     # automatically accept the license prompt
-    echo "y" | android update sdk --filter platform-tools,build-tools-${ANDROID_BUILD_TOOL_VERSION},android-${ANDROID_PLATFORM_VERSION},extra-android-support --no-ui --force
+    echo "y" | android update sdk --filter platform-tools,build-tools-${ANDROID_BUILD_TOOL_VERSION},android-${ANDROID_PLATFORM_VERSION},extra-android-support --no-ui --force >/dev/null
 
     echo $PATH
 fi


### PR DESCRIPTION
I've created a repo that hosts a minimized NDK, containing only the parts of the NDK that our build actually requires: https://github.com/tangrams/mindk

Now Travis can grab a clone of mindk instead of the full NDK, which saves a pretty massive amount of CPU time and RAM on our Travis builds. Total build times for Android on this branch are 3-4 minutes, down from the 10-20 minutes it currently takes. This will also prevent Travis from killing our builds due to memory usage or inactivity, meaning that we can finally trust the build status! ... probably. 

Of course, if we want to change our Android build configuration in the future (e.g. if Google stops hosting the current NDK version) we'll have to update mindk as well, but I've made mindk relatively configurable for those sorts of changes. 