### PR TITLE
Tilt

### DIFF
--- a/android/jni/jniExports.cpp
+++ b/android/jni/jniExports.cpp
@@ -50,8 +50,8 @@ extern "C" {
         Tangram::handlePinchGesture(posX, posY, scale);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_Tangram_handleRotateGesture(JNIEnv* jniEnv, jobject obj, jfloat rotation) {
-        Tangram::handleRotateGesture(rotation);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_Tangram_handleRotateGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat rotation) {
+        Tangram::handleRotateGesture(posX, posY, rotation);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_Tangram_handleShoveGesture(JNIEnv* jniEnv, jobject obj, jfloat distance) {

--- a/android/jni/jniExports.cpp
+++ b/android/jni/jniExports.cpp
@@ -53,6 +53,10 @@ extern "C" {
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_Tangram_handleRotateGesture(JNIEnv* jniEnv, jobject obj, jfloat rotation) {
         Tangram::handleRotateGesture(rotation);
     }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_Tangram_handleShoveGesture(JNIEnv* jniEnv, jobject obj, jfloat distance) {
+        Tangram::handleShoveGesture(distance);
+    }
     
 }
 

--- a/android/jni/jniExports.cpp
+++ b/android/jni/jniExports.cpp
@@ -42,8 +42,8 @@ extern "C" {
         Tangram::handleDoubleTapGesture(posX, posY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_Tangram_handlePanGesture(JNIEnv* jniEnv, jobject obj, jfloat velX, jfloat velY) {
-        Tangram::handlePanGesture(velX, velY);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_Tangram_handlePanGesture(JNIEnv* jniEnv, jobject obj, jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
+        Tangram::handlePanGesture(startX, startY, endX, endY);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_Tangram_handlePinchGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat scale) {

--- a/android/src/com/mapzen/tangram/Tangram.java
+++ b/android/src/com/mapzen/tangram/Tangram.java
@@ -37,7 +37,7 @@ public class Tangram extends GLSurfaceView implements Renderer, OnScaleGestureLi
     private static native void handleDoubleTapGesture(float posX, float posY);
     private static native void handlePanGesture(float startX, float startY, float endX, float endY);
     private static native void handlePinchGesture(float posX, float posY, float scale);
-    private static native void handleRotateGesture(float rotation);
+    private static native void handleRotateGesture(float posX, float posY, float rotation);
     private static native void handleShoveGesture(float distance);
 
     private long time = System.nanoTime();
@@ -191,7 +191,10 @@ public class Tangram extends GLSurfaceView implements Renderer, OnScaleGestureLi
     }
 
     public boolean onRotate(RotateGestureDetector detector) {
-        handleRotateGesture(-detector.getRotationDegreesDelta() * (float)(Math.PI / 180));
+        float x = scaleGestureDetector.getFocusX();
+        float y = scaleGestureDetector.getFocusY();
+        float rotation = -detector.getRotationDegreesDelta() * (float)(Math.PI / 180);
+        handleRotateGesture(x, y, rotation);
         return true;
     }
 

--- a/android/src/com/mapzen/tangram/Tangram.java
+++ b/android/src/com/mapzen/tangram/Tangram.java
@@ -202,7 +202,7 @@ public class Tangram extends GLSurfaceView implements Renderer, OnScaleGestureLi
         return;
     }
 
-    // ShoveGestureDetecrot.OnShoveGestureListener methods
+    // ShoveGestureDetector.OnShoveGestureListener methods
     // ===================================================
 
     public boolean onShoveBegin(ShoveGestureDetector detector) {

--- a/android/src/com/mapzen/tangram/Tangram.java
+++ b/android/src/com/mapzen/tangram/Tangram.java
@@ -35,7 +35,7 @@ public class Tangram extends GLSurfaceView implements Renderer, OnScaleGestureLi
     private static native void setPixelScale(float scale);
     private static native void handleTapGesture(float posX, float posY);
     private static native void handleDoubleTapGesture(float posX, float posY);
-    private static native void handlePanGesture(float velX, float velY);
+    private static native void handlePanGesture(float startX, float startY, float endX, float endY);
     private static native void handlePinchGesture(float posX, float posY, float scale);
     private static native void handleRotateGesture(float rotation);
     private static native void handleShoveGesture(float distance);
@@ -142,7 +142,9 @@ public class Tangram extends GLSurfaceView implements Renderer, OnScaleGestureLi
             // We flip the signs of distanceX and distanceY because onScroll provides the distances
             // by which the view being scrolled should move, while handlePanGesture expects the 
             // distances by which the touch point has moved on the screen (these are opposite)
-            handlePanGesture(-distanceX, -distanceY);
+            float x = e2.getX();
+            float y = e2.getY();
+            handlePanGesture(x + distanceX, y + distanceY, x, y);
         }
         return true;
     }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -234,6 +234,12 @@ void handleRotateGesture(float _radians) {
     
 }
 
+void handleShoveGesture(float _distance) {
+    
+    m_view->pitch(_distance);
+    
+}
+
 void teardown() {
     // Release resources!
     logMsg("teardown\n");

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -212,15 +212,14 @@ void handleDoubleTapGesture(float _posX, float _posY) {
     m_view->zoom(1.0);
 }
 
-void handlePanGesture(float _dX, float _dY) {
+void handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
     
-    
-    m_view->toWorldDisplacement(_dX, _dY);
+    glm::vec2 displacement = m_view->toWorldDisplacement(_startX, _startY, _endX, _endY);
 
     // We flip the signs of dx and dy to move the camera in the opposite direction
     // of the intended "world movement", but dy gets flipped once more because screen
     // coordinates have y pointing down and our world coordinates have y pointing up
-    m_view->translate(-_dX, _dY);
+    m_view->translate(-displacement.x, -displacement.y);
 
 }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -198,12 +198,13 @@ void setPixelScale(float _pixelsPerPoint) {
     
 void handleTapGesture(float _posX, float _posY) {
     
-    float dx = m_view->toWorldDistance(_posX - 0.5 * m_view->getWidth());
-    float dy = m_view->toWorldDistance(_posY - 0.5 * m_view->getHeight());
-
-    // Flip y displacement to change from screen coordinates to world coordinates
-    m_view->translate(dx, -dy);
+    float viewCenterX = 0.5f * m_view->getWidth();
+    float viewCenterY = 0.5f * m_view->getHeight();
     
+    m_view->screenToGroundPlane(viewCenterX, viewCenterY);
+    m_view->screenToGroundPlane(_posX, _posY);
+
+    m_view->translate((_posX - viewCenterX), (_posY - viewCenterY));
 
 }
 
@@ -214,12 +215,10 @@ void handleDoubleTapGesture(float _posX, float _posY) {
 
 void handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
     
-    glm::vec2 displacement = m_view->toWorldDisplacement(_startX, _startY, _endX, _endY);
+    m_view->screenToGroundPlane(_startX, _startY);
+    m_view->screenToGroundPlane(_endX, _endY);
 
-    // We flip the signs of dx and dy to move the camera in the opposite direction
-    // of the intended "world movement", but dy gets flipped once more because screen
-    // coordinates have y pointing down and our world coordinates have y pointing up
-    m_view->translate(-displacement.x, -displacement.y);
+    m_view->translate(_startX - _endX, _startY - _endY);
 
 }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -226,9 +226,10 @@ void handlePinchGesture(float _posX, float _posY, float _scale) {
     m_view->zoom(log2f(_scale));
 }
     
-void handleRotateGesture(float _radians) {
+void handleRotateGesture(float _posX, float _posY, float _radians) {
     
-    m_view->roll(_radians);
+    m_view->screenToGroundPlane(_posX, _posY);
+    m_view->orbit(_posX, _posY, _radians);
     
 }
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -45,7 +45,7 @@ void handlePanGesture(float _startX, float _startY, float _endX, float _endY);
 void handlePinchGesture(float _posX, float _posY, float _scale);
 
 // Respond to a rotation gesture with the given incremental rotation in radians
-void handleRotateGesture(float _rotation);
+void handleRotateGesture(float _posX, float _posY, float _rotation);
 
 // Respond to a two-finger shove with the given distance
 void handleShoveGesture(float _distance);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -47,5 +47,8 @@ void handlePinchGesture(float _posX, float _posY, float _scale);
 // Respond to a rotation gesture with the given incremental rotation in radians
 void handleRotateGesture(float _rotation);
 
+// Respond to a two-finger shove with the given distance
+void handleShoveGesture(float _distance);
+
 }
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -39,7 +39,7 @@ void handleTapGesture(float _posX, float _posY);
 void handleDoubleTapGesture(float _posX, float _posY);
 
 // Respond to a drag with the given displacement in screen coordinates (x right, y down)
-void handlePanGesture(float _dX, float _dY);
+void handlePanGesture(float _startX, float _startY, float _endX, float _endY);
 
 // Respond to a pinch at the given position in screen coordinates with the given incremental scale
 void handlePinchGesture(float _posX, float _posY, float _scale);

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -117,6 +117,15 @@ void View::pitch(float _dpitch) {
 
 }
 
+void View::orbit(float _x, float _y, float _radians) {
+    
+    glm::vec2 radial = { _x, _y };
+    glm::vec2 displacement = glm::rotate(radial, _radians) - radial;
+    translate(-displacement.x, -displacement.y);
+    roll(_radians);
+    
+}
+
 void View::update() {
     
     if (!m_dirty) {

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -206,6 +206,18 @@ void View::updateMatrices() {
 
 void View::updateTiles() {
     
+    /* To extend this tile updating step to account for an arbitrary view frustrum, we'll take advantage of the
+     * fact that this process is essentially rasterization; the projection of the view frustrum is the geometry
+     * and the tiles are our raster grid. Thus, we'll approach the problem by treating the projection of the view
+     * frustrum onto the tile plane (the view trapezoid) as two triangles, then rasterizing those triangles into tiles.
+     * 
+     * Implementation steps:
+     * 1. Represent the existing view rectangle as two triangles and rasterize those into a set of tiles that should
+     *    match the existing visible tile set.
+     * 2. Calculate the view trapezoid from the view frustrum, use the trapezoid to form the two triangles and then
+     *    rasterize those into tiles which should fully cover the visible space. 
+     */
+    
     m_visibleTiles.clear();
     
     float tileSize = 2 * MapProjection::HALF_CIRCUMFERENCE * pow(2, -(int)m_zoom);

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -226,7 +226,7 @@ void View::updateTiles() {
      * frustrum onto the tile plane (the view trapezoid) as two triangles, then rasterizing those triangles into tiles.
      * 
      * Implementation steps:
-     * 1. Represent the existing view rectangle as two triangles and rasterize those into a set of tiles that should
+     * 1. Represent the existing view trapezoid as two triangles and rasterize those into a set of tiles that should
      *    match the existing visible tile set.
      * 2. Calculate the view trapezoid from the view frustrum, use the trapezoid to form the two triangles and then
      *    rasterize those into tiles which should fully cover the visible space. 

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -5,6 +5,7 @@
 #include "util/tileID.h"
 #include "platform.h"
 #include "glm/gtc/matrix_transform.hpp"
+#include "glm/gtx/rotate_vector.hpp"
 
 constexpr float View::s_maxZoom; // Create a stack reference to the static member variable
 
@@ -80,6 +81,13 @@ void View::setRoll(float _roll) {
     
 }
 
+void View::setPitch(float _pitch) {
+
+    m_pitch = glm::mod(_pitch, (float)TWO_PI);
+    m_dirty = true;
+
+}
+
 void View::translate(double _dx, double _dy) {
 
     setPosition(m_pos.x + _dx, m_pos.y + _dy);
@@ -101,6 +109,12 @@ void View::roll(float _droll) {
     
     setRoll(m_roll + _droll);
     
+}
+
+void View::pitch(float _dpitch) {
+
+    setPitch(m_pitch + _dpitch);
+
 }
 
 void View::update() {
@@ -180,10 +194,11 @@ void View::updateMatrices() {
     // TODO: this is a simple heuristic that deserves more thought
     float near = m_pos.z / 50.0;
     
-    glm::vec3 up = {cos(m_roll + HALF_PI), sin(m_roll + HALF_PI), 0.0f};
+    glm::vec3 up = glm::rotateZ(glm::rotateX(glm::vec3(0.f, 1.f, 0.f), m_pitch), m_roll);
+    glm::vec3 at = glm::rotateZ(glm::rotateX(glm::vec3(0.f, 0.f, -1.f), m_pitch), m_roll);
     
     // update view and projection matrices
-    m_view = glm::lookAt(glm::vec3(0.0, 0.0, 0.0), glm::vec3(0.0, 0.0, -1.0), up);
+    m_view = glm::lookAt(glm::vec3(0.f, 0.f, 0.f), at, up);
     m_proj = glm::perspective(fovy, m_aspect, near, (float)m_pos.z + 1.0f);
     m_viewProj = m_proj * m_view;
     

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -238,38 +238,38 @@ void View::updateTiles() {
     float invTileSize = 1.0 / tileSize;
     
     // Find bounds of view frustum in world space (i.e. project view frustum onto z = 0 plane)
-    glm::vec2 bottomLeft = { 0.f, 0.f };
-    glm::vec2 bottomRight = { m_vpWidth, 0.f };
-    glm::vec2 topRight = { m_vpWidth, m_vpHeight };
-    glm::vec2 topLeft = { 0.f, m_vpHeight };
-    screenToGroundPlane(bottomLeft.x, bottomLeft.y);
-    screenToGroundPlane(bottomRight.x, bottomRight.y);
-    screenToGroundPlane(topRight.x, topRight.y);
-    screenToGroundPlane(topLeft.x, topLeft.y);
+    glm::vec2 viewBottomLeft = { 0.f, 0.f };
+    glm::vec2 viewBottomRight = { m_vpWidth, 0.f };
+    glm::vec2 viewTopRight = { m_vpWidth, m_vpHeight };
+    glm::vec2 viewTopLeft = { 0.f, m_vpHeight };
+    screenToGroundPlane(viewBottomLeft.x, viewBottomLeft.y);
+    screenToGroundPlane(viewBottomRight.x, viewBottomRight.y);
+    screenToGroundPlane(viewTopRight.x, viewTopRight.y);
+    screenToGroundPlane(viewTopLeft.x, viewTopLeft.y);
     
-    // Find axis-aligned bounding box of projected frustum
-    float left = fminf(fminf(fminf(bottomLeft.x, bottomRight.x), topLeft.x), topRight.x);
-    float right = fmaxf(fmaxf(fmaxf(bottomLeft.x, bottomRight.x), topLeft.x), topRight.x);
-    float bottom = fminf(fminf(fminf(bottomLeft.y, bottomRight.y), topLeft.y), topRight.y);
-    float top = fmaxf(fmaxf(fmaxf(bottomLeft.y, bottomRight.y), topLeft.y), topRight.y);
+    // Find axis-aligned bounding box of projected frustum (in coordinates relative to camera position)
+    float aabbLeft = fminf(fminf(fminf(viewBottomLeft.x, viewBottomRight.x), viewTopLeft.x), viewTopRight.x);
+    float aabbRight = fmaxf(fmaxf(fmaxf(viewBottomLeft.x, viewBottomRight.x), viewTopLeft.x), viewTopRight.x);
+    float aabbBottom = fminf(fminf(fminf(viewBottomLeft.y, viewBottomRight.y), viewTopLeft.y), viewTopRight.y);
+    float aabbTop = fmaxf(fmaxf(fmaxf(viewBottomLeft.y, viewBottomRight.y), viewTopLeft.y), viewTopRight.y);
     
-    // Find bounds of viewable area in map space
-    float vpLeftEdge = m_pos.x + left + MapProjection::HALF_CIRCUMFERENCE;
-    float vpRightEdge = m_pos.x + right + MapProjection::HALF_CIRCUMFERENCE;
-    float vpBottomEdge = -m_pos.y - top + MapProjection::HALF_CIRCUMFERENCE;
-    float vpTopEdge = -m_pos.y - bottom + MapProjection::HALF_CIRCUMFERENCE;
+    // Find bounds of viewable area in tile space
+    float tileLeftEdge = m_pos.x + aabbLeft + MapProjection::HALF_CIRCUMFERENCE;
+    float tileRightEdge = m_pos.x + aabbRight + MapProjection::HALF_CIRCUMFERENCE;
+    float tileBottomEdge = -m_pos.y - aabbTop + MapProjection::HALF_CIRCUMFERENCE;
+    float tileTopEdge = -m_pos.y - aabbBottom + MapProjection::HALF_CIRCUMFERENCE;
     
-    int tileX = (int) fmax(0, vpLeftEdge * invTileSize);
-    int tileY = (int) fmax(0, vpBottomEdge * invTileSize);
+    int tileX = (int) fmax(0, tileLeftEdge * invTileSize);
+    int tileY = (int) fmax(0, tileBottomEdge * invTileSize);
     
     float x = tileX * tileSize;
     float y = tileY * tileSize;
     
     int maxTileIndex = pow(2, m_zoom);
     
-    while (x < vpRightEdge && tileX < maxTileIndex) {
+    while (x < tileRightEdge && tileX < maxTileIndex) {
         
-        while (y < vpTopEdge && tileY < maxTileIndex) {
+        while (y < tileTopEdge && tileY < maxTileIndex) {
             
             m_visibleTiles.insert(TileID(tileX, tileY, m_zoom));
 
@@ -278,7 +278,7 @@ void View::updateTiles() {
             
         }
         
-        tileY = (int) vpBottomEdge * invTileSize;
+        tileY = (int) tileBottomEdge * invTileSize;
         y = tileY * tileSize;
         
         tileX++;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -66,6 +66,10 @@ public:
     /* Changes the pitch angle by the given amount in radians */
     void pitch(float _drad);
     
+    /* Rotates the view by the given amount in radians and translates the view such that 
+       the given position on the ground plane remains stationary in screen space */
+    void orbit(float _x, float _y, float _radians);
+    
     /* Gets the current zoom */
     float getZoom() const { return m_zoom; }
 

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -101,10 +101,9 @@ public:
     
     float getHeight() const { return m_vpHeight; }
     
-    /* Calculate the distance in map projection units represented by the given distance in screen space */
-    float toWorldDistance(float _screenDistance) const;
-    
-    glm::vec2 toWorldDisplacement(float _startX, float _startY, float _endX, float _endY) const;
+    /* Calculate the position on the ground plane (z = 0) under the given screen space coordinates, 
+       replacing the inputs coordinates with world-space coordinates */
+    void screenToGroundPlane(float& _screenX, float& _screenY) const;
     
     /* Returns the set of all tiles visible at the current position and zoom */
     const std::set<TileID>& getVisibleTiles();
@@ -131,6 +130,7 @@ protected:
     glm::mat4 m_view;
     glm::mat4 m_proj;
     glm::mat4 m_viewProj;
+    glm::mat4 m_invViewProj;
     
     float m_roll = 0.f;
     float m_pitch = 0.f;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -50,6 +50,9 @@ public:
     
     /* Sets the roll angle of the view in radians (default is 0) */
     void setRoll(float _rad);
+
+    /* Sets the pitch angle of the view in radians (default is 0) */
+    void setPitch(float _rad);
     
     /* Moves the position of the view */
     void translate(double _dx, double _dy);
@@ -59,6 +62,9 @@ public:
     
     /* Changes the roll angle by the given amount in radians */
     void roll(float _drad);
+
+    /* Changes the pitch angle by the given amount in radians */
+    void pitch(float _drad);
     
     /* Gets the current zoom */
     float getZoom() const { return m_zoom; }
@@ -68,6 +74,9 @@ public:
     
     /* Get the current roll angle in radians */
     float getRoll() const { return m_roll; }
+    
+    /* Get the current pitch angle in radians */
+    float getPitch() const { return m_pitch; }
     
     /* Updates the view and projection matrices if properties have changed */
     void update();
@@ -124,6 +133,7 @@ protected:
     glm::mat4 m_viewProj;
     
     float m_roll = 0;
+    float m_pitch = 0;
     
     float m_zoom;
     float m_initZoom = 16.0;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -104,7 +104,7 @@ public:
     /* Calculate the distance in map projection units represented by the given distance in screen space */
     float toWorldDistance(float _screenDistance) const;
     
-    void toWorldDisplacement(float& _screenX, float& _screenY) const;
+    glm::vec2 toWorldDisplacement(float _startX, float _startY, float _endX, float _endY) const;
     
     /* Returns the set of all tiles visible at the current position and zoom */
     const std::set<TileID>& getVisibleTiles();
@@ -132,8 +132,8 @@ protected:
     glm::mat4 m_proj;
     glm::mat4 m_viewProj;
     
-    float m_roll = 0;
-    float m_pitch = 0;
+    float m_roll = 0.f;
+    float m_pitch = 0.f;
     
     float m_zoom;
     float m_initZoom = 16.0;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -106,7 +106,7 @@ public:
     float getHeight() const { return m_vpHeight; }
     
     /* Calculate the position on the ground plane (z = 0) under the given screen space coordinates, 
-       replacing the inputs coordinates with world-space coordinates */
+       replacing the input coordinates with world-space coordinates */
     void screenToGroundPlane(float& _screenX, float& _screenY) const;
     
     /* Returns the set of all tiles visible at the current position and zoom */

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -108,7 +108,9 @@
 - (void)respondToPanGesture:(UIPanGestureRecognizer *)panRecognizer {
     CGPoint displacement = [panRecognizer translationInView:self.view];
     [panRecognizer setTranslation:{0, 0} inView:self.view];
-    Tangram::handlePanGesture(displacement.x * self.pixelScale, displacement.y * self.pixelScale);
+    CGPoint end = [panRecognizer locationInView:self.view];
+    CGPoint start = {end.x - displacement.x, end.y -    displacement.y};
+    Tangram::handlePanGesture(start.x * self.pixelScale, start.y * self.pixelScale, end.x * self.pixelScale, end.y * self.pixelScale);
 }
 
 - (void)respondToPinchGesture:(UIPinchGestureRecognizer *)pinchRecognizer {

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -109,7 +109,7 @@
     CGPoint displacement = [panRecognizer translationInView:self.view];
     [panRecognizer setTranslation:{0, 0} inView:self.view];
     CGPoint end = [panRecognizer locationInView:self.view];
-    CGPoint start = {end.x - displacement.x, end.y -    displacement.y};
+    CGPoint start = {end.x - displacement.x, end.y - displacement.y};
     Tangram::handlePanGesture(start.x * self.pixelScale, start.y * self.pixelScale, end.x * self.pixelScale, end.y * self.pixelScale);
 }
 

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -121,9 +121,10 @@
 }
 
 - (void)respondToRotationGesture:(UIRotationGestureRecognizer *)rotationRecognizer {
+    CGPoint position = [rotationRecognizer locationInView:self.view];
     CGFloat rotation = rotationRecognizer.rotation;
     [rotationRecognizer setRotation:0.0];
-    Tangram::handleRotateGesture(rotation);
+    Tangram::handleRotateGesture(position.x * self.pixelScale, position.y * self.pixelScale, rotation);
 }
 
 - (void)respondToShoveGesture:(UIPanGestureRecognizer *)shoveRecognizer {

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -59,6 +59,7 @@
     //3. Pan
     UIPanGestureRecognizer *panRecognizer = [[UIPanGestureRecognizer alloc]
                                             initWithTarget:self action:@selector(respondToPanGesture:)];
+    panRecognizer.maximumNumberOfTouches = 1;
     
     //4. Pinch
     UIPinchGestureRecognizer *pinchRecognizer = [[UIPinchGestureRecognizer alloc]
@@ -67,6 +68,11 @@
     //5. Rotate
     UIRotationGestureRecognizer *rotationRecognizer = [[UIRotationGestureRecognizer alloc]
                                                         initWithTarget:self action:@selector(respondToRotationGesture:)];
+    
+    //6. Shove
+    UIPanGestureRecognizer *shoveRecognizer = [[UIPanGestureRecognizer alloc]
+                                             initWithTarget:self action:@selector(respondToShoveGesture:)];
+    shoveRecognizer.minimumNumberOfTouches = 2;
     
     // Use the delegate method 'shouldRecognizeSimultaneouslyWithGestureRecognizer' for gestures that can be concurrent
     panRecognizer.delegate = self;
@@ -79,6 +85,7 @@
     [self.view addGestureRecognizer:panRecognizer];
     [self.view addGestureRecognizer:pinchRecognizer];
     [self.view addGestureRecognizer:rotationRecognizer];
+    [self.view addGestureRecognizer:shoveRecognizer];
     
     [self setupGL];
     
@@ -115,6 +122,12 @@
     CGFloat rotation = rotationRecognizer.rotation;
     [rotationRecognizer setRotation:0.0];
     Tangram::handleRotateGesture(rotation);
+}
+
+- (void)respondToShoveGesture:(UIPanGestureRecognizer *)shoveRecognizer {
+    CGPoint displacement = [shoveRecognizer translationInView:self.view];
+    [shoveRecognizer setTranslation:{0, 0} inView:self.view];
+    Tangram::handleShoveGesture(displacement.y / self.view.bounds.size.height);
 }
 
 - (void)dealloc

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -10,6 +10,7 @@ const double scroll_multiplier = 0.05; // scaling for zoom
 
 bool was_panning = false;
 bool rotating = false;
+bool shoving = false;
 double last_mouse_up = -double_tap_time; // First click should never trigger a double tap
 double last_x_down = 0.0;
 double last_y_down = 0.0;
@@ -66,7 +67,9 @@ void scroll_callback(GLFWwindow* window, double scrollx, double scrolly) {
     
     double x, y;
     glfwGetCursorPos(window, &x, &y);
-    if (rotating) {
+    if (shoving) {
+        Tangram::handleShoveGesture(scroll_multiplier * scrolly);
+    } else if (rotating) {
         Tangram::handleRotateGesture(scroll_multiplier * scrolly);
     } else {
         Tangram::handlePinchGesture(x, y, 1.0 + scroll_multiplier * scrolly);
@@ -77,6 +80,7 @@ void scroll_callback(GLFWwindow* window, double scrollx, double scrolly) {
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
 {
     rotating = (mods & GLFW_MOD_SHIFT) != 0; // Whether one or more shift keys is down
+    shoving = (mods & GLFW_MOD_CONTROL) != 0; // Whether one or more control keys is down
 }
 
 

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -70,7 +70,7 @@ void scroll_callback(GLFWwindow* window, double scrollx, double scrolly) {
     if (shoving) {
         Tangram::handleShoveGesture(scroll_multiplier * scrolly);
     } else if (rotating) {
-        Tangram::handleRotateGesture(scroll_multiplier * scrolly);
+        Tangram::handleRotateGesture(x, y, scroll_multiplier * scrolly);
     } else {
         Tangram::handlePinchGesture(x, y, 1.0 + scroll_multiplier * scrolly);
     }

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -53,7 +53,7 @@ void cursor_pos_callback(GLFWwindow* window, double x, double y) {
     if (action == GLFW_PRESS) {
         
         if (was_panning) {
-            Tangram::handlePanGesture(x - last_x_down, y - last_y_down);
+            Tangram::handlePanGesture(last_x_down, last_y_down, x, y);
         }
         
         was_panning = true;


### PR DESCRIPTION
Changes:

 - Adds camera 'pitch', allowing views at a range of angles to the z-axis
 - Adds a gesture (two-finger 'shove') to control camera pitch
 - Adapts existing input gestures (pan, rotate) to maintain their physically intuitive behavior. Panning will move the view such that the point on the ground plane that started under your finger will remain under your finger. Rotating will orbit the view around the central point of rotation. 
 - Adds a simplistic tile coverage algorithm that overestimates visible tiles, but fully covers the viewable area with a tilted view. 

Future:

 - The tile coverage algorithm will be improved in a subsequent PR. For the next implementation we will want to cover the viewable area with tiles of varying zoom levels, resulting in lower-detail geometry for more distant parts of the viewable area. 