### PR TITLE
some tinkerings

### DIFF
--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -5,6 +5,7 @@
 #include "tileData.h"
 #include "mapTile.h"
 #include "tileManager.h"
+#include "labels/labelContainer.h"
 
 //---- DataSource Implementation----
 

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -1,6 +1,7 @@
 #include "geoJson.h"
 #include "platform.h"
 #include "tileID.h"
+#include "labels/labelContainer.h"
 
 #include "geoJsonSource.h"
 #include "rapidjson/error/en.h"

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -1,6 +1,7 @@
 #include "pbfParser.h"
 #include "platform.h"
 #include "tileID.h"
+#include "labels/labelContainer.h"
 
 #include <sstream>
 #include <fstream>

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -45,10 +45,10 @@ void DebugStyle::addData(TileData &_data, MapTile &_tile, const MapProjection &_
         GLuint abgr = 0xff0000ff;
         
         vertices.reserve(4);
-        vertices.push_back({ -1.f, -1.f, 0.f, abgr });
-        vertices.push_back({  1.f, -1.f, 0.f, abgr });
-        vertices.push_back({  1.f,  1.f, 0.f, abgr });
-        vertices.push_back({ -1.f,  1.f, 0.f, abgr });
+        vertices.push_back({{ -1.f, -1.f, 0.f }, abgr });
+        vertices.push_back({{  1.f, -1.f, 0.f }, abgr });
+        vertices.push_back({{  1.f,  1.f, 0.f }, abgr });
+        vertices.push_back({{ -1.f,  1.f, 0.f }, abgr });
         
         mesh->addVertices(std::move(vertices), { 0, 1, 2, 3, 0 });
         mesh->compileVertexBuffer();

--- a/core/src/style/debugStyle.h
+++ b/core/src/style/debugStyle.h
@@ -9,9 +9,7 @@ protected:
     
     struct PosColVertex {
         // Position Data
-        GLfloat pos_x;
-        GLfloat pos_y;
-        GLfloat pos_z;
+        glm::vec3 pos;
         // Color Data
         GLuint abgr;
     };

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -1,5 +1,6 @@
 #include <cstdio>
 #include "debugTextStyle.h"
+#include "text/fontContext.h"
 
 DebugTextStyle::DebugTextStyle(const std::string& _fontName, std::string _name, float _fontSize, unsigned int _color, bool _sdf, GLenum _drawMode)
 : TextStyle(_fontName, _name, _fontSize, _color, _sdf, false, _drawMode) {

--- a/core/src/style/debugTextStyle.h
+++ b/core/src/style/debugTextStyle.h
@@ -9,10 +9,8 @@ class DebugTextStyle : public TextStyle {
 protected:
 
     struct PosTexID {
-        float pos_x;
-        float pos_y;
-        float tex_u;
-        float tex_v;
+        glm::vec2 pos;
+        glm::vec2 uv;
         float fsID;
     };
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -46,10 +46,7 @@ void PolygonStyle::buildLine(Line& _line, StyleParams& _params, Properties& _pro
     Builders::buildPolyLine(_line, PolyLineOptions(), output);
     
     for (size_t i = 0; i < points.size(); i++) {
-        glm::vec3 p = points[i];
-        glm::vec3 n = glm::vec3(0.0f, 0.0f, 1.0f);
-        glm::vec2 u = texcoords[i];
-        vertices.push_back({ p.x, p.y, p.z, n.x, n.y, n.z, u.x, u.y, abgr });
+        vertices.push_back({ points[i], glm::vec3(0.0f, 0.0f, 1.0f), texcoords[i], abgr, 0.0f });
     }
 
     auto& mesh = static_cast<PolygonStyle::Mesh&>(_mesh);
@@ -87,10 +84,7 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, StyleParams& _params, Propert
     Builders::buildPolygon(_polygon, output);
     
     for (size_t i = 0; i < points.size(); i++) {
-        glm::vec3 p = points[i];
-        glm::vec3 n = normals[i];
-        glm::vec2 u = texcoords[i];
-        vertices.push_back({ p.x, p.y, p.z, n.x, n.y, n.z, u.x, u.y, abgr, layer });
+        vertices.push_back({ points[i], normals[i], texcoords[i], abgr, layer });
     }
     
     // Outlines for water polygons

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -9,16 +9,11 @@ protected:
     
     struct PosNormColVertex {
         // Position Data
-        GLfloat pos_x;
-        GLfloat pos_y;
-        GLfloat pos_z;
+        glm::vec3 pos;
         // Normal Data
-        GLfloat norm_x;
-        GLfloat norm_y;
-        GLfloat norm_z;
+        glm::vec3 norm;
         // UV Data
-        GLfloat texcoord_x;
-        GLfloat texcoord_y;
+        glm::vec2 texcoord;
         // Color Data
         GLuint abgr;
         // Layer Data

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -62,7 +62,7 @@ void PolylineStyle::buildLine(Line& _line, StyleParams& _params, Properties& _pr
         const glm::vec3& p = points[i];
         const glm::vec2& uv = texcoords[i];
         const glm::vec2& en = scalingVecs[i];
-        vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, halfWidth, abgr, layer });
+        vertices.push_back({ p, uv, en, halfWidth, abgr, layer });
     }
     
     if (_params.outline.on) {
@@ -96,7 +96,7 @@ void PolylineStyle::buildLine(Line& _line, StyleParams& _params, Properties& _pr
             const glm::vec3& p = points[i];
             const glm::vec2& uv = texcoords[i];
             const glm::vec2& en = scalingVecs[i];
-            vertices.push_back({ p.x, p.y, p.z, uv.x, uv.y, en.x, en.y, halfWidth, abgrOutline, layer - 1.f });
+            vertices.push_back({ p, uv, en, halfWidth, abgrOutline, layer - 1.f });
         }
         
     }

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -9,15 +9,11 @@ protected:
     
     struct PosNormEnormColVertex {
         //Position Data
-        GLfloat pos_x;
-        GLfloat pos_y;
-        GLfloat pos_z;
+        glm::vec3 pos;
+        // UV Data
+        glm::vec2 texcoord;
         // Extrude Normals Data
-        GLfloat texcoord_x;
-        GLfloat texcoord_y;
-        // Extrude Normals Data
-        GLfloat enorm_x;
-        GLfloat enorm_y;
+        glm::vec2 enorm;
         GLfloat ewidth;
         // Color Data
         GLuint abgr;

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -61,10 +61,10 @@ void SpriteStyle::addData(TileData& _data, MapTile& _tile, const MapProjection& 
     vertices.reserve(4);
 
     float size = 0.2;
-    vertices.push_back({  size,  size, 0.f, 1.f, 0.f });
-    vertices.push_back({ -size,  size, 0.f, 0.f, 0.f });
-    vertices.push_back({ -size, -size, 0.f, 0.f, 1.f });
-    vertices.push_back({  size, -size, 0.f, 1.f, 1.f });
+    vertices.push_back({{  size,  size, 0.f },{ 1.f, 0.f }});
+    vertices.push_back({{ -size,  size, 0.f },{ 0.f, 0.f }});
+    vertices.push_back({{ -size, -size, 0.f },{ 0.f, 1.f }});
+    vertices.push_back({{  size, -size, 0.f },{ 1.f, 1.f }});
 
     mesh->addVertices(std::move(vertices), { 0, 1, 2, 2, 3, 0 });
     mesh->compileVertexBuffer();

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -9,12 +9,9 @@ protected:
 
     struct PosUVVertex {
         // Position Data
-        GLfloat pos_x;
-        GLfloat pos_y;
-        GLfloat pos_z;
+        glm::vec3 pos;
         // UV Data
-        GLfloat u;
-        GLfloat v;
+        glm::vec2 uv;
     };
 
     virtual void constructVertexLayout() override;

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -1,5 +1,6 @@
 #include "style.h"
 #include "scene/scene.h"
+#include "util/vboMesh.h"
 
 Style::Style(std::string _name, GLenum _drawMode) : m_name(_name), m_drawMode(_drawMode) {
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -1,4 +1,5 @@
 #include "textStyle.h"
+#include "text/fontContext.h"
 
 MapTile* TextStyle::s_processedTile = nullptr;
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -6,18 +6,19 @@
 #include <set>
 
 #include "platform.h"
-#include "tile/tileManager.h"
-#include "view/view.h"
-#include "style/textStyle.h"
-#include "style/debugTextStyle.h"
-#include "style/debugStyle.h"
-#include "style/spriteStyle.h"
-#include "scene/sceneLoader.h"
 #include "scene/scene.h"
-#include "util/error.h"
+#include "scene/sceneLoader.h"
 #include "stl_util.hpp"
-#include "util/tileID.h"
+#include "style/debugStyle.h"
+#include "style/debugTextStyle.h"
+#include "style/spriteStyle.h"
+#include "style/textStyle.h"
+#include "text/fontContext.h"
+#include "tile/tileManager.h"
+#include "util/error.h"
 #include "util/skybox.h"
+#include "util/tileID.h"
+#include "view/view.h"
 
 namespace Tangram {
 

--- a/core/src/tile/labels/labelContainer.cpp
+++ b/core/src/tile/labels/labelContainer.cpp
@@ -1,5 +1,6 @@
 #include "labelContainer.h"
 #include "tile/mapTile.h"
+#include "text/fontContext.h"
 
 LabelContainer::LabelContainer() {}
 

--- a/core/src/tile/labels/labelContainer.cpp
+++ b/core/src/tile/labels/labelContainer.cpp
@@ -54,7 +54,7 @@ void LabelContainer::updateOcclusions() {
     std::set<std::pair<Label*, Label*>> occlusions;
     std::vector<isect2d::AABB> aabbs;
 
-    for(int i = 0; i < m_labelUnits.size(); i++) {
+    for(size_t i = 0; i < m_labelUnits.size(); i++) {
         auto& labelUnit = m_labelUnits[i];
         auto label = labelUnit.getWeakLabel();
 
@@ -107,7 +107,7 @@ void LabelContainer::updateOcclusions() {
         }
     }
     
-    for(int i = 0; i < m_labelUnits.size(); i++) {
+    for(size_t i = 0; i < m_labelUnits.size(); i++) {
         auto& labelUnit = m_labelUnits[i];
         auto label = labelUnit.getWeakLabel();
         

--- a/core/src/tile/labels/labelContainer.h
+++ b/core/src/tile/labels/labelContainer.h
@@ -2,15 +2,16 @@
 
 #include "label.h"
 #include "util/tileID.h"
-#include "text/fontContext.h"
 #include "isect2d.h"
 #include "view/view.h"
 #include <memory>
+#include <mutex>
 #include <vector>
 #include <set>
 #include <map>
 
 class MapTile;
+class FontContext;
 
 struct LabelUnit {
 

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -2,6 +2,9 @@
 #include "style/style.h"
 #include "view/view.h"
 #include "util/tileID.h"
+#include "util/vboMesh.h"
+#include "text/fontContext.h"
+#include "labels/labelContainer.h"
 
 #include "glm/gtc/matrix_transform.hpp"
 #include "glm/gtc/type_ptr.hpp"

--- a/core/src/tile/mapTile.h
+++ b/core/src/tile/mapTile.h
@@ -1,22 +1,23 @@
 #pragma once
 
-#include <unordered_map>
+#include <map>
 #include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
-#include "glm/vec2.hpp"
 #include "glm/mat4x4.hpp"
+#include "glm/vec2.hpp"
 
-#include "label.h"
-#include "text/textBuffer.h"
-#include "view/view.h"
-#include "labels/labelContainer.h"
-#include "util/vboMesh.h"
-#include "util/mapProjection.h"
-#include "util/texture.h"
+#include "tileID.h"
 
+class Label;
+class LabelContainer;
+class MapProjection;
 class Style;
+class TextBuffer;
+class VboMesh;
 class View;
-struct TileID;
 
 /* Tile of vector map data
  * 
@@ -52,8 +53,8 @@ public:
 
     /* Adds drawable geometry to the tile and associates it with a <Style>
      * 
-     * Use std::move to pass in the mesh by move semantics; Geometry in the mesh must have coordinates relative to
-     * the tile origin.
+     * Use std::move to pass in the mesh by move semantics; Geometry in the mesh
+     * must have coordinates relative to the tile origin.
      */
     void addGeometry(const Style& _style, std::unique_ptr<VboMesh> _mesh);
     

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -200,19 +200,33 @@ void TileManager::removeTile(std::map< TileID, std::shared_ptr<MapTile> >::itera
 
 void TileManager::updateProxyTiles(const TileID& _tileID, bool _zoomingIn) {
     if (_zoomingIn) {
-        // zoom in - add parent
+        // zoom in - try parent first
         const auto& parentID = _tileID.getParent();
         const auto& parentTileIter = m_tileSet.find(parentID);
-        if (parentID.isValid() && parentTileIter != m_tileSet.end()) {
+        if (parentTileIter != m_tileSet.end()) {
             parentTileIter->second->incProxyCounter();
+            return;
         }
-    } else {
-        for(int i = 0; i < 4; i++) {
-            const auto& childID = _tileID.getChild(i);
-            const auto& childTileIter = m_tileSet.find(childID);
-            if(childID.isValid(m_view->s_maxZoom) && childTileIter != m_tileSet.end()) {
-                childTileIter->second->incProxyCounter();
-            }
+    }
+
+    int found = 0;
+    if (m_view->s_maxZoom > _tileID.z) {
+      for(int i = 0; i < 4; i++) {
+        const auto& childID = _tileID.getChild(i);
+        const auto& childTileIter = m_tileSet.find(childID);
+        if(childTileIter != m_tileSet.end()) {
+          childTileIter->second->incProxyCounter();
+          found++;
+        }
+      }
+    }
+
+    if (found < 4 && !_zoomingIn) {
+        // fallback
+        const auto& parentID = _tileID.getParent();
+        const auto& parentTileIter = m_tileSet.find(parentID);
+        if (parentTileIter != m_tileSet.end()) {
+            parentTileIter->second->incProxyCounter();
         }
     }
 }
@@ -221,7 +235,7 @@ void TileManager::cleanProxyTiles(const TileID& _tileID) {
     // check if parent proxy is present
     const auto& parentID = _tileID.getParent();
     const auto& parentTileIter = m_tileSet.find(parentID);
-    if (parentID.isValid() && parentTileIter != m_tileSet.end()) {
+    if (parentTileIter != m_tileSet.end()) {
         parentTileIter->second->decProxyCounter();
     }
     
@@ -229,7 +243,7 @@ void TileManager::cleanProxyTiles(const TileID& _tileID) {
     for(int i = 0; i < 4; i++) {
         const auto& childID = _tileID.getChild(i);
         const auto& childTileIter = m_tileSet.find(childID);
-        if(childID.isValid(m_view->s_maxZoom) && childTileIter != m_tileSet.end()) {
+        if (childTileIter != m_tileSet.end()) {
             childTileIter->second->decProxyCounter();
         }
     }

--- a/core/src/util/geoJson.cpp
+++ b/core/src/util/geoJson.cpp
@@ -1,5 +1,6 @@
 #include "geoJson.h"
 #include "platform.h"
+#include "util/mapProjection.h"
 
 void GeoJson::extractPoint(const rapidjson::Value& _in, Point& _out, const MapTile& _tile) {
     

--- a/core/src/util/shaderProgram.cpp
+++ b/core/src/util/shaderProgram.cpp
@@ -11,7 +11,7 @@ ShaderProgram::ShaderProgram() {
     m_glVertexShader = 0;
     m_needsBuild = true;
     m_freeTextureUnit = 0;
-
+    m_generation = -1;
 }
 
 ShaderProgram::~ShaderProgram() {

--- a/core/src/util/vboMesh.cpp
+++ b/core/src/util/vboMesh.cpp
@@ -15,6 +15,7 @@ VboMesh::VboMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
 
     m_isUploaded = false;
     m_isCompiled = false;
+    m_generation = -1;
 
     setDrawMode(_drawMode);
 }


### PR DESCRIPTION
Hey Matt, I found the cause for unexpected disappearing proxies: the logic was specifically tailored for switching proxies depending on the zoom direction. So when the view is tilted, panning would only consider children as proxies. The logic could still be improved. I'll look into the sorting of the load queue next.