### PR TITLE
Rename methods of Style and update comments

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -19,14 +19,14 @@ using namespace YAML;
 void SceneLoader::loadScene(const std::string& _file, Scene& _scene, TileManager& _tileManager, View& _view) {
 
     std::string configString = stringFromResource(_file.c_str());
-    
+
     Node config = YAML::Load(configString);
-    
+
     loadSources(config["sources"], _tileManager);
     loadLayers(config["layers"], _scene, _tileManager);
     loadCameras(config["cameras"], _view);
     loadLights(config["lights"], _scene);
-    
+
 }
 
 glm::vec4 parseVec4(const Node& node) {
@@ -56,21 +56,21 @@ glm::vec3 parseVec3(const Node& node) {
 }
 
 void SceneLoader::loadSources(Node sources, TileManager& tileManager) {
-    
+
     if(!sources) {
         logMsg("Warning: No source defined in the yaml scene configuration.\n");
         return;
     }
-    
+
     for (auto it = sources.begin(); it != sources.end(); ++it) {
-        
+
         const Node source = it->second;
         std::string name = it->first.as<std::string>();
         std::string type = source["type"].as<std::string>();
         std::string url = source["url"].as<std::string>();
-        
+
         std::unique_ptr<DataSource> sourcePtr;
-        
+
         if (type == "GeoJSONTiles") {
             sourcePtr = std::unique_ptr<DataSource>(new GeoJsonSource(name, url));
         } else if (type == "TopoJSONTiles") {
@@ -78,24 +78,24 @@ void SceneLoader::loadSources(Node sources, TileManager& tileManager) {
         } else if (type == "MVT") {
             sourcePtr = std::unique_ptr<DataSource>(new MVTSource(name, url));
         }
-        
+
         if (sourcePtr) {
             tileManager.addDataSource(std::move(sourcePtr));
         }
     }
-    
+
 }
 
 void SceneLoader::loadLights(Node lights, Scene& scene) {
 
-    if (!lights) { 
-        
+    if (!lights) {
+
         // Add an ambient light if nothing else is specified
         std::unique_ptr<AmbientLight> amb(new AmbientLight("defaultLight"));
         amb->setAmbientColor({ .5f, .5f, .5f, 1.f });
         scene.addLight(std::move(amb));
 
-        return; 
+        return;
     }
 
     for (auto it = lights.begin(); it != lights.end(); ++it) {
@@ -167,11 +167,11 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
             if (exponent) {
                 sLightPtr->setCutoffExponent(exponent.as<float>());
             }
-            
+
             lightPtr = std::unique_ptr<Light>(sLightPtr);
 
         }
-        
+
         Node origin = light["origin"];
         if (origin) {
             const std::string originStr = origin.as<std::string>();
@@ -183,7 +183,7 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
                 lightPtr->setOrigin(LightOrigin::GROUND);
             }
         }
-        
+
         Node ambient = light["ambient"];
         if (ambient) {
             lightPtr->setAmbientColor(parseVec4(ambient));
@@ -206,14 +206,14 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
 }
 
 void SceneLoader::loadCameras(Node cameras, View& view) {
-    
+
     // To correctly match the behavior of the webGL library we'll need a place to store multiple view instances.
     // Since we only have one global view right now, we'll just apply the settings from the first active camera we find.
-    
+
     for (auto it = cameras.begin(); it != cameras.end(); ++it) {
-        
+
         const Node camera = it->second;
-        
+
         const std::string type = camera["type"].as<std::string>();
         if (type == "perspective") {
             // The default camera
@@ -221,12 +221,12 @@ void SceneLoader::loadCameras(Node cameras, View& view) {
             if (fov) {
                 // TODO
             }
-            
+
             Node focal = camera["focal_length"];
             if (focal) {
                 // TODO
             }
-            
+
             Node vanishing = camera["vanishing_point"];
             if (vanishing) {
                 // TODO
@@ -240,11 +240,11 @@ void SceneLoader::loadCameras(Node cameras, View& view) {
         } else if (type == "flat") {
             // TODO
         }
-        
+
         double x = -74.00976419448854;
         double y = 40.70532700869127;
         float z = 16;
-        
+
         Node position = camera["position"];
         if (position) {
             x = position[0].as<double>();
@@ -255,20 +255,20 @@ void SceneLoader::loadCameras(Node cameras, View& view) {
         }
         glm::dvec2 projPos = view.getMapProjection().LonLatToMeters(glm::dvec2(x, y));
         view.setPosition(projPos.x, projPos.y);
-        
+
         Node zoom = camera["zoom"];
         if (zoom) {
             z = zoom.as<float>();
         }
         view.setZoom(z);
-        
+
         Node active = camera["active"];
         if (active) {
             break;
         }
-        
+
     }
-    
+
 }
 
 void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager) {
@@ -281,10 +281,10 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
     auto polygonStyle = std::unique_ptr<PolygonStyle>(new PolygonStyle("polygons"));
     auto polylineStyle = std::unique_ptr<PolylineStyle>(new PolylineStyle("lines"));
     auto debugStyle = std::unique_ptr<DebugStyle>(new DebugStyle("debug"));
-    
+
     // TODO: configure style properties in styles block
-    polygonStyle->setLighting(LightingType::vertex);
-    polylineStyle->setLighting(LightingType::vertex);
+    polygonStyle->setLightingType(LightingType::vertex);
+    polylineStyle->setLightingType(LightingType::vertex);
 
     for (auto layerIt = layers.begin(); layerIt != layers.end(); ++layerIt) {
 
@@ -318,7 +318,7 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
 
             Node width = styleProps["width"];
             if (width) { params.width = width.as<float>(); }
-            
+
             Node cap = styleProps["cap"];
             if (cap) {
                 std::string capString = cap.as<std::string>();
@@ -326,7 +326,7 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
                 else if (capString == "sqaure") { params.line.cap = CapTypes::SQUARE; }
                 else if (capString == "round") { params.line.cap = CapTypes::ROUND; }
             }
-            
+
             Node join = styleProps["join"];
             if (join) {
                 std::string joinString = join.as<std::string>();
@@ -334,12 +334,12 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
                 else if (joinString == "miter") { params.line.join = JoinTypes::MITER; }
                 else if (joinString == "round") { params.line.join = JoinTypes::ROUND; }
             }
-            
+
             Node outline = styleProps["outline"];
             if (outline) {
-                
+
                 params.outline.on = true;
-                
+
                 Node color = outline["color"];
                 if (color) {
                     glm::vec4 c = parseVec4(color);
@@ -349,10 +349,10 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
                     (uint32_t(c.r * 255));
                     // TODO: color helper funtions
                 }
-                
+
                 Node width = outline["width"];
                 if (width) { params.outline.width = width.as<float>(); }
-                
+
                 Node cap = outline["cap"];
                 if (cap) {
                     std::string capString = cap.as<std::string>();
@@ -360,7 +360,7 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
                     else if (capString == "sqaure") { params.outline.line.cap = CapTypes::SQUARE; }
                     else if (capString == "round") { params.outline.line.cap = CapTypes::ROUND; }
                 }
-                
+
                 Node join = outline["join"];
                 if (join) {
                     std::string joinString = join.as<std::string>();
@@ -368,7 +368,7 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
                     else if (joinString == "miter") { params.outline.line.join = JoinTypes::MITER; }
                     else if (joinString == "round") { params.outline.line.join = JoinTypes::ROUND; }
                 }
-                
+
             }
 
             // match to built-in styles
@@ -389,5 +389,5 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
     scene.addStyle(std::move(debugStyle));
 
     // tileManager isn't used yet, but we'll need it soon to get the list of data sources
-    
+
 }

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -9,7 +9,7 @@ DebugTextStyle::DebugTextStyle(const std::string& _fontName, std::string _name, 
 void DebugTextStyle::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) const {
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::TILE_INFOS)) {
-        prepareDataProcessing(_tile);
+        onBeginBuildTile(_tile);
 
         Mesh* mesh = new Mesh(m_vertexLayout, m_drawMode);
 
@@ -38,7 +38,7 @@ void DebugTextStyle::addData(TileData& _data, MapTile& _tile, const MapProjectio
 
         _tile.addGeometry(*this, std::unique_ptr<VboMesh>(mesh));
 
-        finishDataProcessing(_tile);
+        onEndBuildTile(_tile);
     }
 
 }

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -2,20 +2,20 @@
 #include "texture.h"
 
 SpriteStyle::SpriteStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
-    
+
     constructVertexLayout();
     constructShaderProgram();
-    
+
 }
 
 SpriteStyle::~SpriteStyle() {
-    
+
     m_texture->destroy();
-    
+
 }
 
 void SpriteStyle::constructVertexLayout() {
-    
+
     m_vertexLayout = std::shared_ptr<VertexLayout>(new VertexLayout({
         {"a_position", 3, GL_FLOAT, false, 0},
         {"a_uv", 2, GL_FLOAT, false, 0},
@@ -24,51 +24,51 @@ void SpriteStyle::constructVertexLayout() {
 }
 
 void SpriteStyle::constructShaderProgram() {
-    
+
     std::string fragShaderSrcStr = stringFromResource("texture.fs");
     std::string vertShaderSrcStr = stringFromResource("texture.vs");
-    
+
     m_shaderProgram = std::make_shared<ShaderProgram>();
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
-    
+
     m_texture = std::shared_ptr<Texture>(new Texture("mapzen-logo.png"));
 }
 
 void SpriteStyle::buildPoint(Point& _point, StyleParams& _params, Properties& _props, VboMesh& _mesh) const {
-    
+
 }
 
 void SpriteStyle::buildLine(Line& _line, StyleParams& _params, Properties& _props, VboMesh& _mesh) const {
-    
+
 }
 
 void SpriteStyle::buildPolygon(Polygon& _polygon, StyleParams& _params, Properties& _props, VboMesh& _mesh) const {
-    
+
 }
 
-void SpriteStyle::setupFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
+void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
     m_texture->update(0);
     m_texture->bind(0);
     m_shaderProgram->setUniformi("u_tex", 0);
 }
 
 void SpriteStyle::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) const {
-    
+
     Mesh* mesh = new Mesh(m_vertexLayout, m_drawMode);
-    
+
     std::vector<PosUVVertex> vertices;
-    
+
     vertices.reserve(4);
-    
+
     float size = 0.2;
     vertices.push_back({  size,  size, 0.f, 1.f, 0.f });
     vertices.push_back({ -size,  size, 0.f, 0.f, 0.f });
     vertices.push_back({ -size, -size, 0.f, 0.f, 1.f });
     vertices.push_back({  size, -size, 0.f, 1.f, 1.f });
-    
+
     mesh->addVertices(std::move(vertices), { 0, 1, 2, 2, 3, 0 });
     mesh->compileVertexBuffer();
-    
+
     _tile.addGeometry(*this, std::unique_ptr<VboMesh>(mesh));
-    
+
 }

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -4,9 +4,9 @@
 #include "util/typedMesh.h"
 
 class SpriteStyle : public Style {
-    
+
 protected:
-    
+
     struct PosUVVertex {
         // Position Data
         GLfloat pos_x;
@@ -16,7 +16,7 @@ protected:
         GLfloat u;
         GLfloat v;
     };
-    
+
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
     virtual void buildPoint(Point& _point, StyleParams& _params, Properties& _props, VboMesh& _mesh) const override;
@@ -25,19 +25,19 @@ protected:
     virtual void addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) const override;
 
     typedef TypedMesh<PosUVVertex> Mesh;
-    
+
     virtual VboMesh* newMesh() const override {
         return nullptr;
     };
-    
+
     std::shared_ptr<Texture> m_texture;
-    
+
 public:
-    
-    virtual void setupFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
-    
+
+    virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
+
     SpriteStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);
-    
+
     virtual ~SpriteStyle();
-    
+
 };

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -7,7 +7,7 @@ Style::Style(std::string _name, GLenum _drawMode) : m_name(_name), m_drawMode(_d
 Style::~Style() {
 }
 
-void Style::setMaterial(const std::shared_ptr<Material>& _material){
+void Style::setMaterial(const std::shared_ptr<Material>& _material) {
 
     if ( m_material ) {
         m_material->removeFromProgram(m_shaderProgram);
@@ -15,32 +15,34 @@ void Style::setMaterial(const std::shared_ptr<Material>& _material){
 
     m_material = _material;
     m_material->injectOnProgram(m_shaderProgram);
-    
+
 }
 
 void Style::addLayer(const std::pair<std::string, StyleParams>& _layer) {
+
     m_layers.push_back(_layer);
+
 }
 
 void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection)  const {
-    prepareDataProcessing(_tile);
+    onBeginBuildTile(_tile);
 
     VboMesh* mesh = newMesh();
-    
+
     for (auto& layer : _data.layers) {
-        
+
         // Skip any layers that this style doesn't have a rule for
         auto it = m_layers.begin();
         while (it != m_layers.end() && it->first != layer.name) { ++it; }
         if (it == m_layers.end()) { continue; }
 
         StyleParams params = it->second;
-        
+
         // Loop over all features
         for (auto& feature : layer.features) {
 
             feature.props.numericProps["zoom"] = _tile.getID().z;
-            
+
             switch (feature.geometryType) {
                 case GeometryType::POINTS:
                     // Build points
@@ -73,27 +75,28 @@ void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapPr
 
         _tile.addGeometry(*this, std::unique_ptr<VboMesh>(mesh));
     }
-    finishDataProcessing(_tile);
+    onEndBuildTile(_tile);
 }
 
-void Style::setupFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
-    
+void Style::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
+
     // Set up material
     if (!m_material) {
         setMaterial(std::make_shared<Material>());
     }
-    
+
     m_material->setupProgram(m_shaderProgram);
-    
+
     // Set up lights
     for (const auto& light : _scene->getLights()) {
-        light.second->setupProgram(_view,m_shaderProgram);
+        light.second->setupProgram(_view, m_shaderProgram);
     }
-    
+
     m_shaderProgram->setUniformf("u_zoom", _view->getZoom());
+
 }
 
-void Style::setLighting( LightingType _lType ){
+void Style::setLightingType(LightingType _lType){
 
     if ( _lType == LightingType::vertex ) {
         m_shaderProgram->removeSourceBlock("defines", "#define TANGRAM_LIGHTING_FRAGMENT\n");
@@ -105,17 +108,17 @@ void Style::setLighting( LightingType _lType ){
         m_shaderProgram->removeSourceBlock("defines", "#define TANGRAM_LIGHTING_VERTEX\n");
         m_shaderProgram->removeSourceBlock("defines", "#define TANGRAM_LIGHTING_FRAGMENT\n");
     }
-    
+
 }
-    
-void Style::setupTile(const std::shared_ptr<MapTile>& _tile) {
+
+void Style::onBeginDrawTile(const std::shared_ptr<MapTile>& _tile) {
     // No-op by default
 }
 
-void Style::prepareDataProcessing(MapTile& _tile) const {
+void Style::onBeginBuildTile(MapTile& _tile) const {
     // No-op by default
 }
 
-void Style::finishDataProcessing(MapTile& _tile) const {
+void Style::onEndBuildTile(MapTile& _tile) const {
     // No-op by default
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -174,7 +174,7 @@ void TextStyle::buildPolygon(Polygon& _polygon, StyleParams& _params, Properties
     }
 }
 
-void TextStyle::prepareDataProcessing(MapTile& _tile) const {
+void TextStyle::onBeginBuildTile(MapTile& _tile) const {
     auto ftContext = LabelContainer::GetInstance()->getFontContext();
     auto buffer = ftContext->genTextBuffer();
 
@@ -188,7 +188,7 @@ void TextStyle::prepareDataProcessing(MapTile& _tile) const {
     TextStyle::s_processedTile = &_tile;
 }
 
-void TextStyle::finishDataProcessing(MapTile& _tile) const {
+void TextStyle::onEndBuildTile(MapTile& _tile) const {
     auto ftContext = LabelContainer::GetInstance()->getFontContext();
 
     TextStyle::s_processedTile = nullptr;
@@ -197,7 +197,7 @@ void TextStyle::finishDataProcessing(MapTile& _tile) const {
     ftContext->unlock();
 }
 
-void TextStyle::setupTile(const std::shared_ptr<MapTile>& _tile) {
+void TextStyle::onBeginDrawTile(const std::shared_ptr<MapTile>& _tile) {
     auto buffer = _tile->getTextBuffer(*this);
 
     if (buffer) {
@@ -213,7 +213,7 @@ void TextStyle::setupTile(const std::shared_ptr<MapTile>& _tile) {
     }
 }
 
-void TextStyle::setupFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
+void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
     auto ftContext = LabelContainer::GetInstance()->getFontContext();
     const auto& atlas = ftContext->getAtlas();
     float projectionMatrix[16] = {0};
@@ -238,7 +238,7 @@ void TextStyle::setupFrame(const std::shared_ptr<View>& _view, const std::shared
     glDisable(GL_DEPTH_TEST);
 }
 
-void TextStyle::teardown() {
+void TextStyle::onEndDrawFrame() {
     glDisable(GL_BLEND);
     glEnable(GL_DEPTH_TEST);
 }

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -23,8 +23,8 @@ protected:
     virtual void buildPoint(Point& _point, StyleParams& _params, Properties& _props, VboMesh& _mesh) const override;
     virtual void buildLine(Line& _line, StyleParams& _params, Properties& _props, VboMesh& _mesh) const override;
     virtual void buildPolygon(Polygon& _polygon, StyleParams& _params, Properties& _props, VboMesh& _mesh) const override;
-    virtual void prepareDataProcessing(MapTile& _tile) const override;
-    virtual void finishDataProcessing(MapTile& _tile) const override;
+    virtual void onBeginBuildTile(MapTile& _tile) const override;
+    virtual void onEndBuildTile(MapTile& _tile) const override;
 
     typedef TypedMesh<PosTexID> Mesh;
 
@@ -43,9 +43,9 @@ public:
     TextStyle(const std::string& _fontName, std::string _name, float _fontSize, unsigned int _color = 0xffffff,
               bool _sdf = false, bool _sdfMultisampling = false, GLenum _drawMode = GL_TRIANGLES);
 
-    virtual void setupFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
-    virtual void setupTile(const std::shared_ptr<MapTile>& _tile) override;
-    virtual void teardown() override;
+    virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
+    virtual void onBeginDrawTile(const std::shared_ptr<MapTile>& _tile) override;
+    virtual void onEndDrawFrame() override;
 
     virtual ~TextStyle();
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -28,12 +28,12 @@ namespace Tangram {
     std::shared_ptr<FontContext> m_ftContext;
     std::shared_ptr<DebugStyle> m_debugStyle;
     std::shared_ptr<Skybox> m_skybox;
-    
+
     static float g_time = 0.0;
     static unsigned long g_flags = 0;
 
     void initialize() {
-        
+
         logMsg("initialize\n");
 
         // Create view
@@ -52,7 +52,7 @@ namespace Tangram {
         // Create a tileManager
         if (!m_tileManager) {
             m_tileManager = TileManager::GetInstance();
-            
+
             // Pass references to the view and scene into the tile manager
             m_tileManager->setView(m_view);
             m_tileManager->setScene(m_scene);
@@ -60,7 +60,7 @@ namespace Tangram {
 
         SceneLoader loader;
         loader.loadScene("config.yaml", *m_scene, *m_tileManager, *m_view);
-        
+
         // Hard-coded setup for stuff that isn't loaded through the config file yet
         m_ftContext = std::make_shared<FontContext>();
         m_ftContext->addFont("FiraSans-Medium.ttf", "FiraSans");
@@ -68,17 +68,17 @@ namespace Tangram {
         m_labelContainer = LabelContainer::GetInstance();
         m_labelContainer->setFontContext(m_ftContext);
         m_labelContainer->setView(m_view);
-        
+
         std::unique_ptr<Style> textStyle0(new TextStyle("FiraSans", "Textstyle0", 15.0f, 0xF7F0E1, true, true));
         textStyle0->addLayer({ "roads", StyleParams() });
         textStyle0->addLayer({ "places", StyleParams() });
         textStyle0->addLayer({ "pois", StyleParams() });
         m_scene->addStyle(std::move(textStyle0));
-        
+
         std::unique_ptr<Style> textStyle1(new TextStyle("Futura", "Textstyle1", 18.0f, 0x26241F, true, true));
         textStyle1->addLayer({ "landuse", StyleParams() });
         m_scene->addStyle(std::move(textStyle1));
-        
+
         std::unique_ptr<Style> debugTextStyle(new DebugTextStyle("FiraSans", "DebugTextStyle", 30.0f, 0xDC3522, true));
         m_scene->addStyle(std::move(debugTextStyle));
 
@@ -102,7 +102,7 @@ namespace Tangram {
     }
 
     void resize(int _newWidth, int _newHeight) {
-        
+
         logMsg("resize: %d x %d\n", _newWidth, _newHeight);
 
         glViewport(0, 0, _newWidth, _newHeight);
@@ -110,7 +110,7 @@ namespace Tangram {
         if (m_view) {
             m_view->setSize(_newWidth, _newHeight);
         }
-        
+
         if (m_ftContext) {
             m_ftContext->setScreenSize(m_view->getWidth(), m_view->getHeight());
             m_labelContainer->setScreenSize(m_view->getWidth(), m_view->getHeight());
@@ -121,23 +121,23 @@ namespace Tangram {
     }
 
     void update(float _dt) {
-    
+
         g_time += _dt;
 
         if (m_view) {
-            
+
             m_view->update();
 
             m_tileManager->updateTileSet();
 
             if(m_view->changedOnLastUpdate() || m_tileManager->hasTileSetChanged() || Label::s_needUpdate) {
                 Label::s_needUpdate = false;
-                
+
                 for (const auto& mapIDandTile : m_tileManager->getVisibleTiles()) {
                     const std::shared_ptr<MapTile>& tile = mapIDandTile.second;
                     tile->update(_dt, *m_view);
                 }
-                
+
                 // update labels for specific style
                 for (const auto& style : m_scene->getStyles()) {
                     for (const auto& mapIDandTile : m_tileManager->getVisibleTiles()) {
@@ -145,10 +145,10 @@ namespace Tangram {
                         tile->updateLabels(_dt, *style, *m_view);
                     }
                 }
-                
+
                 // manage occlusions
                 m_labelContainer->updateOcclusions();
-                
+
                 for (const auto& style : m_scene->getStyles()) {
                     for (const auto& mapIDandTile : m_tileManager->getVisibleTiles()) {
                         const std::shared_ptr<MapTile>& tile = mapIDandTile.second;
@@ -156,46 +156,46 @@ namespace Tangram {
                     }
                 }
             }
-            
+
             if (Label::s_needUpdate) {
                 requestRender();
             }
         }
-        
+
         if(m_scene) {
             // Update lights and styles
         }
     }
 
     void render() {
-        
+
         // Set up openGL for new frame
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        
+
         // Loop over all styles
         for (const auto& style : m_scene->getStyles()) {
-            style->setupFrame(m_view, m_scene);
+            style->onBeginDrawFrame(m_view, m_scene);
 
             // Loop over all tiles in m_tileSet
             for (const auto& mapIDandTile : m_tileManager->getVisibleTiles()) {
                 const std::shared_ptr<MapTile>& tile = mapIDandTile.second;
                 if (tile->hasGeometry()) {
                     // Draw tile!
-                    style->setupTile(tile);
+                    style->onBeginDrawTile(tile);
                     tile->draw(*style, *m_view);
                 }
             }
 
-            style->teardown();
+            style->onEndDrawFrame();
         }
 
         m_skybox->draw(*m_view);
-        
+
         while (Error::hadGlError("Tangram::render()")) {}
     }
 
     void setViewPosition(double _lon, double _lat) {
-        
+
         glm::dvec2 meters = m_view->getMapProjection().LonLatToMeters({ _lon, _lat});
         m_view->setPosition(meters.x, meters.y);
 
@@ -207,7 +207,7 @@ namespace Tangram {
         glm::dvec2 degrees = m_view->getMapProjection().MetersToLonLat(meters);
         _lon = degrees.x;
         _lat = degrees.y;
-        
+
     }
 
     float getViewRotation() {
@@ -215,7 +215,7 @@ namespace Tangram {
         return m_view->getRoll();
 
     }
-    
+
     float getViewZoom() {
 
         return m_view->getZoom();
@@ -223,7 +223,7 @@ namespace Tangram {
     }
 
     void setPixelScale(float _pixelsPerPoint) {
-        
+
         if (m_view) {
             m_view->setPixelScale(_pixelsPerPoint);
         }
@@ -231,14 +231,14 @@ namespace Tangram {
         for (auto& style : m_scene->getStyles()) {
             style->setPixelScale(_pixelsPerPoint);
         }
-        
+
     }
-        
+
     void handleTapGesture(float _posX, float _posY) {
-        
+
         float viewCenterX = 0.5f * m_view->getWidth();
         float viewCenterY = 0.5f * m_view->getHeight();
-        
+
         m_view->screenToGroundPlane(viewCenterX, viewCenterY);
         m_view->screenToGroundPlane(_posX, _posY);
 
@@ -247,12 +247,12 @@ namespace Tangram {
     }
 
     void handleDoubleTapGesture(float _posX, float _posY) {
-        
+
         handlePinchGesture(_posX, _posY, 2.f);
     }
 
     void handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
-        
+
         m_view->screenToGroundPlane(_startX, _startY);
         m_view->screenToGroundPlane(_endX, _endY);
 
@@ -260,33 +260,33 @@ namespace Tangram {
     }
 
     void handlePinchGesture(float _posX, float _posY, float _scale) {
-        
+
         float viewCenterX = 0.5f * m_view->getWidth();
         float viewCenterY = 0.5f * m_view->getHeight();
-        
+
         m_view->screenToGroundPlane(viewCenterX, viewCenterY);
         m_view->screenToGroundPlane(_posX, _posY);
-        
+
         m_view->translate((_posX - viewCenterX)*(1-1/_scale), (_posY - viewCenterY)*(1-1/_scale));
-        
+
         m_view->zoom(log2f(_scale));
     }
-        
+
     void handleRotateGesture(float _posX, float _posY, float _radians) {
-        
+
         m_view->screenToGroundPlane(_posX, _posY);
         m_view->orbit(_posX, _posY, _radians);
-        
+
     }
 
     void handleShoveGesture(float _distance) {
-        
+
         m_view->pitch(_distance);
-        
+
     }
-    
+
     void setDebugFlag(DebugFlags _flag, bool _on) {
-        
+
         if (_on) {
             g_flags |= (1 << _flag); // |ing with a bitfield that is 0 everywhere except index _flag; sets index _flag to 1
         } else {
@@ -294,13 +294,13 @@ namespace Tangram {
         }
 
         m_view->setZoom(m_view->getZoom()); // Force the view to refresh
-        
+
     }
-    
+
     bool getDebugFlag(DebugFlags _flag) {
-        
+
         return (g_flags & (1 << _flag)) != 0; // &ing with a bitfield that is 0 everywhere except index _flag will yield 0 iff index _flag is 0
-        
+
     }
 
     void teardown() {
@@ -312,9 +312,9 @@ namespace Tangram {
     }
 
     void onContextDestroyed() {
-        
+
         logMsg("context destroyed\n");
-        
+
         // The OpenGL context has been destroyed since the last time resources were created,
         // so we invalidate all data that depends on OpenGL object handles.
 
@@ -323,7 +323,7 @@ namespace Tangram {
 
         // Buffer objects are invalidated and re-uploaded the next time they are used
         VboMesh::invalidateAllVBOs();
-        
+
     }
 
 }


### PR DESCRIPTION
No functionality changes; simply updating the method names and comments in `Style` to better reflect current usage. 

I also just turned on white space stripping in my editor, so there are a lot of changes for that (sorry!)