### PR TITLE
Derivative extension fix

### DIFF
--- a/core/resources/sdf.fs
+++ b/core/resources/sdf.fs
@@ -2,11 +2,15 @@
 precision mediump float;
 #define LOWP lowp
 #else
-#define LOWP 
+#define LOWP
 #endif
 
 #ifdef TANGRAM_SDF_MULTISAMPLING
-#extension GL_OES_standard_derivatives : enable
+    #ifdef GL_OES_standard_derivatives
+        #extension GL_OES_standard_derivatives : enable
+    #else
+        #undef TANGRAM_SDF_MULTISAMPLING
+    #endif
 #endif
 
 uniform sampler2D u_tex;
@@ -29,7 +33,7 @@ float sample(in vec2 uv, float w, in float off) {
 
 float sampleAlpha(in vec2 uv, float distance, in float off) {
     float alpha = contour(distance, distance, off);
-    
+
     #ifdef TANGRAM_SDF_MULTISAMPLING
         float dscale = 0.354; // 1 / sqrt(2)
         vec2 duv = dscale * (dFdx(uv) + dFdy(uv));
@@ -39,7 +43,7 @@ float sampleAlpha(in vec2 uv, float distance, in float off) {
                    + sample(box.zw, distance, off)
                    + sample(box.xw, distance, off)
                    + sample(box.zy, distance, off);
-        
+
         alpha = (alpha + 0.5 * asum) / 2.0;
     #endif
 
@@ -50,10 +54,11 @@ void main(void) {
     if (v_alpha == 0.0) {
         discard;
     }
-    
+
     float distance = texture2D(u_tex, v_uv).a;
     float alpha = sampleAlpha(v_uv, distance, sdf) * tint;
     alpha = pow(alpha, 1.0 / gamma);
-    
+
     gl_FragColor = vec4(u_color, v_alpha * alpha);
 }
+


### PR DESCRIPTION
Fixing shader when GL_OES_standard_derivatives is not available after testing on Raspberry Pi.