### PR TITLE
wip - Sort tiles by distance for loading

### DIFF
--- a/core/src/tile/mapTile.h
+++ b/core/src/tile/mapTile.h
@@ -88,6 +88,28 @@ public:
     void decProxyCounter() { m_proxyCounter = m_proxyCounter > 0 ? m_proxyCounter - 1 : 0; }
     void resetProxyCounter() { m_proxyCounter = 0; }
 
+    enum ProxyID {
+      None = 0,
+      Child1 = 1 << 0,
+      Child2 = 1 << 1,
+      Child3 = 1 << 2,
+      Child4 = 1 << 3,
+      Parent = 1 << 4,
+      Parent2 = 1 << 5,
+    };
+
+    bool hasProxy(ProxyID id) { return (m_proxies & id) != 0; }
+
+    void clearProxies() { m_proxies = 0; }
+
+    bool setProxy(ProxyID id) {
+      if ((m_proxies & id) == 0) {
+        m_proxies |= id;
+        return true;
+      }
+      return false;
+    }
+
 private:
 
     TileID m_id;
@@ -96,7 +118,9 @@ private:
      * A Counter for number of tiles this tile acts a proxy for
      */
     int m_proxyCounter = 0;
-    
+
+    uint8_t m_proxies = 0;
+
     const MapProjection* m_projection = nullptr;
     
     float m_scale = 1;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -95,6 +95,7 @@ void TileManager::updateTileSet() {
     }
     
     const std::set<TileID>& visibleTiles = m_view->getVisibleTiles();
+    bool cleanupTiles = false;
 
     // Loop over visibleTiles and add any needed tiles to tileSet
     {
@@ -119,13 +120,14 @@ void TileManager::updateTileSet() {
 
             } else {
                 // visibleTiles is missing an element present in tileSet (handled below)
+                cleanupTiles = true;
                 ++setTilesIter;
             }
         }
     }
 
     // Loop over tileSet and remove any tiles that are neither visible nor proxies
-    {
+    if (cleanupTiles) {
         auto setTilesIter = m_tileSet.begin();
         auto visTilesIter = visibleTiles.begin();
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -96,13 +96,13 @@ private:
     
     /*
      * Checks and updates m_tileSet with proxy tiles for every new visible tile
-     *  @_tileID: TileID of the new visible tile for which proxies needs to be added
+     *  @_tile: MapTile, the new visible tile for which proxies needs to be added
      */
-    void updateProxyTiles(const TileID& _tileID);
+    void updateProxyTiles(MapTile& _tile);
     
     /*
-     *  Once a visible tile finishes loaded and is added to m_tileSet, all its proxy(ies) MapTiles are removed
+     *  Once a visible tile finishes loading and is added to m_tileSet, all its proxy(ies) MapTiles are removed
      */
-    void cleanProxyTiles(const TileID& _tileID);
+    void cleanProxyTiles(MapTile& _tile);
 
 };

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -78,6 +78,7 @@ private:
     std::list<std::unique_ptr<TileWorker> > m_workers;
     
     std::list<std::unique_ptr<TileTask> > m_queuedTiles;
+    std::list<TileID> m_loadQueue;
     
     bool m_tileSetChanged = false;
     

--- a/core/src/util/mapProjection.cpp
+++ b/core/src/util/mapProjection.cpp
@@ -89,3 +89,9 @@ glm::dvec4 MercatorProjection::TileLonLatBounds(const TileID _tileCoord) const {
     lonLatBounds = glm::dvec4(boundMin.x, boundMin.y, boundMax.x, boundMax.y);
     return lonLatBounds;
 }
+
+glm::dvec2 MercatorProjection::TileCenter(const TileID _tileCoord) const {
+    return PixelsToMeters(glm::dvec2(_tileCoord.x*m_TileSize +m_TileSize*0.5,
+                                     (_tileCoord.y*m_TileSize+m_TileSize*0.5)),
+                          _tileCoord.z);
+}

--- a/core/src/util/mapProjection.h
+++ b/core/src/util/mapProjection.h
@@ -116,6 +116,16 @@ public:
      *       z,w: max bounds in lon lat
      */
     virtual glm::dvec4 TileLonLatBounds(const TileID _tileCoord) const = 0;
+
+    /* 
+     * Returns center of the given tile
+     *  Arguments:
+     *    _tileCoord: glm::ivec3 (x,y and zoom)
+     *  Return value:
+     *    center in projection-meters (glm::dvec2)
+     *       x,y : position in projection meters
+     */
+    virtual glm::dvec2 TileCenter(const TileID _tileCoord) const = 0;
     
     /* 
      * Returns the projection type of a given projection instance 
@@ -148,6 +158,7 @@ public:
     virtual glm::dvec2 PixelsToRaster(const glm::dvec2 _pix, const int _zoom) const override;
     virtual glm::dvec4 TileBounds(const TileID _tileCoord) const override;
     virtual glm::dvec4 TileLonLatBounds(const TileID _tileCoord) const override;
+    virtual glm::dvec2 TileCenter(const TileID _tileCoord) const override;
     virtual ~MercatorProjection() {}
 };
 

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -153,11 +153,14 @@ int main(void) {
         double currentTime = glfwGetTime();
         double delta = currentTime - lastTime;
         lastTime = currentTime;
-        
+
+        /* Update view and current tiles */
+        Tangram::update(delta);
+
+        /* Start loading new tiles */
         processNetworkQueue();
 
         /* Render here */
-        Tangram::update(delta);
         Tangram::render();
 
         /* Swap front and back buffers */


### PR DESCRIPTION
I'm not sure what the best way is to update the load order of tiles that were already submitted via source->loadTileData (when the view has position has changed). One option would be to make the backend poll the TileManager for the next tile request. Any suggestions?
