### PR TITLE
Typed Mesh vbo data

### DIFF
--- a/core/src/util/vboMesh.h
+++ b/core/src/util/vboMesh.h
@@ -96,8 +96,8 @@ protected:
     void checkValidity();
 
     template <typename T>
-    void compile(std::vector<std::vector<T>> vertices,
-                 std::vector<std::vector<int>> indices,
+    void compile(std::vector<std::vector<T>>& vertices,
+                 std::vector<std::vector<int>>& indices,
                  int divider = 1) {
 
         int vertexOffset = 0, indexOffset = 0;
@@ -147,5 +147,8 @@ protected:
         m_vertexOffsets.emplace_back(indexOffset, vertexOffset);
 
         m_isCompiled = true;
+        
+        vertices.clear();
+        indices.clear();
     }
 };

--- a/core/src/util/vboMesh.h
+++ b/core/src/util/vboMesh.h
@@ -148,10 +148,9 @@ protected:
 
         m_isCompiled = true;
         
-        std::vector<std::vector<T>> vdump;
-        std::vector<std::vector<int>> idump;
-        
-        vertices.swap(vdump);
-        indices.swap(idump);
+        // To efficiently free the memory in these vectors, we can
+        // swap their contents with new, empty vectors
+        std::vector<std::vector<T>>().swap(vertices);
+        std::vector<std::vector<int>>().swap(indices);
     }
 };

--- a/core/src/util/vboMesh.h
+++ b/core/src/util/vboMesh.h
@@ -148,7 +148,10 @@ protected:
 
         m_isCompiled = true;
         
-        vertices.clear();
-        indices.clear();
+        std::vector<std::vector<T>> vdump;
+        std::vector<std::vector<int>> idump;
+        
+        vertices.swap(vdump);
+        indices.swap(idump);
     }
 };


### PR DESCRIPTION
In the compilation step of the typed mesh, make sure that the data is cleared from the CPU after compilation. Also reduce copy by using references.