### PR TITLE
Android API level 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifndef ANDROID_ARCH
 endif
 
 ifndef ANDROID_API_LEVEL
-	ANDROID_API_LEVEL = android-19
+	ANDROID_API_LEVEL = android-15
 endif
 
 UNIT_TESTS_CMAKE_PARAMS = \

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,11 +20,11 @@ dependencies {
 
 android {
 
-    compileSdkVersion 19
+    compileSdkVersion 15
     buildToolsVersion "21.1.2"
 
     sourceSets.main {
-        
+
         manifest.srcFile 'AndroidManifest.xml'
         java.srcDirs = ['src']
         jni.srcDirs = []

--- a/android/src/com/mapzen/tangram/Tangram.java
+++ b/android/src/com/mapzen/tangram/Tangram.java
@@ -101,8 +101,8 @@ public class Tangram implements Renderer, OnTouchListener, OnScaleGestureListene
         this.okClient = new OkHttpClient();
         okClient.setConnectTimeout(10, TimeUnit.SECONDS);
         okClient.setReadTimeout(30, TimeUnit.SECONDS);
-        File cacheDir = new File(mainApp.getExternalCacheDir().getAbsolutePath() + "/tile_cache");
         try {
+            File cacheDir = new File(mainApp.getExternalCacheDir().getAbsolutePath() + "/tile_cache");
             Cache okTileCache = new Cache(cacheDir, TILE_CACHE_SIZE);
             okClient.setCache(okTileCache);
         } catch (Exception e) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -272,7 +272,8 @@ namespace Tangram {
 
         m_view->translate((_posX - viewCenterX)*(1-1/_scale), (_posY - viewCenterY)*(1-1/_scale));
 
-        m_view->zoom(log2f(_scale));
+        static float invLog2 = 1 / log(2);
+        m_view->zoom(log(_scale) * invLog2);
 
         requestRender();
     }

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -13,21 +13,21 @@ if [[ ${PLATFORM} == "osx" ]]; then
 fi
 
 if [[ ${PLATFORM} == "linux" ]]; then
-    
+
     GLFW_VERSION="3.1.1"
-    
+
     #Add PPA for CMake 2.8.11
     sudo add-apt-repository -y ppa:kalakris/cmake > /dev/null
     #Add PPA for gcc-4.8
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test > /dev/null
-    
+
     sudo apt-get update -qq
 
     #Install a c++11 compatible compiler
     sudo apt-get install -y -qq gcc-4.8 g++-4.8
     export CXX=g++-4.8
     export CC=gcc-4.8
-    
+
     #Install X11, OpenGL, and CMake for GLFW
     sudo apt-get install -y -qq xorg-dev libglu1-mesa-dev cmake
 
@@ -38,14 +38,14 @@ if [[ ${PLATFORM} == "linux" ]]; then
     cmake .
     sudo make install
     cd ../
-    
+
 fi
 
 if [[ ${PLATFORM} == "android" ]]; then
 
     ANDROID_SDK_VERSION="r24.0.2"
     ANDROID_BUILD_TOOL_VERSION="21.1.2"
-    ANDROID_PLATFORM_VERSION="19"
+    ANDROID_PLATFORM_VERSION="15"
 
     # install jdk7 and 32bit dependencies for android sdk
     sudo apt-get update -qq

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -58,7 +58,7 @@ if [[ ${PLATFORM} == "android" ]]; then
 
     # Install android ndk
     echo "Cloning mindk..."
-    git clone --quiet --depth 1 --branch linux https://github.com/tangrams/mindk.git
+    git clone --quiet --depth 1 --branch linux-x86_64-api15-armv7 https://github.com/tangrams/mindk.git
     export ANDROID_NDK=$PWD/mindk/android-ndk-r10d
     echo "Done."
 


### PR DESCRIPTION
Eraser maps will support Android versions back to API level 15 (Android 4.0.3 Ice Cream Sandwich) so Tangram will need to support the same range of software. Until now we have been building for API level 19. Reaching compatibility with 15 required only 2 small changes to Tangram code and some modifications to our CI configuration. 