### PR TITLE
World to clip-space optimization

### DIFF
--- a/core/src/tile/labels/label.cpp
+++ b/core/src/tile/labels/label.cpp
@@ -60,7 +60,7 @@ void Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
         case Type::DEBUG:
         case Type::POINT:
         {
-            glm::vec4 v1 = worldToClipSpace(_mvp, glm::vec4(m_transform.m_modelPosition1, 0.0, 1.0));
+            glm::vec4 v1 = mapWorldToClipSpace(_mvp, m_transform.m_modelPosition1);
             
             if (v1.w <= 0) {
                 m_visible = false;
@@ -76,8 +76,8 @@ void Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
         case Type::LINE:
         {
             // project label position from mercator world space to clip coordinates
-            glm::vec4 v1 = worldToClipSpace(_mvp, glm::vec4(m_transform.m_modelPosition1, 0.0, 1.0));
-            glm::vec4 v2 = worldToClipSpace(_mvp, glm::vec4(m_transform.m_modelPosition2, 0.0, 1.0));
+            glm::vec4 v1 = mapWorldToClipSpace(_mvp, m_transform.m_modelPosition1);
+            glm::vec4 v2 = mapWorldToClipSpace(_mvp, m_transform.m_modelPosition2);
             
             // check whether the label is behind the camera using the perspective division factor
             if (v1.w <= 0 || v2.w <= 0) {

--- a/core/src/util/geom.cpp
+++ b/core/src/util/geom.cpp
@@ -66,6 +66,18 @@ float angleBetweenPoints(const glm::vec2& _p1, const glm::vec2& _p2) {
     return (float) atan2(p1p2.x, -p1p2.y);
 }
 
+/* 
+ * Optimized world to clip space transformation for 2d-map coordinates based on 
+ * our modelViewMatrix, and on the fact that the map position is on a 2d-plane
+ */
+glm::vec4 mapWorldToClipSpace(const glm::mat4& _mvp, const glm::vec2& _mapPos) {
+
+    return glm::vec4(_mapPos.x * _mvp[0][0] + _mvp[3][0],
+                     _mapPos.y * _mvp[1][1] + _mvp[3][1],
+                     _mvp[3][2],
+                     _mvp[0][3] * _mapPos.x + _mvp[1][3] * _mapPos.y + _mvp[3][3]);
+}
+
 glm::vec4 worldToClipSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosition) {
     return _mvp * _worldPosition;
 }

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -92,6 +92,8 @@ float angleBetweenPoints(const glm::vec2& _p1, const glm::vec2& _p2);
 /* Computes the clip coordinates from position in world space and a model view matrix */
 glm::vec4 worldToClipSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosition);
 
+glm::vec4 mapWorldToClipSpace(const glm::mat4& _mvp, const glm::vec2& _mercatorPos);
+
 /* Computes the screen coordinates from a coordinate in clip space and a screen size */
 glm::vec2 clipToScreenSpace(const glm::vec4& _clipCoords, const glm::vec2& _screenSize);
 


### PR DESCRIPTION
Small optimization, instead of performing a full matrix multiplication based on our view transform matrix and model matrix that only uses translation (~15% speedup). 