### PR TITLE
Use raw arrays for compiled vertex and index data

### DIFF
--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -32,10 +32,6 @@ MapTile::MapTile(MapTile&& _other) : m_id(std::move(m_id)), m_proxyCounter(std::
 
 MapTile::~MapTile() {
 
-    m_geometry.clear();
-    m_buffers.clear();
-    m_labels.clear();
-
 }
 
 void MapTile::addGeometry(const Style& _style, std::unique_ptr<VboMesh> _mesh) {

--- a/core/src/util/vboMesh.cpp
+++ b/core/src/util/vboMesh.cpp
@@ -32,6 +32,9 @@ VboMesh::VboMesh() {
 VboMesh::~VboMesh() {
     if (m_glVertexBuffer) glDeleteBuffers(1, &m_glVertexBuffer);
     if (m_glIndexBuffer) glDeleteBuffers(1, &m_glIndexBuffer);
+    
+    delete[] m_glVertexData;
+    delete[] m_glIndexData;
 }
 
 void VboMesh::setVertexLayout(std::shared_ptr<VertexLayout> _vertexLayout) {
@@ -63,12 +66,12 @@ void VboMesh::upload() {
 
     // TODO check if compiled?
     // Buffer vertex data
-    int vertexBytes = m_glVertexData.size();
+    int vertexBytes = m_nVertices * m_vertexLayout->getStride();
 
     glBindBuffer(GL_ARRAY_BUFFER, m_glVertexBuffer);
-    glBufferData(GL_ARRAY_BUFFER, vertexBytes, m_glVertexData.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, vertexBytes, m_glVertexData, GL_STATIC_DRAW);
 
-    if (!m_glIndexData.empty()) {
+    if (m_glIndexData) {
         
         if (m_glIndexBuffer == 0) {
             glGenBuffers(1, &m_glIndexBuffer);
@@ -76,8 +79,7 @@ void VboMesh::upload() {
 
         // Buffer element index data
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_glIndexBuffer);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_glIndexData.size() * sizeof(GLushort),
-                     m_glIndexData.data(), GL_STATIC_DRAW);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_nIndices * sizeof(GLushort), m_glIndexData, GL_STATIC_DRAW);
     }
 
     // m_glVertexData.resize(0);

--- a/core/src/util/vboMesh.h
+++ b/core/src/util/vboMesh.h
@@ -81,12 +81,12 @@ protected:
     int m_nVertices;
     GLuint m_glVertexBuffer;
     // Compiled vertices for upload
-    std::vector<GLbyte> m_glVertexData;
+    GLbyte* m_glVertexData = nullptr;
 
     int m_nIndices;
     GLuint m_glIndexBuffer;
     // Compiled  indices for upload
-    std::vector<GLushort> m_glIndexData;
+    GLushort* m_glIndexData = nullptr;
 
     GLenum m_drawMode;
 
@@ -112,14 +112,11 @@ protected:
         int vPos = 0, iPos = 0;
 
         int stride = m_vertexLayout->getStride();
-        m_glVertexData.resize(stride * m_nVertices);
-        GLbyte* vBuffer = m_glVertexData.data();
+        m_glVertexData = new GLbyte[stride * m_nVertices];
 
-        GLushort* iBuffer = nullptr;
         bool useIndices = m_nIndices > 0;
         if (useIndices) {
-            m_glIndexData.resize(m_nIndices);
-            iBuffer = m_glIndexData.data();
+            m_glIndexData = new GLushort[m_nIndices];
         }
 
         for (size_t i = 0; i < vertices.size(); i++) {
@@ -127,7 +124,7 @@ protected:
             size_t nVertices = curVertices.size();
             int nBytes = nVertices * stride;
 
-            std::memcpy(vBuffer + vPos, (GLbyte*)curVertices.data(), nBytes);
+            std::memcpy(m_glVertexData + vPos, (GLbyte*)curVertices.data(), nBytes);
             vPos += nBytes;
 
             if (useIndices) {
@@ -140,7 +137,7 @@ protected:
                 }
 
                 for (int idx : indices[i]) {
-                    iBuffer[iPos++] = idx + vertexOffset;
+                    m_glIndexData[iPos++] = idx + vertexOffset;
                 }
                 indexOffset += indices[i].size();
             }


### PR DESCRIPTION
In master right now, the most expensive operation that happens on the rendering thread is destroying the `VboMesh` from every tile that goes out of view. This comes down to the fact that `VboMesh` holds its vertex data and index data in `std::vector`s and destroying a large `std::vector` is measurably quite slow (maybe it has to call a destructor on every element? not sure). 

This change replaces those `std::vector`s with raw arrays of bytes and shorts, which can be quickly and simply destroyed with a `delete[]`