### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,21 @@
-all: android osx osx-xcode ios
+all: android osx ios
 
 .PHONY: clean
 .PHONY: clean-android
 .PHONY: clean-osx
-.PHONY: clean-osx-xcode
+.PHONY: clean-xcode
 .PHONY: clean-ios
 .PHONY: clean-rpi
 .PHONY: clean-linux
 .PHONY: android
 .PHONY: osx
-.PHONY: osx-xcode
+.PHONY: xcode
 .PHONY: ios
 .PHONY: rpi
 .PHONY: linux
 .PHONY: check-ndk
 .PHONY: cmake-osx
-.PHONY: cmake-osx-xcode
+.PHONY: cmake-xcode
 .PHONY: cmake-android
 .PHONY: cmake-ios
 .PHONY: cmake-rpi
@@ -24,7 +24,7 @@ all: android osx osx-xcode ios
 
 ANDROID_BUILD_DIR = build/android
 OSX_BUILD_DIR = build/osx
-OSX_XCODE_BUILD_DIR = build/osx-xcode
+OSX_XCODE_BUILD_DIR = build/xcode
 IOS_BUILD_DIR = build/ios
 RPI_BUILD_DIR = build/rpi
 LINUX_BUILD_DIR = build/linux
@@ -79,7 +79,7 @@ RPI_CMAKE_PARAMS = \
 LINUX_CMAKE_PARAMS = \
 	-DPLATFORM_TARGET=linux
 
-clean: clean-android clean-osx clean-ios clean-rpi clean-tests clean-osx-xcode clean-linux
+clean: clean-android clean-osx clean-ios clean-rpi clean-tests clean-xcode clean-linux
 
 clean-android:
 	@cd android/ && \
@@ -99,7 +99,7 @@ clean-rpi:
 clean-linux:
 	rm -rf ${LINUX_BUILD_DIR}
 
-clean-osx-xcode:
+clean-xcode:
 	rm -rf ${OSX_XCODE_BUILD_DIR}
 
 clean-tests:
@@ -129,12 +129,12 @@ osx: ${OSX_BUILD_DIR}/Makefile
 
 ${OSX_BUILD_DIR}/Makefile: cmake-osx
 
-osx-xcode: ${OSX_XCODE_BUILD_DIR}/${OSX_XCODE_PROJ}
+xcode: ${OSX_XCODE_BUILD_DIR}/${OSX_XCODE_PROJ}
 	xcodebuild -target ${OSX_TARGET} -project ${OSX_XCODE_BUILD_DIR}/${OSX_XCODE_PROJ}
 
 ${OSX_XCODE_BUILD_DIR}/${OSX_XCODE_PROJ}: cmake-osx-xcode
 
-cmake-osx-xcode:
+cmake-xcode:
 	@mkdir -p ${OSX_XCODE_BUILD_DIR} 
 	@cd ${OSX_XCODE_BUILD_DIR} && \
 	cmake ../.. ${DARWIN_XCODE_CMAKE_PARAMS}

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ all: android osx ios
 .PHONY: osx
 .PHONY: xcode
 .PHONY: ios
+.PHONY: ios-sim
 .PHONY: rpi
 .PHONY: linux
 .PHONY: check-ndk
@@ -18,6 +19,7 @@ all: android osx ios
 .PHONY: cmake-xcode
 .PHONY: cmake-android
 .PHONY: cmake-ios
+.PHONY: cmake-ios-sim
 .PHONY: cmake-rpi
 .PHONY: cmake-linux
 .PHONY: install-android
@@ -26,6 +28,7 @@ ANDROID_BUILD_DIR = build/android
 OSX_BUILD_DIR = build/osx
 OSX_XCODE_BUILD_DIR = build/xcode
 IOS_BUILD_DIR = build/ios
+IOS_SIM_BUILD_DIR = build/ios-sim
 RPI_BUILD_DIR = build/rpi
 LINUX_BUILD_DIR = build/linux
 TESTS_BUILD_DIR = build/tests
@@ -45,10 +48,6 @@ ifndef ANDROID_API_LEVEL
 	ANDROID_API_LEVEL = android-19
 endif
 
-ifndef IOS_PLATFORM
-	IOS_PLATFORM = SIMULATOR
-endif
-
 UNIT_TESTS_CMAKE_PARAMS = \
 	-DUNIT_TESTS=1
 
@@ -62,7 +61,6 @@ ANDROID_CMAKE_PARAMS = \
 
 IOS_CMAKE_PARAMS = \
 	-DPLATFORM_TARGET=ios \
-	-DIOS_PLATFORM=${IOS_PLATFORM} \
 	-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_DIR}/iOS.toolchain.cmake \
 	-G Xcode
 
@@ -153,6 +151,16 @@ cmake-ios:
 	@mkdir -p ${IOS_BUILD_DIR}
 	@cd ${IOS_BUILD_DIR} && \
 	cmake ../.. ${IOS_CMAKE_PARAMS}
+
+ios-sim: ${IOS_SIM_BUILD_DIR}/${IOS_XCODE_PROJ}
+	xcodebuild -target ${IOS_TARGET} -project ${IOS_SIM_BUILD_DIR}/${IOS_XCODE_PROJ}
+
+${IOS_SIM_BUILD_DIR}/${IOS_XCODE_PROJ}: cmake-ios-sim
+
+cmake-ios-sim:
+	@mkdir -p ${IOS_SIM_BUILD_DIR}
+	@cd ${IOS_SIM_BUILD_DIR} && \
+	cmake ../.. ${IOS_CMAKE_PARAMS} -DIOS_PLATFORM=SIMULATOR
 
 rpi: cmake-rpi
 	@cd ${RPI_BUILD_DIR} && \

--- a/Makefile
+++ b/Makefile
@@ -129,17 +129,17 @@ osx: ${OSX_BUILD_DIR}/Makefile
 
 ${OSX_BUILD_DIR}/Makefile: cmake-osx
 
-osx-xcode: cmake-osx-xcode ${OSX_XCODE_BUILD_DIR}
+osx-xcode: ${OSX_XCODE_BUILD_DIR}/${OSX_XCODE_PROJ}
 	xcodebuild -target ${OSX_TARGET} -project ${OSX_XCODE_BUILD_DIR}/${OSX_XCODE_PROJ}
 
+${OSX_XCODE_BUILD_DIR}/${OSX_XCODE_PROJ}: cmake-osx-xcode
+
 cmake-osx-xcode:
-ifeq ($(wildcard ${OSX_XCODE_BUILD_DIR}/${OSX_XCODE_PROJ}/.*),)
 	@mkdir -p ${OSX_XCODE_BUILD_DIR} 
 	@cd ${OSX_XCODE_BUILD_DIR} && \
 	cmake ../.. ${DARWIN_XCODE_CMAKE_PARAMS}
-endif
 
-cmake-osx: 
+cmake-osx:
 	@mkdir -p ${OSX_BUILD_DIR} 
 	@cd ${OSX_BUILD_DIR} && \
 	cmake ../.. ${DARWIN_CMAKE_PARAMS}
@@ -150,11 +150,9 @@ ios: ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ}
 ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ}: cmake-ios
 
 cmake-ios:
-ifeq ($(wildcard ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ}/.*),)
 	@mkdir -p ${IOS_BUILD_DIR}
 	@cd ${IOS_BUILD_DIR} && \
 	cmake ../.. ${IOS_CMAKE_PARAMS}
-endif
 
 rpi: cmake-rpi
 	@cd ${RPI_BUILD_DIR} && \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cd build/linux/bin/ && ./tangram
 For running on the iOS simulator, generate and compile an XCode project:
 
 ```bash
-make ios
+make ios-sim
 ```
 
 Then just open the Xcode project and run/debug from there: 
@@ -73,7 +73,7 @@ For running on iOS devices you will need an iOS developer account, a valid code 
 First generate an XCode project without compiling:
 
 ```bash
-make cmake-ios IOS_PLATFORM=OS
+make cmake-ios
 ```
 
 Then open the Xcode project and set up your developer account information to run on a device:

--- a/travis/script_build.sh
+++ b/travis/script_build.sh
@@ -18,7 +18,7 @@ fi
 if [[ ${PLATFORM} == "ios" ]]; then
     # Build ios project
     echo "Building ios project (simulator)"
-    make -j ios
+    make ios-sim
 fi
 
 if [[ ${PLATFORM} == "android" ]]; then


### PR DESCRIPTION
Just a few usability improvements to our build process based on typical usage (for me):
 - allows cmake to update xcode projects without forcing you to clean the project; I end up needing to clean xcode projects a lot and it's just a waste to recompile our dependencies each time
 - makes the iOS build target devices by default (instead of the simulator) and makes it easier to build both options and switch between them quickly