### PR TITLE
Datasource cleanup

### DIFF
--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -8,6 +8,11 @@
 
 //---- DataSource Implementation----
 
+DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate) :
+    m_name(_name), m_urlTemplate(_urlTemplate) {
+
+}
+
 bool DataSource::hasTileData(const TileID& _tileID) const {
     
     return m_tileStore.find(_tileID) != m_tileStore.end();
@@ -38,19 +43,7 @@ void DataSource::setTileData(const TileID& _tileID, const std::shared_ptr<TileDa
         m_tileStore[_tileID] = _tileData;
 }
 
-void DataSource::setUrlTemplate(const std::string& _urlTemplate){
-    m_urlTemplate = _urlTemplate;
-}
-
-//---- NetworkDataSource Implementation----
-
-NetworkDataSource::NetworkDataSource() {
-}
-
-NetworkDataSource::~NetworkDataSource() {
-}
-
-void NetworkDataSource::constructURL(const TileID& _tileCoord, std::string& _url) {
+void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const {
 
     _url.assign(m_urlTemplate);
 
@@ -68,7 +61,7 @@ void NetworkDataSource::constructURL(const TileID& _tileCoord, std::string& _url
     }
 }
 
-bool NetworkDataSource::loadTileData(const TileID& _tileID, TileManager& _tileManager) {
+bool DataSource::loadTileData(const TileID& _tileID, TileManager& _tileManager) {
     
     bool success = true; // Begin optimistically
     
@@ -94,7 +87,7 @@ bool NetworkDataSource::loadTileData(const TileID& _tileID, TileManager& _tileMa
     return success;
 }
 
-void NetworkDataSource::cancelLoadingTile(const TileID& _tileID) {
+void DataSource::cancelLoadingTile(const TileID& _tileID) {
     std::string url;
     constructURL(_tileID, url);
     cancelUrlRequest(url);

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -66,7 +66,7 @@ bool DataSource::loadTileData(const TileID& _tileID, TileManager& _tileManager) 
     bool success = true; // Begin optimistically
     
     if (hasTileData(_tileID)) {
-        // Tile has been fetched already!
+        _tileManager.addToWorkerQueue(m_tileStore[_tileID], _tileID, this);
         return success;
     }
 

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -5,8 +5,8 @@
 #include "geoJsonSource.h"
 
 
-GeoJsonSource::GeoJsonSource() {
-    m_urlTemplate = "http://vector.mapzen.com/osm/all/[z]/[x]/[y].json";
+GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate) :
+    DataSource(_name, _urlTemplate) {
 }
 
 std::shared_ptr<TileData> GeoJsonSource::parse(const MapTile& _tile, std::vector<char>& _rawData) const {

--- a/core/src/data/geoJsonSource.h
+++ b/core/src/data/geoJsonSource.h
@@ -6,7 +6,7 @@
 
 
 /* Extends NetworkDataSource class to read Mapzen's GeoJSON vector tiles */
-class GeoJsonSource: public NetworkDataSource {
+class GeoJsonSource: public DataSource {
     
 protected:
     
@@ -14,6 +14,6 @@ protected:
     
 public:
     
-    GeoJsonSource();
+    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate);
     
 };

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -7,8 +7,8 @@
 
 #include "mvtSource.h"
 
-MVTSource::MVTSource() {
-    m_urlTemplate = "http://vector.mapzen.com/osm/all/[z]/[x]/[y].mapbox";
+MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate) : 
+    DataSource(_name, _urlTemplate) {
 }
 
 std::shared_ptr<TileData> MVTSource::parse(const MapTile& _tile, std::vector<char>& _rawData) const {

--- a/core/src/data/mvtSource.h
+++ b/core/src/data/mvtSource.h
@@ -5,7 +5,7 @@
 #include "tileData.h"
 
 
-class MVTSource : public NetworkDataSource {
+class MVTSource : public DataSource {
     
 protected:
     
@@ -13,6 +13,6 @@ protected:
     
 public:
     
-    MVTSource();
+    MVTSource(const std::string& _name, const std::string& _urlTemplate);
     
 };

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -64,21 +64,21 @@ void loadSources(Node sources, TileManager& tileManager) {
     for (auto it = sources.begin(); it != sources.end(); ++it) {
         
         const Node source = it->second;
+        std::string name = it->first.as<std::string>();
         std::string type = source["type"].as<std::string>();
         std::string url = source["url"].as<std::string>();
         
         std::unique_ptr<DataSource> sourcePtr;
         
         if (type == "GeoJSONTiles") {
-            sourcePtr = std::unique_ptr<DataSource>(new GeoJsonSource());
+            sourcePtr = std::unique_ptr<DataSource>(new GeoJsonSource(name, url));
         } else if (type == "TopoJSONTiles") {
             // TODO
         } else if (type == "MVT") {
-            sourcePtr = std::unique_ptr<DataSource>(new MVTSource());
+            sourcePtr = std::unique_ptr<DataSource>(new MVTSource(name, url));
         }
         
         if (sourcePtr) {
-            sourcePtr->setUrlTemplate(url);
             tileManager.addDataSource(std::move(sourcePtr));
         }
     }

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -42,7 +42,7 @@ void TileManager::addToWorkerQueue(std::vector<char>&& _rawData, const TileID& _
     
 }
 
-void TileManager::addToWorkerQueue(std::shared_ptr<TileData> _parsedData, const TileID& _tileID, DataSource* _source) {
+void TileManager::addToWorkerQueue(std::shared_ptr<TileData>& _parsedData, const TileID& _tileID, DataSource* _source) {
 
     std::lock_guard<std::mutex> lock(m_queueTileMutex);
     m_queuedTiles.emplace_back(std::unique_ptr<TileTask>(new TileTask(_parsedData, _tileID, _source)));

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -38,14 +38,14 @@ TileManager::~TileManager() {
 void TileManager::addToWorkerQueue(std::vector<char>&& _rawData, const TileID& _tileId, DataSource* _source) {
     
     std::lock_guard<std::mutex> lock(m_queueTileMutex);
-    m_queuedTiles.push_back(std::unique_ptr<TileTask>(new TileTask(std::move(_rawData), _tileId, _source)));
+    m_queuedTiles.emplace_back(std::unique_ptr<TileTask>(new TileTask(std::move(_rawData), _tileId, _source)));
     
 }
 
 void TileManager::addToWorkerQueue(std::shared_ptr<TileData> _parsedData, const TileID& _tileID, DataSource* _source) {
 
     std::lock_guard<std::mutex> lock(m_queueTileMutex);
-    m_queuedTiles.push_back(std::unique_ptr<TileTask>(new TileTask(_parsedData, _tileID, _source)));
+    m_queuedTiles.emplace_back(std::unique_ptr<TileTask>(new TileTask(_parsedData, _tileID, _source)));
 
 }
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -53,7 +53,7 @@ public:
 
     void addToWorkerQueue(std::vector<char>&& _rawData, const TileID& _id, DataSource* _source);
 
-    void addToWorkerQueue(std::shared_ptr<TileData> _parsedData, const TileID& _id, DataSource* _source);
+    void addToWorkerQueue(std::shared_ptr<TileData>& _parsedData, const TileID& _id, DataSource* _source);
     
     /* Returns the set of currently visible tiles */
     const std::map<TileID, std::shared_ptr<MapTile>>& getVisibleTiles() { return m_tileSet; }

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -52,6 +52,8 @@ public:
     void updateTileSet();
 
     void addToWorkerQueue(std::vector<char>&& _rawData, const TileID& _id, DataSource* _source);
+
+    void addToWorkerQueue(std::shared_ptr<TileData> _parsedData, const TileID& _id, DataSource* _source);
     
     /* Returns the set of currently visible tiles */
     const std::map<TileID, std::shared_ptr<MapTile>>& getVisibleTiles() { return m_tileSet; }
@@ -75,7 +77,7 @@ private:
     const static size_t MAX_WORKERS = 4;
     std::list<std::unique_ptr<TileWorker> > m_workers;
     
-    std::list<std::unique_ptr<WorkerData>> m_queuedTiles;
+    std::list<std::unique_ptr<TileTask> > m_queuedTiles;
     
     bool m_tileSetChanged = false;
     

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -23,19 +23,19 @@ struct TileTask {
     }
 
     TileTask(std::vector<char>&& _rawTileData, const TileID& _tileID, DataSource* _source) :
-        tileID(std::move(_tileID)),
+        tileID(_tileID),
         rawTileData(std::move(_rawTileData)),
         source(_source) {
     }
 
     TileTask(std::shared_ptr<TileData>& _tileData, const TileID& _tileID, DataSource* _source) :
-        tileID(std::move(_tileID)),
+        tileID(_tileID),
         parsedTileData(_tileData),
         source(_source) {       
     }
 
     TileTask(TileTask&& _other) :
-        tileID(std::move(_other.tileID)),
+        tileID(_other.tileID),
         parsedTileData(std::move(_other.parsedTileData)),
         rawTileData(std::move(_other.rawTileData)),
         source(std::move(_other.source)) {

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -35,7 +35,7 @@ struct TileTask {
     }
 
     TileTask(TileTask&& _other) :
-        tileID(_other.tileID),
+        tileID(std::move(_other.tileID)),
         parsedTileData(std::move(_other.parsedTileData)),
         rawTileData(std::move(_other.rawTileData)),
         source(std::move(_other.source)) {

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -28,7 +28,7 @@ struct TileTask {
         source(_source) {
     }
 
-    TileTask(std::shared_ptr<TileData> _tileData, const TileID& _tileID, DataSource* _source) :
+    TileTask(std::shared_ptr<TileData>& _tileData, const TileID& _tileID, DataSource* _source) :
         tileID(_tileID),
         parsedTileData(_tileData),
         source(_source) {       

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -23,13 +23,13 @@ struct TileTask {
     }
 
     TileTask(std::vector<char>&& _rawTileData, const TileID& _tileID, DataSource* _source) :
-        tileID(_tileID),
+        tileID(std::move(_tileID)),
         rawTileData(std::move(_rawTileData)),
         source(_source) {
     }
 
     TileTask(std::shared_ptr<TileData>& _tileData, const TileID& _tileID, DataSource* _source) :
-        tileID(_tileID),
+        tileID(std::move(_tileID)),
         parsedTileData(_tileData),
         source(_source) {       
     }

--- a/core/src/util/tileID.h
+++ b/core/src/util/tileID.h
@@ -16,7 +16,6 @@ struct TileID {
     
     TileID(int _x, int _y, int _z) : x(_x), y(_y), z(_z) {};
     TileID(const TileID& _rhs): x(_rhs.x), y(_rhs.y), z(_rhs.z) {};
-    TileID(const TileID&& _rhs): x(std::move(_rhs.x)), y(std::move(_rhs.y)), z(std::move(_rhs.z)) {};
 
     bool operator< (const TileID& _rhs) const {
         return z > _rhs.z || (z == _rhs.z && (x < _rhs.x || (x == _rhs.x && y < _rhs.y)));

--- a/core/src/util/tileID.h
+++ b/core/src/util/tileID.h
@@ -16,6 +16,7 @@ struct TileID {
     
     TileID(int _x, int _y, int _z) : x(_x), y(_y), z(_z) {};
     TileID(const TileID& _rhs): x(_rhs.x), y(_rhs.y), z(_rhs.z) {};
+    TileID(const TileID&& _rhs): x(std::move(_rhs.x)), y(std::move(_rhs.y)), z(std::move(_rhs.z)) {};
 
     bool operator< (const TileID& _rhs) const {
         return z > _rhs.z || (z == _rhs.z && (x < _rhs.x || (x == _rhs.x && y < _rhs.y)));


### PR DESCRIPTION
 - Remove NetworkDataSource; it was an unnecessary abstraction layer. When we want to actually implement non-network data sources we should do it with something more like a component model (i.e. sources have a transfer component, a parser component, etc.)

 - Update the comments in DataSource to reflect the current implementation

 - Reorganize WorkerData (now TileTask) to contain an optional shared pointer to previously-parsed tile data. This is to prevent a weird trick we had to do in tileManager where we created a task with an empty 'raw data' vector and then ignored that vector in the tile worker. The data flow is a bit clearer now. 
