### PR TITLE
Pretty roads

### DIFF
--- a/core/resources/polygon.vs
+++ b/core/resources/polygon.vs
@@ -40,7 +40,7 @@ void main() {
     
     // Proxy tiles have u_tile_zoom < 0, so this re-scaling will place proxy tiles deeper in
     // the depth buffer than non-proxy tiles by a distance that increases with tile zoom
-    gl_Position.z /= 1. + .1 * (abs(u_tile_zoom) + u_tile_zoom);
+    gl_Position.z /= 1. + .1 * (abs(u_tile_zoom) - u_tile_zoom);
     
     #ifdef TANGRAM_DEPTH_DELTA
         gl_Position.z -= a_layer * TANGRAM_DEPTH_DELTA * gl_Position.w;

--- a/core/resources/polygon.vs
+++ b/core/resources/polygon.vs
@@ -6,7 +6,7 @@ uniform mat4 u_modelView;
 uniform mat4 u_modelViewProj;
 uniform mat3 u_normalMatrix;
 uniform float u_time;
-uniform float u_tileDepthOffset;
+uniform float u_tile_zoom;
 
 #pragma tangram: material
 #pragma tangram: vertex_lighting
@@ -38,7 +38,9 @@ void main() {
 
     gl_Position = u_modelViewProj * a_position;
     
-    gl_Position.z /= u_tileDepthOffset;
+    // Proxy tiles have u_tile_zoom < 0, so this re-scaling will place proxy tiles deeper in
+    // the depth buffer than non-proxy tiles by a distance that increases with tile zoom
+    gl_Position.z /= 1. + .1 * (abs(u_tile_zoom) + u_tile_zoom);
     
     #ifdef TANGRAM_DEPTH_DELTA
         gl_Position.z -= a_layer * TANGRAM_DEPTH_DELTA * gl_Position.w;

--- a/core/resources/polyline.fs
+++ b/core/resources/polyline.fs
@@ -14,22 +14,6 @@ varying vec2 v_texcoord;
 
 void main(void) {
     
-    vec4 color = v_color;
-
-    /* 
-     * Use texture coordinates to darken fragments closer to the center of the polyline,
-     * creating an outline effect.
-     */
+    gl_FragColor = v_color;
     
-    float radius = abs(v_texcoord.x - 0.5); // distance from center of line in texture coordinates
-    
-    float threshold = 0.35; // distance within which color will be darkened
-    
-    float darken = step(threshold, radius); // 0.0 if radius < threshold, else 1.0
-    
-    darken = clamp(darken, 0.5, 1.0); // reduce color values by 1/2 in darkened fragments
-
-  	color.rgb = color.rgb * darken;
-    // color.rgb = pow(color.rgb, vec3(1.0/2.2)); // gamma correction
-	gl_FragColor = color;
 }

--- a/core/resources/polyline.vs
+++ b/core/resources/polyline.vs
@@ -49,7 +49,7 @@ void main() {
     
     // Proxy tiles have u_tile_zoom < 0, so this re-scaling will place proxy tiles deeper in
     // the depth buffer than non-proxy tiles by a distance that increases with tile zoom
-    gl_Position.z /= 1. + .1 * (abs(u_tile_zoom) + u_tile_zoom);
+    gl_Position.z /= 1. + .1 * (abs(u_tile_zoom) - u_tile_zoom);
     
     #ifdef TANGRAM_DEPTH_DELTA
         gl_Position.z -= a_layer * TANGRAM_DEPTH_DELTA * gl_Position.w;

--- a/core/resources/polyline.vs
+++ b/core/resources/polyline.vs
@@ -4,8 +4,12 @@ precision highp float;
 
 uniform mat4 u_modelView;
 uniform mat4 u_modelViewProj;
+uniform mat3 u_normalMatrix;
 uniform float u_time;
 uniform float u_tileDepthOffset;
+
+#pragma tangram: material
+#pragma tangram: vertex_lighting
 
 attribute vec4 a_position;
 attribute vec4 a_color;
@@ -25,17 +29,22 @@ varying vec2 v_texcoord;
 
 void main() {
 
-	v_normal = vec3(0.,0.,1.);
+    v_normal = vec3(0.,0.,1.);
 
-	v_color = a_color;
-  	v_texcoord = a_texcoord;
+    v_color = a_color;
+    v_texcoord = a_texcoord;
 
 	vec4 v_pos = a_position;
   	v_pos.xyz += a_extrudeNormal * (a_extrudeWidth*2.0);
 
-	v_eyeToPoint = vec3(u_modelView * a_position);
+    v_eyeToPoint = vec3(u_modelView * a_position);
+    
+    #ifdef TANGRAM_LIGHTS
+        v_normal = normalize(u_normalMatrix * v_normal);
+        lightVertex(v_eyeToPoint, v_normal, v_color);
+    #endif
 
-	gl_Position = u_modelViewProj * v_pos;
+    gl_Position = u_modelViewProj * v_pos;
     gl_Position.z /= u_tileDepthOffset;
     
     #ifdef TANGRAM_DEPTH_DELTA

--- a/core/resources/polyline.vs
+++ b/core/resources/polyline.vs
@@ -6,6 +6,8 @@ uniform mat4 u_modelView;
 uniform mat4 u_modelViewProj;
 uniform mat3 u_normalMatrix;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_tile_zoom;
 uniform float u_tileDepthOffset;
 
 #pragma tangram: material
@@ -34,8 +36,8 @@ void main() {
     v_color = a_color;
     v_texcoord = a_texcoord;
 
-	vec4 v_pos = a_position;
-  	v_pos.xyz += a_extrudeNormal * (a_extrudeWidth*2.0);
+    vec4 v_pos = a_position;
+    v_pos.xyz += a_extrudeNormal * (a_extrudeWidth * 2.) * pow(2., u_tile_zoom - u_zoom);
 
     v_eyeToPoint = vec3(u_modelView * a_position);
     

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -4,6 +4,11 @@
 #include <ctime>
 
 PolylineStyle::PolylineStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
+    m_material.setEmissionEnabled(false);
+    m_material.setAmbientEnabled(true);
+    m_material.setDiffuse(glm::vec4(1.0));
+    m_material.setSpecularEnabled(true);
+    
     constructVertexLayout();
     constructShaderProgram();
 }
@@ -29,6 +34,8 @@ void PolylineStyle::constructShaderProgram() {
     
     m_shaderProgram = std::make_shared<ShaderProgram>();
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+    
+    m_material.injectOnProgram(m_shaderProgram);
 }
 
 void PolylineStyle::buildPoint(Point& _point, std::string& _layer, Properties& _props, VboMesh& _mesh) const {
@@ -42,7 +49,8 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     std::vector<glm::vec2> texcoords;
     std::vector<glm::vec2> scalingVecs;
     
-    GLuint abgr = 0xff767676; // Default road color
+    GLuint abgr = 0xff686868; // Default road color
+    GLuint abgrOutline = 0xff777777;
     GLfloat layer = sortKeyToLayer(_props.numericProps["sort_key"]) + 3;
     
     float halfWidth = 0.02;
@@ -62,15 +70,27 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     }
     
     PolyLineOutput lineOutput = { points, indices, scalingVecs, texcoords };
-    PolyLineOptions lineOptions = { CapTypes::ROUND, JoinTypes::ROUND, halfWidth };
+    PolyLineOptions lineOptions = { CapTypes::ROUND, JoinTypes::MITER, halfWidth };
     Builders::buildPolyLine(_line, lineOptions, lineOutput);
     
     for (size_t i = 0; i < points.size(); i++) {
         const glm::vec3& p = points[i];
         const glm::vec2& uv = texcoords[i];
         const glm::vec2& en = scalingVecs[i];
-        vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, halfWidth, abgr, layer });
+        vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, 0.6f * halfWidth, abgr, layer });
     }
+    
+    size_t outlineStart = points.size();
+    
+    Builders::buildOutline(_line, lineOptions, lineOutput);
+    
+    for (size_t i = outlineStart; i < points.size(); i++) {
+        const glm::vec3& p = points[i];
+        const glm::vec2& uv = texcoords[i];
+        const glm::vec2& en = scalingVecs[i];
+        vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, halfWidth, abgrOutline, layer - 1.f });
+    }
+    
     
     // Make sure indices get correctly offset
     int vertOffset = _mesh.numVertices();

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -73,6 +73,9 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     PolyLineOptions lineOptions = { CapTypes::ROUND, JoinTypes::MITER, halfWidth };
     Builders::buildPolyLine(_line, lineOptions, lineOutput);
     
+    /*
+     * Populate polyline vertices
+     */
     for (size_t i = 0; i < points.size(); i++) {
         const glm::vec3& p = points[i];
         const glm::vec2& uv = texcoords[i];
@@ -80,18 +83,25 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
         vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, 0.6f * halfWidth, abgr, layer });
     }
     
-    size_t outlineStart = points.size();
-    
-    Builders::buildPolyLine(_line, lineOptions, lineOutput);
-    
-    for (size_t i = outlineStart; i < points.size(); i++) {
+    /*
+     * Populate outline vertices
+     */
+    for (size_t i = 0; i < points.size(); i++) {
         const glm::vec3& p = points[i];
         const glm::vec2& uv = texcoords[i];
         const glm::vec2& en = scalingVecs[i];
         vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, halfWidth, abgrOutline, layer - 1.f });
     }
     
-    
+    /*
+     * add outline indices with apt offset
+     */
+    size_t oldSize = indices.size();
+    indices.reserve(2 * oldSize);
+    for(int i = 0; i < oldSize; i++) {
+        indices.push_back(points.size() + indices[i]);
+    }
+
     // Make sure indices get correctly offset
     int vertOffset = _mesh.numVertices();
     for (auto& ind : indices) {

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -82,7 +82,7 @@ void PolylineStyle::buildLine(Line& _line, std::string& _layer, Properties& _pro
     
     size_t outlineStart = points.size();
     
-    Builders::buildOutline(_line, lineOptions, lineOutput);
+    Builders::buildPolyLine(_line, lineOptions, lineOutput);
     
     for (size_t i = outlineStart; i < points.size(); i++) {
         const glm::vec3& p = points[i];

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -67,6 +67,8 @@ void Style::setupFrame(const std::shared_ptr<View>& _view, const std::shared_ptr
     for (const auto& light : _scene->getLights()) {
         light.second->setupProgram(m_shaderProgram);
     }
+    
+    m_shaderProgram->setUniformf("u_zoom", _view->getZoom());
 }
 
 void Style::setupTile(const std::shared_ptr<MapTile>& _tile) {

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -102,6 +102,7 @@ void MapTile::draw(const Style& _style, const View& _view) {
             offset = 1.0f + log(_view.s_maxZoom + 2);
         }
         shader->setUniformf("u_tileDepthOffset", offset);
+        shader->setUniformf("u_tile_zoom", m_id.z);
 
         styleMesh->draw(shader);
     }

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -94,15 +94,8 @@ void MapTile::draw(const Style& _style, const View& _view) {
         shader->setUniformMatrix4f("u_modelViewProj", glm::value_ptr(modelViewProjMatrix));
         shader->setUniformMatrix3f("u_normalMatrix", glm::value_ptr(normalMatrix));
 
-        // Set tile offset for proxy tiles
-        float offset = 0;
-        if (m_proxyCounter > 0) {
-            offset = 1.0f + log((_view.s_maxZoom + 1) / (_view.s_maxZoom + 1 - m_id.z));
-        } else {
-            offset = 1.0f + log(_view.s_maxZoom + 2);
-        }
-        shader->setUniformf("u_tileDepthOffset", offset);
-        shader->setUniformf("u_tile_zoom", m_id.z);
+        // Set the tile zoom level, using the sign to indicate whether the tile is a proxy
+        shader->setUniformf("u_tile_zoom", m_proxyCounter > 0 ? -m_id.z : m_id.z);
 
         styleMesh->draw(shader);
     }

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -204,7 +204,7 @@ void View::updateMatrices() {
     // set near and far clipping distances as a function of camera z
     // TODO: this is a simple heuristic that deserves more thought
     float near = m_pos.z / 50.0;
-    float far = m_pos.z + 1.f;
+    float far = 3. * m_pos.z / cos(m_pitch) + 1.f;
     
     glm::vec3 eye = { 0.f, 0.f, 0.f };
     glm::vec3 at = glm::rotateZ(glm::rotateX(glm::vec3(0.f, 0.f, -1.f), m_pitch), m_roll);


### PR DESCRIPTION
The goal of this branch was just to make the make the polyline style more visually appealing with two changes:

 - Use outline geometry instead of an outline-faking shader to provide road outlines (allows gpu super-sampling to anti-alias the outlines)
 - Make line width continuous with changes in zoom (since visual width of roads isn't physical anyway, we may as well make it look nice)

I ended up also making a change to proxy tile rendering to save using a mostly redundant uniform in every shader. To make road widths continuous with zoom, the shader needs to now both the current view zoom and the zoom level of the tile being drawn (we could actually just use the difference of these, but I anticipate wanting the view zoom for more effects in the future so I kept them separated). We already had a uniform `u_tileDepthOffset` which was a function of the tile zoom level and whether the tile was a proxy or not. We can effectively encode this information in a signed tile zoom, where zooms < 0 represent proxy tiles. This also changes the application of the proxy depth offset in vertex shaders, but we end up with the same proxy behavior (as far as I can tell).