### PR TITLE
Use of typed mesh for rasbperry pi platform

### DIFF
--- a/rpi/src/main.cpp
+++ b/rpi/src/main.cpp
@@ -15,7 +15,7 @@
 
 #include "util/shaderProgram.h"
 #include "util/vertexLayout.h"
-#include "util/vboMesh.h"
+#include "util/typedMesh.h"
 #include "util/geom.h"
 
 #define KEY_ESC      113    // q
@@ -102,7 +102,8 @@ struct PosUVColorVertex {
     // Color Data
     GLuint abgr;
 };
-std::shared_ptr<VboMesh> mouseMesh;
+typedef TypedMesh<PosUVColorVertex> Mesh;
+std::shared_ptr<Mesh> mouseMesh;
 
 static void initOpenGL(){
     bcm_host_init();
@@ -229,9 +230,9 @@ static void initOpenGL(){
             indices.push_back(2); indices.push_back(3); indices.push_back(0);
         }
         
-        mouseMesh = std::shared_ptr<VboMesh>(new VboMesh(vertexLayout));
-        mouseMesh->addVertices((GLbyte*)vertices.data(), vertices.size());
-        mouseMesh->addIndices(indices.data(), indices.size());
+        mouseMesh = std::shared_ptr<Mesh>(new Mesh(vertexLayout, GL_TRIANGLES));
+        mouseMesh->addVertices(std::move(vertices), std::move(indices));
+        mouseMesh->compileVertexBuffer();
     }
 }
 

--- a/toolchains/raspberrypi.cmake
+++ b/toolchains/raspberrypi.cmake
@@ -1,6 +1,6 @@
 # options
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fpermissive -g")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_CXX_FLAGS} -L/opt/vc/lib/ -lGLESv2 -lEGL -lbcm_host -lvchiq_arm -lvcos -lrt")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_CXX_FLAGS} -L/opt/vc/lib/ -lGLESv2 -lEGL -lbcm_host -lvchiq_arm -lvcos -lrt -lpthread")
 set(CXX_FLAGS_DEBUG "-g -O0")
 set(EXECUTABLE_NAME "tangram")
 


### PR DESCRIPTION
The build is failing on rasbperryPi due to the use of the old VboMesh class, this PR fixes it by using the new typed mesh.

Fixes #93 