### PR TITLE
Concurrent gesture fix

### DIFF
--- a/android/src/com/mapzen/tangram/Tangram.java
+++ b/android/src/com/mapzen/tangram/Tangram.java
@@ -132,26 +132,12 @@ public class Tangram implements Renderer, OnTouchListener, OnScaleGestureListene
 
     public boolean onTouch(View v, MotionEvent event) {
 
-        // Pass the event to gesture detectors in order of decreasing specificity
-
+        gestureDetector.onTouchEvent(event);
         shoveGestureDetector.onTouchEvent(event);
-
-        if (shoveGestureDetector.isInProgress()) {
-            return true;
-        }
-
         scaleGestureDetector.onTouchEvent(event);
         rotateGestureDetector.onTouchEvent(event);
 
-        if (scaleGestureDetector.isInProgress() || rotateGestureDetector.isInProgress()) {
-            return true;
-        }
-
-        if (gestureDetector.onTouchEvent(event)) {
-            return true;
-        }
-
-        return false;
+        return true;
 
     }
 
@@ -230,7 +216,7 @@ public class Tangram implements Renderer, OnTouchListener, OnScaleGestureListene
     // ===================================================
 
     public boolean onScaleBegin(ScaleGestureDetector detector) {
-        return true;
+        return !shoveGestureDetector.isInProgress();
     }
 
     public boolean onScale(ScaleGestureDetector detector) {
@@ -246,7 +232,7 @@ public class Tangram implements Renderer, OnTouchListener, OnScaleGestureListene
     // =====================================================
 
     public boolean onRotateBegin(RotateGestureDetector detector) {
-        return true;
+        return !shoveGestureDetector.isInProgress();
     }
 
     public boolean onRotate(RotateGestureDetector detector) {
@@ -265,7 +251,7 @@ public class Tangram implements Renderer, OnTouchListener, OnScaleGestureListene
     // ===================================================
 
     public boolean onShoveBegin(ShoveGestureDetector detector) {
-        return true;
+        return !(scaleGestureDetector.isInProgress() || rotateGestureDetector.isInProgress());
     }
 
     public boolean onShove(ShoveGestureDetector detector) {


### PR DESCRIPTION
Mostly this is just to make concurrent gestures on android less insane. Concurrent rotation and scale are allowed, but rotation/scale and tilt (shove) are mutually exclusive. The limitation of this fix is that gestures in which the touches begin in a horizontal orientation (within ~20 degrees of the screen's x-axis) will always be recognized as a shove, even if the touches move in opposite directions. This is a consequence of the gesture library that we use on android and we'll probably revisit this in the future. 