### PR TITLE
WIP - use callback functions in builder

### DIFF
--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -58,10 +58,8 @@ void PolygonStyle::buildPoint(Point& _point, void* _styleParam, Properties& _pro
 
 void PolygonStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
     std::vector<PosNormColVertex> vertices;
-    std::vector<int> indices;
 
     PolyLineOutput output = {
-      indices,
       [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {
         float halfWidth =  0.2f;
         GLuint abgr = 0xff969696; // Default road color
@@ -74,13 +72,12 @@ void PolygonStyle::buildLine(Line& _line, void* _styleParam, Properties& _props,
     Builders::buildPolyLine(_line, PolyLineOptions(), output);
 
     auto& mesh = static_cast<PolygonStyle::Mesh&>(_mesh);
-    mesh.addVertices(std::move(vertices), std::move(indices));
+    mesh.addVertices(std::move(vertices), std::move(output.indices));
 }
 
 void PolygonStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
 
     std::vector<PosNormColVertex> vertices;
-    std::vector<int> indices;
 
     StyleParams* params = static_cast<StyleParams*>(_styleParam);
     GLuint abgr = params->color;
@@ -94,7 +91,6 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties
     float minHeight = _props.numericProps["min_height"]; // Inits to zero if not present in data
 
     PolygonOutput output = {
-      indices,
       [&](const glm::vec3& coord, const glm::vec3& normal, const glm::vec2& uv){
         vertices.push_back({ coord, normal, uv, abgr, layer });
       },
@@ -132,5 +128,5 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties
     */
 
     auto& mesh = static_cast<PolygonStyle::Mesh&>(_mesh);
-    mesh.addVertices(std::move(vertices), std::move(indices));
+    mesh.addVertices(std::move(vertices), std::move(output.indices));
 }

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -105,9 +105,6 @@ void PolylineStyle::buildPoint(Point& _point, void* _styleParam, Properties& _pr
 void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
     std::vector<PosNormEnormColVertex> vertices;
     std::vector<int> indices;
-    std::vector<glm::vec3> points;
-    std::vector<glm::vec2> texcoords;
-    std::vector<glm::vec2> scalingVecs;
 
     StyleParams* params = static_cast<StyleParams*>(_styleParam);
     GLuint abgr = params->color;
@@ -120,52 +117,41 @@ void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props
 
     float halfWidth = params->width * .5f;
 
-    PolyLineOutput lineOutput = { points, indices, scalingVecs, texcoords };
-    PolyLineOptions lineOptions = { params->cap, params->join, halfWidth };
-    Builders::buildPolyLine(_line, lineOptions, lineOutput);
+    PolyLineOptions lineOptions = { params->cap, params->join };
 
-    // populate polyline vertices
-    for (size_t i = 0; i < points.size(); i++) {
-        const glm::vec3& p = points[i];
-        const glm::vec2& uv = texcoords[i];
-        const glm::vec2& en = scalingVecs[i];
-        vertices.push_back({ p, uv, en, halfWidth, abgr, layer });
-    }
+    PolyLineOutput lineOutput {
+      indices,
+      [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {
+        vertices.push_back({ coord, uv, normal, halfWidth, abgr, layer });
+      }
+    };
+
+    Builders::buildPolyLine(_line, lineOptions, lineOutput);
 
     if (params->outlineOn) {
 
         GLuint abgrOutline = params->outlineColor;
         halfWidth += params->outlineWidth * .5f;
 
-        size_t outlineStart = 0;
-
         if (params->outlineCap != params->cap || params->outlineJoin != params->join) {
             // need to re-triangulate with different cap and/or join
-            outlineStart = points.size();
             lineOptions.cap = params->outlineCap;
             lineOptions.join = params->outlineJoin;
             Builders::buildPolyLine(_line, lineOptions, lineOutput);
-
         } else {
-
             // re-use indices from original line
             size_t oldSize = indices.size();
-            size_t offset = points.size();
+            size_t offset = vertices.size();
             indices.reserve(2 * oldSize);
+
             for(size_t i = 0; i < oldSize; i++) {
-                indices.push_back(offset + indices[i]);
+                 indices.push_back(offset + indices[i]);
             }
-
+            for (size_t i = 0; i < offset; i++) {
+              const auto& v = vertices[i];
+              vertices.push_back({ v.pos, v.texcoord, v.enorm, halfWidth, abgrOutline, layer - 1.f });
+            }
         }
-
-        // populate outline vertices
-        for (size_t i = outlineStart; i < points.size(); i++) {
-            const glm::vec3& p = points[i];
-            const glm::vec2& uv = texcoords[i];
-            const glm::vec2& en = scalingVecs[i];
-            vertices.push_back({ p, uv, en, halfWidth, abgrOutline, layer - 1.f });
-        }
-
     }
 
     auto& mesh = static_cast<PolylineStyle::Mesh&>(_mesh);

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -104,7 +104,6 @@ void PolylineStyle::buildPoint(Point& _point, void* _styleParam, Properties& _pr
 
 void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
     std::vector<PosNormEnormColVertex> vertices;
-    std::vector<int> indices;
 
     StyleParams* params = static_cast<StyleParams*>(_styleParam);
     GLuint abgr = params->color;
@@ -120,7 +119,6 @@ void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props
     PolyLineOptions lineOptions = { params->cap, params->join };
 
     PolyLineOutput lineOutput {
-      indices,
       [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {
         vertices.push_back({ coord, uv, normal, halfWidth, abgr, layer });
       }
@@ -140,12 +138,12 @@ void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props
             Builders::buildPolyLine(_line, lineOptions, lineOutput);
         } else {
             // re-use indices from original line
-            size_t oldSize = indices.size();
+            size_t oldSize = lineOutput.indices.size();
             size_t offset = vertices.size();
-            indices.reserve(2 * oldSize);
+            lineOutput.indices.reserve(2 * oldSize);
 
             for(size_t i = 0; i < oldSize; i++) {
-                 indices.push_back(offset + indices[i]);
+                 lineOutput.indices.push_back(offset + lineOutput.indices[i]);
             }
             for (size_t i = 0; i < offset; i++) {
               const auto& v = vertices[i];
@@ -155,7 +153,7 @@ void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props
     }
 
     auto& mesh = static_cast<PolylineStyle::Mesh&>(_mesh);
-    mesh.addVertices(std::move(vertices), std::move(indices));
+    mesh.addVertices(std::move(vertices), std::move(lineOutput.indices));
 }
 
 void PolylineStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const {

--- a/core/src/util/builders.h
+++ b/core/src/util/builders.h
@@ -30,13 +30,12 @@ typedef std::function<void(const glm::vec3& coord, const glm::vec3& normal, cons
 typedef std::function<void(size_t reserve)> SizeHintFn;
 
 struct PolygonOutput {
-    std::vector<int>& indices; // indices for drawing the polyon as triangles are added to this vector
+    std::vector<int> indices; // indices for drawing the polyon as triangles are added to this vector
     PolygonVertexFn addVertex;
     SizeHintFn sizeHint;
     size_t numVertices = 0;
-    PolygonOutput(std::vector<int>& indices, PolygonVertexFn addVertex, SizeHintFn sizeHint = SizeHintFn())
-      : indices(indices),
-        addVertex(addVertex),
+    PolygonOutput(PolygonVertexFn addVertex, SizeHintFn sizeHint = SizeHintFn())
+      : addVertex(addVertex),
         sizeHint(sizeHint){}
 };
 
@@ -46,11 +45,10 @@ struct PolygonOutput {
 typedef std::function<void(const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv)> PolyLineVertexFn;
 
 struct PolyLineOutput {
-    std::vector<int>& indices; // indices for drawing the polyline as triangles are added to this vector
+    std::vector<int> indices; // indices for drawing the polyline as triangles are added to this vector
     PolyLineVertexFn addVertex;
     size_t numVertices = 0;
-
-    PolyLineOutput(std::vector<int>& indices, PolyLineVertexFn addVertex) : indices(indices), addVertex(addVertex){}
+    PolyLineOutput(PolyLineVertexFn addVertex) : addVertex(addVertex){}
 };
 
 class Builders {

--- a/core/src/util/builders.h
+++ b/core/src/util/builders.h
@@ -20,32 +20,42 @@ enum class JoinTypes {
 struct PolyLineOptions {
     CapTypes cap;
     JoinTypes join;
-    float halfWidth;
     
-    PolyLineOptions() : cap(CapTypes::BUTT), join(JoinTypes::MITER), halfWidth(0.02f) {};
-    PolyLineOptions(CapTypes _c, JoinTypes _j, float _hw) : cap(_c), join(_j), halfWidth(_hw) {};
+    PolyLineOptions() : cap(CapTypes::BUTT), join(JoinTypes::MITER) {};
+    PolyLineOptions(CapTypes _c, JoinTypes _j) : cap(_c), join(_j) {};
 };
+
+typedef std::function<void(const glm::vec3& coord, const glm::vec3& normal, const glm::vec2& uv)> PolygonVertexFn;
+
+typedef std::function<void(size_t reserve)> SizeHintFn;
 
 struct PolygonOutput {
-    std::vector<glm::vec3>& points; // tesselated output coordinates are added to this vector
     std::vector<int>& indices; // indices for drawing the polyon as triangles are added to this vector
-    std::vector<glm::vec3>& normals; // normal vectors for each output coordinate are added to this vector
-    std::vector<glm::vec2>& texcoords; // if not null, 2D texture coordinates for each output coordinate are added to this vector
+    PolygonVertexFn addVertex;
+    SizeHintFn sizeHint;
+    size_t numVertices = 0;
+    PolygonOutput(std::vector<int>& indices, PolygonVertexFn addVertex, SizeHintFn sizeHint = SizeHintFn())
+      : indices(indices),
+        addVertex(addVertex),
+        sizeHint(sizeHint){}
 };
 
+// coord  tesselated output coordinate
+// normal extrusion vector of the output coordinate
+// uv     texture coordinate of the output coordinate
+typedef std::function<void(const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv)> PolyLineVertexFn;
+
 struct PolyLineOutput {
-    std::vector<glm::vec3>& points; // tesselated output coordinates are added to this vector
     std::vector<int>& indices; // indices for drawing the polyline as triangles are added to this vector
-    std::vector<glm::vec2>& scalingVecs; // if not null, 2D vectors for scaling the polyline are added to this vector
-    std::vector<glm::vec2>& texcoords; // if not null, 2D texture coordinates for each output coordinate are added to this vector
+    PolyLineVertexFn addVertex;
+    size_t numVertices = 0;
+
+    PolyLineOutput(std::vector<int>& indices, PolyLineVertexFn addVertex) : indices(indices), addVertex(addVertex){}
 };
 
 class Builders {
     
 public:
-    
-    static std::vector<glm::vec2> NO_TEXCOORDS;
-    static std::vector<glm::vec2> NO_SCALING_VECS;
     
     /* Build a tesselated polygon
      * @_polygon input coordinates describing the polygon


### PR DESCRIPTION
- allows to build custom vertices,
  e.g. no need to pass halfWidth through all line builder functions
- avoids temporary vectors for vertex data