### PR TITLE
Move re-draw requests after input events from platform code into core

### DIFF
--- a/android/src/com/mapzen/tangram/Tangram.java
+++ b/android/src/com/mapzen/tangram/Tangram.java
@@ -137,7 +137,6 @@ public class Tangram implements Renderer, OnTouchListener, OnScaleGestureListene
             scaleGestureDetector.onTouchEvent(event) |
             rotateGestureDetector.onTouchEvent(event) |
             shoveGestureDetector.onTouchEvent(event)) {
-            requestRender();
             return true;
         }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -244,6 +244,7 @@ namespace Tangram {
 
         m_view->translate((_posX - viewCenterX), (_posY - viewCenterY));
 
+        requestRender();
     }
 
     void handleDoubleTapGesture(float _posX, float _posY) {
@@ -257,6 +258,8 @@ namespace Tangram {
         m_view->screenToGroundPlane(_endX, _endY);
 
         m_view->translate(_startX - _endX, _startY - _endY);
+
+        requestRender();
     }
 
     void handlePinchGesture(float _posX, float _posY, float _scale) {
@@ -270,6 +273,8 @@ namespace Tangram {
         m_view->translate((_posX - viewCenterX)*(1-1/_scale), (_posY - viewCenterY)*(1-1/_scale));
 
         m_view->zoom(log2f(_scale));
+
+        requestRender();
     }
 
     void handleRotateGesture(float _posX, float _posY, float _radians) {
@@ -277,12 +282,14 @@ namespace Tangram {
         m_view->screenToGroundPlane(_posX, _posY);
         m_view->orbit(_posX, _posY, _radians);
 
+        requestRender();
     }
 
     void handleShoveGesture(float _distance) {
 
         m_view->pitch(_distance);
 
+        requestRender();
     }
 
     void setDebugFlag(DebugFlags _flag, bool _on) {

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -104,13 +104,11 @@
 - (void)respondToTapGesture:(UITapGestureRecognizer *)tapRecognizer {
     CGPoint location = [tapRecognizer locationInView:self.view];
     Tangram::handleTapGesture(location.x * self.pixelScale, location.y * self.pixelScale);
-    [self renderOnce];
 }
 
 - (void)respondToDoubleTapGesture:(UITapGestureRecognizer *)doubleTapRecognizer {
     CGPoint location = [doubleTapRecognizer locationInView:self.view];
     Tangram::handleDoubleTapGesture(location.x * self.pixelScale, location.y * self.pixelScale);
-    [self renderOnce];
 }
 
 - (void)respondToPanGesture:(UIPanGestureRecognizer *)panRecognizer {
@@ -119,7 +117,6 @@
     CGPoint end = [panRecognizer locationInView:self.view];
     CGPoint start = {end.x - displacement.x, end.y - displacement.y};
     Tangram::handlePanGesture(start.x * self.pixelScale, start.y * self.pixelScale, end.x * self.pixelScale, end.y * self.pixelScale);
-    [self renderOnce];
 }
 
 - (void)respondToPinchGesture:(UIPinchGestureRecognizer *)pinchRecognizer {
@@ -127,7 +124,6 @@
     CGFloat scale = pinchRecognizer.scale;
     [pinchRecognizer setScale:1.0];
     Tangram::handlePinchGesture(location.x * self.pixelScale, location.y * self.pixelScale, scale);
-    [self renderOnce];
 }
 
 - (void)respondToRotationGesture:(UIRotationGestureRecognizer *)rotationRecognizer {
@@ -135,14 +131,12 @@
     CGFloat rotation = rotationRecognizer.rotation;
     [rotationRecognizer setRotation:0.0];
     Tangram::handleRotateGesture(position.x * self.pixelScale, position.y * self.pixelScale, rotation);
-    [self renderOnce];
 }
 
 - (void)respondToShoveGesture:(UIPanGestureRecognizer *)shoveRecognizer {
     CGPoint displacement = [shoveRecognizer translationInView:self.view];
     [shoveRecognizer setTranslation:{0, 0} inView:self.view];
     Tangram::handleShoveGesture(displacement.y / self.view.bounds.size.height);
-    [self renderOnce];
 }
 
 - (void)dealloc


### PR DESCRIPTION
Instead of needing the input code on every platform to request re-drawing after an input event, this just makes the core input handlers request a re-draw. Simple. 