### PR TITLE
Make labels as unique_ptr owned by LabelContainer

### DIFF
--- a/core/src/tile/labels/labelContainer.cpp
+++ b/core/src/tile/labels/labelContainer.cpp
@@ -50,7 +50,7 @@ void LabelContainer::removeLabels(const TileID& _tileID) {
     }
 }
 
-const std::vector<std::shared_ptr<Label>>& LabelContainer::getLabels(const std::string& _styleName, const TileID& _tileID) {
+const std::vector<std::unique_ptr<Label>>& LabelContainer::getLabels(const std::string& _styleName, const TileID& _tileID) {
     return m_labels[_styleName][_tileID];
 }
 
@@ -76,7 +76,7 @@ void LabelContainer::updateOcclusions() {
         }
     }
     
-    std::set<std::pair<std::shared_ptr<Label>, std::shared_ptr<Label>>> occlusions;
+    std::set<std::pair<Label*, Label*>> occlusions;
     std::vector<isect2d::AABB> aabbs;
     
     for (auto& styleTilepair : m_labels) {
@@ -89,7 +89,7 @@ void LabelContainer::updateOcclusions() {
                 }
                 
                 isect2d::AABB aabb = label->getAABB();
-                aabb.m_userData = (void*) &label;
+                aabb.m_userData = (void*) (label.get());
                 aabbs.push_back(aabb);
             }
         }
@@ -102,8 +102,8 @@ void LabelContainer::updateOcclusions() {
         const auto& aabb1 = aabbs[pair.first];
         const auto& aabb2 = aabbs[pair.second];
         
-        auto l1 = *(std::shared_ptr<Label>*) aabb1.m_userData;
-        auto l2 = *(std::shared_ptr<Label>*) aabb2.m_userData;
+        auto l1 = (Label*)aabb1.m_userData;
+        auto l2 = (Label*)aabb2.m_userData;
         
         // narrow phase
         if (intersect(l1->getOBB(), l2->getOBB())) {

--- a/core/src/tile/labels/labelContainer.h
+++ b/core/src/tile/labels/labelContainer.h
@@ -40,7 +40,7 @@ public:
     const std::shared_ptr<FontContext>& getFontContext() { return m_ftContext; }
 
     /* Returns a const list of labels for a <TileID> and a style name */
-    const std::vector<std::shared_ptr<Label>>& getLabels(const std::string& _styleName, const TileID& _tileID);
+    const std::vector<std::unique_ptr<Label>>& getLabels(const std::string& _styleName, const TileID& _tileID);
     
     void updateOcclusions();
     
@@ -52,7 +52,7 @@ private:
 
     LabelContainer();
     // map of <Style>s containing all <Label>s by <TileID>s
-    std::map<std::string, std::map<TileID, std::vector<std::shared_ptr<Label>>>> m_labels;
+    std::map<std::string, std::map<TileID, std::vector<std::unique_ptr<Label>>>> m_labels;
     // map of <Style>s containing all <Label>s by <TileID>s, accessed from tile threads
     std::map<std::string, std::map<TileID, std::vector<Label>>> m_pendingLabels;
 

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -65,7 +65,7 @@ void MapTile::updateLabels(float _dt, const Style& _style, const View& _view, st
     glm::mat4 mvp = _view.getViewProjectionMatrix() * m_modelMatrix;
     glm::vec2 screenSize = glm::vec2(_view.getWidth(), _view.getHeight());
     
-    for(auto label : _labelContainer->getLabels(_style.getName(), getID())) {
+    for(auto& label : _labelContainer->getLabels(_style.getName(), getID())) {
         label->update(mvp, screenSize, _dt);
     }
 }
@@ -77,7 +77,7 @@ void MapTile::pushLabelTransforms(const Style& _style, std::shared_ptr<LabelCont
 
         ftContext->lock();
         
-        for(auto label : _labelContainer->getLabels(_style.getName(), getID())) {
+        for(auto& label : _labelContainer->getLabels(_style.getName(), getID())) {
             label->pushTransform();
         }
         


### PR DESCRIPTION
- Previous labels were shared between mapTile and LabelContainer.. but maptile can use a label reference from
labelContainer.
- This will also help us further refine our label and label occlusion work!