### PR TITLE
Screen-ray to ground plane

### DIFF
--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -162,7 +162,7 @@ glm::dmat2 View::getBoundsRect() const {
 
 }
 
-void View::screenToGroundPlane(float& _screenX, float& _screenY) const {
+glm::vec2 View::screenToGroundPlane(float& _screenX, float& _screenY) const {
     
     // Cast a ray and find its intersection with the z = 0 plane,
     // following the technique described here: http://antongerdelan.net/opengl/raycasting.html
@@ -174,7 +174,7 @@ void View::screenToGroundPlane(float& _screenX, float& _screenY) const {
     if (ray_world.z != 0.f) {
         t = -m_pos.z / ray_world.z;
     }
-
+    
     ray_world *= fabs(t);
     
     // Determine the maximum distance from the view position at which tiles can be drawn; If the projected point 
@@ -188,6 +188,8 @@ void View::screenToGroundPlane(float& _screenX, float& _screenY) const {
     
     _screenX = ray_world.x;
     _screenY = ray_world.y;
+    
+    return glm::vec2(t, ray_world.z);
 }
 
 const std::set<TileID>& View::getVisibleTiles() {
@@ -241,6 +243,7 @@ void View::updateMatrices() {
     // update view and projection matrices
     m_view = glm::lookAt(eye, at, up);
     m_proj = glm::perspective(fovy, m_aspect, near, far);
+
     m_viewProj = m_proj * m_view;
     m_invViewProj = glm::inverse(m_viewProj);
     
@@ -330,10 +333,21 @@ void View::updateTiles() {
     glm::vec2 viewTR = { m_vpWidth, 0.f        }; // top right
     glm::vec2 viewTL = { 0.f,       0.f        }; // top left
     
-    screenToGroundPlane(viewBL.x, viewBL.y);
-    screenToGroundPlane(viewBR.x, viewBR.y);
-    screenToGroundPlane(viewTR.x, viewTR.y);
-    screenToGroundPlane(viewTL.x, viewTL.y);
+    glm::vec2 s0 = screenToGroundPlane(viewBL.x, viewBL.y);
+    glm::vec2 s1 = screenToGroundPlane(viewBR.x, viewBR.y);
+    glm::vec2 s2 = screenToGroundPlane(viewTR.x, viewTR.y);
+    glm::vec2 s3 = screenToGroundPlane(viewTL.x, viewTL.y);
+
+    // is the camera looking up
+    if (m_pitch > M_PI_2) {
+        // if the distance to the ground positive for each of the projected rays coming out of screen space
+        if (s0.y > 0.f && s1.y > 0.f && s2.y > 0.f && s3.y > 0.f) {
+            // is the intersection with the ground having solutions in R
+            if (s0.x < .0f || s1.x < 0.f || s2.x < 0.f || s3.x < 0.f) {
+                return;
+            }
+        }
+    }
     
     // Transformation from world space to tile space
     double hc = MapProjection::HALF_CIRCUMFERENCE;

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -162,7 +162,7 @@ glm::dmat2 View::getBoundsRect() const {
 
 }
 
-glm::vec2 View::screenToGroundPlane(float& _screenX, float& _screenY) const {
+float View::screenToGroundPlane(float& _screenX, float& _screenY) const {
     
     // Cast a ray and find its intersection with the z = 0 plane,
     // following the technique described here: http://antongerdelan.net/opengl/raycasting.html
@@ -189,7 +189,7 @@ glm::vec2 View::screenToGroundPlane(float& _screenX, float& _screenY) const {
     _screenX = ray_world.x;
     _screenY = ray_world.y;
     
-    return glm::vec2(t, ray_world.z);
+    return t;
 }
 
 const std::set<TileID>& View::getVisibleTiles() {
@@ -333,19 +333,16 @@ void View::updateTiles() {
     glm::vec2 viewTR = { m_vpWidth, 0.f        }; // top right
     glm::vec2 viewTL = { 0.f,       0.f        }; // top left
     
-    glm::vec2 s0 = screenToGroundPlane(viewBL.x, viewBL.y);
-    glm::vec2 s1 = screenToGroundPlane(viewBR.x, viewBR.y);
-    glm::vec2 s2 = screenToGroundPlane(viewTR.x, viewTR.y);
-    glm::vec2 s3 = screenToGroundPlane(viewTL.x, viewTL.y);
+    float t0 = screenToGroundPlane(viewBL.x, viewBL.y);
+    float t1 = screenToGroundPlane(viewBR.x, viewBR.y);
+    float t2 = screenToGroundPlane(viewTR.x, viewTR.y);
+    float t3 = screenToGroundPlane(viewTL.x, viewTL.y);
 
     // is the camera looking up
     if (m_pitch > M_PI_2) {
-        // if the distance to the ground positive for each of the projected rays coming out of screen space
-        if (s0.y > 0.f && s1.y > 0.f && s2.y > 0.f && s3.y > 0.f) {
-            // is the intersection with the ground having solutions in R
-            if (s0.x < .0f || s1.x < 0.f || s2.x < 0.f || s3.x < 0.f) {
-                return;
-            }
+        // is the intersection with the ground having solutions in R
+        if (t0 < .0f && t1 < 0.f && t2 < 0.f && t3 < 0.f) {
+            return;
         }
     }
     

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -112,7 +112,7 @@ public:
     
     /* Calculate the position on the ground plane (z = 0) under the given screen space coordinates, 
        replacing the input coordinates with world-space coordinates */
-    void screenToGroundPlane(float& _screenX, float& _screenY) const;
+    glm::vec2 screenToGroundPlane(float& _screenX, float& _screenY) const;
     
     /* Returns the set of all tiles visible at the current position and zoom */
     const std::set<TileID>& getVisibleTiles();

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -112,7 +112,7 @@ public:
     
     /* Calculate the position on the ground plane (z = 0) under the given screen space coordinates, 
        replacing the input coordinates with world-space coordinates */
-    glm::vec2 screenToGroundPlane(float& _screenX, float& _screenY) const;
+    float screenToGroundPlane(float& _screenX, float& _screenY) const;
     
     /* Returns the set of all tiles visible at the current position and zoom */
     const std::set<TileID>& getVisibleTiles();


### PR DESCRIPTION
Previously tiles behind the camera were loaded when camera was looking above the horizon, this is a small change which automatically stop updating the tile-set when the screen-ray to ground has intersections solutions behind the camera.