### PR TITLE
Lod label discard

### DIFF
--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -74,6 +74,7 @@ namespace Tangram {
             m_ftContext->addFont("FuturaStd-Condensed.ttf", "Futura");
             m_labelContainer = LabelContainer::GetInstance();
             m_labelContainer->setFontContext(m_ftContext);
+            m_labelContainer->setView(m_view);
 
             std::unique_ptr<Style> textStyle0(new TextStyle("FiraSans", "Textstyle0", 15.0f, 0xF7F0E1, true, true));
             textStyle0->addLayers({
@@ -159,8 +160,6 @@ namespace Tangram {
             m_tileManager->updateTileSet();
 
             if(m_view->changedOnLastUpdate() || m_tileManager->hasTileSetChanged()) {
-                m_labelContainer->setViewProjectionMatrix(m_view->getViewProjectionMatrix());
-                
                 for (const auto& mapIDandTile : m_tileManager->getVisibleTiles()) {
                     const std::shared_ptr<MapTile>& tile = mapIDandTile.second;
                     tile->update(_dt, *m_view);

--- a/core/src/tile/labels/labelContainer.cpp
+++ b/core/src/tile/labels/labelContainer.cpp
@@ -9,7 +9,7 @@ LabelContainer::~LabelContainer() {
 }
 
 int LabelContainer::LODDiscardFunc(float _maxZoom, float _zoom) {
-    return (int) MIN(ceil(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5) - 0.5), MAX_LOD);
+    return (int) MIN(floor(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5)), MAX_LOD);
 }
 
 bool LabelContainer::addLabel(MapTile& _tile, const std::string& _styleName, LabelTransform _transform, std::string _text, Label::Type _type) {

--- a/core/src/tile/labels/labelContainer.cpp
+++ b/core/src/tile/labels/labelContainer.cpp
@@ -24,7 +24,7 @@ bool LabelContainer::addLabel(MapTile& _tile, const std::string& _styleName, Lab
         std::shared_ptr<Label> l(new Label(_transform, _text, textID, _type));
 
         l->rasterize(currentBuffer);
-        l->update(m_viewProjection * _tile.getModelMatrix(), m_screenSize, 0);
+        l->update(m_view->getViewProjectionMatrix() * _tile.getModelMatrix(), m_screenSize, 0);
         std::unique_ptr<TileID> tileID(new TileID(_tile.getID()));
         _tile.addLabel(_styleName, l);
 

--- a/core/src/tile/labels/labelContainer.cpp
+++ b/core/src/tile/labels/labelContainer.cpp
@@ -15,7 +15,7 @@ int LabelContainer::LODDiscardFunc(float _maxZoom, float _zoom) {
 bool LabelContainer::addLabel(MapTile& _tile, const std::string& _styleName, LabelTransform _transform, std::string _text, Label::Type _type) {
     auto currentBuffer = m_ftContext->getCurrentBuffer();
 
-    if (m_currentZoom - _tile.getID().z > LODDiscardFunc(View::s_maxZoom, m_currentZoom)) {
+    if ( (m_currentZoom - _tile.getID().z) > LODDiscardFunc(View::s_maxZoom, m_currentZoom)) {
         return false;
     }
 

--- a/core/src/tile/labels/labelContainer.h
+++ b/core/src/tile/labels/labelContainer.h
@@ -4,6 +4,7 @@
 #include "util/tileID.h"
 #include "text/fontContext.h"
 #include "isect2d.h"
+#include "view/view.h"
 #include <memory>
 #include <vector>
 #include <set>
@@ -64,11 +65,13 @@ public:
 
     void updateOcclusions();
     
-    void setViewProjectionMatrix(glm::mat4 _viewProjection) { m_viewProjection = _viewProjection; }
+    void setView(std::shared_ptr<View> _view) { m_view = _view; }
     
     void setScreenSize(int _width, int _height) { m_screenSize = glm::vec2(_width, _height); }
 
 private:
+    
+    int LODDiscardFunc(float _maxZoom, float _zoom);
 
     LabelContainer();
     std::vector<LabelUnit> m_labelUnits;
@@ -81,5 +84,7 @@ private:
     
     glm::mat4 m_viewProjection;
     glm::vec2 m_screenSize;
+    std::shared_ptr<View> m_view;
+    float m_currentZoom;
 
 };

--- a/core/src/tile/labels/labelContainer.h
+++ b/core/src/tile/labels/labelContainer.h
@@ -13,25 +13,25 @@
 class MapTile;
 
 struct LabelUnit {
-    
+
 private:
     std::weak_ptr<Label> m_label;
-    
+
 public:
     std::unique_ptr<TileID> m_tileID;
     std::string m_styleName;
-    
+
     LabelUnit(std::shared_ptr<Label>& _label, std::unique_ptr<TileID>& _tileID, const std::string& _styleName) : m_label(std::move(_label)), m_tileID(std::move(_tileID)), m_styleName(_styleName) {}
-    
+
     LabelUnit(LabelUnit&& _other) : m_label(std::move(_other.m_label)), m_tileID(std::move(_other.m_tileID)), m_styleName(_other.m_styleName) {}
-    
+
     LabelUnit& operator=(LabelUnit&& _other) {
         m_label = std::move(_other.m_label);
         m_tileID = std::move(_other.m_tileID);
         m_styleName = std::move(_other.m_styleName);
         return *this;
     }
-    
+
     // Could return a null pointer
     std::shared_ptr<Label> getWeakLabel() { return m_label.lock(); }
 };
@@ -64,13 +64,13 @@ public:
     const std::shared_ptr<FontContext>& getFontContext() { return m_ftContext; }
 
     void updateOcclusions();
-    
+
     void setView(std::shared_ptr<View> _view) { m_view = _view; }
-    
+
     void setScreenSize(int _width, int _height) { m_screenSize = glm::vec2(_width, _height); }
 
 private:
-    
+
     int LODDiscardFunc(float _maxZoom, float _zoom);
 
     LabelContainer();
@@ -79,10 +79,9 @@ private:
 
     // reference to the <FontContext>
     std::shared_ptr<FontContext> m_ftContext;
-    
+
     std::mutex m_mutex;
-    
-    glm::mat4 m_viewProjection;
+
     glm::vec2 m_screenSize;
     std::shared_ptr<View> m_view;
     float m_currentZoom;

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -9,8 +9,6 @@
 #include "glm/gtc/matrix_transform.hpp"
 #include "glm/gtx/rotate_vector.hpp"
 
-#define MAX_LOD 6
-
 constexpr float View::s_maxZoom; // Create a stack reference to the static member variable
 
 double invLodFunc(double d) {

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -11,6 +11,8 @@
 #include "util/mapProjection.h"
 #include "util/tileID.h"
 
+#define MAX_LOD 6
+
 /* ViewModule
  * 1. Stores a representation of the current view into the map world
  * 2. Determines which tiles are visible in the current view


### PR DESCRIPTION
Add a function that decreases the possible distance to camera for a label at high zoom when level-of-detail is happening. This happens to discard labels at horizon when you're tilting the camera close to the ground plane. We could consolidate by applying this only for line labels. 

Edit: results of this function: http://cpp.sh/3cvb