### PR TITLE
Simple layer depth ordering

### DIFF
--- a/android/src/com/mapzen/tangram/Tangram.java
+++ b/android/src/com/mapzen/tangram/Tangram.java
@@ -53,8 +53,9 @@ public class Tangram extends GLSurfaceView implements Renderer, OnScaleGestureLi
         super(mainApp);
         
         setEGLContextClientVersion(2);
-        setRenderer(this);
         setPreserveEGLContextOnPause(true);
+        setEGLConfigChooser(8, 8, 8, 8, 24, 0);
+        setRenderer(this);
         
         mainApp.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
         

--- a/core/resources/polygon.vs
+++ b/core/resources/polygon.vs
@@ -15,6 +15,7 @@ attribute vec4 a_position;
 attribute vec4 a_color;
 attribute vec3 a_normal;
 attribute vec2 a_texcoord;
+attribute float a_layer;
 
 varying vec4 v_color;
 varying vec3 v_eyeToPoint;
@@ -38,4 +39,5 @@ void main() {
     gl_Position = u_modelViewProj * a_position;
     
     gl_Position.z /= u_tileDepthOffset;
+    gl_Position.z -= a_layer * DEPTH_DELTA * gl_Position.w;
 }

--- a/core/resources/polygon.vs
+++ b/core/resources/polygon.vs
@@ -39,5 +39,8 @@ void main() {
     gl_Position = u_modelViewProj * a_position;
     
     gl_Position.z /= u_tileDepthOffset;
-    gl_Position.z -= a_layer * DEPTH_DELTA * gl_Position.w;
+    
+    #ifdef TANGRAM_DEPTH_DELTA
+        gl_Position.z -= a_layer * TANGRAM_DEPTH_DELTA * gl_Position.w;
+    #endif
 }

--- a/core/resources/polyline.vs
+++ b/core/resources/polyline.vs
@@ -16,6 +16,8 @@ attribute float a_extrudeWidth;
 attribute vec3 a_normal;
 attribute vec2 a_texcoord;
 
+attribute float a_layer;
+
 varying vec4 v_color;
 varying vec3 v_eyeToPoint;
 varying vec3 v_normal;
@@ -35,4 +37,5 @@ void main() {
 
 	gl_Position = u_modelViewProj * v_pos;
     gl_Position.z /= u_tileDepthOffset;
+    gl_Position.z -= a_layer * DEPTH_DELTA * gl_Position.w;
 }

--- a/core/resources/polyline.vs
+++ b/core/resources/polyline.vs
@@ -37,5 +37,8 @@ void main() {
 
 	gl_Position = u_modelViewProj * v_pos;
     gl_Position.z /= u_tileDepthOffset;
-    gl_Position.z -= a_layer * DEPTH_DELTA * gl_Position.w;
+    
+    #ifdef TANGRAM_DEPTH_DELTA
+        gl_Position.z -= a_layer * TANGRAM_DEPTH_DELTA * gl_Position.w;
+    #endif
 }

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -79,19 +79,19 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properti
     GLuint abgr = 0xffaaaaaa; // Default color
     GLfloat layer = 0;
     
-    if (_layer.compare("buildings") == 0) {
+    if (_layer == "buildings") {
         layer = 4;
         abgr = 0xffe6f0f2;
-    } else if (_layer.compare("water") == 0) {
+    } else if (_layer == "water") {
         layer = 2;
         abgr = 0xff917d1a;
-    } else if (_layer.compare("roads") == 0) {
+    } else if (_layer == "roads") {
         layer = 3;
         abgr = 0xff969696;
-    } else if (_layer.compare("earth") == 0) {
+    } else if (_layer == "earth") {
         layer = 0;
         abgr = 0xffa9b9c2;
-    } else if (_layer.compare("landuse") == 0) {
+    } else if (_layer == "landuse") {
         layer = 1;
         abgr = 0xff669171;
     }

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -18,7 +18,8 @@ void PolygonStyle::constructVertexLayout() {
         {"a_position", 3, GL_FLOAT, false, 0},
         {"a_normal", 3, GL_FLOAT, false, 0},
         {"a_texcoord", 2, GL_FLOAT, false, 0},
-        {"a_color", 4, GL_UNSIGNED_BYTE, true, 0}
+        {"a_color", 4, GL_UNSIGNED_BYTE, true, 0},
+        {"a_layer", 1, GL_FLOAT, false, 0}
     }));
     
 }
@@ -76,16 +77,22 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properti
     PolygonOutput output = { points, indices, normals, texcoords };
     
     GLuint abgr = 0xffaaaaaa; // Default color
+    GLfloat layer = 0;
     
     if (_layer.compare("buildings") == 0) {
+        layer = 4;
         abgr = 0xffe6f0f2;
     } else if (_layer.compare("water") == 0) {
+        layer = 2;
         abgr = 0xff917d1a;
     } else if (_layer.compare("roads") == 0) {
+        layer = 3;
         abgr = 0xff969696;
     } else if (_layer.compare("earth") == 0) {
+        layer = 0;
         abgr = 0xffa9b9c2;
     } else if (_layer.compare("landuse") == 0) {
+        layer = 1;
         abgr = 0xff669171;
     }
     
@@ -107,7 +114,7 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properti
         glm::vec3 p = points[i];
         glm::vec3 n = normals[i];
         glm::vec2 u = texcoords[i];
-        vertices.push_back({ p.x, p.y, p.z, n.x, n.y, n.z, u.x, u.y, abgr });
+        vertices.push_back({ p.x, p.y, p.z, n.x, n.y, n.z, u.x, u.y, abgr, layer });
     }
     
     // Outlines for water polygons

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -1,5 +1,6 @@
 #include "polygonStyle.h"
 #include "util/builders.h"
+#include "roadLayers.h"
 
 PolygonStyle::PolygonStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
     m_material.setEmissionEnabled(false);
@@ -80,7 +81,7 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properti
     GLfloat layer = 0;
     
     if (_layer == "buildings") {
-        layer = 250;
+        layer = ROAD_LAYER_OFFSET + 4;
         abgr = 0xffe6f0f2;
     } else if (_layer == "water") {
         layer = 2;

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -80,7 +80,7 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, std::string& _layer, Properti
     GLfloat layer = 0;
     
     if (_layer == "buildings") {
-        layer = 4;
+        layer = 250;
         abgr = 0xffe6f0f2;
     } else if (_layer == "water") {
         layer = 2;

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -20,6 +20,8 @@ protected:
         GLfloat texcoord_y;
         // Color Data
         GLuint abgr;
+        // Layer Data
+        GLfloat layer;
     };
     
     virtual void constructVertexLayout() override;

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -41,19 +41,27 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     std::vector<glm::vec2> texcoords;
     std::vector<glm::vec2> scalingVecs;
     
-    GLuint abgr = 0xff969696; // Default road color
-    GLfloat layer = 3;
+    GLuint abgr = 0xff767676; // Default road color
+    GLfloat sort_key = _props.numericProps["sort_key"];
+    int thousands = sort_key / 1000;
+    int hundreds = fmodf(sort_key, 1000.f) / 100;
+    int ones = fmodf(sort_key, 10.f);
+    float reduced_sort_key = 30.f*thousands + 10.f*hundreds + ones;
+    GLfloat layer = 110.f + reduced_sort_key;
+    
     float halfWidth = 0.02;
     
-    if(_props.stringProps["kind"] == "highway"){
+    const std::string& kind = _props.stringProps["kind"];
+    
+    if (kind == "highway") {
         halfWidth = 0.02;
-    } else if(_props.stringProps["kind"] == "major_road"){
+    } else if (kind == "major_road") {
         halfWidth = 0.015;
-    } else if(_props.stringProps["kind"] == "minor_road"){
+    } else if (kind == "minor_road") {
         halfWidth = 0.01;
-    } else if(_props.stringProps["kind"] == "rail"){
+    } else if (kind == "rail") {
         halfWidth = 0.002;
-    } else if(_props.stringProps["kind"] == "path"){
+    } else if (kind == "path") {
         halfWidth = 0.005;
     }
     
@@ -62,9 +70,9 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     Builders::buildPolyLine(_line, lineOptions, lineOutput);
     
     for (size_t i = 0; i < points.size(); i++) {
-        glm::vec3 p = points[i];
-        glm::vec2 uv = texcoords[i];
-        glm::vec2 en = scalingVecs[i];
+        const glm::vec3& p = points[i];
+        const glm::vec2& uv = texcoords[i];
+        const glm::vec2& en = scalingVecs[i];
         vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, halfWidth, abgr, layer });
     }
     

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -15,7 +15,8 @@ void PolylineStyle::constructVertexLayout() {
         {"a_texcoord", 2, GL_FLOAT, false, 0},
         {"a_extrudeNormal", 2, GL_FLOAT, false, 0},
         {"a_extrudeWidth", 1, GL_FLOAT, false, 0},
-        {"a_color", 4, GL_UNSIGNED_BYTE, true, 0}
+        {"a_color", 4, GL_UNSIGNED_BYTE, true, 0},
+        {"a_layer", 1, GL_FLOAT, false, 0}
     }));
     
 }
@@ -41,6 +42,7 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     std::vector<glm::vec2> scalingVecs;
     
     GLuint abgr = 0xff969696; // Default road color
+    GLfloat layer = 3;
     float halfWidth = 0.02;
     
     if(_props.stringProps["kind"] == "highway"){
@@ -63,7 +65,7 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
         glm::vec3 p = points[i];
         glm::vec2 uv = texcoords[i];
         glm::vec2 en = scalingVecs[i];
-        vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, halfWidth, abgr });
+        vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, halfWidth, abgr, layer });
     }
     
     // Make sure indices get correctly offset

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -1,5 +1,6 @@
 #include "polylineStyle.h"
 #include "util/builders.h"
+#include "roadLayers.h"
 #include <ctime>
 
 PolylineStyle::PolylineStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
@@ -42,12 +43,8 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     std::vector<glm::vec2> scalingVecs;
     
     GLuint abgr = 0xff767676; // Default road color
-    GLfloat sort_key = _props.numericProps["sort_key"];
-    int thousands = sort_key / 1000;
-    int hundreds = fmodf(sort_key, 1000.f) / 100;
-    int ones = fmodf(sort_key, 10.f);
-    float reduced_sort_key = 30.f*thousands + 10.f*hundreds + ones;
-    GLfloat layer = 110.f + reduced_sort_key;
+    float reduced_sort_key = reduceSortKey(_props.numericProps["sort_key"]);
+    GLfloat layer = reduced_sort_key - MIN_ROAD_LAYER + 3;
     
     float halfWidth = 0.02;
     

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -43,8 +43,7 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     std::vector<glm::vec2> scalingVecs;
     
     GLuint abgr = 0xff767676; // Default road color
-    float reduced_sort_key = reduceSortKey(_props.numericProps["sort_key"]);
-    GLfloat layer = reduced_sort_key - MIN_ROAD_LAYER + 3;
+    GLfloat layer = sortKeyToLayer(_props.numericProps["sort_key"]) + 3;
     
     float halfWidth = 0.02;
     

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -18,8 +18,10 @@ protected:
         GLfloat enorm_x;
         GLfloat enorm_y;
         GLfloat ewidth;
-        //Color Data
+        // Color Data
         GLuint abgr;
+        // Layer Data
+        GLfloat layer;
     };
     
     virtual void constructVertexLayout() override;

--- a/core/src/style/roadLayers.h
+++ b/core/src/style/roadLayers.h
@@ -1,0 +1,16 @@
+#pragma once
+
+constexpr float reduceSortKey(float _key) {
+    
+    return 30.f * (((int)_key % 10000) / 1000) +
+           10.f * (((int)_key % 1000) / 100) +
+           1.f  * ((int)_key % 10);
+    
+}
+
+const int MIN_ROAD_SORT_KEY = -3109;
+const int MAX_ROAD_SORT_KEY = 3100;
+
+constexpr float MIN_ROAD_LAYER = reduceSortKey(MIN_ROAD_SORT_KEY);
+constexpr float MAX_ROAD_LAYER = reduceSortKey(MAX_ROAD_SORT_KEY);
+constexpr float ROAD_LAYER_OFFSET = MAX_ROAD_LAYER - MIN_ROAD_LAYER;

--- a/core/src/style/roadLayers.h
+++ b/core/src/style/roadLayers.h
@@ -1,5 +1,11 @@
 #pragma once
 
+/* This function and the related variables serve to map the 'sort_key' property of road features into a smaller range
+ * so that it can be used for geometry layering using the z-buffer. The sort_key property ranges between MIN_ROAD_SORT_KEY
+ * and MAX_ROAD_SORT_KEY. 'reduceSortKey' is a one-to-one mapping of sort_key that preserves ordering and maintains an integer 
+ * distance between successive values.
+ */
+
 constexpr float reduceSortKey(float _key) {
     
     return 30.f * (((int)_key % 10000) / 1000) +
@@ -8,9 +14,20 @@ constexpr float reduceSortKey(float _key) {
     
 }
 
+// These values are a function of the server code that generates sort_key
 const int MIN_ROAD_SORT_KEY = -3109;
 const int MAX_ROAD_SORT_KEY = 3100;
 
+// The minimum 'reduceSortKey' output
 constexpr float MIN_ROAD_LAYER = reduceSortKey(MIN_ROAD_SORT_KEY);
+
+// The maximum 'reduceSortKey' output
 constexpr float MAX_ROAD_LAYER = reduceSortKey(MAX_ROAD_SORT_KEY);
+
+// The total number of possible road layers
 constexpr float ROAD_LAYER_OFFSET = MAX_ROAD_LAYER - MIN_ROAD_LAYER;
+
+// Maps _key from the range [MIN_ROAD_SORT_KEY, MAX_ROAD_SORT_KEY] to the range [0, ROAD_LAYER_OFFSET]
+constexpr float sortKeyToLayer(float _key) {
+    return reduceSortKey(_key) - MIN_ROAD_LAYER;
+}

--- a/core/src/util/shaderProgram.cpp
+++ b/core/src/util/shaderProgram.cpp
@@ -216,6 +216,9 @@ void ShaderProgram::applySourceBlocks(std::string& _vertSrcOut, std::string& _fr
     _vertSrcOut.insert(0, "#pragma tangram: defines\n");
     _fragSrcOut.insert(0, "#pragma tangram: defines\n");
     
+    float depthDelta = 1.f / (1 << 16);
+    _vertSrcOut.insert(0, "#define DEPTH_DELTA "+std::to_string(depthDelta)+"\n");
+    
     Light::assembleLights(m_sourceBlocks);
     
     for (auto& block : m_sourceBlocks) {

--- a/core/src/util/shaderProgram.cpp
+++ b/core/src/util/shaderProgram.cpp
@@ -217,7 +217,7 @@ void ShaderProgram::applySourceBlocks(std::string& _vertSrcOut, std::string& _fr
     _fragSrcOut.insert(0, "#pragma tangram: defines\n");
     
     float depthDelta = 1.f / (1 << 16);
-    _vertSrcOut.insert(0, "#define DEPTH_DELTA "+std::to_string(depthDelta)+"\n");
+    _vertSrcOut.insert(0, "#define TANGRAM_DEPTH_DELTA "+std::to_string(depthDelta)+"\n");
     
     Light::assembleLights(m_sourceBlocks);
     


### PR DESCRIPTION
Provides a simple mechanism for separating layers in depth space, to prevent z-fighting and unintended occlusion. 

 - Adds a #define to all shaders that specifies the minimum resolvable depth delta (approximately)
 - Adds a 'layer' attribute to all vertices, specifying a tiebreaker value to order geometry at the same z value
 - Add a function (and associated constants) to map the 'sort_key' value of road features to a 'layer' value

TODO:

 - Evaluate road layering in more areas; Road depth ordinality will always match sort_key ordinality, but it's possible that this creates unforseen artifacts with other geometry in extreme cases.
 - Naturally, this will need another design pass when layers are specified in the style sheet, but this is useful for making sure we can order features correctly in our rendering pipeline. 

