### PR TITLE
Screen space label orientations

### DIFF
--- a/core/resources/text.vs
+++ b/core/resources/text.vs
@@ -2,7 +2,7 @@
 precision mediump float;
 #define LOWP lowp
 #else
-#define LOWP 
+#define LOWP
 #endif
 
 attribute LOWP float a_fsid;
@@ -25,6 +25,7 @@ varying float v_alpha;
 #define theta   tdata.z
 #define txp     tdataPrecision.x
 #define typ     tdataPrecision.y
+#define trp     tdataPrecision.z
 
 /*
  * Converts (i, j) pixel coordinates to the corresponding (u, v) in
@@ -56,16 +57,17 @@ void main() {
     // reads the transform data and its precision
     vec4 tdata = texture2D(u_transforms, uv1);
     vec4 tdataPrecision = texture2D(u_transforms, uv2);
-    
+
     float txe = u_resolution.x / 255.0; // max error on x
-    float txy = u_resolution.y / 255.0; // max error on y
+    float tye = u_resolution.y / 255.0; // max error on y
+    float tre = (2.0 * PI) / 255.0;
 
     // transforms from [0..1] to [0..resolution] and add lost precision
     tx = u_resolution.x * tx + (txp * txe);
-    ty = u_resolution.y * ty + (typ * txy);
+    ty = u_resolution.y * ty + (typ * tye);
 
     // scale from [0..1] to [0..2pi]
-    theta = theta * 2.0 * PI;
+    theta = theta * 2.0 * PI + (trp * tre);
 
     float st = sin(theta);
     float ct = cos(theta);

--- a/core/src/style/fontStyle.cpp
+++ b/core/src/style/fontStyle.cpp
@@ -64,18 +64,7 @@ void FontStyle::buildLine(Line& _line, std::string& _layer, Properties& _props, 
                     return;
                 }
 
-                p1p2 = glm::normalize(p1p2);
-                float rot = (float) atan2(p1p2.x, p1p2.y) + M_PI_2;
-
-                float offset = 1.0f;
-                if (rot > M_PI_2 || rot < -M_PI_2) {
-                    rot += M_PI;
-                    offset = -1;
-                }
-
-                glm::vec2 position = (p1 + p2) / 2.0f + p1p2 * 0.2f * offset;
-
-                auto label = labelContainer->addLabel(FontStyle::processedTile->getID(), m_name, { position, 1.0f, rot }, prop.second);
+                auto label = labelContainer->addLabel(FontStyle::processedTile->getID(), m_name, { p1, p2, 1.0f }, prop.second);
 
                 label->rasterize();
             }
@@ -83,7 +72,7 @@ void FontStyle::buildLine(Line& _line, std::string& _layer, Properties& _props, 
     }
 
     ftContext->clearState();
-    
+
     if (textBuffer->getVertices(&vertData, &nVerts)) {
          _mesh.addVertices((GLbyte*)vertData.data(), nVerts);
     }
@@ -145,7 +134,7 @@ void FontStyle::setupFrame(const std::shared_ptr<View>& _view, const std::shared
     atlas->update();
     atlas->bind();
 
-    m_shaderProgram->setUniformi("u_tex", atlas->getTextureSlot()); 
+    m_shaderProgram->setUniformi("u_tex", atlas->getTextureSlot());
     m_shaderProgram->setUniformf("u_resolution", _view->getWidth(), _view->getHeight());
     m_shaderProgram->setUniformf("u_color", 1.0, 1.0, 1.0);
     m_shaderProgram->setUniformMatrix4f("u_proj", projectionMatrix);

--- a/core/src/tile/labels/label.cpp
+++ b/core/src/tile/labels/label.cpp
@@ -14,6 +14,14 @@ void Label::rasterize() {
     m_buffer->rasterize(m_text, m_id);
 }
 
+glm::vec4 Label::projectToScreen(const glm::mat4& _mvp, glm::vec4 _worldPosition) {
+    // mimic gpu vertex projection to screen
+    glm::vec4 screenPosition = _mvp * _worldPosition;
+    screenPosition = screenPosition / screenPosition.w; // perspective division
+
+    return screenPosition;
+}
+
 void Label::updateTransform(const LabelTransform& _transform, const glm::mat4& _mvp, const glm::vec2& _screenSize) {
     m_transform = _transform;
 
@@ -22,11 +30,22 @@ void Label::updateTransform(const LabelTransform& _transform, const glm::mat4& _
 
     float alpha = m_transform.m_alpha;
 
-    glm::vec4 screenPosition = glm::vec4(m_transform.m_modelPosition, 0.0f, 1.0f);
+    glm::vec4 p1 = projectToScreen(_mvp, glm::vec4(m_transform.m_modelPosition1, 0.0, 1.0));
+    glm::vec4 p2 = projectToScreen(_mvp, glm::vec4(m_transform.m_modelPosition2, 0.0, 1.0));
+    glm::vec4 p1p2 = p2 - p1;
 
-    // mimic gpu vertex projection to screen
-    screenPosition = _mvp * screenPosition;
-    screenPosition = screenPosition / screenPosition.w; // perspective division
+    p1p2 = glm::normalize(p1p2);
+
+    float rot = (float) atan2(p1p2.x, p1p2.y) + M_PI_2;
+
+    float offset = 1.0f;
+
+    if (rot > M_PI_2 || rot < -M_PI_2) {
+        rot += M_PI;
+        offset = -1;
+    }
+
+    glm::vec4 screenPosition = (p1 + p2) / 2.0f;
 
     // from normalized device coordinates to screen space coordinate system
     // top-left screen axis, y pointing down
@@ -37,5 +56,5 @@ void Label::updateTransform(const LabelTransform& _transform, const glm::mat4& _
     alpha = screenPosition.x > _screenSize.x || screenPosition.x < 0 ? 0.0 : alpha;
     alpha = screenPosition.y > _screenSize.y || screenPosition.y < 0 ? 0.0 : alpha;
 
-    m_buffer->transformID(m_id, screenPosition.x, screenPosition.y, m_transform.m_rotation, alpha);
+    m_buffer->transformID(m_id, screenPosition.x, screenPosition.y, rot, alpha);
 }

--- a/core/src/tile/labels/label.cpp
+++ b/core/src/tile/labels/label.cpp
@@ -21,11 +21,8 @@ void Label::updateTransform(const LabelTransform& _transform, const glm::mat4& _
 
     glm::vec2 p1 = worldToScreenSpace(_mvp, glm::vec4(m_transform.m_modelPosition1, 0.0, 1.0), _screenSize);
     glm::vec2 p2 = worldToScreenSpace(_mvp, glm::vec4(m_transform.m_modelPosition2, 0.0, 1.0), _screenSize);
-    glm::vec2 p1p2 = p2 - p1;
 
-    p1p2 = glm::normalize(p1p2);
-
-    float rot = angleBetween(p1, p2) + M_PI_2;
+    float rot = angleBetweenPoints(p1, p2) + M_PI_2;
 
     if (rot > M_PI_2 || rot < -M_PI_2) { // un-readable labels
         rot += M_PI;

--- a/core/src/tile/labels/label.cpp
+++ b/core/src/tile/labels/label.cpp
@@ -14,43 +14,24 @@ void Label::rasterize() {
     m_buffer->rasterize(m_text, m_id);
 }
 
-glm::vec4 Label::projectToScreen(const glm::mat4& _mvp, glm::vec4 _worldPosition) {
-    // mimic gpu vertex projection to screen
-    glm::vec4 screenPosition = _mvp * _worldPosition;
-    screenPosition = screenPosition / screenPosition.w; // perspective division
-
-    return screenPosition;
-}
-
 void Label::updateTransform(const LabelTransform& _transform, const glm::mat4& _mvp, const glm::vec2& _screenSize) {
     m_transform = _transform;
 
-    float halfWidth = _screenSize.x * 0.5f;
-    float halfHeight = _screenSize.y * 0.5f;
-
     float alpha = m_transform.m_alpha;
 
-    glm::vec4 p1 = projectToScreen(_mvp, glm::vec4(m_transform.m_modelPosition1, 0.0, 1.0));
-    glm::vec4 p2 = projectToScreen(_mvp, glm::vec4(m_transform.m_modelPosition2, 0.0, 1.0));
-    glm::vec4 p1p2 = p2 - p1;
+    glm::vec2 p1 = worldToScreenSpace(_mvp, glm::vec4(m_transform.m_modelPosition1, 0.0, 1.0), _screenSize);
+    glm::vec2 p2 = worldToScreenSpace(_mvp, glm::vec4(m_transform.m_modelPosition2, 0.0, 1.0), _screenSize);
+    glm::vec2 p1p2 = p2 - p1;
 
     p1p2 = glm::normalize(p1p2);
 
-    float rot = (float) atan2(p1p2.x, p1p2.y) + M_PI_2;
+    float rot = angleBetween(p1, p2) + M_PI_2;
 
-    float offset = 1.0f;
-
-    if (rot > M_PI_2 || rot < -M_PI_2) {
+    if (rot > M_PI_2 || rot < -M_PI_2) { // un-readable labels
         rot += M_PI;
-        offset = -1;
     }
 
-    glm::vec4 screenPosition = (p1 + p2) / 2.0f;
-
-    // from normalized device coordinates to screen space coordinate system
-    // top-left screen axis, y pointing down
-    screenPosition.x = (screenPosition.x + 1) * halfWidth;
-    screenPosition.y = (1 - screenPosition.y) * halfHeight;
+    glm::vec2 screenPosition = (p1 + p2) / 2.0f;
 
     // don't display out of screen labels, and out of screen translations or not yet implemented in fstash
     alpha = screenPosition.x > _screenSize.x || screenPosition.x < 0 ? 0.0 : alpha;
@@ -58,3 +39,4 @@ void Label::updateTransform(const LabelTransform& _transform, const glm::mat4& _
 
     m_buffer->transformID(m_id, screenPosition.x, screenPosition.y, rot, alpha);
 }
+

--- a/core/src/tile/labels/label.h
+++ b/core/src/tile/labels/label.h
@@ -28,8 +28,6 @@ public:
 
 private:
 
-    glm::vec4 projectToScreen(const glm::mat4& _mvp, glm::vec4 _worldPosition);
-
     LabelTransform m_transform;
     std::string m_text;
     std::shared_ptr<TextBuffer> m_buffer; // the buffer in which this label text id is associated to

--- a/core/src/tile/labels/label.h
+++ b/core/src/tile/labels/label.h
@@ -6,9 +6,9 @@
 #include <string>
 
 struct LabelTransform {
-    glm::vec2 m_modelPosition;
+    glm::vec2 m_modelPosition1;
+    glm::vec2 m_modelPosition2;
     float m_alpha;
-    float m_rotation;
 };
 
 class Label {
@@ -28,9 +28,11 @@ public:
 
 private:
 
+    glm::vec4 projectToScreen(const glm::mat4& _mvp, glm::vec4 _worldPosition);
+
     LabelTransform m_transform;
     std::string m_text;
     std::shared_ptr<TextBuffer> m_buffer; // the buffer in which this label text id is associated to
     fsuint m_id;
-    
+
 };

--- a/core/src/util/geom.cpp
+++ b/core/src/util/geom.cpp
@@ -17,7 +17,7 @@ float mapValue(const float& _value, const float& _inputMin, const float& _inputM
         return _outputMin;
     } else {
         float outVal = ((_value - _inputMin) / (_inputMax - _inputMin) * (_outputMax - _outputMin) + _outputMin);
-        
+
         if( _clamp ){
             if(_outputMax < _outputMin){
                 if( outVal < _outputMax )outVal = _outputMax;
@@ -59,3 +59,26 @@ glm::vec3 getWithLength(const glm::vec3& _vec, float _length) {
 bool isPowerOf2(unsigned int _val) {
     return _val > 0 && (_val & (_val - 1)) == 0;
 }
+
+float angleBetween(const glm::vec2& _p1, const glm::vec2& _p2) {
+    glm::vec2 p1p2 = _p2 - _p1;
+    p1p2 = glm::normalize(p1p2);
+    return (float) atan2(p1p2.x, -p1p2.y);
+}
+
+glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosition, const glm::vec2& _screenSize) {
+    float halfWidth = _screenSize.x * 0.5f;
+    float halfHeight = _screenSize.y * 0.5f;
+
+    // mimic gpu vertex projection to screen
+    glm::vec4 screenPosition = _mvp * _worldPosition;
+    screenPosition = screenPosition / screenPosition.w; // perspective division
+
+    // from normalized device coordinates to screen space coordinate system
+    // top-left screen axis, y pointing down
+    screenPosition.x = (screenPosition.x + 1) * halfWidth;
+    screenPosition.y = (1 - screenPosition.y) * halfHeight;
+
+    return glm::vec2(screenPosition);
+}
+

--- a/core/src/util/geom.cpp
+++ b/core/src/util/geom.cpp
@@ -60,7 +60,7 @@ bool isPowerOf2(unsigned int _val) {
     return _val > 0 && (_val & (_val - 1)) == 0;
 }
 
-float angleBetween(const glm::vec2& _p1, const glm::vec2& _p2) {
+float angleBetweenPoints(const glm::vec2& _p1, const glm::vec2& _p2) {
     glm::vec2 p1p2 = _p2 - _p1;
     p1p2 = glm::normalize(p1p2);
     return (float) atan2(p1p2.x, -p1p2.y);

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -3,7 +3,10 @@
 #include <vector>
 #include <cmath>
 
+#include "glm/glm.hpp"
 #include "glm/vec3.hpp"
+#include "glm/vec2.hpp"
+#include "glm/mat4x4.hpp"
 
 #ifndef PI
 #define PI 3.14159265358979323846
@@ -68,7 +71,7 @@ void wrapRad(double& _rads);
 
 /* Map a value from the range [_inputMin, _inputMax] into the range [_outputMin, _outputMax];
  * If _clamp is true, the output is strictly within the output range.
- * Ex: mapValue(5, 0, 10, 0, 360) == 180 
+ * Ex: mapValue(5, 0, 10, 0, 360) == 180
  */
 float mapValue(const float& _value, const float& _inputMin, const float& _inputMax, const float& _outputMin, const float& _outputMax, bool _clamp = true);
 
@@ -82,3 +85,9 @@ void setLength(glm::vec3& _vec, float _length);
 glm::vec3 getWithLength(const glm::vec3& _vec, float _length);
 
 bool isPowerOf2(unsigned int _val);
+
+/* Computes the angle in radians between two points in 2d space */
+float angleBetween(const glm::vec2& _p1, const glm::vec2& _p2);
+
+glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosition, const glm::vec2& _screenSize);
+

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -86,8 +86,8 @@ glm::vec3 getWithLength(const glm::vec3& _vec, float _length);
 
 bool isPowerOf2(unsigned int _val);
 
-/* Computes the angle in radians between two points in 2d space */
-float angleBetween(const glm::vec2& _p1, const glm::vec2& _p2);
+/* Computes the angle in radians between two points with the axis y = 0 in 2d space */
+float angleBetweenPoints(const glm::vec2& _p1, const glm::vec2& _p2);
 
 glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosition, const glm::vec2& _screenSize);
 


### PR DESCRIPTION
Computes angle of labels in screen spaces after projecting their "anchor" point from world space to screen space, this fix the labels orientation broken on arbitrary camera orientation.