### PR TITLE
Travis android on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
         - os: osx
           env: PLATFORM=ios
           compiler: clang
-        - os: osx
+        - os: linux
           env: PLATFORM=android
           compiler: gcc
         - os: linux

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <application android:label="@string/app_name" android:icon="@drawable/ic_launcher" android:debuggable="true">
+    <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
         <activity android:name="MainActivity"
                   android:label="@string/app_name"
                   android:configChanges="orientation|screenSize">

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.1.3'
     }
 }
 

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -68,4 +68,7 @@ if [[ ${PLATFORM} == "android" ]]; then
     echo "Updating Android SDK..."
     echo "y" | android update sdk --all --filter platform-tools,build-tools-${ANDROID_BUILD_TOOL_VERSION},android-${ANDROID_PLATFORM_VERSION},extra-android-support --no-ui --force >/dev/null
     echo "Done."
+
+    # Make gradle executable
+    chmod +x gradlew
 fi

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -47,9 +47,6 @@ if [[ ${PLATFORM} == "android" ]]; then
     ANDROID_BUILD_TOOL_VERSION="21.1.2"
     ANDROID_PLATFORM_VERSION="19"
 
-    # Install ant
-    brew install ant
-
     # Install android sdk
     wget https://dl-ssl.google.com/android/android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
     tar -zxf android-sdk_${ANDROID_SDK_VERSION}-macosx.zip

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -47,6 +47,9 @@ if [[ ${PLATFORM} == "android" ]]; then
     ANDROID_BUILD_TOOL_VERSION="21.1.2"
     ANDROID_PLATFORM_VERSION="19"
 
+    # install jdk7 and 32bit dependencies for android sdk
+    sudo apt-get -qq -y install openjdk-7-jdk lib32z1-dev lib32stdc++6
+
     # Install android sdk
     wget https://dl-ssl.google.com/android/android-sdk_${ANDROID_SDK_VERSION}-linux.tgz
     tar -zxf android-sdk_${ANDROID_SDK_VERSION}-linux.tgz
@@ -69,6 +72,7 @@ if [[ ${PLATFORM} == "android" ]]; then
     echo "y" | android update sdk --all --filter platform-tools,build-tools-${ANDROID_BUILD_TOOL_VERSION},android-${ANDROID_PLATFORM_VERSION},extra-android-support --no-ui --force >/dev/null
     echo "Done."
 
-    # Make gradle executable
-    chmod +x gradlew
+    # Make sure gradlew is executable
+    chmod +x android/gradlew
+
 fi

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -48,6 +48,7 @@ if [[ ${PLATFORM} == "android" ]]; then
     ANDROID_PLATFORM_VERSION="19"
 
     # install jdk7 and 32bit dependencies for android sdk
+    sudo apt-get update -qq
     sudo apt-get -qq -y install openjdk-7-jdk lib32z1-dev lib32stdc++6
 
     # Install android sdk

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -48,9 +48,9 @@ if [[ ${PLATFORM} == "android" ]]; then
     ANDROID_PLATFORM_VERSION="19"
 
     # Install android sdk
-    wget https://dl-ssl.google.com/android/android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
-    tar -zxf android-sdk_${ANDROID_SDK_VERSION}-macosx.zip
-    export ANDROID_HOME=$PWD/android-sdk-macosx
+    wget https://dl-ssl.google.com/android/android-sdk_${ANDROID_SDK_VERSION}-linux.tgz
+    tar -zxf android-sdk_${ANDROID_SDK_VERSION}-linux.tgz
+    export ANDROID_HOME=$PWD/android-sdk-linux
 
     # Install android ndk
     echo "Cloning mindk..."

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -57,7 +57,7 @@ if [[ ${PLATFORM} == "android" ]]; then
 
     # Install android ndk
     echo "Cloning mindk..."
-    git clone --quiet --depth 1 https://github.com/tangrams/mindk.git
+    git clone --quiet --depth 1 --branch linux https://github.com/tangrams/mindk.git
     export ANDROID_NDK=$PWD/mindk/android-ndk-r10d
     echo "Done."
 


### PR DESCRIPTION
Travis' OS X machines aren't quite as reliable as their Linux machines, so to reduce the meaningless build failures we've been getting recently, I moved the Android build over to a Linux machine on Travis. It does basically the same things as the OS X build, except that is uses a new branch of mindk that hosts the Linux version of the NDK. 