### PR TITLE
Some smarts in pruning labels

### DIFF
--- a/core/src/tile/labels/labelContainer.cpp
+++ b/core/src/tile/labels/labelContainer.cpp
@@ -78,6 +78,8 @@ void LabelContainer::updateOcclusions() {
     
     // no priorities, only occlude one of the two occluded label
     for (auto& pair : occlusions) {
-        pair.first->setVisible(false);
+        //if(pair.second->isVisible()) {
+            pair.first->setVisible(false);
+        //}
     }
 }

--- a/core/src/tile/labels/labelContainer.cpp
+++ b/core/src/tile/labels/labelContainer.cpp
@@ -78,8 +78,8 @@ void LabelContainer::updateOcclusions() {
     
     // no priorities, only occlude one of the two occluded label
     for (auto& pair : occlusions) {
-        //if(pair.second->isVisible()) {
+        if(pair.second->isVisible()) {
             pair.first->setVisible(false);
-        //}
+        }
     }
 }


### PR DESCRIPTION
- A very small change!!
- previous every first label in the label-collision pair was set with visibility as 'false'
- now we make sure only one of the 2 labels is marked as false!!!

Example: Consider 3 labels A,B,C,D,E making collision pairs as: (A,B), (B,A), (C,B), (D,A), (E,B)
                Previously implementation: all A,B,C,D and E will be marked invisible
                Changed implementation: Only A,C and A,C and E are marked invisible and B, D as visible.

I think we can still do better pruning of labels ... like this change will not catch the following:
    - Consider labels A,B,C making collision pairs as: (A,B) and (B,C) [in this order].
        - We can be fine with just making B invisible (since its the common one in the collision pairs), but we prune
        out A and B both in both previous and the new implementation!!.. So a todo.. :D
       - This change will however catch this case if order of processing pairs is swapped ... (B,C) and (A,B)!!