### PR TITLE
WIP - flyweight Keys + variant Value

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 	url = https://github.com/blair1618/yaml-cpp.git
 	branch = no-boost
 	ignore = untracked
+[submodule "core/include/variant"]
+        path = core/include/variant
+        url = https://github.com/mapbox/variant.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-if(UNIT_TESTS) 
-    include(${PROJECT_SOURCE_DIR}/toolchains/unitTests.cmake)
-    return()
-endif()
-
 # platform lookup
 set(SUPPORTED_TARGETS darwin ios android raspberrypi linux)
 
@@ -36,6 +31,12 @@ list(FIND SUPPORTED_TARGETS ${varplatform} target_in_list)
 
 if(target_in_list EQUAL -1)
     message(SEND_ERROR "${varplatform} not in supported targets: ${SUPPORTED_TARGETS}")
+    return()
+endif()
+
+if(UNIT_TESTS) 
+    include(${PROJECT_SOURCE_DIR}/toolchains/unitTests.cmake)
+#   include(${PROJECT_SOURCE_DIR}/toolchains/linux.tests.cmake)
     return()
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,10 @@ UNIT_TESTS_CMAKE_PARAMS = \
 ANDROID_CMAKE_PARAMS = \
 	-DPLATFORM_TARGET=android \
 	-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_DIR}/android.toolchain.cmake \
-	-DMAKE_BUILD_TOOL=$$ANDROID_NDK/prebuilt/darwin-x86_64/bin/make \
+	-DMAKE_BUILD_TOOL=$$ANDROID_NDK/prebuilt/linux-x86_64/bin/make \
+	-DANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-4.9 \
 	-DANDROID_ABI=${ANDROID_ARCH} \
-	-DANDROID_STL=c++_shared \
+	-DANDROID_STL=gnustl_static \
 	-DANDROID_NATIVE_API_LEVEL=${ANDROID_API_LEVEL}
 
 IOS_CMAKE_PARAMS = \

--- a/core/dependencies/tess2/CMakeLists.txt
+++ b/core/dependencies/tess2/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(INCLUDE_DIR libtess2/Include)
 set(SOURCE_DIR libtess2/Source)
 
+add_definitions(-DNDEBUG)
+
 file(GLOB_RECURSE FOUND_SOURCES "${SOURCE_DIR}/*.c")
 
 include_directories(${INCLUDE_DIR})

--- a/core/include/core/algorithm.hpp
+++ b/core/include/core/algorithm.hpp
@@ -1,0 +1,2196 @@
+#ifndef CORE_ALGORITHM_HPP
+#define CORE_ALGORITHM_HPP
+
+#include <algorithm>
+
+#include <core/functional.hpp>
+#include <core/utility.hpp>
+#include <core/range.hpp>
+
+namespace core {
+inline namespace v1 {
+namespace impl {
+
+template <class InputIt1, class InputIt2, class Predicate>
+bool equal (
+  range<InputIt1> r1,
+  range<InputIt2> r2,
+  Predicate&& p,
+  ::std::random_access_iterator_tag,
+  ::std::random_access_iterator_tag
+) {
+  if (r1.size() != r2.size()) { return false; }
+  return ::std::equal(
+    begin(r1),
+    end(r1),
+    begin(r2),
+    ::std::forward<Predicate>(p)
+  );
+}
+
+template <class InputIt1, class InputIt2, class Predicate>
+bool equal (
+  range<InputIt1> r1,
+  range<InputIt2> r2,
+  Predicate&& p,
+  ::std::input_iterator_tag,
+  ::std::input_iterator_tag
+) {
+  while (not r1.empty() and not r2.empty()) {
+    if (not ::std::forward<Predicate>(p)(r1.front(), r2.front())) {
+      return false;
+    }
+    r1.pop_front();
+    r2.pop_front();
+  }
+  return r1.empty() and r2.empty();
+}
+
+} /* namespace impl */
+
+/* non-range based algorithms */
+template <class T>
+constexpr T const& min (T const& lhs, T const& rhs) {
+  return (rhs < lhs) ? rhs : lhs;
+}
+
+template <class T, class Compare>
+constexpr T const& min (T const& lhs, T const& rhs, Compare compare) {
+  return compare(rhs, lhs) ? rhs : lhs;
+}
+
+template <class T>
+constexpr T const& max (T const& lhs, T const& rhs) {
+  return (lhs < rhs) ? rhs : lhs;
+}
+
+template <class T, class Compare>
+constexpr T const& max (T const& lhs, T const& rhs, Compare compare) {
+  return compare(lhs, rhs) ? rhs : lhs;
+}
+
+/* extension */
+template <class T>
+constexpr T const& clamp (T const& value, T const& low, T const& high) {
+  return value < low
+    ? low
+    : high < value
+      ? high
+      : value;
+}
+
+template <class T, class Compare>
+constexpr T const& clamp (
+  T const& value,
+  T const& low,
+  T const& high,
+  Compare compare
+) {
+  return compare(value, low)
+    ? low
+    : compare(high, value)
+      ? high
+      : value;
+}
+
+/* N4318 */
+template <class T>
+constexpr auto abs_diff (T const& a, T const& b) -> decltype(
+  (a < b) ? b - a : a - b
+) { return (a < b) ? b - a : a - b; }
+
+template <class T, class Compare>
+constexpr auto abs_diff (T const& a, T const& b, Compare compare) -> decltype(
+  compare(a, b) ? b - a : a - b
+) { return compare(a, b) ? b - a : a - b; }
+
+template <class T, class Compare, class Difference>
+constexpr auto abs_diff (
+  T const& a,
+  T const& b,
+  Compare compare,
+  Difference diff
+) -> decltype(compare(a, b) ? diff(b, a) : diff(a, b)) {
+  return compare(a, b) ? diff(b, a) : diff(a, b);
+}
+
+/* non-modifying sequence algorithms */
+template <class Range, class UnaryPredicate>
+auto all_of (Range&& rng, UnaryPredicate&& p) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "all_of requires InputIterators");
+  return ::std::all_of(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(p)
+  );
+}
+
+template <class Range, class UnaryPredicate>
+auto any_of (Range&& rng, UnaryPredicate&& p) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "any_of requires InputIterators");
+  return ::std::any_of(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(p)
+  );
+}
+
+template <class Range, class UnaryPredicate>
+auto none_of (Range&& rng, UnaryPredicate&& p) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "none_of requires InputIterators");
+  return ::std::none_of(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(p)
+  );
+}
+
+template <class Range, class UnaryFunction>
+auto for_each (Range&& rng, UnaryFunction&& f) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<UnaryFunction>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "for_each requires InputIterators");
+  return ::std::for_each(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryFunction>(f)
+  );
+}
+
+template <class Range, class UnaryFunction, class UnaryPredicate>
+UnaryFunction for_each_if (Range&& r, UnaryFunction uf, UnaryPredicate up) {
+  auto range = make_range(::std::forward<Range>(r));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "for_each_if requires InputIterators");
+  while (not range.empty()) {
+    if (up(range.front())) { uf(range.front()); }
+    range.pop_front();
+  }
+  return uf;
+}
+
+template <class Range, class UnaryFunction, class UnaryPredicate>
+auto for_each_while (
+  Range&& r,
+  UnaryFunction f,
+  UnaryPredicate p
+) -> decltype(begin(make_range(::std::forward<Range>(r)))) {
+  auto range = make_range(::std::forward<Range>(r));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "for_each_while requires InputIterators");
+  while (not range.empty()) {
+    if (not p(range.front())) { break; }
+    f(range.front());
+    range.pop_front();
+  }
+  return range.begin();
+}
+
+template <class Range, class UnaryFunction, class T>
+auto for_each_until (
+  Range&& r,
+  UnaryFunction f,
+  T const& value
+) -> decltype(begin(make_range(::std::forward<Range>(r)))) {
+  auto range = make_range(::std::forward<Range>(r));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "for_each_until requires InputIterators");
+  while (not range.empty()) {
+    if (range.front() == value) { break; }
+    f(range.front());
+    range.pop_front();
+  }
+  return range.begin();
+}
+
+template <class Range, class T>
+auto count (Range&& rng, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(
+    ::std::count(
+      ::std::begin(::std::forward<Range>(rng)),
+      ::std::end(::std::forward<Range>(rng)),
+      value
+    )
+  )
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "count requires InputIterators");
+  return ::std::count(::std::begin(range), ::std::end(range), value);
+}
+
+template <class Range, class UnaryPredicate>
+auto count_if (Range&& rng, UnaryPredicate&& p) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(
+    ::std::count_if(
+      ::std::begin(::std::forward<Range>(rng)),
+      ::std::end(::std::forward<Range>(rng)),
+      ::std::forward<UnaryPredicate>(p)
+    )
+  )
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "count_if requires InputIterators");
+  return ::std::count_if(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(p)
+  );
+}
+
+template <class Range, class InputIt>
+auto mismatch(Range&& rng, InputIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  ::std::pair<
+    decltype(::std::begin(::std::forward<Range>(rng))),
+    decay_t<InputIt>
+  >
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "mismatch requires InputIterators");
+  return ::std::mismatch(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<InputIt>(it)
+  );
+}
+
+template <class Range, class InputIt, class BinaryPredicate>
+auto mismatch(Range&& rng, InputIt&& it, BinaryPredicate&& bp) -> enable_if_t<
+  is_range<Range>::value,
+  ::std::pair<
+    decltype(::std::begin(::std::forward<Range>(rng))),
+    decay_t<InputIt>
+  >
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "mismatch requires InputIterators");
+  return ::std::mismatch(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<InputIt>(it),
+    ::std::forward<BinaryPredicate>(bp)
+  );
+}
+
+template <class InputIt1, class InputIt2, class BinaryPredicate>
+bool equal (
+  InputIt1 first1,
+  InputIt1 last1,
+  InputIt2 first2,
+  InputIt2 last2,
+  BinaryPredicate bp
+) {
+  auto r1 = make_range(first1, last1);
+  auto r2 = make_range(first2, last2);
+  using tag1 = typename decltype(r1)::iterator_category;
+  using tag2 = typename decltype(r2)::iterator_category;
+  return impl::equal(r1, r2, bp, tag1 { }, tag2 { });
+}
+
+template <class InputIt1, class InputIt2>
+bool equal (InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2) {
+  return equal(first1, last1, first2, last2, core::equal_to<> { });
+}
+
+template <
+  class Range1,
+  class Range2,
+  enable_if_t<
+    meta::all<is_range<Range1>, is_range<Range2>>::value,
+    ::std::size_t
+  > = __LINE__
+> bool equal (Range1&& range1, Range2&& range2) {
+  auto r1 = make_range(::std::forward<Range1>(range1));
+  auto r2 = make_range(::std::forward<Range2>(range2));
+  static constexpr auto is_input1 = decltype(r1)::is_input;
+  static constexpr auto is_input2 = decltype(r2)::is_input;
+  static_assert(is_input1, "equal requires InputIterators");
+  static_assert(is_input2, "equal requires InputIterators");
+  return equal(r1.begin(), r1.end(), r2.begin(), r2.end);
+}
+
+template <
+  class Range1,
+  class Range2,
+  class BinaryPredicate,
+  enable_if_t<
+    meta::all<is_range<Range1>, is_range<Range2>>::value,
+    ::std::size_t
+  > = __LINE__
+> bool equal (Range1&& range1, Range2&& range2, BinaryPredicate&& bp) {
+  auto r1 = make_range(::std::forward<Range1>(range1));
+  auto r2 = make_range(::std::forward<Range2>(range2));
+  static constexpr auto is_input1 = decltype(r1)::is_input;
+  static constexpr auto is_input2 = decltype(r2)::is_input;
+  static_assert(is_input1, "equal requires InputIterators");
+  static_assert(is_input2, "equal requires InputIterators");
+  return equal(
+    r1.begin(),
+    r1.end(),
+    r2.begin(),
+    r2.end(),
+    ::std::forward<BinaryPredicate>(bp)
+  );
+}
+
+template <
+  class Range,
+  class InputIt,
+  enable_if_t<
+    meta::all<is_range<Range>, meta::none<is_range<InputIt>>>::value,
+    ::std::size_t
+  > = __LINE__
+> bool equal (Range&& rng, InputIt&& it) {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "equal requires InputIterators");
+  return ::std::equal(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<InputIt>(it)
+  );
+}
+
+template <
+  class Range,
+  class InputIt,
+  class BinaryPredicate,
+  enable_if_t<
+    meta::all<is_range<Range>, meta::none<is_range<InputIt>>>::value,
+    ::std::size_t
+  > = __LINE__
+> bool equal (Range&& rng, InputIt&& it, BinaryPredicate&& bp) {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "equal requires InputIterators");
+  return ::std::equal(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<InputIt>(it),
+    ::std::forward<BinaryPredicate>(bp)
+  );
+}
+
+template <class Range, class T>
+auto find (Range&& rng, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "find requires InputIterators");
+  return ::std::find(::std::begin(range), ::std::end(range), value);
+}
+
+template <class Range, class UnaryPredicate>
+auto find_if (Range&& rng, UnaryPredicate&& p) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "find_if requires InputIterators");
+  return ::std::find_if(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(p)
+  );
+}
+
+template <class Range, class UnaryPredicate>
+auto find_if_not (Range&& rng, UnaryPredicate&& p) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "find_if_not requires InputIterators");
+  return ::std::find_if_not(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(p)
+  );
+}
+
+template <class Range1, class Range2>
+auto find_end (Range1&& rng1, Range2&& rng2) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decltype(::std::begin(::std::forward<Range1>(rng1)))
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_forward1 = decltype(range1)::is_forward;
+  static constexpr auto is_forward2 = decltype(range2)::is_forward;
+  static_assert(is_forward1, "find_end requires ForwardIterators");
+  static_assert(is_forward2, "find_end requires ForwardIterators");
+  return ::std::find_end(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2)
+  );
+}
+
+template <class Range1, class Range2, class BinaryPred>
+auto find_end (Range1&& rng1, Range2&& rng2, BinaryPred& bp) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decltype(::std::begin(::std::forward<Range1>(rng1)))
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_forward1 = decltype(range1)::is_forward;
+  static constexpr auto is_forward2 = decltype(range2)::is_forward;
+  static_assert(is_forward1, "find_end requires ForwardIterators");
+  static_assert(is_forward2, "find_end requires ForwardIterators");
+  return ::std::find_end(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<BinaryPred>(bp)
+  );
+}
+
+template <class IRange, class FRange>
+auto find_first_of (IRange&& irng, FRange&& frng) -> enable_if_t<
+  all_traits<is_range<IRange>, is_range<FRange>>::value,
+  decltype(::std::begin(::std::forward<IRange>(irng)))
+> {
+  auto irange = make_range(::std::forward<IRange>(irng));
+  auto frange = make_range(::std::forward<FRange>(frng));
+  static constexpr auto is_input = decltype(irange)::is_input;
+  static constexpr auto is_forward = decltype(frange)::is_forward;
+  static_assert(is_input, "find_first_of requires InputIterators");
+  static_assert(is_forward, "find_first_of requires ForwardIterators");
+  return ::std::find_first_of(
+    ::std::begin(irange),
+    ::std::end(irange),
+    ::std::begin(frange),
+    ::std::end(frange)
+  );
+}
+
+template <class IRange, class FRange, class BinaryPred>
+auto find_first_of (
+  IRange&& irng,
+  FRange&& frng,
+  BinaryPred&& bp
+) -> enable_if_t<
+  all_traits<is_range<IRange>, is_range<FRange>>::value,
+  decltype(::std::begin(::std::forward<IRange>(irng)))
+> {
+  auto irange = make_range(::std::forward<IRange>(irng));
+  auto frange = make_range(::std::forward<FRange>(frng));
+  static constexpr auto is_input = decltype(irange)::is_input;
+  static constexpr auto is_forward = decltype(frange)::is_forward;
+  static_assert(is_input, "find_first_of requires InputIterators");
+  static_assert(is_forward, "find_first_of requires ForwardIterators");
+  return ::std::find_first_of(
+    ::std::begin(irange),
+    ::std::end(irange),
+    ::std::begin(frange),
+    ::std::end(frange),
+    ::std::forward<BinaryPred>(bp)
+  );
+}
+
+template <class Range>
+auto adjacent_find (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "adjacent_find requires ForwardIterators");
+  return ::std::adjacent_find(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class BinaryPredicate>
+auto adjacent_find (Range&& rng, BinaryPredicate&& bp) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "adjacent_find requires ForwardIterators");
+  return ::std::adjacent_find(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<BinaryPredicate>(bp)
+  );
+}
+
+template <class Range1, class Range2>
+auto search (Range1&& rng1, Range2&& rng2) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decltype(::std::begin(::std::forward<Range1>(rng1)))
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_forward1 = decltype(range1)::is_forward;
+  static constexpr auto is_forward2 = decltype(range2)::is_forward;
+  static_assert(is_forward1, "search requires ForwardIterators");
+  static_assert(is_forward2, "search requires ForwardIterators");
+  return ::std::search(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2)
+  );
+}
+
+template <class Range1, class Range2, class BinaryPred>
+auto search (Range1&& rng1, Range2&& rng2, BinaryPred&& bp) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decltype(::std::begin(::std::forward<Range1>(rng1)))
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_forward1 = decltype(range1)::is_forward;
+  static constexpr auto is_forward2 = decltype(range2)::is_forward;
+  static_assert(is_forward1, "search requires ForwardIterators");
+  static_assert(is_forward2, "search requires ForwardIterators");
+  return ::std::search(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<BinaryPred>(bp)
+  );
+}
+
+template <class Range, class Size, class T>
+auto search_n (Range&& rng, Size&& count, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "search_n requires ForwardIterators");
+  return ::std::search_n(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Size>(count),
+    value
+  );
+}
+
+template <class Range, class Size, class T, class BinaryPred>
+auto search_n (
+  Range&& rng,
+  Size&& count,
+  T const& value,
+  BinaryPred&& bp
+) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "search_n requires ForwardIterators");
+  return ::std::search_n(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Size>(count),
+    value,
+    ::std::forward<BinaryPred>(bp)
+  );
+}
+
+/* modifying sequence algorithms */
+template <class Range, class OutputIt>
+auto copy (Range&& rng, OutputIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "copy requires InputIterators");
+  return ::std::copy(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range, class OutputIt, class UnaryPredicate>
+auto copy_if (Range&& rng, OutputIt&& it, UnaryPredicate&& up) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "copy_if requires InputIterators");
+  return ::std::copy_if(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<UnaryPredicate>(up)
+  );
+}
+
+template <class Range, class OutputIt, class T>
+OutputIt copy_until (Range&& r, OutputIt it, T const& value) {
+  auto range = make_range(::std::forward<Range>(r));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "copy_until requires InputIterators");
+  while (not range.empty()) {
+    if (range.front() == value) { break; }
+    *it++ = range.front();
+    range.pop_front();
+  }
+  return it;
+}
+
+template <class Range, class BidirIt>
+auto copy_backward (Range&& rng, BidirIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<BidirIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "copy_backward requires BidirectionalIterators");
+  return ::std::copy_backward(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<BidirIt>(it)
+  );
+}
+
+template <class Range, class OutputIt>
+auto move (Range&& rng, OutputIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "move requires InputIterators");
+  return ::std::move(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range, class BidirIt>
+auto move_backward (Range&& rng, BidirIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<BidirIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "move_backward requires BidirectionalIterators");
+  return ::std::move_backward(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<BidirIt>(it)
+  );
+}
+
+template <class Range, class T>
+auto fill (Range&& rng, T const& value) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "fill requires ForwardIterators");
+  return ::std::fill(::std::begin(range), ::std::end(range), value);
+}
+
+template <class Range, class OutputIt, class UnaryOperation>
+auto transform (
+  Range&& rng,
+  OutputIt&& it,
+  UnaryOperation&& op
+) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "transform requires InputIterators");
+  return ::std::transform(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<UnaryOperation>(op)
+  );
+}
+
+template <class Range, class OutputIt, class UnaryOperation, class UnaryPred>
+auto transform_if (
+  Range&& rng,
+  OutputIt it,
+  UnaryOperation op,
+  UnaryPred up
+) -> enable_if_t<
+  is_range<Range>::value,
+  OutputIt
+> {
+  auto range = make_range(::core::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "transform_if requires ForwardIterators");
+  while (not range.empty()) {
+    if (up(range.front())) {
+      *it = op(range.front());
+      ++it;
+    }
+    range.pop_front();
+  }
+  return it;
+}
+
+template <
+  class Range,
+  class InputIt,
+  class OutputIt,
+  class BinaryOperation,
+  enable_if_t<
+    meta::all<is_range<Range>, meta::none<is_range<InputIt>>>::value,
+    ::std::size_t
+  > = __LINE__
+> decay_t<OutputIt> transform (
+  Range&& r,
+  InputIt&& in,
+  OutputIt&& out,
+  BinaryOperation&& op
+) {
+  auto range = make_range(::std::forward<Range>(r));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "transform requires InputIterators");
+  return ::std::transform(
+    range.begin(),
+    range.end(),
+    ::std::forward<InputIt>(in),
+    ::std::forward<OutputIt>(out),
+    ::std::forward<BinaryOperation>(op));
+}
+
+template <
+  class Range1,
+  class Range2,
+  class OutputIt,
+  class BinaryOperation,
+  enable_if_t<
+    meta::all<is_range<Range1>, is_range<Range2>>::value,
+    ::std::size_t
+  > = __LINE__
+> decay_t<OutputIt> transform (
+  Range1&& rng1,
+  Range2&& rng2,
+  OutputIt&& it,
+  BinaryOperation&& op
+) {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "transform requires InputIterators");
+  static_assert(is_input2, "transform requires InputIterators");
+  return ::std::transform(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<BinaryOperation>(op)
+  );
+}
+
+template <
+  class Range1,
+  class Range2,
+  class OutputIt,
+  class BinaryOperation,
+  class BinaryPredicate
+> auto transform_if (
+  Range1&& rng1,
+  Range2&& rng2,
+  OutputIt it,
+  BinaryOperation op,
+  BinaryPredicate bp
+) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  OutputIt
+> {
+  auto range1 = make_range(::core::forward<Range1>(rng1));
+  auto range2 = make_range(::core::forward<Range2>(rng2));
+  static constexpr auto is_forward1 = decltype(range1)::is_forward;
+  static constexpr auto is_forward2 = decltype(range2)::is_forward;
+  static_assert(is_forward1, "transform_if requires ForwardIterators");
+  static_assert(is_forward2, "transform_if requires ForwardIterators");
+  while (not range1.empty()) {
+    if (bp(range1.front(), range2.front())) {
+      *it = op(range1.front(), range2.front());
+      ++it;
+    }
+    range1.pop_front();
+    range2.pop_front();
+  }
+  return it;
+}
+
+template <class Range, class T>
+auto remove (Range&& rng, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "remove requires ForwardIterators");
+  return ::std::remove(::std::begin(range), ::std::end(range), value);
+}
+
+template <class Range, class UnaryPredicate>
+auto remove_if (Range&& rng, UnaryPredicate&& up) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "remove_if requires ForwardIterators");
+  return ::std::remove_if(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(up)
+  );
+}
+
+template <class Range, class OutputIt, class T>
+auto remove_copy (Range&& rng, OutputIt&& it, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "remove_copy requires InputIterators");
+  return ::std::remove_copy(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    value
+  );
+}
+
+template <class Range, class OutputIt, class UnaryPred>
+auto remove_copy_if (Range&& rng, OutputIt&& it, UnaryPred&& up) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "remove_copy_if requires InputIterators");
+  return ::std::remove_copy_if(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<UnaryPred>(up)
+  );
+}
+
+template <class Range, class T>
+auto remove_erase (Range&& rng, T const& val) -> enable_if_t<
+  is_range<Range>::value
+> {
+  ::std::forward<Range>(rng).erase(
+    remove(::std::forward<Range>(rng), val),
+    ::std::end(::std::forward<Range>(rng))
+  );
+}
+
+template <class Range, class UnaryPred>
+auto remove_erase_if (Range&& rng, UnaryPred&& up) -> enable_if_t<
+  is_range<Range>::value
+> {
+  ::std::forward<Range>(rng).erase(
+    remove_if(
+      ::std::forward<Range>(rng),
+      ::std::forward<UnaryPred>(up)
+    ),
+    ::std::end(::std::forward<Range>(rng))
+  );
+}
+
+template <class Range, class T>
+auto replace (Range&& rng, T const& old, T const& value) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_input;
+  static_assert(is_forward, "replace requires ForwardIterators");
+  return ::std::replace(
+    ::std::begin(range),
+    ::std::end(range),
+    old,
+    value
+  );
+}
+
+template <class Range, class UnaryPred, class T>
+auto replace_if (Range&& rng, UnaryPred&& up, T const& value) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "replace_if requires ForwardIterators");
+  return ::std::replace_if(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPred>(up),
+    value
+  );
+}
+
+template <class Range, class OutputIt, class T>
+auto replace_copy (
+  Range&& rng,
+  OutputIt&& it,
+  T const& old,
+  T const& value
+) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "replace_copy requires InputIterators");
+  return ::std::replace_copy(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    old,
+    value
+  );
+}
+
+template <class Range, class OutputIt, class UnaryPred, class T>
+auto replace_copy_if (
+  Range&& rng,
+  OutputIt&& it,
+  UnaryPred&& up,
+  T const& value
+) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "replace_copy_if requires InputIterators");
+  return ::std::replace_copy_if(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<UnaryPred>(up),
+    value
+  );
+}
+
+template <class Range, class ForwardIt>
+auto swap_ranges (Range&& rng, ForwardIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<ForwardIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "swap_ranges requires ForwardIterators");
+  return ::std::swap_ranges(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<ForwardIt>(it)
+  );
+}
+
+template <class Range>
+auto reverse (Range&& rng) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "reverse requires BidirectionalIterators");
+  return ::std::reverse(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class OutputIt>
+auto reverse_copy (Range&& rng, OutputIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "reverse_copy requires BidirectionalIterators");
+  return ::std::reverse_copy(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range, class ForwardIt>
+auto rotate (Range&& rng, ForwardIt&& it) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "rotate requires ForwardIterators");
+  ::std::rotate(
+    ::std::begin(range),
+    ::std::forward<ForwardIt>(it),
+    ::std::end(range)
+  );
+}
+
+template <class Range, class ForwardIt, class OutputIt>
+auto rotate_copy (Range&& rng, ForwardIt&& it, OutputIt&& ot) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "rotate_copy requires ForwardIterators");
+  return ::std::rotate_copy(
+    ::std::begin(range),
+    ::std::forward<ForwardIt>(it),
+    ::std::end(range),
+    ::std::forward<OutputIt>(ot)
+  );
+}
+
+template <class Range, class URNG>
+auto shuffle (Range&& rng, URNG&& g) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "shuffle requires RandomAccessIterators");
+  return ::std::shuffle(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<URNG>(g)
+  );
+}
+
+template <class Range>
+auto unique (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "unique requires ForwardIterators");
+  return ::std::unique(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class BinaryPredicate>
+auto unique (Range&& rng, BinaryPredicate&& bp) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "unique requires ForwardIterators");
+  return ::std::unique(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<BinaryPredicate>(bp)
+  );
+}
+
+template <class Range, class OutputIt>
+auto unique_copy (Range&& rng, OutputIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "unique_copy requires InputIterators");
+  return ::std::unique_copy(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range, class OutputIt, class BinaryPred>
+auto unique_copy (Range&& rng, OutputIt&& it, BinaryPred&& bp) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "unique_copy requires InputIterators");
+  return ::std::unique_copy(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<BinaryPred>(bp)
+  );
+}
+
+/* partitioning operations */
+template <class Range, class UnaryPredicate>
+auto is_partitioned (Range&& rng, UnaryPredicate&& up) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "is_partitioned requires InputIterators");
+  return ::std::is_partitioned(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(up)
+  );
+}
+
+template <class Range, class UnaryPredicate>
+auto partition (Range&& rng, UnaryPredicate&& up) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "partition requires ForwardIterators");
+  return ::std::partition(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(up)
+  );
+}
+
+template <class Range, class OutputTrue, class OutputFalse, class UnaryPred>
+auto partition_copy (
+  Range&& rng,
+  OutputTrue&& ot,
+  OutputFalse&& of,
+  UnaryPred&& up
+) -> enable_if_t<
+  is_range<Range>::value,
+  ::std::pair<decay_t<OutputTrue>, decay_t<OutputFalse>>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "partition_copy requires InputIterators");
+  return ::std::partition_copy(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputTrue>(ot),
+    ::std::forward<OutputFalse>(of),
+    ::std::forward<UnaryPred>(up)
+  );
+}
+
+template <class Range, class UnaryPredicate>
+auto stable_partition (Range&& rng, UnaryPredicate&& up) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "stable_partition requires BidirectionalIterators");
+  return ::std::stable_partition(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(up)
+  );
+}
+
+template <class Range, class UnaryPredicate>
+auto partition_point (Range&& rng, UnaryPredicate&& up) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "partition_point requires ForwardIterators");
+  return ::std::partition_point(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<UnaryPredicate>(up)
+  );
+}
+
+/* sorting operations */
+
+template <class Range>
+auto is_sorted (Range&& rng) -> enable_if_t<is_range<Range>::value, bool> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "is_sorted requires ForwardIterators");
+  return ::std::is_sorted(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto is_sorted (Range&& rng, Compare&& compare) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "is_sorted requires ForwardIterators");
+  return ::std::is_sorted(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(compare)
+  );
+}
+
+template <class Range>
+auto is_sorted_until (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "is_sorted_until requires ForwardIterators");
+  return ::std::is_sorted_until(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto is_sorted_until (Range&& rng, Compare&& compare) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "is_sorted_until requires ForwardIterators");
+  return ::std::is_sorted_until(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(compare)
+  );
+}
+
+template <class Range>
+auto sort (Range&& rng) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "sort requires RandomAccessIterators");
+  return ::std::sort(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto sort (Range&& rng, Compare&& cmp) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "sort requires RandomAccessIterators");
+  return ::std::sort(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range, class RandomIt>
+auto partial_sort (Range&& rng, RandomIt&& it) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "partial_sort requires RandomAccessIterators");
+  return ::std::partial_sort(
+    ::std::begin(range),
+    ::std::forward<RandomIt>(it),
+    ::std::end(range)
+  );
+}
+
+template <class Range, class RandomIt, class Compare>
+auto partial_sort (Range&& rng, RandomIt&& it, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "partial_sort requires RandomAccessIterators");
+  return ::std::partial_sort(
+    ::std::begin(range),
+    ::std::forward<RandomIt>(it),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class IRange, class RRange>
+auto partial_sort_copy (IRange&& irng, RRange&& rrng) -> enable_if_t<
+  all_traits<is_range<IRange>, is_range<RRange>>::value,
+  decltype(::std::begin(::std::forward<RRange>(rrng)))
+> {
+  auto irange = make_range(::std::forward<IRange>(irng));
+  auto rrange = make_range(::std::forward<RRange>(rrng));
+  static constexpr auto is_input = decltype(irange)::is_input;
+  static constexpr auto is_random = decltype(rrange)::is_random_access;
+  static_assert(is_input, "partial_sort_copy requires InputIterators");
+  static_assert(is_random, "partial_sort_copy requires RandomAccessIterators");
+  return ::std::partial_sort_copy(
+    ::std::begin(irange),
+    ::std::end(irange),
+    ::std::begin(rrange),
+    ::std::end(rrange)
+  );
+}
+
+template <class IRange, class RRange, class Compare>
+auto partial_sort_copy (
+  IRange&& irng,
+  RRange&& rrng,
+  Compare&& cmp
+) -> enable_if_t<
+  all_traits<is_range<IRange>, is_range<RRange>>::value,
+  decltype(::std::begin(::std::forward<RRange>(rrng)))
+> {
+  auto irange = make_range(::std::forward<IRange>(irng));
+  auto rrange = make_range(::std::forward<RRange>(rrng));
+  static constexpr auto is_input = decltype(irange)::is_input;
+  static constexpr auto is_random = decltype(rrange)::is_random_access;
+  static_assert(is_input, "partial_sort_copy requires InputIterators");
+  static_assert(is_random, "partial_sort_copy requires RandomAccessIterators");
+  return ::std::partial_sort_copy(
+    ::std::begin(irange),
+    ::std::end(irange),
+    ::std::begin(rrange),
+    ::std::end(rrange),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto stable_sort (Range&& rng) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "stable_sort requires RandomAccessIterators");
+  return ::std::stable_sort(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto stable_sort (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "stable_sort requires RandomAccessIterators");
+  return ::std::stable_sort(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range, class RandomIt>
+auto nth_element (Range&& rng, RandomIt&& it) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "nth_element requires RandomAccessIterators");
+  return ::std::nth_element(
+    ::std::begin(range),
+    ::std::forward<RandomIt>(it),
+    ::std::end(range)
+  );
+}
+
+template <class Range, class RandomIt, class Compare>
+auto nth_element (Range&& rng, RandomIt&& it, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "nth_element requires RandomAccessIterators");
+  return ::std::nth_element(
+    ::std::begin(range),
+    ::std::forward<RandomIt>(it),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+/* binary search operations (on sorted ranges) */
+template <class Range, class T>
+auto lower_bound (Range&& rng, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "lower_bound requires ForwardIterators");
+  return ::std::lower_bound(::std::begin(range), ::std::end(range), value);
+}
+
+template <class Range, class T, class Compare>
+auto lower_bound (Range&& rng, T const& value, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "lower_bound requires ForwardIterators");
+  return ::std::lower_bound(
+    ::std::begin(range),
+    ::std::end(range),
+    value,
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range, class T>
+auto upper_bound (Range&& rng, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "upper_bound requires ForwardIterators");
+  return ::std::upper_bound(::std::begin(range), ::std::end(range), value);
+}
+
+template <class Range, class T, class Compare>
+auto upper_bound (Range&& rng, T const& value, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "upper_bound requires ForwardIterators");
+  return ::std::upper_bound(
+    ::std::begin(range),
+    ::std::end(range),
+    value,
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range, class T>
+auto binary_search (Range&& rng, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "binary_search requires ForwardIterators");
+  return ::std::binary_search(::std::begin(range), ::std::end(range), value);
+}
+
+template <class Range, class T, class Compare>
+auto binary_search (Range&& rng, T const& value, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "binary_search requires ForwardIterators");
+  return ::std::binary_search(
+    ::std::begin(range),
+    ::std::end(range),
+    value,
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range, class T>
+auto equal_range (Range&& rng, T const& value) -> enable_if_t<
+  is_range<Range>::value,
+  range<decltype(::std::begin(::std::forward<Range>(rng)))>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "equal_range requires ForwardIterators");
+  return ::std::equal_range(::std::begin(range), ::std::end(range), value);
+}
+
+template <class Range, class T, class Compare>
+auto equal_range (Range&& rng, T const& value, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  range<decltype(::std::begin(::std::forward<Range>(rng)))>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "equal_range requires ForwardIterators");
+  return ::std::equal_range(
+    ::std::begin(range),
+    ::std::end(range),
+    value,
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+/* set operations (on sorted ranges) */
+template <class Range1, class Range2, class OutputIt>
+auto merge (Range1&& rng1, Range2&& rng2, OutputIt&& it) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "merge requires InputIterators");
+  static_assert(is_input2, "merge requires InputIterators");
+  return ::std::merge(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt, class Compare>
+auto merge (
+  Range1&& rng1,
+  Range2&& rng2,
+  OutputIt&& it,
+  Compare&& cmp
+) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "merge requires InputIterators");
+  static_assert(is_input2, "merge requires InputIterators");
+  return ::std::merge(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range, class BidirIt>
+auto inplace_merge (Range&& rng, BidirIt&& it) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "inplace_merge requires BidirectionalIterators");
+  return ::std::inplace_merge(
+    ::std::begin(range),
+    ::std::forward<BidirIt>(it),
+    ::std::end(range)
+  );
+}
+
+template <class Range, class BidirIt, class Compare>
+auto inplace_merge (Range&& rng, BidirIt&& it, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "inplace_merge requires BidirectionalIterators");
+  return ::std::inplace_merge(
+    ::std::begin(range),
+    ::std::forward<BidirIt>(it),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range1, class Range2>
+auto includes (Range1&& rng1, Range2&& rng2) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  bool
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "includes requires InputIterators");
+  static_assert(is_input2, "includes requires InputIterators");
+  return ::std::includes(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2)
+  );
+}
+
+template <class Range1, class Range2, class Compare>
+auto includes (Range1&& rng1, Range2&& rng2, Compare&& cmp) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  bool
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "includes requires InputIterators");
+  static_assert(is_input2, "includes requires InputIterators");
+  return ::std::includes(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt>
+auto set_difference (Range1&& rng1, Range2&& rng2, OutputIt&& it) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "set_difference requires InputIterators");
+  static_assert(is_input2, "set_difference requires InputIterators");
+  return ::std::set_difference(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt, class Compare>
+auto set_difference (
+  Range1&& rng1,
+  Range2&& rng2,
+  OutputIt&& it,
+  Compare&& cmp
+) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "set_difference requires InputIterators");
+  static_assert(is_input2, "set_difference requires InputIterators");
+  return ::std::set_difference(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt>
+auto set_intersection (Range1&& rng1, Range2&& rng2, OutputIt&& it) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "set_intersection requires InputIterators");
+  static_assert(is_input2, "set_intersection requires InputIterators");
+  return ::std::set_intersection(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt, class Compare>
+auto set_intersection (
+  Range1&& rng1,
+  Range2&& rng2,
+  OutputIt&& it,
+  Compare&& cmp
+) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "set_intersection requires InputIterators");
+  static_assert(is_input2, "set_intersection requires InputIterators");
+  return ::std::set_intersection(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt>
+auto set_symmetric_difference (Range1&& rng1, Range2&& rng2, OutputIt&& it) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "set_symmetric_difference requires InputIterators");
+  static_assert(is_input2, "set_symmetric_difference requires InputIterators");
+  return ::std::set_symmetric_difference(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt, class Compare>
+auto set_symmetric_difference (
+  Range1&& rng1,
+  Range2&& rng2,
+  OutputIt&& it,
+  Compare&& cmp
+) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "set_symmetric_difference requires InputIterators");
+  static_assert(is_input2, "set_symmetric_difference requires InputIterators");
+  return ::std::set_symmetric_difference(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt>
+auto set_union (Range1&& rng1, Range2&& rng2, OutputIt&& it) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "set_union requires InputIterators");
+  static_assert(is_input2, "set_union requires InputIterators");
+  return ::std::set_union(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range1, class Range2, class OutputIt, class Compare>
+auto set_union (
+  Range1&& rng1,
+  Range2&& rng2,
+  OutputIt&& it,
+  Compare&& cmp
+) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  decay_t<OutputIt>
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "set_union requires InputIterators");
+  static_assert(is_input2, "set_union requires InputIterators");
+  return ::std::set_union(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+/* heap operations */
+template <class Range>
+auto is_heap (Range&& rng) -> enable_if_t<is_range<Range>::value, bool> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "is_heap requires RandomAccessIterators");
+  return ::std::is_heap(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto is_heap (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "is_heap requires RandomAccessIterators");
+  return ::std::is_heap(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto is_heap_until (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "is_heap_until requires RandomAccessIterators");
+  return ::std::is_heap_until(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto is_heap_until (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "is_heap_until requires RandomAccessIterators");
+  return ::std::is_heap_until(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto make_heap (Range&& rng) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "make_heap requires RandomAccessIterators");
+  return ::std::make_heap(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto make_heap (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "make_heap requires RandomAccessIterators");
+  return ::std::make_heap(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto push_heap (Range&& rng) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "push_heap requires RandomAccessIterators");
+  return ::std::push_heap(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto push_heap (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "push_heap requires RandomAccessIterators");
+  return ::std::push_heap(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto pop_heap (Range&& rng) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "pop_heap requires RandomAccessIterators");
+  return ::std::pop_heap(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto pop_heap (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "pop_heap requires RandomAccessIterators");
+  return ::std::pop_heap(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto sort_heap (Range&& rng) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "sort_heap requires RandomAccessIterators");
+  return ::std::sort_heap(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto sort_heap (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_random = decltype(range)::is_random_access;
+  static_assert(is_random, "sort_heap requires RandomAccessIterators");
+  return ::std::sort_heap(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+/* min/max operations */
+template <class Range>
+auto max_element (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "max_element requires ForwardIterators");
+  return ::std::max_element(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto max_element (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "max_element requires ForwardIterators");
+  return ::std::max_element(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto min_element (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "min_element requires ForwardIterators");
+  return ::std::min_element(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto min_element (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  decltype(::std::begin(::std::forward<Range>(rng)))
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "min_element requires ForwardIterators");
+  return ::std::min_element(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto minmax_element (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  ::std::pair<
+    decltype(::std::begin(::std::forward<Range>(rng))),
+    decltype(::std::begin(::std::forward<Range>(rng)))
+  >
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "minmax_element requires ForwardIterators");
+  return ::std::minmax_element(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto minmax_element (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  ::std::pair<
+    range<decltype(::std::begin(::std::forward<Range>(rng)))>,
+    range<decltype(::std::begin(::std::forward<Range>(rng)))>
+  >
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "minmax_element requires ForwardIterators");
+  return ::std::minmax_element(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range1, class Range2>
+auto lexicographical_compare (Range1&& rng1, Range2&& rng2) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  bool
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "lexicographical_compare requires InputIterators");
+  static_assert(is_input2, "lexicographical_compare requires InputIterators");
+  return ::std::lexicographical_compare(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2)
+  );
+}
+
+template <class Range1, class Range2, class Compare>
+auto lexicographical_compare (
+  Range1&& rng1,
+  Range2&& rng2,
+  Compare&& cmp
+) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  bool
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_input1 = decltype(range1)::is_input;
+  static constexpr auto is_input2 = decltype(range2)::is_input;
+  static_assert(is_input1, "lexicographical_compare requires InputIterators");
+  static_assert(is_input2, "lexicographical_compare requires InputIterators");
+  return ::std::lexicographical_compare(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::end(range2),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range1, class Range2>
+auto is_permutation (Range1&& rng1, Range2&& rng2) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  bool
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_forward1 = decltype(range1)::is_forward;
+  static constexpr auto is_forward2 = decltype(range2)::is_forward;
+  static_assert(is_forward1, "is_permutation requires ForwardIterators");
+  static_assert(is_forward2, "is_permutation requires ForwardIterators");
+  return ::std::is_permutation(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2)
+  );
+}
+
+template <class Range1, class Range2, class BinaryPredicate>
+auto is_permutation (
+  Range1&& rng1,
+  Range2&& rng2,
+  BinaryPredicate&& bp
+) -> enable_if_t<
+  all_traits<is_range<Range1>, is_range<Range2>>::value,
+  bool
+> {
+  auto range1 = make_range(::std::forward<Range1>(rng1));
+  auto range2 = make_range(::std::forward<Range2>(rng2));
+  static constexpr auto is_forward1 = decltype(range1)::is_forward;
+  static constexpr auto is_forward2 = decltype(range2)::is_forward;
+  static_assert(is_forward1, "is_permutation requires ForwardIterators");
+  static_assert(is_forward2, "is_permutation requires ForwardIterators");
+  return ::std::is_permutation(
+    ::std::begin(range1),
+    ::std::end(range1),
+    ::std::begin(range2),
+    ::std::forward<BinaryPredicate>(bp)
+  );
+}
+
+template <class Range>
+auto next_permutation (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "next_permutation requires BidirectionalIterators");
+  return ::std::next_permutation(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto next_permutation (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "next_permutation requires BidirectionalIterators");
+  return ::std::next_permutation(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+template <class Range>
+auto prev_permutation (Range&& rng) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "prev_permutation requires BidirectionalIterators");
+  return ::std::prev_permutation(::std::begin(range), ::std::end(range));
+}
+
+template <class Range, class Compare>
+auto prev_permutation (Range&& rng, Compare&& cmp) -> enable_if_t<
+  is_range<Range>::value,
+  bool
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  static constexpr auto is_bidir = decltype(range)::is_bidirectional;
+  static_assert(is_bidir, "prev_permutation requires BidirectionalIterators");
+  return ::std::prev_permutation(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<Compare>(cmp)
+  );
+}
+
+}} /* namespace core::v1 */
+
+#endif /* CORE_ALGORITHM_HPP */

--- a/core/include/core/any.hpp
+++ b/core/include/core/any.hpp
@@ -1,0 +1,340 @@
+#ifndef CORE_ANY_HPP
+#define CORE_ANY_HPP
+
+#ifdef CORE_NO_RTTI
+  #error "core::any requires RTTI"
+#endif /* CORE_NO_RTTI */
+
+#include <typeinfo>
+#include <memory>
+
+#include <cstdlib>
+#include <cstring>
+
+#include <core/type_traits.hpp>
+#include <core/utility.hpp>
+
+#ifndef CORE_NO_EXCEPTIONS
+#include <stdexcept>
+#endif /* CORE_NO_EXCEPTIONS */
+
+namespace core {
+inline namespace v1 {
+namespace impl {
+
+using data_type = add_pointer_t<void>;
+
+template <class Type>
+using is_small = meta::boolean<
+  sizeof(decay_t<Type>) <= sizeof(data_type) and
+  ::std::is_nothrow_copy_constructible<Type>::value
+>;
+
+struct any_dispatch {
+  using destroy_function = add_pointer_t<void(data_type&)>;
+  using clone_function = add_pointer_t<void(data_type const&, data_type&)>;
+  using move_function = add_pointer_t<void(data_type&, data_type&)>;
+  using type_function = add_pointer_t<::std::type_info const&()>;
+
+  destroy_function const destroy;
+  clone_function const clone;
+  move_function const move;
+  type_function const type;
+};
+
+template <class Type, bool=is_small<Type>::value> struct any_dispatch_select;
+
+template <class Type>
+struct any_dispatch_select<Type, true> {
+  using value_type = Type;
+  using const_pointer = add_pointer_t<add_const_t<value_type>>;
+  using pointer = add_pointer_t<value_type>;
+  using allocator_type = ::std::allocator<value_type>;
+  using allocator_traits = ::std::allocator_traits<allocator_type>;
+
+  static void clone (data_type const& source, data_type& data) {
+    allocator_type alloc { };
+    auto val = reinterpret_cast<const_pointer const>(::std::addressof(source));
+    auto ptr = reinterpret_cast<pointer>(::std::addressof(data));
+    allocator_traits::construct(alloc, ptr, *val);
+  }
+
+  static void move (data_type& source, data_type& data) {
+    allocator_type alloc { };
+    auto val = reinterpret_cast<pointer>(::std::addressof(source));
+    auto ptr = reinterpret_cast<pointer>(::std::addressof(data));
+    allocator_traits::construct(alloc, ptr, ::core::move(*val));
+  }
+
+  static void destroy (data_type& data) {
+    allocator_type alloc { };
+    auto ptr = reinterpret_cast<pointer>(::std::addressof(data));
+    allocator_traits::destroy(alloc, ptr);
+  }
+};
+
+template <class Type>
+struct any_dispatch_select<Type, false> {
+  using value_type = Type;
+  using pointer = add_pointer_t<value_type>;
+  using allocator_type = ::std::allocator<value_type>;
+  using allocator_traits = ::std::allocator_traits<allocator_type>;
+
+  static void clone (data_type const& source, data_type& data) {
+    allocator_type alloc { };
+    auto const& value = *static_cast<pointer const>(source);
+    auto pointer = allocator_traits::allocate(alloc, 1);
+    auto scope = make_scope_guard([&alloc, pointer] {
+      allocator_traits::deallocate(alloc, pointer, 1);
+    });
+    allocator_traits::construct(alloc, pointer, value);
+    scope.dismiss();
+    data = pointer;
+  }
+
+  static void move (data_type& source, data_type& data) {
+    allocator_type alloc { };
+    auto& value = *static_cast<pointer>(source);
+    auto pointer = allocator_traits::allocate(alloc, 1);
+    auto scope = make_scope_guard([&alloc, pointer] {
+      allocator_traits::deallocate(alloc, pointer, 1);
+    });
+    allocator_traits::construct(alloc, pointer, ::core::move(value));
+    scope.dismiss();
+    data = pointer;
+  }
+
+  static void destroy (data_type& data) {
+    allocator_type alloc { };
+    auto value = static_cast<pointer>(data);
+    allocator_traits::destroy(alloc, value);
+    allocator_traits::deallocate(alloc, value, 1);
+  }
+};
+
+template <class Type>
+any_dispatch const* get_any_dispatch () {
+  static any_dispatch const instance = {
+    any_dispatch_select<Type>::destroy,
+    any_dispatch_select<Type>::clone,
+    any_dispatch_select<Type>::move,
+    [] () -> ::std::type_info const& { return typeid(Type); }
+  };
+  return ::std::addressof(instance);
+}
+
+template <>
+inline any_dispatch const* get_any_dispatch<void> () {
+  static any_dispatch const instance = {
+    [] (data_type&) { },
+    [] (data_type const&, data_type&) { },
+    [] (data_type&, data_type&) { },
+    [] () -> ::std::type_info const& { return typeid(void); }
+  };
+  return ::std::addressof(instance);
+}
+
+} /* namespace impl */
+
+/* Forgive the ugly preprocessor macro in the middle of this file */
+#ifndef CORE_NO_EXCEPTIONS
+class bad_any_cast final : public ::std::bad_cast {
+public:
+  virtual char const* what () const noexcept override {
+    return "bad any cast";
+  }
+};
+
+[[noreturn]] inline void throw_bad_any_cast () { throw bad_any_cast { }; }
+#else /* CORE_NO_EXCEPTIONS */
+[[noreturn]] inline void throw_bad_any_cast () { ::std::abort(); }
+#endif /* CORE_NO_EXCEPTIONS */
+
+class any final {
+  template <class ValueType>
+  friend ValueType const* any_cast (any const*) noexcept;
+  template <class ValueType> friend ValueType* any_cast (any*) noexcept;
+
+  impl::any_dispatch const* table;
+  impl::data_type data;
+
+  template <class ValueType>
+  any (ValueType&& value, ::std::true_type&&) :
+    table { impl::get_any_dispatch<decay_t<ValueType>>() },
+    data { nullptr }
+  {
+    using value_type = decay_t<ValueType>;
+    using allocator_type = ::std::allocator<value_type>;
+    allocator_type alloc { };
+    auto pointer = reinterpret_cast<value_type*>(::std::addressof(this->data));
+    ::std::allocator_traits<allocator_type>::construct(
+      alloc, pointer, ::std::forward<ValueType>(value)
+    );
+  }
+
+  template <class ValueType>
+  any (ValueType&& value, ::std::false_type&&) :
+    table { impl::get_any_dispatch<decay_t<ValueType>>() },
+    data { nullptr }
+  {
+    using value_type = decay_t<ValueType>;
+    using allocator_type = ::std::allocator<value_type>;
+    allocator_type alloc { };
+    auto pointer = ::std::allocator_traits<allocator_type>::allocate(alloc, 1);
+    ::std::allocator_traits<allocator_type>::construct(
+      alloc, pointer, ::std::forward<ValueType>(value)
+    );
+    this->data = pointer;
+  }
+
+  template <class ValueType>
+  ValueType const* cast (::std::true_type&&) const {
+    return reinterpret_cast<ValueType const*>(::std::addressof(this->data));
+  }
+
+  template <class ValueType>
+  ValueType* cast (::std::true_type&&) {
+    return reinterpret_cast<ValueType*>(::std::addressof(this->data));
+  }
+
+  template <class ValueType>
+  ValueType const* cast (::std::false_type&&) const {
+    return static_cast<ValueType const*>(this->data);
+  }
+
+  template <class ValueType>
+  ValueType* cast (::std::false_type&&) {
+    return static_cast<ValueType*>(this->data);
+  }
+
+public:
+  any (any const& that) :
+    table { that.table },
+    data { nullptr }
+  { this->table->clone(that.data, this->data); }
+
+  any (any&& that) noexcept :
+    table { that.table },
+    data { nullptr }
+  { this->table->move(that.data, this->data); }
+
+  any () noexcept :
+    table { impl::get_any_dispatch<void>() },
+    data { nullptr }
+  { }
+
+  template <
+    class ValueType,
+    class=enable_if_t<not ::std::is_same<any, decay_t<ValueType>>::value>
+  > any (ValueType&& value) :
+    any { ::std::forward<ValueType>(value), impl::is_small<ValueType> { } }
+  { }
+
+  ~any () noexcept { this->clear(); }
+
+  any& operator = (any const& that) {
+    any { that }.swap(*this);
+    return *this;
+  }
+
+  any& operator = (any&& that) noexcept {
+    any { ::std::move(that) }.swap(*this);
+    return *this;
+  }
+
+  template <
+    class ValueType,
+    class=enable_if_t<not ::std::is_same<any, decay_t<ValueType>>::value>
+  > any& operator = (ValueType&& value) {
+    any {
+      ::std::forward<ValueType>(value),
+      impl::is_small<ValueType> { }
+    }.swap(*this);
+    return *this;
+  }
+
+  void swap (any& that) noexcept {
+    using ::std::swap;
+    swap(this->table, that.table);
+    swap(this->data, that.data);
+  }
+
+  void clear () noexcept {
+    this->table->destroy(this->data);
+    this->table = impl::get_any_dispatch<void>();
+  }
+
+  ::std::type_info const& type () const noexcept {
+    return this->table->type();
+  }
+
+  bool empty () const noexcept {
+    return this->table == impl::get_any_dispatch<void>();
+  }
+
+};
+
+template <class ValueType>
+ValueType const* any_cast (any const* operand) noexcept {
+  return operand and operand->type() == typeid(ValueType)
+    ? operand->cast<ValueType>(impl::is_small<ValueType> { })
+    : nullptr;
+}
+
+template <class ValueType>
+ValueType* any_cast (any* operand) noexcept {
+  return operand and operand->type() == typeid(ValueType)
+    ? operand->cast<ValueType>(impl::is_small<ValueType> { })
+    : nullptr;
+}
+
+template <
+  class ValueType,
+  class=enable_if_t<
+    meta::any<
+      ::std::is_reference<ValueType>,
+      ::std::is_copy_constructible<ValueType>
+    >::value
+  >
+> ValueType any_cast (any const& operand) {
+  using type = remove_reference_t<ValueType>;
+  auto pointer = any_cast<add_const_t<type>>(::std::addressof(operand));
+  if (not pointer) { throw_bad_any_cast(); }
+  return *pointer;
+}
+
+template <
+  class ValueType,
+  class=enable_if_t<
+    meta::any<
+      ::std::is_reference<ValueType>,
+      ::std::is_copy_constructible<ValueType>
+    >::value
+  >
+> ValueType any_cast (any&& operand) {
+  using type = remove_reference_t<ValueType>;
+  auto pointer = any_cast<type>(::std::addressof(operand));
+  if (not pointer) { throw_bad_any_cast(); }
+  return *pointer;
+}
+
+template <
+  class ValueType,
+  class=enable_if_t<
+    meta::any<
+      ::std::is_reference<ValueType>,
+      ::std::is_copy_constructible<ValueType>
+    >::value
+  >
+> ValueType any_cast (any& operand) {
+  using type = remove_reference_t<ValueType>;
+  auto pointer = any_cast<type>(::std::addressof(operand));
+  if (not pointer) { throw_bad_any_cast(); }
+  return *pointer;
+}
+
+inline void swap (any& lhs, any& rhs) noexcept { lhs.swap(rhs); }
+
+}} /* namespace core::v1 */
+
+#endif /* CORE_ANY_HPP */

--- a/core/include/core/array.hpp
+++ b/core/include/core/array.hpp
@@ -1,0 +1,38 @@
+#ifndef CORE_ARRAY_HPP
+#define CORE_ARRAY_HPP
+
+#include <array>
+
+#include <core/type_traits.hpp>
+#include <core/functional.hpp>
+#include <core/utility.hpp>
+
+namespace core {
+inline namespace v1 {
+
+template <class V = void, class... Args>
+constexpr auto make_array (Args&&... args) -> ::std::array<
+  conditional_t<
+    meta::all<
+      ::std::is_void<V>,
+      meta::none<is_reference_wrapper<Args>...>
+    >::value,
+    common_type_t<Args...>,
+    V
+  >,
+  sizeof...(Args)
+> { return {{ core::forward<Args>(args)... }}; }
+
+template <class T, ::std::size_t N, ::std::size_t... Is>
+constexpr auto to_array (T (&array)[N], index_sequence<Is...>) -> ::std::array<
+  remove_cv_t<T>, N
+> { return {{ array[Is]... }}; }
+
+template <class T, ::std::size_t N>
+constexpr auto to_array (T (&array)[N]) -> ::std::array<remove_cv_t<T>, N> {
+  return core::to_array(array, make_index_sequence<N> { });
+}
+
+}} /* namespace core::v1 */
+
+#endif /* CORE_ARRAY_HPP */

--- a/core/include/core/functional.hpp
+++ b/core/include/core/functional.hpp
@@ -1,0 +1,459 @@
+#ifndef CORE_FUNCTIONAL_HPP
+#define CORE_FUNCTIONAL_HPP
+
+#include <functional>
+#include <tuple>
+#include <array>
+
+#include <core/type_traits.hpp>
+#include <core/utility.hpp>
+
+namespace core {
+inline namespace v1 {
+
+template <class T> struct is_reference_wrapper : ::std::false_type { };
+template <class T>
+struct is_reference_wrapper<::std::reference_wrapper<T>> :
+  ::std::true_type
+{ };
+
+template <class T>
+struct is_reference_wrapper<::std::reference_wrapper<T> const> :
+  ::std::true_type
+{ };
+
+template <class T>
+struct is_reference_wrapper<::std::reference_wrapper<T> volatile> :
+  ::std::true_type
+{ };
+
+template <class T>
+struct is_reference_wrapper<::std::reference_wrapper<T> const volatile> :
+  ::std::true_type
+{ };
+
+template <class F> struct function_traits;
+
+template <class R, class... Args>
+struct function_traits<R(*)(Args...)> : function_traits<R(Args...)> { };
+
+template <class C, class R>
+struct function_traits<R(C::*)> : function_traits<R(C&)> { };
+
+template <class C, class R, class... Args>
+struct function_traits<R(C::*)(Args...)> : function_traits<R(C&, Args...)> { };
+
+template <class C, class R, class... Args>
+struct function_traits<R(C::*)(Args...) const volatile> :
+  function_traits<R(C volatile const&, Args...)>
+{ };
+
+template <class C, class R, class... Args>
+struct function_traits<R(C::*)(Args...) volatile> :
+  function_traits<R(C volatile&, Args...)>
+{ };
+
+template <class C, class R, class... Args>
+struct function_traits<R(C::*)(Args...) const> :
+  function_traits<R(C const&, Args...)>
+{ };
+
+template <class R, class... Args>
+struct function_traits<R(Args...)> {
+  using return_type = R;
+
+  using pointer = return_type(*)(Args...);
+  static constexpr ::std::size_t arity = sizeof...(Args);
+
+  template < ::std::size_t N>
+  using argument = typename ::std::tuple_element<
+    N,
+    ::std::tuple<Args...>
+  >::type;
+};
+
+template <class F> struct function_traits {
+  using functor_type = function_traits<decltype(&decay_t<F>::operator())>;
+  using return_type = typename functor_type::return_type;
+  using pointer = typename functor_type::pointer;
+  static constexpr ::std::size_t arity = functor_type::arity - 1;
+  template <::std::size_t N>
+  using argument = typename functor_type::template argument<N>;
+};
+
+/* N3727 */
+template <class Functor, class... Args>
+auto invoke (Functor&& f, Args&&... args) -> enable_if_t<
+  ::std::is_member_pointer<decay_t<Functor>>::value,
+  result_of_t<Functor&&(Args&&...)>
+> { return ::std::mem_fn(f)(core::forward<Args>(args)...); }
+
+template <class Functor, class... Args>
+constexpr auto invoke (Functor&& f, Args&&... args) -> enable_if_t<
+  not ::std::is_member_pointer<decay_t<Functor>>::value,
+  result_of_t<Functor&&(Args&&...)>
+> { return core::forward<Functor>(f)(core::forward<Args>(args)...); }
+
+namespace impl {
+
+template <class F, class T, ::std::size_t... I>
+auto apply (F&& f, T&& t, index_sequence<I...>) -> decltype(
+  invoke(core::forward<F>(f), ::std::get<I>(core::forward<T>(t))...)
+) { return invoke(core::forward<F>(f), ::std::get<I>(core::forward<T>(t))...); }
+
+} /* namespace impl */
+
+template <
+  class Functor,
+  class T,
+  class I = make_index_sequence<::std::tuple_size<decay_t<T>>::value>
+> auto apply (Functor&& f, T&& t) -> decltype(
+  impl::apply(core::forward<Functor>(f), core::forward<T>(t), I())
+) { return impl::apply(core::forward<Functor>(f), core::forward<T>(t), I()); }
+
+
+namespace impl {
+
+template <class U, ::std::size_t... I>
+auto unpack (U&& u, index_sequence<I...>) -> decltype(
+  core::invoke(::std::get<I>(core::forward<U>(u))...)
+) { return core::invoke(::std::get<I>(core::forward<U>(u))...); }
+
+template <class F, class U, ::std::size_t... I>
+auto runpack (F&& f, U&& u, index_sequence<I...>) -> decltype(
+  core::invoke(core::forward<F>(f), core::forward<U>(u).at(I)...)
+) { return core::invoke(core::forward<F>(f), core::forward<U>(u).at(I)...); }
+
+} /* namespace impl */
+
+struct unpack_t final { };
+constexpr unpack_t unpack { };
+
+struct runpack_t final { };
+constexpr runpack_t runpack { };
+
+/* Use apply instead */
+template <
+  class F,
+  class U,
+  class I = make_index_sequence<::std::tuple_size<decay_t<U>>::value>
+> [[gnu::deprecated]] auto invoke (unpack_t, F&& f, U&& u) -> enable_if_t<
+  is_unpackable<decay_t<U>>::value,
+  decltype(impl::apply(core::forward<F>(f), core::forward<U>(u), I { }))
+> { return impl::apply(core::forward<F>(f), core::forward<U>(u), I { }); }
+
+template <
+  class U,
+  class I = make_index_sequence<::std::tuple_size<decay_t<U>>::value>
+> [[gnu::deprecated]] auto invoke (unpack_t, U&& u) -> enable_if_t<
+  is_unpackable<decay_t<U>>::value,
+  decltype(impl::unpack(core::forward<U>(u), I { }))
+> { return impl::unpack(core::forward<U>(u), I { }); }
+
+/* Modified to force clang to *not* select this function in a bizarre corner
+ * case.
+ */
+template <
+  class F,
+  class R,
+  class=enable_if_t<is_runpackable<decay_t<R>>::value>,
+  class I = make_index_sequence<function_traits<F>::arity>
+> auto invoke (runpack_t, F&& f, R&& r) -> decltype(
+  impl::runpack(core::forward<F>(f), core::forward<R>(r), I { })
+) { return impl::runpack(core::forward<F>(f), core::forward<R>(r), I { }); }
+
+template <class F>
+struct apply_functor {
+  explicit apply_functor (F&& f) : f(core::forward<F>(f)) { }
+
+  template <class Applicable>
+  auto operator () (Applicable&& args) -> decltype(
+    core::apply(core::forward<F>(this->f), core::forward<Applicable>(args))
+  ) { return apply(core::forward<F>(f), core::forward<Applicable>(args)); }
+private:
+  F f;
+};
+
+template <class F>
+auto make_apply (F&& f) -> apply_functor<F> {
+  return apply_functor<F> { core::forward<F>(f) };
+}
+
+/* function objects -- arithmetic */
+template <class T=void>
+struct plus : impl::binary<T, T, T> {
+  constexpr T operator () (T const& l, T const& r) const { return l + r; }
+};
+
+template <class T=void>
+struct minus : impl::binary<T, T, T> {
+  constexpr T operator () (T const& l, T const& r) const { return l - r; }
+};
+
+template <class T=void>
+struct multiplies : impl::binary<T, T, T> {
+  constexpr T operator () (T const& l, T const& r) const { return l * r; }
+};
+
+template <class T=void>
+struct divides : impl::binary<T, T, T> {
+  constexpr T operator () (T const& l, T const& r) const { return l / r; }
+};
+
+template <class T=void>
+struct modulus : impl::binary<T, T, T> {
+  constexpr T operator () (T const& l, T const& r) const { return l % r; }
+};
+
+template <class T=void>
+struct negate : impl::unary<T, T> {
+  constexpr T operator () (T const& arg) const { return -arg; }
+};
+
+/* function objects -- comparisons */
+template <class T=void>
+struct equal_to : impl::binary<T, T, bool> {
+  constexpr bool operator () (T const& l, T const& r) const { return l == r; }
+};
+
+template <class T=void>
+struct not_equal_to : impl::binary<T, T, bool> {
+  constexpr bool operator () (T const& l, T const& r) const { return l != r; }
+};
+
+template <class T=void>
+struct greater_equal : impl::binary<T, T, bool> {
+  constexpr bool operator () (T const& l, T const& r) const { return l >= r; }
+};
+
+template <class T=void>
+struct less_equal : impl::binary<T, T, bool> {
+  constexpr bool operator () (T const& l, T const& r) const { return l <= r; }
+};
+
+template <class T=void>
+struct greater : impl::binary<T, T, bool> {
+  constexpr bool operator () (T const& l, T const& r) const { return l > r; }
+};
+
+template <class T=void>
+struct less : impl::binary<T, T, bool> {
+  constexpr bool operator () (T const& l, T const& r) const { return l < r; }
+};
+
+/* function objects -- logical */
+template <class T=void>
+struct logical_and : impl::binary<T, T, bool> {
+  constexpr bool operator () (T const& l, T const& r) const { return l and r; }
+};
+
+template <class T=void>
+struct logical_or : impl::binary<T, T, bool> {
+  constexpr bool operator () (T const& l, T const& r) const { return l or r; }
+};
+
+template <class T=void>
+struct logical_not : impl::unary<T, bool>  {
+  constexpr bool operator () (T const& arg) const { return not arg; }
+};
+
+/* function objects -- bitwise */
+
+template <class T=void>
+struct bit_and : impl::binary<T, T, T> {
+  constexpr bool operator () (T const& l, T const& r) const { return l & r; }
+};
+
+template <class T=void>
+struct bit_or : impl::binary<T, T, T> {
+  constexpr bool operator () (T const& l, T const& r) const { return l | r; }
+};
+
+template <class T=void>
+struct bit_xor : impl::binary<T, T, T> {
+  constexpr bool operator () (T const& l, T const& r) const { return l ^ r; }
+};
+
+template <class T=void>
+struct bit_not : impl::unary<T, T> {
+  constexpr bool operator () (T const& arg) const { return ~arg; }
+};
+
+/* function objects -- arithmetic specializations */
+template <> struct plus<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) + core::forward<U>(u)
+  ) { return core::forward<T>(t) + core::forward<U>(u); }
+};
+
+template <> struct minus<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) - core::forward<U>(u)
+  ) { return core::forward<T>(t) - core::forward<U>(u); }
+};
+
+template <> struct multiplies<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) * core::forward<U>(u)
+  ) { return core::forward<T>(t) * core::forward<U>(u); }
+};
+
+template <> struct divides<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) / core::forward<U>(u)
+  ) { return core::forward<T>(t) / core::forward<U>(u); }
+};
+
+template <> struct modulus<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) % core::forward<U>(u)
+  ) { return core::forward<T>(t) % core::forward<U>(u); }
+};
+
+template <> struct negate<void> {
+  using is_transparent = void;
+
+  template <class T>
+  constexpr auto operator () (T&& t) const -> decltype(core::forward<T>(t)) {
+    return core::forward<T>(t);
+  }
+};
+
+/* function objects -- comparison specialization */
+template <> struct equal_to<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) == core::forward<U>(u)
+  ) { return core::forward<T>(t) == core::forward<U>(u); }
+};
+
+template <> struct not_equal_to<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) != core::forward<U>(u)
+  ) { return core::forward<T>(t) != core::forward<U>(u); }
+};
+
+template <> struct greater_equal<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) >= core::forward<U>(u)
+  ) { return core::forward<T>(t) >= core::forward<U>(u); }
+};
+
+template <> struct less_equal<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) <= core::forward<U>(u)
+  ) { return core::forward<T>(t) <= core::forward<U>(u); }
+};
+
+template <> struct greater<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) > core::forward<U>(u)
+  ) { return core::forward<T>(t) > core::forward<U>(u); }
+};
+
+template <> struct less<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) < core::forward<U>(u)
+  ) { return core::forward<T>(t) < core::forward<U>(u); }
+};
+
+/* function objects -- logical specializations */
+template <> struct logical_and<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) and core::forward<U>(u)
+  ) { return core::forward<T>(t) and core::forward<U>(u); }
+};
+
+template <> struct logical_or<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) or core::forward<U>(u)
+  ) { return core::forward<T>(t) or core::forward<U>(u); }
+};
+
+template <> struct logical_not<void> {
+  using is_transparent = void;
+
+  template <class T>
+  constexpr auto operator () (T&& t) const -> decltype(
+    not core::forward<T>(t)
+  ) { return not core::forward<T>(t); }
+};
+
+/* function objects -- bitwise specializations */
+template <> struct bit_and<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) & core::forward<U>(u)
+  ) { return core::forward<T>(t) & core::forward<U>(u); }
+};
+
+template <> struct bit_or<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) | core::forward<U>(u)
+  ) { return core::forward<T>(t) | core::forward<U>(u); }
+};
+
+template <> struct bit_xor<void> {
+  using is_transparent = void;
+
+  template <class T, class U>
+  constexpr auto operator () (T&& t, U&& u) const -> decltype(
+    core::forward<T>(t) ^ core::forward<U>(u)
+  ) { return core::forward<T>(t) ^ core::forward<U>(u); }
+};
+
+template <> struct bit_not<void> {
+  using is_transparent = void;
+
+  template <class T>
+  constexpr auto operator () (T&& t) const -> decltype(~core::forward<T>(t)) {
+    return ~core::forward<T>(t);
+  }
+};
+
+}} /* namespace core::v1 */
+
+#endif /* CORE_FUNCTIONAL_HPP */

--- a/core/include/core/internal.hpp
+++ b/core/include/core/internal.hpp
@@ -1,0 +1,285 @@
+#ifndef CORE_INTERNAL_HPP
+#define CORE_INTERNAL_HPP
+
+/* This is a header containing common implementation specific code, to
+ * reduce the complexity of the other headers, especially those that are
+ * closely intertwined, such as <core/functional.hpp> and <core/type_traits.hpp>
+ *
+ * Additionally, some of this code is duplicated elsewhere (such as class_of,
+ * and meta::identity), but aliases are placed to lessen any impact that this
+ * might have.
+ */
+
+#include <type_traits>
+#include <functional>
+#include <utility>
+
+#include <core/meta.hpp>
+
+namespace core {
+inline namespace v1 {
+namespace impl {
+
+/* deduce_t workaround for gcc */
+template <class...> struct deducer { using type = void; };
+
+/* extremely useful custom type traits */
+template <class T> struct class_of : meta::identity<T> { };
+template <class Signature, class T>
+struct class_of<Signature T::*> : meta::identity<T> { };
+
+/* aliases */
+template <class... Ts> using deduce_t = typename deducer<Ts...>::type;
+template <class T> using class_of_t = typename class_of<T>::type;
+template <class T> using decay_t = typename ::std::decay<T>::type;
+template <class T>
+using remove_reference_t = typename ::std::remove_reference<T>::type;
+template <bool B, class T = void>
+using enable_if_t = typename ::std::enable_if<B, T>::type;
+
+/* is_nothrow_swappable plumbing */
+using ::std::declval;
+using ::std::swap;
+
+template <class, class, class=void>
+struct is_swappable : ::std::false_type { };
+
+template <class T, class U>
+struct is_swappable<
+  T,
+  U,
+  deduce_t<
+    decltype(swap(declval<T&>(), declval<U&>())),
+    decltype(swap(declval<U&>(), declval<T&>()))
+  >
+> : ::std::true_type { };
+
+template <class T, class U>
+struct is_nothrow_swappable : meta::all<
+  is_swappable<T, U>,
+  meta::boolean<noexcept(swap(declval<T&>(), declval<U&>()))>,
+  meta::boolean<noexcept(swap(declval<U&>(), declval<T&>()))>
+> { };
+
+/* used below but also for the functional objects defined later to cut down
+ * on unnecessary code. Defined due to deprecation in C++11, and removal in
+ * C++17. I remove the _function part of the name because it's an internal
+ * API and never you mind.
+ */
+template <class T, class U, class R>
+struct binary {
+  using second_argument_type = U;
+  using first_argument_type = T;
+  using result_type = R;
+};
+
+template <class T, class R>
+struct unary {
+  using argument_type = T;
+  using result_type = R;
+};
+
+/*
+ * If I can't amuse myself when working with C++ templates, then life isn't
+ * worth living. Bury me with my chevrons.
+ */
+template <class T>
+constexpr T&& pass (remove_reference_t<T>& t) noexcept {
+  return static_cast<T&&>(t);
+}
+
+template <class T>
+constexpr T&& pass (remove_reference_t<T>&& t) noexcept {
+  return static_cast<T&&>(t);
+}
+
+/* INVOKE pseudo-expression plumbing, *much* more simplified than previous
+ * versions of core
+ */
+struct undefined { constexpr undefined (...) noexcept { } };
+
+/* We get some weird warnings under clang, so we actually give these functions
+ * a body to get rid of it.
+ */
+template <class... Args>
+constexpr undefined INVOKE (undefined, Args&&...) noexcept {
+  return undefined { };
+}
+
+template <class Functor, class... Args>
+constexpr auto INVOKE (Functor&& f, Args&&... args) -> enable_if_t<
+  not ::std::is_member_pointer<decay_t<Functor>>::value,
+  decltype(pass<Functor>(f)(pass<Args>(args)...))
+> { return pass<Functor>(f)(pass<Args>(args)...); }
+
+template <class Functor, class... Args>
+auto INVOKE (Functor&& f, Args&&... args) -> enable_if_t<
+  ::std::is_member_pointer<decay_t<Functor>>::value,
+  decltype(::std::mem_fn(pass<Functor>(f))(pass<Args>(args)...))
+> { return ::std::mem_fn(pass<Functor>(f))(pass<Args>(args)...); }
+
+template <bool, class...> struct invoke_of { };
+template <class... Args> struct invoke_of<true, Args...> :
+  meta::identity<decltype(INVOKE(declval<Args>()...))>
+{ };
+
+/* Used to provide lambda based 'pattern matching' for variant and optional
+ * types.
+ *
+ * Based off of Dave Abrahams C++11 'generic lambda' example
+ */
+
+template <class... Lambdas> struct overload;
+template <class Lambda> struct overload<Lambda> : Lambda {
+  using call_type = Lambda;
+  using call_type::operator ();
+};
+
+template <class Lambda, class... Lambdas>
+struct overload<Lambda, Lambdas...> :
+  private Lambda,
+  private overload<Lambdas...>::call_type
+{
+  using base_type = typename overload<Lambdas...>::call_type;
+
+  using lambda_type = Lambda;
+  using call_type = overload;
+
+  overload (Lambda&& lambda, Lambdas&&... lambdas) :
+    lambda_type(pass<Lambda>(lambda)),
+    base_type(pass<Lambdas>(lambdas)...)
+  { }
+
+  using lambda_type::operator ();
+  using base_type::operator ();
+};
+
+template <class... Lambdas>
+auto make_overload(Lambdas&&... lambdas) -> overload<Lambdas...> {
+  return overload<Lambdas...> { pass<Lambdas>(lambdas)... };
+}
+
+/* union used for variant<Ts...> and implementing aligned_union, which is
+ * not provided by gcc 4.8.x, but is provided by clang. (aligned_union_t is
+ * the only alias missing from <type_traits>
+ */
+template <class... Ts> union discriminate;
+template <> union discriminate<> { };
+template <class T, class... Ts>
+union discriminate<T, Ts...> {
+  T value;
+  discriminate<Ts...> rest;
+};
+
+#if 0
+// #include <stdint.h>
+// #include <limits>
+// const int UINT32_MAX = std::numeric_limits<int32_t>::max();
+// const int UINT8_MAX = std::numeric_limits<int8_t>::max();
+// const int UINT16_MAX = std::numeric_limits<int16_t>::max();
+
+#ifndef UINT32_C
+#define UINT64_C(c) c
+#define UINT32_C(c) c
+#define UINT8_C(c) c
+#endif
+
+/* implementations of MurmurHash2 *Endian Neutral* (but not alignment!) */
+template <::std::size_t=sizeof(::std::size_t)> struct murmur;
+template <> struct murmur<4> {
+  constexpr murmur () = default;
+
+  ::std::size_t operator () (void const* p, ::std::size_t len) const noexcept {
+    static constexpr ::std::uint32_t magic = UINT32_C(0x5BD1E995);
+    static constexpr auto shift = 24;
+
+    auto hash = len;
+    auto data = static_cast<::std::uint8_t const*>(p);
+
+    while (len >= sizeof(::std::uint32_t)) {
+      ::std::uint32_t mix = data[0];
+      mix |= ::std::uint32_t(data[1]) <<  8;
+      mix |= ::std::uint32_t(data[2]) << 16;
+      mix |= ::std::uint32_t(data[3]) << 24;
+
+      mix *= magic;
+      mix ^= mix >> shift;
+      mix *= magic;
+
+      hash *= magic;
+      hash ^= mix;
+
+      data += sizeof(::std::uint32_t);
+      len -= sizeof(::std::uint32_t);
+    }
+
+    switch (len) {
+     case 3: hash ^= ::std::uint32_t(data[2]) << 16; //[[clang::fallthrough]];
+     case 2: hash ^= ::std::uint32_t(data[1]) <<  8; //[[clang::fallthrough]];
+      case 1: hash ^= ::std::uint32_t(data[0]);
+              hash *= magic;
+    }
+
+    hash ^= hash >> 13;
+    hash *= magic;
+    hash ^= hash >> 15;
+
+    return hash;
+  }
+};
+
+template <> struct murmur<8> {
+  constexpr murmur () = default;
+
+  ::std::size_t operator () (void const* p, ::std::size_t len) const noexcept {
+    static constexpr ::std::uint64_t magic = UINT64_C(0xC6A4A7935BD1E995);
+    static constexpr auto shift = 47;
+
+    ::std::size_t hash = len * magic;
+
+    auto data = static_cast<::std::uint8_t const*>(p);
+
+    while (len >= sizeof(::std::uint64_t)) {
+      ::std::uint64_t mix = data[0];
+      mix |= ::std::uint64_t(data[1]) <<  8;
+      mix |= ::std::uint64_t(data[2]) << 16;
+      mix |= ::std::uint64_t(data[3]) << 24;
+      mix |= ::std::uint64_t(data[4]) << 32;
+      mix |= ::std::uint64_t(data[5]) << 40;
+      mix |= ::std::uint64_t(data[6]) << 48;
+      mix |= ::std::uint64_t(data[7]) << 54;
+
+      mix *= magic;
+      mix ^= mix >> shift;
+      mix *= magic;
+
+      hash ^= mix;
+      hash *= magic;
+
+      data += sizeof(::std::uint64_t);
+      len -= sizeof(::std::uint64_t);
+    }
+
+    switch (len & 7) {
+      case 7: hash ^= ::std::uint64_t(data[6]) << 48; // [[clang::fallthrough]];
+      case 6: hash ^= ::std::uint64_t(data[5]) << 40; // [[clang::fallthrough]];
+      case 5: hash ^= ::std::uint64_t(data[4]) << 32; // [[clang::fallthrough]];
+      case 4: hash ^= ::std::uint64_t(data[3]) << 24; // [[clang::fallthrough]];
+      case 3: hash ^= ::std::uint64_t(data[2]) << 16; // [[clang::fallthrough]];
+      case 2: hash ^= ::std::uint64_t(data[1]) << 8;  // [[clang::fallthrough]];
+      case 1: hash ^= ::std::uint64_t(data[0]);
+              hash *= magic;
+    }
+
+    hash ^= hash >> shift;
+    hash *= magic;
+    hash ^= hash >> shift;
+
+    return hash;
+  }
+};
+#endif
+
+}}} /* namespace core::v1::impl */
+
+#endif /* CORE_INTERNAL_HPP */

--- a/core/include/core/iterator.hpp
+++ b/core/include/core/iterator.hpp
@@ -1,0 +1,244 @@
+#ifndef CORE_ITERATOR_HPP
+#define CORE_ITERATOR_HPP
+
+#include <functional>
+#include <iterator>
+#include <ostream>
+
+#include <core/type_traits.hpp>
+
+namespace core {
+inline namespace v1 {
+
+/* capacity */
+template <class Container>
+constexpr auto size (Container const& container) noexcept -> decltype(
+  container.size()
+) { return container.size(); }
+
+template <class T, ::std::size_t N>
+constexpr ::std::size_t size (T const (&)[N]) noexcept { return N; }
+
+template <class Container>
+constexpr bool empty (Container const& container) noexcept {
+  return container.empty();
+}
+
+template <class T, std::size_t N>
+constexpr bool empty (T const (&)[N]) noexcept { return false; }
+
+/* element access */
+template <class Container>
+constexpr auto front (Container const& container) -> decltype(
+  container.front()
+) { return container.front(); }
+
+template <class Container>
+constexpr auto front (Container& container) -> decltype(container.front()) {
+  return container.front();
+}
+
+template <class T, ::std::size_t N>
+constexpr T const& front (T const (&array)[N]) noexcept { return array[0]; }
+
+template <class T, ::std::size_t N>
+constexpr T& front (T (&array)[N]) noexcept { return array[0]; }
+
+template <class Container>
+constexpr auto back (Container const& container) -> decltype(
+  container.back()
+) { return container.back(); }
+
+template <class Container>
+constexpr auto back (Container& container) -> decltype(container.back()) {
+  return container.back();
+}
+
+template <class T, ::std::size_t N>
+constexpr T const& back (T const (&array)[N]) noexcept { return array[N - 1]; }
+
+template <class T, ::std::size_t N>
+constexpr T& back (T (&array)[N]) noexcept { return array[N - 1]; }
+
+/* data access */
+template <class Container>
+constexpr auto data (Container const& container) noexcept -> decltype(
+  container.data()
+) { return container.data(); }
+
+template <class Container>
+constexpr auto data (Container& container) noexcept -> decltype(
+  container.data()
+) { return container.data(); }
+
+template <class T, ::std::size_t N>
+constexpr T const* data (T const (&array)[N]) noexcept { return array; }
+
+template <class T, ::std::size_t N>
+constexpr T* data (T (&array)[N]) noexcept { return array; }
+
+/* iteration */
+template <class Container>
+auto cbegin (Container const& container) -> decltype(::std::begin(container)) {
+  return ::std::begin(container);
+}
+
+template <class Container>
+auto cend (Container const& container) -> decltype(::std::end(container)) {
+  return ::std::end(container);
+}
+
+template <class Container>
+auto rbegin (Container const& container) -> decltype(container.rbegin()) {
+  return container.rbegin();
+}
+
+template <class Container>
+auto rbegin (Container& container) -> decltype(container.rbegin()) {
+  return container.rbegin();
+}
+
+template <class Container>
+auto crbegin (Container const& container) -> decltype(rbegin(container)) {
+  return rbegin(container);
+}
+
+template <class Container>
+auto rend (Container const& container) -> decltype(container.rend()) {
+  return container.rend();
+}
+
+template <class Container>
+auto rend (Container& container) -> decltype(container.rend()) {
+  return container.rend();
+}
+
+template <class Container>
+auto crend (Container const& container) -> decltype(rend(container)) {
+  return rend(container);
+}
+
+template <class Iterator>
+::std::reverse_iterator<Iterator> make_reverse_iterator (Iterator iter) {
+  return ::std::reverse_iterator<Iterator>(iter);
+}
+
+template <
+  class T,
+  class CharT=char,
+  class Traits=::std::char_traits<CharT>
+> struct infix_ostream_iterator final : ::std::iterator<
+  ::std::output_iterator_tag,
+  void,
+  void,
+  void,
+  void
+> {
+  using ostream_type = ::std::basic_ostream<CharT, Traits>;
+  using traits_type = Traits;
+  using char_type = CharT;
+
+  infix_ostream_iterator (ostream_type& os) :
+    infix_ostream_iterator { os, nullptr }
+  { }
+
+  infix_ostream_iterator (ostream_type& os, char_type const* delimiter) :
+    os { os },
+    delimiter { delimiter },
+    first { true }
+  { }
+
+  infix_ostream_iterator& operator = (T const& item) {
+    if (not first and delimiter) { this->os.get() << delimiter; }
+    os.get() << item;
+    this->first = false;
+    return *this;
+  }
+
+  infix_ostream_iterator& operator ++ (int) { return *this; }
+  infix_ostream_iterator& operator ++ () { return *this; }
+  infix_ostream_iterator& operator * () { return *this; }
+
+private:
+  ::std::reference_wrapper<ostream_type> os;
+  char_type const* delimiter;
+  bool first;
+};
+
+template <class T>
+struct number_iterator final {
+  using iterator_category = ::std::bidirectional_iterator_tag;
+  using difference_type = T;
+  using value_type = T;
+  using reference = add_lvalue_reference_t<T>;
+  using pointer = add_pointer_t<T>;
+
+  static_assert(::std::is_integral<value_type>::value, "");
+
+  explicit number_iterator (value_type value, value_type step=1) noexcept :
+    value { value },
+    step { step }
+  { }
+
+  number_iterator (number_iterator const&) noexcept = default;
+  number_iterator () noexcept = default;
+  ~number_iterator () noexcept = default;
+
+  number_iterator& operator = (number_iterator const&) noexcept = default;
+
+  void swap (number_iterator& that) noexcept {
+    ::std::swap(this->value, that.value);
+    ::std::swap(this->value, that.value);
+  }
+
+  reference operator * () noexcept { return this->value; }
+
+  number_iterator& operator ++ () noexcept {
+    this->value += this->step;
+    return *this;
+  }
+
+  number_iterator& operator -- () noexcept {
+    this->value -= this->step;
+    return *this;
+  }
+
+  number_iterator operator ++ (int) const noexcept {
+    return number_iterator { this->value + this->step };
+  }
+
+  number_iterator operator -- (int) const noexcept {
+    return number_iterator { this->value - this->step };
+  }
+
+  bool operator == (number_iterator const& that) const noexcept {
+    return this->value == that.value and this->step == that.step;
+  }
+
+  bool operator != (number_iterator const& that) const noexcept {
+    return this->value != that.value and this->step == that.step;
+  }
+
+private:
+  value_type value { };
+  value_type step { static_cast<value_type>(1) };
+};
+
+template <class T>
+void swap (number_iterator<T>& lhs, number_iterator<T>& rhs) noexcept {
+  lhs.swap(rhs);
+}
+
+template <class T>
+number_iterator<T> make_number_iterator (T value, T step) noexcept {
+  return number_iterator<T> { value, step };
+}
+
+template <class T>
+number_iterator<T> make_number_iterator (T value) noexcept {
+  return number_iterator<T> { value };
+}
+
+}} /* namespace core::v1 */
+
+#endif /* CORE_ITERATOR_HPP */

--- a/core/include/core/memory.hpp
+++ b/core/include/core/memory.hpp
@@ -1,0 +1,986 @@
+#ifndef CORE_MEMORY_HPP
+#define CORE_MEMORY_HPP
+
+#include <memory>
+#include <bitset>
+#include <tuple>
+
+#include <cstddef>
+#include <cstdlib>
+
+#include <core/type_traits.hpp>
+#include <core/algorithm.hpp>
+#include <core/range.hpp>
+
+#ifndef CORE_NO_EXCEPTIONS
+#include <stdexcept>
+#endif /* CORE_NO_EXCEPTIONS */
+
+#ifndef CORE_NO_RTTI
+#include <typeinfo>
+#endif /* CORE_NO_RTTI */
+
+/* Small hack just for GCC 4.8. Just trust me, it's needed */
+#if defined(__GNUC__) && defined(__GNUC_MINOR__)
+  #if __GNUC__ == 4 && __GNUC_MINOR__ == 8
+  namespace std { using ::max_align_t; } /* namespace std */
+  #endif
+#endif /* defined(__GNUC__) */
+
+namespace core {
+inline namespace v1 {
+namespace impl {
+
+template <class T>
+using deep_lvalue = conditional_t<
+  ::std::is_reference<T>::value, T, T const&
+>;
+
+template <class T, class D, class=void> struct pointer :
+  identity<add_pointer_t<T>>
+{ };
+
+template <class T, class D>
+struct pointer<T, D, deduce_t<typename D::pointer>> :
+  identity<typename D::pointer>
+{ };
+
+template <class T, class D> using pointer_t = typename pointer<T, D>::type;
+
+} /* namespace impl */
+
+namespace memory {
+
+template <::std::size_t N>
+struct arena final {
+  static_assert(N != 0, "N may not be 0");
+
+  using size_type = ::std::size_t;
+
+  arena () noexcept : current { } { }
+  ~arena () noexcept = default;
+
+  arena (arena const&) noexcept = delete;
+  arena& operator = (arena const&) noexcept = delete;
+
+  static constexpr size_type alignment () noexcept {
+    return alignof(::std::max_align_t);
+  }
+  static constexpr size_type size () noexcept { return N; }
+  size_type max_size () const noexcept { return N; }
+  size_type used () const noexcept { return this->current; }
+  void reset () noexcept { this->current = 0; }
+
+  void* allocate (size_type n) {
+    if (not this->inside(n)) { return nullptr; }
+    auto ptr = this->pointer() + this->current;
+    this->current += n;
+    return ptr;
+  }
+
+  void deallocate (void* p, size_type n) {
+    auto incoming = static_cast<::std::uint8_t*>(p) + n;
+    auto ptr = this->pointer() + this->current;
+    if (ptr != incoming) { return; }
+    this->current -= n;
+  }
+
+  /* used by arena_allocator to permit default construction */
+  static arena& ref () noexcept {
+    static arena instance;
+    return instance;
+  }
+
+private:
+  bool inside (size_type n) const noexcept { return (this->current + n) < N; }
+  ::std::uint8_t* pointer () noexcept {
+    return reinterpret_cast<::std::uint8_t*>(::std::addressof(this->data));
+  }
+
+  aligned_storage_t<N, alignof(::std::max_align_t)> data;
+  size_type current; // byte index
+};
+
+} /* namespace memory */
+
+template <class T, ::std::size_t N>
+struct arena_allocator {
+  using difference_type = ::std::ptrdiff_t;
+  using value_type = T;
+  using size_type = ::std::size_t;
+
+  using const_reference = add_lvalue_reference_t<add_const_t<value_type>>;
+  using const_pointer = add_pointer_t<add_const_t<value_type>>;
+  using reference = add_lvalue_reference_t<value_type>;
+  using pointer = add_pointer_t<value_type>;
+
+  using const_void_pointer = add_pointer_t<add_const_t<void>>;
+  using void_pointer = add_pointer_t<void>;
+
+  using propagate_on_container_copy_assignment = ::std::true_type;
+  using propagate_on_container_move_assignment = ::std::true_type;
+  using propagate_on_container_swap = ::std::true_type;
+
+  using is_always_equal = ::std::false_type;
+
+  template <class, ::std::size_t> friend struct arena_allocator;
+  template <class U> struct rebind { using other = arena_allocator<U, N>; };
+
+  explicit arena_allocator (memory::arena<N>& ref) noexcept : ref { ref } { }
+  arena_allocator () noexcept : arena_allocator { memory::arena<N>::ref() } { }
+
+  template <class U>
+  arena_allocator (arena_allocator<U, N> const& that) noexcept :
+    ref { that.ref }
+  { }
+
+  arena_allocator (arena_allocator const& that) noexcept :
+    ref { that.ref }
+  { }
+
+  template <class U>
+  arena_allocator& operator = (arena_allocator<U, N> const& that) noexcept {
+    arena_allocator { that }.swap(*this);
+    return *this;
+  }
+
+  arena_allocator& operator = (arena_allocator const& that) noexcept = default;
+
+  void swap (arena_allocator& that) noexcept {
+    ::std::swap(this->ref, that.ref);
+  }
+
+  pointer allocate (size_type n, const_void_pointer=nullptr) noexcept {
+    return static_cast<pointer>(this->arena().allocate(n * sizeof(value_type)));
+  }
+
+  void deallocate (pointer ptr, size_type n) noexcept {
+    this->arena().deallocate(ptr, n * sizeof(value_type));
+  }
+
+  size_type max_size () const noexcept { return N / sizeof(value_type); }
+
+  memory::arena<N> const& arena () const noexcept { return this->ref; }
+  memory::arena<N>& arena () noexcept { return this->ref; }
+
+private:
+  ::std::reference_wrapper<memory::arena<N>> ref;
+};
+
+/* poly-ptr related definitions */
+#ifndef CORE_NO_RTTI
+/* poly_ptr copier */
+template <class T, class D, class U>
+::std::unique_ptr<T, D> default_poly_copy (
+  ::std::unique_ptr<T, D> const& ptr
+) {
+  auto value = *dynamic_cast<U*>(ptr.get());
+  auto const& deleter = ptr.get_deleter();
+  return ::std::unique_ptr<T, D> { new U { ::std::move(value) }, deleter };
+}
+
+/* null-state poly_ptr copier (don't copy that poly!) */
+template <class T, class D>
+::std::unique_ptr<T, D> null_poly_copy (
+  ::std::unique_ptr<T, D> const&
+) noexcept { return ::std::unique_ptr<T, D> { }; }
+#endif /* CORE_NO_RTTI */
+
+#ifndef CORE_NO_EXCEPTIONS
+struct bad_polymorphic_reset : ::std::logic_error {
+  using ::std::logic_error::logic_error;
+};
+
+[[noreturn]] inline void throw_bad_poly_reset (char const* msg) {
+  throw bad_polymorphic_reset { msg };
+}
+#else /* CORE_NO_EXCEPTIONS */
+[[noreturn]] inline void throw_bad_poly_reset (char const*) { ::std::abort(); }
+#endif /* CORE_NO_EXCEPTIONS */
+
+/* deep_ptr copier */
+template <class T>
+struct default_copy {
+  using pointer = T*;
+
+  constexpr default_copy () = default;
+  template <class U> default_copy (default_copy<U> const&) noexcept { }
+
+  pointer operator ()(pointer const ptr) const { return new T { *ptr }; }
+};
+
+#ifndef CORE_NO_RTTI
+template <class T, class Deleter=::std::default_delete<T>>
+struct poly_ptr final {
+  using unique_type = ::std::unique_ptr<T, Deleter>;
+  using element_type = typename unique_type::element_type;
+  using deleter_type = typename unique_type::deleter_type;
+  using copier_type = unique_type (*)(unique_type const&);
+  using pointer = typename unique_type::pointer;
+
+  template <class U>
+  explicit poly_ptr (U* ptr) noexcept :
+    poly_ptr { ptr, deleter_type { } }
+  { }
+
+  template <class U, class E>
+  explicit poly_ptr (
+    ::std::unique_ptr<U, E>&& ptr,
+    copier_type copier=::std::addressof(
+      default_poly_copy<element_type, deleter_type, U>
+    )
+  ) noexcept :
+    copier { copier },
+    ptr { ::std::move(ptr) }
+  {
+    constexpr bool abstract = ::std::is_abstract<U>::value;
+    constexpr bool base = ::std::is_base_of<element_type, U>::value;
+
+    static_assert(not abstract, "cannot create poly_ptr with abstract ptr");
+    static_assert(base, "cannot create poly_ptr with non-derived type");
+  }
+
+  template <class U, class E>
+  poly_ptr (
+    U* ptr, E&& deleter,
+    copier_type copier=::std::addressof(
+      default_poly_copy<element_type, deleter_type, U>
+    )
+  ) noexcept :
+    poly_ptr {
+      unique_type { ::std::move(ptr), ::std::forward<E>(deleter) }, copier
+    }
+  { }
+
+  poly_ptr (poly_ptr const& that) :
+    copier { that.copier },
+    ptr { that.copier(that.ptr) }
+  { }
+
+  poly_ptr (poly_ptr&& that) noexcept :
+    copier { ::std::move(that.copier) },
+    ptr { ::std::move(that.ptr) }
+  { that.copier = null_poly_copy<element_type, deleter_type>; }
+
+  constexpr poly_ptr () noexcept { }
+
+  ~poly_ptr () noexcept { }
+
+  template <class U, class E>
+  poly_ptr& operator = (::std::unique_ptr<U, E>&& ptr) {
+    poly_ptr { ::std::move(ptr) }.swap(*this);
+    return *this;
+  }
+
+  template <class U>
+  poly_ptr& operator = (U* ptr) {
+    poly_ptr { ptr }.swap(*this);
+    return *this;
+  }
+
+  poly_ptr& operator = (::std::nullptr_t) noexcept {
+    this->reset();
+    return *this;
+  }
+
+  poly_ptr& operator = (poly_ptr const& that) {
+    return *this = poly_ptr { that };
+  }
+
+  poly_ptr& operator = (poly_ptr&& that) noexcept {
+    poly_ptr { ::std::move(that) }.swap(*this);
+    return *this;
+  }
+
+  explicit operator bool () const noexcept { return bool(this->ptr); }
+
+  add_lvalue_reference_t<element_type> operator * () const noexcept {
+    return *this->ptr;
+  }
+
+  pointer operator -> () const noexcept { return this->ptr.get(); }
+
+  pointer get () const noexcept { return this->ptr.get(); }
+
+  deleter_type const& get_deleter () const noexcept {
+    return this->ptr.get_deleter();
+  }
+
+  deleter_type& get_deleter () noexcept { return this->ptr.get_deleter(); }
+
+  copier_type const& get_copier () const noexcept { return this->copier; }
+  copier_type& get_copier () noexcept { return this->copier; }
+
+  pointer release () noexcept {
+    this->copier = null_poly_copy<element_type, deleter_type>;
+    return this->ptr.release();
+  }
+
+  void reset (pointer ptr = pointer { }) {
+    constexpr auto invalid = "cannot reset null poly_ptr with valid pointer";
+    constexpr auto type = "cannot reset poly_ptr with different type";
+
+    if (ptr and not this->ptr) { throw_bad_poly_reset(invalid); }
+    if (ptr and typeid(*this->ptr) != typeid(*ptr)) {
+      throw_bad_poly_reset(type);
+    }
+
+    this->ptr.reset(ptr);
+    if (not ptr) { this->copier = null_poly_copy<element_type, deleter_type>; }
+  }
+
+  void swap (poly_ptr& that) noexcept {
+    using ::std::swap;
+    swap(this->get_copier(), that.get_copier());
+    swap(this->ptr, that.ptr);
+  }
+
+private:
+  static_assert(
+    ::std::is_polymorphic<element_type>::value,
+    "cannot create a poly_ptr with a non-polymorphic type"
+  );
+
+  copier_type copier { null_poly_copy<element_type, deleter_type> };
+  unique_type ptr;
+};
+#endif /* CORE_NO_RTTI */
+
+template <
+  class T,
+  class Deleter=::std::default_delete<T>,
+  class Copier=default_copy<T>
+> struct deep_ptr final {
+
+  using element_type = T;
+  using deleter_type = Deleter;
+  using copier_type = Copier;
+  using pointer = impl::pointer_t<element_type, deleter_type>;
+
+  static_assert(
+    ::std::is_same<result_of_t<copier_type(pointer)>, pointer>::value,
+    "deleter_type and copier_type have differing pointer types"
+  );
+
+  using data_type = ::std::tuple<pointer, deleter_type, copier_type>;
+
+  deep_ptr (
+    pointer ptr,
+    impl::deep_lvalue<deleter_type> deleter,
+    impl::deep_lvalue<copier_type> copier
+  ) noexcept :
+    data { ptr, deleter, copier }
+  { }
+
+  deep_ptr (
+    pointer ptr,
+    remove_reference_t<deleter_type>&& deleter,
+    remove_reference_t<copier_type>&& copier
+  ) noexcept :
+    data { ::std::move(ptr), ::std::move(deleter), ::std::move(copier) }
+  { }
+
+  template <class U, class E>
+  deep_ptr (::std::unique_ptr<U, E>&& that) noexcept :
+    deep_ptr {
+      that.release(),
+      ::std::move(that.get_deleter()),
+      copier_type { }
+    }
+  { }
+
+  explicit deep_ptr (pointer ptr) noexcept :
+    deep_ptr { ptr, deleter_type { }, copier_type { } }
+  { }
+
+  constexpr deep_ptr (::std::nullptr_t) noexcept : deep_ptr { } { }
+
+  deep_ptr (deep_ptr const& that) :
+    deep_ptr {
+      that.get() ? that.get_copier()(that.get()) : that.get(),
+      that.get_deleter(),
+      that.get_copier()
+    }
+  { }
+
+  deep_ptr (deep_ptr&& that) noexcept :
+    data {
+      that.release(),
+      ::std::move(that.get_deleter()),
+      ::std::move(that.get_copier())
+    }
+  { }
+
+  constexpr deep_ptr () noexcept : data { } { }
+
+  ~deep_ptr () noexcept {
+    auto& ptr = ::std::get<0>(this->data);
+    if (not ptr) { return; }
+    this->get_deleter()(ptr);
+    ptr = nullptr;
+  }
+
+  deep_ptr& operator = (::std::nullptr_t) noexcept {
+    this->reset();
+    return *this;
+  }
+
+  deep_ptr& operator = (deep_ptr const& that) {
+    return *this = deep_ptr { that };
+  }
+
+  deep_ptr& operator = (deep_ptr&& that) noexcept {
+    deep_ptr { ::std::move(that) }.swap(*this);
+    return *this;
+  }
+
+  explicit operator bool () const noexcept { return this->get(); }
+
+  add_lvalue_reference_t<element_type> operator * () const noexcept {
+    return *this->get();
+  }
+  pointer operator -> () const noexcept { return this->get(); }
+  pointer get () const noexcept { return ::std::get<0>(this->data); }
+
+  deleter_type const& get_deleter () const noexcept {
+    return ::std::get<1>(this->data);
+  }
+
+  deleter_type& get_deleter () noexcept { return ::std::get<1>(this->data); }
+
+  copier_type const& get_copier () const noexcept {
+    return ::std::get<2>(this->data);
+  }
+
+  copier_type& get_copier () noexcept { return ::std::get<2>(this->data); }
+
+  pointer release () noexcept {
+    auto ptr = this->get();
+    ::std::get<0>(this->data) = nullptr;
+    return ptr;
+  }
+
+  void reset (pointer ptr = pointer { }) noexcept {
+    using ::std::swap;
+    swap(::std::get<0>(this->data), ptr);
+    if (not ptr) { return; }
+    this->get_deleter()(ptr);
+  }
+
+  void swap (deep_ptr& that) noexcept(is_nothrow_swappable<data_type>::value) {
+    using ::std::swap;
+    swap(this->data, that.data);
+  }
+
+private:
+  data_type data;
+};
+
+template <class W>
+struct observer_ptr final {
+  using element_type = W;
+
+  using const_pointer = add_pointer_t<add_const_t<element_type>>;
+  using pointer = add_pointer_t<element_type>;
+
+  using const_reference = add_lvalue_reference_t<add_const_t<element_type>>;
+  using reference = add_lvalue_reference_t<element_type>;
+
+  observer_ptr (observer_ptr const&) noexcept = default;
+
+  constexpr observer_ptr (::std::nullptr_t) noexcept : ptr { nullptr } { }
+  explicit observer_ptr (pointer ptr) noexcept : ptr { ptr } { }
+
+  template <
+    class T,
+    class=enable_if_t<::std::is_convertible<pointer, add_pointer_t<T>>::value>
+  > explicit observer_ptr (add_pointer_t<T> ptr) noexcept :
+    ptr { dynamic_cast<pointer>(ptr) }
+  { }
+
+  template <
+    class T,
+    class=enable_if_t<::std::is_convertible<pointer, add_pointer_t<T>>::value>
+  > observer_ptr (observer_ptr<T> const& that) noexcept :
+    observer_ptr { that.get() }
+  { }
+
+  constexpr observer_ptr () noexcept : observer_ptr { nullptr } { }
+  ~observer_ptr () noexcept { this->ptr = nullptr; }
+
+  template <
+    class T,
+    class=enable_if_t<::std::is_convertible<pointer, add_pointer_t<T>>::value>
+  > observer_ptr& operator = (add_pointer_t<T> ptr) noexcept {
+    observer_ptr { ptr }.swap(*this);
+    return *this;
+  }
+
+  observer_ptr& operator = (observer_ptr const&) noexcept = default;
+
+  template <
+    class T,
+    class=enable_if_t<::std::is_convertible<pointer, add_pointer_t<T>>::value>
+  > observer_ptr& operator = (observer_ptr<T> const& that) noexcept {
+    observer_ptr { that }.swap(*this);
+    return *this;
+  }
+
+  observer_ptr& operator = (::std::nullptr_t) noexcept {
+    this->reset();
+    return *this;
+  }
+
+  void swap (observer_ptr& that) noexcept {
+    using ::std::swap;
+    swap(this->ptr, that.ptr);
+  }
+
+  explicit operator const_pointer () const noexcept { return this->get(); }
+  explicit operator pointer () noexcept { return this->get(); }
+  explicit operator bool () const noexcept { return this->get(); }
+
+  reference operator * () const noexcept { return *this->get(); }
+  pointer operator -> () const noexcept { return this->get(); }
+  pointer get () const noexcept { return this->ptr; }
+
+  pointer release () noexcept {
+    auto result = this->get();
+    this->reset();
+    return result;
+  }
+
+  void reset (pointer ptr = nullptr) noexcept { this->ptr = ptr; }
+
+private:
+  pointer ptr;
+};
+
+template <class T, ::std::size_t N, class U, ::std::size_t M>
+bool operator == (
+  arena_allocator<T, N> const& lhs,
+  arena_allocator<U, M> const& rhs
+) noexcept {
+  return N == M and
+    ::std::addressof(lhs.arena()) == ::std::addressof(rhs.arena());
+}
+
+template <class T, ::std::size_t N, class U, ::std::size_t M>
+bool operator != (
+  arena_allocator<T, N> const& lhs,
+  arena_allocator<U, M> const& rhs
+) noexcept { return N != M or
+  ::std::addressof(lhs.arena()) != ::std::addressof(rhs.arena());
+}
+
+#ifndef CORE_NO_RTTI
+/* poly_ptr convention for type and deleter is: T, D : U, E */
+template <class T, class D, class U, class E>
+bool operator == (
+  poly_ptr<T, D> const& lhs,
+  poly_ptr<U, E> const& rhs
+) noexcept { return lhs.get() == rhs.get(); }
+
+template <class T, class D, class U, class E>
+bool operator != (
+  poly_ptr<T, D> const& lhs,
+  poly_ptr<U, E> const& rhs
+) noexcept { return lhs.get() != rhs.get(); }
+
+template <class T, class D, class U, class E>
+bool operator >= (
+  poly_ptr<T, D> const& lhs,
+  poly_ptr<U, E> const& rhs
+) noexcept { return not (lhs < rhs); }
+
+template <class T, class D, class U, class E>
+bool operator <= (
+  poly_ptr<T, D> const& lhs,
+  poly_ptr<U, E> const& rhs
+) noexcept { return not (rhs < lhs); }
+
+template <class T, class D, class U, class E>
+bool operator > (
+  poly_ptr<T, D> const& lhs,
+  poly_ptr<U, E> const& rhs
+) noexcept { return rhs < lhs; }
+
+template <class T, class D, class U, class E>
+bool operator < (
+  poly_ptr<T, D> const& lhs,
+  poly_ptr<U, E> const& rhs
+) noexcept {
+  using common_type = typename ::std::common_type<
+    typename poly_ptr<T, D>::pointer,
+    typename poly_ptr<U, E>::pointer
+  >::type;
+  return ::std::less<common_type> { }(lhs.get(), rhs.get());
+}
+#endif /* CORE_NO_RTTI */
+
+/* deep_ptr convention for type, deleter, copier is
+ * T, D, C : U, E, K
+ */
+template <class T, class D, class C, class U, class E, class K>
+bool operator == (
+  deep_ptr<T, D, C> const& lhs,
+  deep_ptr<U, E, K> const& rhs
+) noexcept { return lhs.get() == rhs.get(); }
+
+template <class T, class D, class C, class U, class E, class K>
+bool operator != (
+  deep_ptr<T, D, C> const& lhs,
+  deep_ptr<U, E, K> const& rhs
+) noexcept { return lhs.get() != rhs.get(); }
+
+template <class T, class D, class C, class U, class E, class K>
+bool operator >= (
+  deep_ptr<T, D, C> const& lhs,
+  deep_ptr<U, E, K> const& rhs
+) noexcept { return not (lhs < rhs); }
+
+template <class T, class D, class C, class U, class E, class K>
+bool operator <= (
+  deep_ptr<T, D, C> const& lhs,
+  deep_ptr<U, E, K> const& rhs
+) noexcept { return not (rhs < lhs); }
+
+template <class T, class D, class C, class U, class E, class K>
+bool operator > (
+  deep_ptr<T, D, C> const& lhs,
+  deep_ptr<U, E, K> const& rhs
+) noexcept { return rhs < lhs; }
+
+template <class T, class D, class C, class U, class E, class K>
+bool operator < (
+  deep_ptr<T, D, C> const& lhs,
+  deep_ptr<U, E, K> const& rhs
+) noexcept {
+  using common_type = common_type_t<
+    typename deep_ptr<T, D, C>::pointer,
+    typename deep_ptr<U, E, K>::pointer
+  >;
+  return ::std::less<common_type> { }(lhs.get(), rhs.get());
+}
+
+#ifndef CORE_NO_RTTI
+/* poly_ptr nullptr operator overloads */
+template <class T, class D>
+bool operator == (poly_ptr<T, D> const& lhs, ::std::nullptr_t) noexcept {
+  return not lhs;
+}
+
+template <class T, class D>
+bool operator == (::std::nullptr_t, poly_ptr<T, D> const& rhs) noexcept {
+  return not rhs;
+}
+
+template <class T, class D>
+bool operator != (poly_ptr<T, D> const& lhs, ::std::nullptr_t) noexcept {
+  return bool(lhs);
+}
+
+template <class T, class D>
+bool operator != (::std::nullptr_t, poly_ptr<T, D> const& rhs) noexcept {
+  return bool(rhs);
+}
+
+template <class T, class D>
+bool operator >= (poly_ptr<T, D> const& lhs, ::std::nullptr_t) noexcept {
+  return not (lhs < nullptr);
+}
+
+template <class T, class D>
+bool operator >= (::std::nullptr_t, poly_ptr<T, D> const& rhs) noexcept {
+  return not (nullptr < rhs);
+}
+
+template <class T, class D>
+bool operator <= (poly_ptr<T, D> const& lhs, ::std::nullptr_t) noexcept {
+  return not (nullptr < lhs);
+}
+
+template <class T, class D>
+bool operator <= (::std::nullptr_t, poly_ptr<T, D> const& rhs) noexcept {
+  return not (rhs < nullptr);
+}
+
+template <class T, class D>
+bool operator > (poly_ptr<T, D> const& lhs, ::std::nullptr_t) noexcept {
+  return nullptr < lhs;
+}
+
+template <class T, class D>
+bool operator > (::std::nullptr_t, poly_ptr<T, D> const& rhs) noexcept {
+  return rhs < nullptr;
+}
+
+template <class T, class D>
+bool operator < (poly_ptr<T, D> const& lhs, ::std::nullptr_t) noexcept {
+  using pointer = typename poly_ptr<T, D>::pointer;
+  return ::std::less<pointer> { }(lhs.get(), nullptr);
+}
+
+template <class T, class D>
+bool operator < (::std::nullptr_t, poly_ptr<T, D> const& rhs) noexcept {
+  using pointer = typename poly_ptr<T, D>::pointer;
+  return ::std::less<pointer> { }(nullptr, rhs.get());
+}
+#endif /* CORE_NO_RTTI */
+
+/* deep_ptr nullptr operator overloads */
+template <class T, class D, class C>
+bool operator == (deep_ptr<T, D, C> const& lhs, ::std::nullptr_t) noexcept {
+  return not lhs;
+}
+
+template <class T, class D, class C>
+bool operator == (::std::nullptr_t, deep_ptr<T, D, C> const& rhs) noexcept {
+  return not rhs;
+}
+
+template <class T, class D, class C>
+bool operator != (deep_ptr<T, D, C> const& lhs, ::std::nullptr_t) noexcept {
+  return bool(lhs);
+}
+
+template <class T, class D, class C>
+bool operator != (::std::nullptr_t, deep_ptr<T, D, C> const& rhs) noexcept {
+  return bool(rhs);
+}
+
+template <class T, class D, class C>
+bool operator >= (deep_ptr<T, D, C> const& lhs, ::std::nullptr_t) noexcept {
+  return not (lhs < nullptr);
+}
+
+template <class T, class D, class C>
+bool operator >= (::std::nullptr_t, deep_ptr<T, D, C> const& rhs) noexcept {
+  return not (nullptr < rhs);
+}
+
+template <class T, class D, class C>
+bool operator <= (deep_ptr<T, D, C> const& lhs, ::std::nullptr_t) noexcept {
+  return not (nullptr < lhs);
+}
+
+template <class T, class D, class C>
+bool operator <= (::std::nullptr_t, deep_ptr<T, D, C> const& rhs) noexcept {
+  return not (rhs < nullptr);
+}
+
+template <class T, class D, class C>
+bool operator > (deep_ptr<T, D, C> const& lhs, ::std::nullptr_t) noexcept {
+  return nullptr < lhs;
+}
+
+template <class T, class D, class C>
+bool operator > (::std::nullptr_t, deep_ptr<T, D, C> const& rhs) noexcept {
+  return rhs < nullptr;
+}
+
+template <class T, class D, class C>
+bool operator < (deep_ptr<T, D, C> const& lhs, ::std::nullptr_t) noexcept {
+  using pointer = typename deep_ptr<T, D, C>::pointer;
+  return ::std::less<pointer> { }(lhs.get(), nullptr);
+}
+
+template <class T, class D, class C>
+bool operator < (::std::nullptr_t, deep_ptr<T, D, C> const& rhs) noexcept {
+  using pointer = typename deep_ptr<T, D, C>::pointer;
+  return ::std::less<pointer> { }(nullptr, rhs.get());
+}
+
+/* observer_ptr and nullptr overloads */
+template <class T, class U>
+bool operator == (
+  observer_ptr<T> const& lhs,
+  observer_ptr<U> const& rhs
+) noexcept { return lhs.get() == rhs.get(); }
+
+template <class T, class U>
+bool operator != (
+  observer_ptr<T> const& lhs,
+  observer_ptr<U> const& rhs
+) noexcept { return lhs.get() != rhs.get(); }
+
+template <class T>
+bool operator == (observer_ptr<T> const& lhs, ::std::nullptr_t) noexcept {
+  return lhs.get() == nullptr;
+}
+
+template <class T>
+bool operator != (observer_ptr<T> const& lhs, ::std::nullptr_t) noexcept {
+  return lhs.get() != nullptr;
+}
+
+template <class T>
+bool operator == (::std::nullptr_t, observer_ptr<T> const& rhs) noexcept {
+  return nullptr == rhs.get();
+}
+
+template <class T>
+bool operator != (::std::nullptr_t, observer_ptr<T> const& rhs) noexcept {
+  return nullptr != rhs.get();
+}
+
+template <class T, class U>
+bool operator >= (
+  observer_ptr<T> const& lhs,
+  observer_ptr<U> const& rhs
+) noexcept { return lhs.get() >= rhs.get(); }
+
+template <class T, class U>
+bool operator <= (
+  observer_ptr<T> const& lhs,
+  observer_ptr<U> const& rhs
+) noexcept { return lhs.get() <= rhs.get(); }
+
+template <class T, class U>
+bool operator > (
+  observer_ptr<T> const& lhs,
+  observer_ptr<U> const& rhs
+) noexcept { return lhs.get() > rhs.get(); }
+
+template <class T, class U>
+bool operator < (
+  observer_ptr<T> const& lhs,
+  observer_ptr<U> const& rhs
+) noexcept { return lhs.get() < rhs.get(); }
+
+/* make_observer */
+template <class W>
+observer_ptr<W> make_observer (W* ptr) noexcept {
+  return observer_ptr<W> { ptr };
+}
+
+template <class W, class D>
+observer_ptr<W> make_observer (::std::unique_ptr<W, D> const& ptr) noexcept {
+  return observer_ptr<W> { ptr.get() };
+}
+
+template <class W>
+observer_ptr<W> make_observer (::std::shared_ptr<W> const& ptr) noexcept {
+  return observer_ptr<W> { ptr.get() };
+}
+
+template <class W>
+observer_ptr<W> make_observer (::std::weak_ptr<W> const& ptr) noexcept {
+  return make_observer(ptr.lock());
+}
+
+template <class W, class C, class D>
+observer_ptr<W> make_observer (deep_ptr<W, C, D> const& ptr) noexcept {
+  return observer_ptr<W> { ptr.get() };
+}
+
+#ifndef CORE_NO_RTTI
+template <class W, class D>
+observer_ptr<W> make_observer (poly_ptr<W, D> const& ptr) noexcept {
+  return observer_ptr<W> { ptr.get() };
+}
+#endif /* CORE_NO_RTTI */
+
+#ifndef CORE_NO_RTTI
+/* make_poly */
+template <
+  class T,
+  class U,
+  class=enable_if_t<
+    ::std::is_polymorphic<T>::value and ::std::is_base_of<T, U>::value
+  >
+> auto make_poly (U&& value) -> poly_ptr<T> {
+  return poly_ptr<T> { new U { ::std::forward<U>(value) } };
+}
+#endif /* CORE_NO_RTTI */
+
+/* make_deep */
+template <
+  class T,
+  class=enable_if_t<not ::std::is_array<T>::value>,
+  class... Args
+> auto make_deep (Args&&... args) -> deep_ptr<T> {
+  return deep_ptr<T> { new T { ::std::forward<Args>(args)... } };
+}
+
+/* make_unique */
+template <
+  class Type,
+  class=enable_if_t<not ::std::is_array<Type>::value>,
+  class... Args
+> auto make_unique(Args&&... args) -> ::std::unique_ptr<Type> {
+  return ::std::unique_ptr<Type> {
+    new Type { ::std::forward<Args>(args)... }
+  };
+}
+
+template <
+  class Type,
+  class=enable_if_t< ::std::is_array<Type>::value>,
+  class=enable_if_t<not ::std::extent<Type>::value>
+> auto make_unique(::std::size_t size) -> ::std::unique_ptr<Type> {
+  return ::std::unique_ptr<Type> { new remove_extent_t<Type>[size] { } };
+}
+
+template <
+  class Type,
+  class=enable_if_t< ::std::is_array<Type>::value>,
+  class=enable_if_t< ::std::extent<Type>::value>,
+  class... Args
+> auto make_unique(Args&&...) -> void = delete;
+
+template <class T, ::std::size_t N>
+void swap (arena_allocator<T, N>& lhs, arena_allocator<T, N>& rhs) noexcept {
+  lhs.swap(rhs);
+}
+
+#ifndef CORE_NO_RTTI
+template <class T, class D>
+void swap (poly_ptr<T, D>& lhs, poly_ptr<T, D>& rhs) noexcept(
+  noexcept(lhs.swap(rhs))
+) { lhs.swap(rhs); }
+#endif /* CORE_NO_RTTI */
+
+template <class T, class D, class C>
+void swap (deep_ptr<T, D, C>& lhs, deep_ptr<T, D, C>& rhs) noexcept(
+  noexcept(lhs.swap(rhs))
+) { lhs.swap(rhs); }
+
+template <class W>
+void swap (observer_ptr<W>& lhs, observer_ptr<W>& rhs) noexcept(
+  noexcept(lhs.swap(rhs))
+) { lhs.swap(rhs); }
+
+}} /* namespace core::v1 */
+
+namespace std {
+
+#ifndef CORE_NO_RTTI
+template <class T, class D>
+struct hash<core::v1::poly_ptr<T, D>> {
+  using value_type = core::v1::poly_ptr<T, D>;
+  size_t operator ()(value_type const& value) const noexcept {
+    return hash<typename value_type::pointer>{ }(value.get());
+  }
+};
+#endif /* CORE_NO_RTTI */
+
+template <class T, class Deleter, class Copier>
+struct hash<core::v1::deep_ptr<T, Deleter, Copier>> {
+  using value_type = core::v1::deep_ptr<T, Deleter, Copier>;
+  size_t operator ()(value_type const& value) const noexcept {
+    return hash<typename value_type::pointer> { }(value.get());
+  }
+};
+
+template <class W>
+struct hash<core::v1::observer_ptr<W>> {
+  using value_type = core::v1::observer_ptr<W>;
+  size_t operator ()(value_type const& value) const noexcept {
+    return hash<typename value_type::pointer> { }(value.get());
+  }
+};
+
+} /* namespace std */
+
+#endif /* CORE_MEMORY_HPP */

--- a/core/include/core/meta.hpp
+++ b/core/include/core/meta.hpp
@@ -1,0 +1,254 @@
+#ifndef CORE_META_HPP
+#define CORE_META_HPP
+
+#include <type_traits>
+#include <limits>
+#include <tuple>
+
+#include <cstdint>
+#include <cstddef>
+
+namespace core {
+namespace meta {
+inline namespace v1 {
+
+template <class T> struct identity { using type = T; };
+
+template <class T, T... I> struct integer_sequence : identity<T> {
+  static_assert(
+    ::std::is_integral<T>::value,
+    "integer_sequence must use an integral type"
+  );
+
+  template <T N> using append = integer_sequence<T, I..., N>;
+  static constexpr ::std::size_t size() noexcept { return sizeof...(I); }
+  using next = append<size()>;
+};
+
+template <class T, T Index, ::std::size_t N>
+struct iota : identity<
+  typename iota<T, Index - 1, N - 1u>::type::next
+> { static_assert(Index >= 0, "Index cannot be negative"); };
+
+template <class T, T Index>
+struct iota<T, Index, 0u> : identity<integer_sequence<T>> { };
+
+template <::std::size_t... I>
+using index_sequence = integer_sequence<::std::size_t, I...>;
+
+template <class T, T N>
+using make_integer_sequence = typename iota<T, N, N>::type;
+
+template <::std::size_t N>
+using make_index_sequence = make_integer_sequence<::std::size_t, N>;
+
+template <class... Ts>
+using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+
+template <::std::size_t I>
+using size = ::std::integral_constant<::std::size_t, I>;
+
+template <bool B> using boolean = ::std::integral_constant<bool, B>;
+template <int I> using integer = ::std::integral_constant<int, I>;
+
+template <class...> struct all;
+template <class T, class... Args>
+struct all<T, Args...> : boolean<T::value and all<Args...>::value> { };
+template <> struct all<> : ::std::true_type { };
+
+template <class...> struct any;
+template <class T, class... Args>
+struct any<T, Args...> : boolean<T::value or any<Args...>::value> { };
+template <> struct any<> : ::std::false_type { };
+
+template <class... Args> using none = boolean<not all<Args...>::value>;
+
+/* type list forward declarations */
+template <class, template <class> class> struct transform;
+template <class, template <class> class> struct count_if;
+template <class, template <class> class> struct find_if;
+template <class, template <class> class> struct filter;
+template <::std::size_t, class> struct element;
+
+template <class, class...> struct push_front;
+template <class, class...> struct push_back;
+template <class, class> struct index;
+template <class, class> struct count;
+template <class, class> struct find;
+
+template <class...> struct merge;
+
+template <class> struct index_sequence_from;
+template <class> struct pop_front;
+template <class> struct pop_back;
+template <class> struct reverse;
+template <class> struct to_pack;
+
+template <class, template <class...> class> struct from_pack;
+
+template <class...> struct pack;
+
+/* type aliases */
+template <class T, template <class> class F>
+using transform_t = typename transform<T, F>::type;
+
+template <class T, template <class> class F>
+using find_if_t = typename find_if<T, F>::type;
+
+template <class T, template <class> class F>
+using filter_t = typename filter<T, F>::type;
+
+template <::std::size_t N, class T>
+using element_t = typename element<N, T>::type;
+
+template <class T, class... Us>
+using push_front_t = typename push_front<T, Us...>::type;
+
+template <class T, class... Us>
+using push_back_t = typename push_back<T, Us...>::type;
+
+template <class T, class V> using find_t = typename find<T, V>::type;
+
+template <class... Ts> using merge_t = typename merge<Ts...>::type;
+
+template <class T> using pop_front_t = typename pop_front<T>::type;
+template <class T> using pop_back_t = typename pop_back<T>::type;
+template <class T> using reverse_t = typename reverse<T>::type;
+
+template <class T, template <class...> class U>
+using from_pack_t = typename from_pack<T, U>::type;
+
+template <> struct pack<> {
+  static constexpr ::std::size_t size() noexcept { return 0u; }
+  static constexpr bool empty () noexcept { return false; }
+};
+
+template <class... Ts>
+struct pack {
+  static constexpr ::std::size_t size () noexcept { return sizeof...(Ts); }
+  static constexpr bool empty () noexcept { return size() == 0; }
+
+  using front = element_t<0, pack>;
+  using back = element_t<size() - 1u, pack>;
+};
+
+template <class... Ts, template <class> class F>
+struct transform<pack<Ts...>, F> :
+  identity<pack<F<Ts>...>>
+{ };
+
+template <class... Ts, template <class> class F>
+struct count_if<pack<Ts...>, F> :
+  meta::size<filter_t<pack<Ts...>, F>::size()>
+{ };
+
+template <template <class> class F>
+struct find_if<pack<>, F> : identity<pack<>> { };
+
+template <class T, class... Ts, template <class> class F>
+struct find_if<pack<T, Ts...>, F> : identity<
+  typename ::std::conditional<
+    F<T>::value,
+    pack<T, Ts...>,
+    find_if_t<pack<Ts...>, F>
+  >::type
+> { };
+
+template <class... Ts, template <class> class F>
+struct filter<pack<Ts...>, F> :
+  merge<
+    typename ::std::conditional<
+      F<Ts>::value,
+      pack<Ts>,
+      pack<>
+    >::type...
+  >
+{ };
+
+template <class T, class... Ts>
+struct element<0u, pack<T, Ts...>> :
+  identity<T>
+{ };
+
+template <::std::size_t N, class T, class... Ts>
+struct element<N, pack<T, Ts...>> :
+  element<N - 1, pack<Ts...>>
+{ static_assert(N < (sizeof...(Ts) + 1), "given index is out of range"); };
+
+template <class... Ts, class... Us>
+struct push_front<pack<Ts...>, Us...> : identity<
+  pack<Us..., Ts...>
+> { };
+
+template <class... Ts, class... Us>
+struct push_back<pack<Ts...>, Us...> : identity<
+  pack<Ts..., Us...>
+> { };
+
+template <class T> struct is {
+  template <class U> using convertible = ::std::is_convertible<T, U>;
+  template <class U> using assignable = ::std::is_assignable<T, U>;
+  template <class U> using base_of = ::std::is_base_of<T, U>;
+  template <class U> using same = ::std::is_same<T, U>;
+
+  template <class U>
+  using nothrow_assignable = ::std::is_nothrow_assignable<T, U>;
+};
+
+template <class T, class... Ts>
+struct count<T, pack<Ts...>> :
+  count_if<pack<Ts...>, is<T>::template same>
+{ };
+
+template <class T, class... Ts>
+struct index<T, pack<Ts...>> : ::std::conditional<
+  find_t<T, pack<Ts...>>::empty(),
+  meta::size<::std::numeric_limits<::std::size_t>::max()>,
+  meta::size<pack<Ts...>::size() - find_t<T, pack<Ts...>>::size()>
+>::type { };
+
+template <class T, class... Ts>
+struct find<T, pack<Ts...>> :
+  find_if<pack<Ts...>, is<T>::template same>
+{ };
+
+template <class... Ts>
+struct merge<pack<Ts...>> : identity<pack<Ts...>> { };
+
+template <class... Ts, class... Us, class... Vs>
+struct merge<pack<Ts...>, pack<Us...>, Vs...> :
+  merge<pack<Ts..., Us...>, Vs...>
+{ };
+
+template <class... Ts> struct index_sequence_from<pack<Ts...>> :
+  index_sequence_for<Ts...>
+{ };
+
+template <class T, class... Ts> struct pop_front<pack<T, Ts...>> :
+  identity<pack<Ts...>>
+{ };
+
+template <class... Ts> struct pop_back<pack<Ts...>> :
+  reverse<pop_front_t<reverse_t<pack<Ts...>>>>
+{ };
+
+template <class... Ts> struct reverse<pack<Ts...>> {
+  template <class T> struct impl;
+  template <::std::size_t... I>
+  struct impl<index_sequence<I...>> : identity<
+    pack<element_t<sizeof...(I) - I - 1u, pack<Ts...>>...>
+  > { };
+  using type = typename impl<index_sequence_for<Ts...>>::type;
+};
+
+template <template <class...> class T, class... Ts>
+struct to_pack<T<Ts...>> : identity<pack<Ts...>> { };
+
+template <class... Ts, template <class...> class To>
+struct from_pack<pack<Ts...>, To> : identity<
+  To<Ts...>
+> { };
+
+}}} /* namespace core::meta::v1 */
+
+#endif /* CORE_META_HPP */

--- a/core/include/core/numeric.hpp
+++ b/core/include/core/numeric.hpp
@@ -1,0 +1,156 @@
+#ifndef CORE_NUMERIC_HPP
+#define CORE_NUMERIC_HPP
+
+#include <numeric>
+
+#include <core/range.hpp>
+
+namespace core {
+inline namespace v1 {
+
+template <class Range, class T>
+auto iota (Range&& rng, T&& value) -> enable_if_t<is_range<Range>::value> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_forward = decltype(range)::is_forward;
+  static_assert(is_forward, "iota requires ForwardIterators");
+  return ::std::iota(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<T>(value)
+  );
+}
+
+template <class Range, class T>
+auto accumulate (Range&& rng, T&& init) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<T>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "accumulate requires InputIterators");
+  return ::std::accumulate(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<T>(init)
+  );
+}
+
+template <class Range, class T, class BinaryOp>
+auto accumulate (Range&& rng, T&& init, BinaryOp&& op) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<T>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "accumulate requires InputIterators");
+  return ::std::accumulate(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<T>(init),
+    ::std::forward<BinaryOp>(op)
+  );
+}
+
+template <class Range, class InputIt, class T>
+auto inner_product (Range&& rng, InputIt&& it, T&& value) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<T>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "inner_product requires InputIterators");
+  return ::std::inner_product(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<InputIt>(it),
+    ::std::forward<T>(value)
+  );
+}
+
+template <class Range, class InputIt, class T, class BinaryOp, class BinaryOp2>
+auto inner_product (
+  Range&& rng,
+  InputIt&& it,
+  T&& value,
+  BinaryOp&& op,
+  BinaryOp2&& op2
+) -> enable_if_t<is_range<Range>::value, decay_t<T>> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "inner_product requires InputIterators");
+  return ::std::inner_product(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<InputIt>(it),
+    ::std::forward<T>(value),
+    ::std::forward<BinaryOp>(op),
+    ::std::forward<BinaryOp2>(op2)
+  );
+}
+
+template <class Range, class OutputIt>
+auto adjacent_difference (Range&& rng, OutputIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "adjacent_difference requires InputIterators");
+  return ::std::adjacent_difference(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range, class OutputIt, class BinaryOp>
+auto adjacent_difference (
+  Range&& rng,
+  OutputIt&& it,
+  BinaryOp&& op
+) -> enable_if_t<is_range<Range>::value, decay_t<OutputIt>> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "adjacent_difference requires InputIterators");
+  return ::std::adjacent_difference(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<BinaryOp>(op)
+  );
+}
+
+template <class Range, class OutputIt>
+auto partial_sum (Range&& rng, OutputIt&& it) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "partial_sum requires InputIterators");
+  return ::std::partial_sum(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it)
+  );
+}
+
+template <class Range, class OutputIt, class BinaryOp>
+auto partial_sum (Range&& rng, OutputIt&& it, BinaryOp&& op) -> enable_if_t<
+  is_range<Range>::value,
+  decay_t<OutputIt>
+> {
+  auto range = make_range(::std::forward<Range>(rng));
+  constexpr auto is_input = decltype(range)::is_input;
+  static_assert(is_input, "partial_sum requires InputIterators");
+  return ::std::partial_sum(
+    ::std::begin(range),
+    ::std::end(range),
+    ::std::forward<OutputIt>(it),
+    ::std::forward<BinaryOp>(op)
+  );
+}
+
+}} /* namespace core::v1 */
+
+#endif /* CORE_NUMERIC_HPP */

--- a/core/include/core/optional.hpp
+++ b/core/include/core/optional.hpp
@@ -1,0 +1,2066 @@
+#ifndef CORE_OPTIONAL_HPP
+#define CORE_OPTIONAL_HPP
+
+#include <initializer_list>
+#include <system_error>
+#include <functional>
+#include <memory>
+
+#include <cstdlib>
+#include <cstdint>
+
+#include <core/type_traits.hpp>
+#include <core/functional.hpp>
+#include <core/utility.hpp>
+
+#ifndef CORE_NO_EXCEPTIONS
+#include <exception>
+#include <stdexcept>
+#endif /* CORE_NO_EXCEPTIONS */
+
+namespace core {
+inline namespace v1 {
+namespace impl {
+
+struct place_t { };
+constexpr place_t place { };
+
+/* this is the default 'false' case */
+template <class T, bool = ::std::is_trivially_destructible<T>::value>
+struct storage {
+  using value_type = T;
+  static constexpr bool nothrow = ::std::is_nothrow_move_constructible<
+    value_type
+  >::value;
+
+  union {
+    ::std::uint8_t dummy;
+    value_type val;
+  };
+  bool engaged { false };
+
+  constexpr storage () noexcept : dummy { '\0' } { }
+  storage (storage const& that) :
+    engaged { that.engaged }
+  {
+    if (not this->engaged) { return; }
+    ::new (::std::addressof(this->val)) value_type(that.val);
+  }
+
+  storage (storage&& that) noexcept(nothrow) :
+    engaged { that.engaged }
+  {
+    if (not this->engaged) { return; }
+    ::new (::std::addressof(this->val)) value_type(::core::move(that.val));
+  }
+
+  constexpr storage (value_type const& value) :
+    val(value),
+    engaged { true }
+  { }
+
+  constexpr storage (value_type&& value) noexcept(nothrow) :
+    val(::core::move(value)),
+    engaged { true }
+  { }
+
+  template <class... Args>
+  constexpr explicit storage (place_t, Args&&... args) :
+    val(::core::forward<Args>(args)...),
+    engaged { true }
+  { }
+
+  ~storage () noexcept { if (this->engaged) { this->val.~value_type(); } }
+};
+
+template <class T>
+struct storage<T, true> {
+  using value_type = T;
+  static constexpr bool nothrow = ::std::is_nothrow_move_constructible<
+    value_type
+  >::value;
+  union {
+    ::std::uint8_t dummy;
+    value_type val;
+  };
+  bool engaged { false };
+
+  constexpr storage () noexcept : dummy { '\0' } { }
+  storage (storage const& that) :
+    engaged { that.engaged }
+  {
+    if (not this->engaged) { return; }
+    ::new (::std::addressof(this->val)) value_type(that.val);
+  }
+
+  storage (storage&& that) noexcept(nothrow) :
+    engaged { that.engaged }
+  {
+    if (not this->engaged) { return; }
+    ::new (::std::addressof(this->val)) value_type(::core::move(that.val));
+  }
+
+  constexpr storage (value_type const& value) :
+    val(value),
+    engaged { true }
+  { }
+
+  constexpr storage (value_type&& value) noexcept(nothrow) :
+    val(::core::move(value)),
+    engaged { true }
+  { }
+
+  template <class... Args>
+  constexpr explicit storage (place_t, Args&&... args) :
+    val(::core::forward<Args>(args)...),
+    engaged { true }
+  { }
+};
+
+} /* namespace impl */
+
+struct in_place_t { };
+struct nullopt_t { constexpr explicit nullopt_t (int) noexcept { } };
+
+constexpr in_place_t in_place { };
+constexpr nullopt_t nullopt { 0 };
+
+#ifndef CORE_NO_EXCEPTIONS
+struct bad_optional_access final : ::std::logic_error {
+  using ::std::logic_error::logic_error;
+};
+
+struct bad_expected_type : ::std::logic_error {
+  using ::std::logic_error::logic_error;
+};
+
+struct bad_result_condition final : ::std::logic_error {
+  using ::std::logic_error::logic_error;
+};
+
+[[noreturn]] inline void throw_bad_optional_access () {
+  throw bad_optional_access { "optional is disengaged" };
+}
+
+[[noreturn]] inline void throw_bad_result_condition () {
+  throw bad_result_condition { "result<T> is valid" };
+}
+
+[[noreturn]] inline void throw_bad_void_result_condition () {
+  throw bad_result_condition { "result<void> is valid" };
+}
+
+[[noreturn]] inline void throw_system_error (::std::error_condition e) {
+  throw ::std::system_error { e.value(), e.category() };
+}
+#else /* CORE_NO_EXCEPTIONS */
+[[noreturn]] inline void throw_bad_optional_access () { ::std::abort(); }
+[[noreturn]] inline void throw_bad_result_condition () { ::std::abort(); }
+[[noreturn]] inline void throw_bad_void_result_condition () { ::std::abort(); }
+[[noreturn]] inline void throw_system_error (::std::error_condition) {
+  ::std::abort();
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class> struct optional;
+template <class> struct expected;
+template <class> struct result;
+
+template <class> struct is_optional : ::std::false_type { };
+template <class> struct is_expected : ::std::false_type { };
+template <class> struct is_result : ::std::false_type { };
+
+template <class T> struct is_optional<optional<T>> : ::std::true_type { };
+template <class T> struct is_expected<expected<T>> : ::std::true_type { };
+template <class T> struct is_result<result<T>> : ::std::true_type { };
+
+template <class T> using is_monadic = meta::any<
+  is_optional<T>,
+  is_expected<T>,
+  is_result<T>
+>;
+
+template <class Type>
+struct optional final : private impl::storage<Type> {
+  using base = impl::storage<Type>;
+  using value_type = typename impl::storage<Type>::value_type;
+
+  /* compiler enforcement */
+  static_assert(
+    not ::std::is_reference<value_type>::value,
+    "Cannot have optional reference (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, nullopt_t>::value,
+    "Cannot have optional<nullopt_t> (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, in_place_t>::value,
+    "Cannot have optional<in_place_t> (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, ::std::nullptr_t>::value,
+    "Cannot have optional nullptr (tautological)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, void>::value,
+    "Cannot have optional<void> (ill-formed)"
+  );
+
+  static_assert(
+    ::std::is_object<value_type>::value,
+    "Cannot have optional with a non-object type (undefined behavior)"
+  );
+
+  static_assert(
+    ::std::is_nothrow_destructible<value_type>::value,
+    "Cannot have optional with non-noexcept destructible (undefined behavior)"
+  );
+
+  constexpr optional () noexcept { }
+  optional (optional const&) = default;
+  optional (optional&&) = default;
+  ~optional () = default;
+
+  constexpr optional (nullopt_t) noexcept { }
+
+  constexpr optional (value_type const& value) :
+    base { value }
+  { }
+
+  constexpr optional (value_type&& value) noexcept(base::nothrow) :
+    base { ::core::move(value) }
+  { }
+
+  template <
+    class... Args,
+    class=enable_if_t< ::std::is_constructible<value_type, Args...>::value>
+  > constexpr explicit optional (in_place_t, Args&&... args) :
+    base { impl::place, ::core::forward<Args>(args)... }
+  { }
+
+  template <
+    class T,
+    class... Args,
+    class=enable_if_t<
+      ::std::is_constructible<
+        value_type,
+        ::std::initializer_list<T>&,
+        Args...
+      >::value
+    >
+  > constexpr explicit optional (
+    in_place_t,
+    ::std::initializer_list<T> il,
+    Args&&... args
+  ) : base { impl::place, il, ::core::forward<Args>(args)... } { }
+
+  optional& operator = (optional const& that) {
+    optional { that }.swap(*this);
+    return *this;
+  }
+
+  optional& operator = (optional&& that) noexcept (
+    meta::all<
+      ::std::is_nothrow_move_assignable<value_type>,
+      ::std::is_nothrow_move_constructible<value_type>
+    >::value
+  ) {
+    optional { ::core::move(that) }.swap(*this);
+    return *this;
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      not ::std::is_same<decay_t<T>, optional>::value and
+      ::std::is_constructible<value_type, T>::value and
+      ::std::is_assignable<value_type&, T>::value
+    >
+  > optional& operator = (T&& value) {
+    if (not this->engaged) { this->emplace(::core::forward<T>(value)); }
+    else { **this = ::core::forward<T>(value); }
+    return *this;
+  }
+
+  optional& operator = (nullopt_t) noexcept {
+    if (this->engaged) {
+      this->val.~value_type();
+      this->engaged = false;
+    }
+    return *this;
+  }
+
+  void swap (optional& that) noexcept(
+    meta::all<
+      is_nothrow_swappable<value_type>,
+      ::std::is_nothrow_move_constructible<value_type>
+    >::value
+  ) {
+    using ::std::swap;
+    if (not *this and not that) { return; }
+    if (*this and that) {
+      swap(**this, *that);
+      return;
+    }
+
+    auto& to_disengage = *this ? *this : that;
+    auto& to_engage = *this ? that : *this;
+
+    to_engage.emplace(::core::move(*to_disengage));
+    to_disengage = nullopt;
+  }
+
+  constexpr explicit operator bool () const { return this->engaged; }
+
+  constexpr value_type const& operator * () const noexcept {
+    return this->val;
+  }
+
+  value_type& operator * () noexcept { return this->val; }
+
+  constexpr value_type const* operator -> () const noexcept {
+    return this->ptr(trait::address<value_type> { });
+  }
+
+  value_type* operator -> () noexcept { return ::std::addressof(this->val); }
+
+  template <class T, class... Args>
+  void emplace (::std::initializer_list<T> il, Args&&... args) {
+    *this = nullopt;
+    ::new (::std::addressof(this->val)) value_type(
+      il,
+      ::core::forward<Args>(args)...
+    );
+    this->engaged = true;
+  }
+
+  template <class... Args>
+  void emplace (Args&&... args) {
+    *this = nullopt;
+    ::new (::std::addressof(this->val)) value_type(
+      ::core::forward<Args>(args)...
+    );
+    this->engaged = true;
+  }
+
+  constexpr value_type const& value () const noexcept(false) {
+    return *this
+      ? **this
+      : (throw_bad_optional_access(), **this);
+  }
+
+  value_type& value () noexcept(false) {
+    if (*this) { return **this; }
+    throw_bad_optional_access();
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        ::std::is_copy_constructible<value_type>,
+        ::std::is_convertible<T, value_type>
+      >::value
+    >
+  > constexpr value_type value_or (T&& val) const& {
+    return *this ? **this : static_cast<value_type>(::core::forward<T>(val));
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        ::std::is_move_constructible<value_type>,
+        ::std::is_convertible<T, value_type>
+      >::value
+    >
+  > value_type value_or (T&& val) && {
+    return *this
+      ? value_type { ::core::move(**this) }
+      : static_cast<value_type>(::core::forward<T>(val));
+  }
+
+  /* member function extensions */
+  template <class Visitor, class... Args>
+  constexpr auto visit (Visitor&& visitor, Args&&... args) const -> common_type_t<
+    invoke_of_t<Visitor, value_type const&, Args...>,
+    invoke_of_t<Visitor, nullopt_t, Args...>
+  > {
+    return *this
+      ? invoke(
+          ::core::forward<Visitor>(visitor),
+          **this,
+          ::core::forward<Args>(args)...)
+      : invoke(
+          ::core::forward<Visitor>(visitor),
+          nullopt,
+          ::core::forward<Args>(args)...);
+  }
+
+  template <class Visitor, class... Args>
+  auto visit (Visitor&& visitor, Args&&... args) -> common_type_t<
+    invoke_of_t<Visitor, value_type&, Args...>,
+    invoke_of_t<Visitor, nullopt_t, Args...>
+  > {
+    return *this
+      ? invoke(
+          ::core::forward<Visitor>(visitor),
+          **this,
+          ::core::forward<Args>(args)...)
+      : invoke(
+          ::core::forward<Visitor>(visitor),
+          nullopt,
+          ::core::forward<Args>(args)...);
+  }
+
+  template <class... Visitors>
+  auto match (Visitors&&... visitors) const -> decltype(
+    this->visit(impl::make_overload(::core::forward<Visitors>(visitors)...))
+  ) {
+    return this->visit(
+      impl::make_overload(::core::forward<Visitors>(visitors)...));
+  }
+
+  template <class... Visitors>
+  auto match (Visitors&&... visitors) -> decltype(
+    this->visit(impl::make_overload(::core::forward<Visitors>(visitors)...))
+  ) {
+    return this->visit(
+      impl::make_overload(::core::forward<Visitors>(visitors)...));
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_optional<invoke_of_t<F, value_type&>>::value>
+  > auto then (F&& f) -> invoke_of_t<F, value_type&> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f), **this); }
+    return nullopt;
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_optional<invoke_of_t<F, value_type const&>>::value>
+  > auto then (F&& f) const -> invoke_of_t<F, value_type const&> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f), **this); }
+    return nullopt;
+  }
+
+  template <class F>
+  auto operator >>= (F&& f) -> decltype(
+    ::std::declval<optional>().then(::core::forward<F>(f))
+  ) { return this->then(::core::forward<F>(f)); }
+
+  template <class F>
+  auto operator >>= (F&& f) const -> decltype(
+    ::std::declval<add_const_t<optional>>().then(::core::forward<F>(f))
+  ) { return this->then(::core::forward<F>(f)); }
+
+private:
+  constexpr value_type const* ptr (::std::false_type) const noexcept {
+    return &this->val;
+  }
+
+  value_type const* ptr (::std::true_type) const noexcept {
+    return ::std::addressof(this->val);
+  }
+};
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class Type>
+struct expected final {
+  using value_type = Type;
+
+  static constexpr bool nothrow = ::std::is_nothrow_move_constructible<
+    value_type
+  >::value;
+
+  /* compiler enforcement */
+  static_assert(
+    not ::std::is_reference<value_type>::value,
+    "Cannot have expected reference (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, nullopt_t>::value,
+    "Cannot have expected<nullopt_t> (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, in_place_t>::value,
+    "Cannot have expected<in_place_t> (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, ::std::exception_ptr>::value,
+    "Cannot have expected<std::exception_ptr> (tautological)"
+  );
+
+  static_assert(
+    ::std::is_object<value_type>::value,
+    "Cannot have expected with non-object type (undefined behavior)"
+  );
+
+  static_assert(
+    ::std::is_nothrow_destructible<value_type>::value,
+    "Cannot have expected with throwable destructor (undefined behavior)"
+  );
+
+  expected (::std::exception_ptr ptr) noexcept :
+    ptr { ptr }
+  { }
+
+  expected (value_type const& val) :
+    val(val),
+    valid { true }
+  { }
+
+  expected (value_type&& val) noexcept(nothrow) :
+    val(::core::move(val)),
+    valid { true }
+  { }
+
+  template <
+    class... Args,
+    class=enable_if_t< ::std::is_constructible<value_type, Args...>::value>
+  > explicit expected (in_place_t, Args&&... args) :
+    val(::core::forward<Args>(args)...),
+    valid { true }
+  { }
+
+  template <
+    class T,
+    class... Args,
+    class=enable_if_t<
+      ::std::is_constructible<
+        value_type,
+        ::std::initializer_list<T>&,
+        Args...
+      >::value
+    >
+  > explicit expected (
+    in_place_t,
+    ::std::initializer_list<T> il,
+    Args&&... args
+  ) : val(il, ::core::forward<Args>(args)...), valid { true } { }
+
+  expected (expected const& that) :
+    valid { that.valid }
+  {
+    if (*this) { ::new (::std::addressof(this->val)) value_type(that.val); }
+    else { ::new (::std::addressof(this->ptr)) ::std::exception_ptr(that.ptr); }
+  }
+
+  expected (expected&& that) noexcept(nothrow) :
+    valid { that.valid }
+  {
+    if (*this) {
+      ::new (::std::addressof(this->val)) value_type(::core::move(that.val));
+    } else {
+      ::new (::std::addressof(this->ptr)) ::std::exception_ptr(that.ptr);
+    }
+  }
+
+  expected () :
+    val { },
+    valid { true }
+  { }
+
+  ~expected () noexcept { this->reset(); }
+
+  expected& operator = (expected const& that) {
+    expected { that }.swap(*this);
+    return *this;
+  }
+
+  expected& operator = (expected&& that) noexcept(
+    meta::all<
+      ::std::is_nothrow_move_assignable<value_type>,
+      ::std::is_nothrow_move_constructible<value_type>
+    >::value
+  ) {
+    expected { ::core::move(that) }.swap(*this);
+    return *this;
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        meta::none<
+          ::std::is_same<decay_t<T>, expected>,
+          ::std::is_same<decay_t<T>, ::std::exception_ptr>
+        >,
+        ::std::is_constructible<value_type, T>,
+        ::std::is_assignable<value_type&, T>
+      >::value
+    >
+  > expected& operator = (T&& value) {
+    if (not *this) { this->emplace(::core::forward<T>(value)); }
+    else { **this = ::core::forward<T>(value); }
+    return *this;
+  }
+
+  expected& operator = (value_type const& value) {
+    if (not *this) { this->emplace(value); }
+    else { **this = value; }
+    return *this;
+  }
+
+  expected& operator = (value_type&& value) {
+    if (not *this) { this->emplace(::core::move(value)); }
+    else { **this = ::core::move(value); }
+    return *this;
+  }
+
+  expected& operator = (::std::exception_ptr ptr) {
+    if (not *this) { this->ptr = ptr; }
+    else {
+      this->val.~value_type();
+      ::new (::std::addressof(this->ptr)) ::std::exception_ptr(ptr);
+      this->valid = false;
+    }
+    return *this;
+  }
+
+  void swap (expected& that) noexcept(
+    meta::all<
+      is_nothrow_swappable<value_type>,
+      ::std::is_nothrow_move_constructible<value_type>
+    >::value
+  ) {
+    using ::std::swap;
+
+    if (not *this and not that) {
+      swap(this->ptr, that.ptr);
+      return;
+    }
+
+    if (*this and that) {
+      swap(this->val, that.val);
+      return;
+    }
+
+    auto& to_invalidate = *this ? *this : that;
+    auto& to_validate = *this ? that : *this;
+    auto ptr = to_validate.ptr;
+    to_validate.emplace(::core::move(*to_invalidate));
+    to_invalidate = ptr;
+  }
+
+  explicit operator bool () const noexcept { return this->valid; }
+
+  value_type const& operator * () const noexcept { return this->val; }
+  value_type& operator * () noexcept { return this->val; }
+
+  value_type const* operator -> () const noexcept {
+    return ::std::addressof(this->val);
+  }
+  value_type* operator -> () noexcept { return ::std::addressof(this->val); }
+
+  template <class T, class... Args>
+  void emplace (::std::initializer_list<T> il, Args&&... args) {
+    this->reset();
+    ::new (::std::addressof(this->val)) value_type(
+      il,
+      ::core::forward<Args>(args)...
+    );
+    this->valid = true;
+  }
+
+  template <class... Args>
+  void emplace (Args&&... args) {
+    this->reset();
+    ::new (::std::addressof(this->val)) value_type(
+      ::core::forward<Args>(args)...
+    );
+    this->valid = true;
+  }
+
+  value_type const& value () const noexcept(false) {
+    if (not *this) { ::std::rethrow_exception(this->ptr); }
+    return **this;
+  }
+
+  value_type& value () noexcept(false) {
+    if (not *this) { ::std::rethrow_exception(this->ptr); }
+    return **this;
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        ::std::is_copy_constructible<value_type>,
+        ::std::is_convertible<T, value_type>
+      >::value
+    >
+  > value_type value_or (T&& val) const& {
+    return *this ? **this : static_cast<value_type>(::core::forward<T>(val));
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        ::std::is_move_constructible<value_type>,
+        ::std::is_convertible<T, value_type>
+      >::value
+    >
+  > value_type value_or (T&& val) && {
+    return *this
+      ? value_type { ::core::move(**this) }
+      : static_cast<value_type>(::core::forward<T>(val));
+  }
+
+  template <class E>
+  E expect () const noexcept(false) {
+    try { this->raise(); }
+    catch (E const& e) { return e; }
+    catch (...) {
+      ::std::throw_with_nested(bad_expected_type { "unexpected exception" });
+    }
+  }
+
+  [[noreturn]] void raise () const noexcept(false) {
+    if (*this) { throw bad_expected_type { "expected<T> is valid" }; }
+    ::std::rethrow_exception(this->ptr);
+  }
+
+  ::std::exception_ptr pointer () const noexcept(false) {
+    if (*this) { throw bad_expected_type { "expected<T> is valid" }; }
+    return this->ptr;
+  }
+
+  [[gnu::deprecated]] ::std::exception_ptr get_ptr () const noexcept(false) {
+    return this->pointer();
+  }
+
+  /* member function 'extensions' */
+  template <class Visitor, class... Args>
+  constexpr auto visit (Visitor&& visitor, Args&&... args) const -> common_type_t<
+    invoke_of_t<Visitor, value_type const&, Args...>,
+    invoke_of_t<Visitor, ::std::exception_ptr const&, Args...>
+  > {
+    return *this
+      ? invoke(
+          ::core::forward<Visitor>(visitor),
+          **this,
+          ::core::forward<Args>(args)...)
+      : invoke(
+          ::core::forward<Visitor>(visitor),
+          this->ptr,
+          ::core::forward<Args>(args)...);
+  }
+
+  template <class Visitor, class... Args>
+  auto visit (Visitor&& visitor, Args&&... args) -> common_type_t<
+    invoke_of_t<Visitor, value_type&, Args...>,
+    invoke_of_t<Visitor, std::exception_ptr&, Args...>
+  > {
+    return *this
+      ? invoke(
+          ::core::forward<Visitor>(visitor),
+          **this,
+          ::core::forward<Args>(args)...)
+      : invoke(
+          ::core::forward<Visitor>(visitor),
+          this->ptr,
+          ::core::forward<Args>(args)...);
+  }
+
+  template <class... Visitors>
+  auto match (Visitors&&... visitors) const -> decltype(
+    this->visit(impl::make_overload(::core::forward<Visitors>(visitors)...))
+  ) {
+    return this->visit(
+      impl::make_overload(::core::forward<Visitors>(visitors)...));
+  }
+
+  template <class... Visitors>
+  auto match (Visitors&&... visitors) -> decltype(
+    this->visit(impl::make_overload(::core::forward<Visitors>(visitors)...))
+  ) {
+    return this->visit(
+      impl::make_overload(::core::forward<Visitors>(visitors)...));
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_expected<invoke_of_t<F, value_type&>>::value>
+  > auto then (F&& f) -> invoke_of_t<F, value_type&> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f), **this); }
+    return this->ptr;
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_expected<invoke_of_t<F, value_type const&>>::value>
+  > auto then (F&& f) const -> invoke_of_t<F, value_type const&> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f), **this); }
+    return this->ptr;
+  }
+
+  template <class F>
+  auto operator >>= (F&& f) -> decltype(
+    ::std::declval<expected>().then(::core::forward<F>(f))
+  ) { return this->then(::core::forward<F>(f)); }
+
+  template <class F>
+  auto operator >>= (F&& f) const -> decltype(
+    ::std::declval<add_const_t<expected>>().then(::core::forward<F>(f))
+  ) { return this->then(::core::forward<F>(f)); }
+
+private:
+
+  void reset () {
+    *this ? this->val.~value_type() : this->ptr.~exception_ptr();
+  }
+
+  union {
+    value_type val;
+    ::std::exception_ptr ptr;
+  };
+  bool valid { false };
+};
+#endif /* CORE_NO_EXCEPTIONS */
+
+
+template <class Type>
+struct result final {
+  template <class U> friend struct result;
+
+  using value_type = Type;
+
+  static constexpr bool nothrow = ::std::is_nothrow_move_constructible<
+    value_type
+  >::value;
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, nullopt_t>::value,
+    "Cannot have result<nullopt_t> (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, in_place_t>::value,
+    "Cannot have result<in_place_t> (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_same<decay_t<value_type>, ::std::error_condition>::value,
+    "Cannot have result<error_condition> (tautological)"
+  );
+
+  static_assert(
+    not ::std::is_error_condition_enum<value_type>::value,
+    "Cannot have result with an error condition enum as the value (ill-formed)"
+  );
+
+  static_assert(
+    not ::std::is_reference<value_type>::value,
+    "Cannot have result<T&> (ill-formed)"
+  );
+
+  static_assert(
+    ::std::is_object<value_type>::value,
+    "Cannot have result with non-object type (undefined behavior)"
+  );
+
+  static_assert(
+    ::std::is_nothrow_destructible<value_type>::value,
+    "Cannot have result with throwable destructor (undefined behavior)"
+  );
+
+  result (int val, ::std::error_category const& cat) noexcept :
+    valid { val == 0 }
+  {
+    if (*this) { ::new (::std::addressof(this->val)) value_type(); }
+    else {
+      ::new (::std::addressof(this->cnd)) ::std::error_condition(val, cat);
+    }
+  }
+
+  template <
+    class ErrorConditionEnum,
+    class=enable_if_t<
+      ::std::is_error_condition_enum<ErrorConditionEnum>::value
+    >
+  > result (ErrorConditionEnum e) noexcept :
+    valid { core::to_integral(e) == 0 }
+  {
+    if (*this) { ::new (::std::addressof(this->val)) value_type(); }
+    else { ::new (::std::addressof(this->cnd)) ::std::error_condition(e); }
+  }
+
+  result (::std::error_condition const& ec) :
+    valid { not ec }
+  {
+    if (*this) { ::new (::std::addressof(this->val)) value_type(); }
+    else { ::new (::std::addressof(this->cnd)) ::std::error_condition(ec); }
+  }
+
+  result (value_type const& val) :
+    val(val),
+    valid { true }
+  { }
+
+  result (value_type&& val) noexcept(nothrow) :
+    val(::core::move(val)),
+    valid { true }
+  { }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        meta::none<::std::is_same<result, result<T>>>,
+        ::std::is_constructible<
+          value_type,
+          add_lvalue_reference_t<add_const_t<T>>
+        >
+      >::value
+    >
+  > result (result<T> const& that) :
+    valid { that.valid }
+  {
+    if (*this) { ::new (::std::addressof(this->val)) value_type(that.val); }
+    else {
+      ::new (::std::addressof(this->cnd)) ::std::error_condition(that.cnd);
+    }
+  }
+
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        meta::none<::std::is_same<result, result<T>>>,
+        ::std::is_constructible<value_type, add_rvalue_reference_t<T>>
+      >::value
+    >
+  > result (result<T>&& that) :
+    valid { that.valid }
+  {
+    if (*this) {
+      ::new (::std::addressof(this->val)) value_type(::core::move(that.val));
+    } else {
+      ::new (::std::addressof(this->cnd)) ::std::error_condition(that.cnd);
+    }
+  }
+
+  template <
+    class... Args,
+    class=enable_if_t<::std::is_constructible<value_type, Args...>::value>
+  > explicit result (in_place_t, Args&&... args) :
+    val(::core::forward<Args>(args)...),
+    valid { true }
+  { }
+
+  template <
+    class T,
+    class... Args,
+    class=enable_if_t<
+      ::std::is_constructible<
+        value_type,
+        ::std::initializer_list<T>&,
+        Args...
+      >::value
+    >
+  > explicit result (
+    in_place_t,
+    ::std::initializer_list<T> il,
+    Args&&... args
+  ) : val(il, ::core::forward<Args>(args)...), valid { true } { }
+
+  result (result const& that) :
+    valid { that.valid }
+  {
+    if (*this) { ::new (::std::addressof(this->val)) value_type(that.val); }
+    else {
+      ::new (::std::addressof(this->cnd)) ::std::error_condition(that.cnd);
+    }
+  }
+
+  result (result&& that) :
+    valid { that.valid }
+  {
+    if (*this) {
+      ::new (::std::addressof(this->val)) value_type(::core::move(that.val));
+    } else {
+      ::new (::std::addressof(this->cnd)) ::std::error_condition(that.cnd);
+    }
+  }
+
+  result () :
+    val { },
+    valid { true }
+  { }
+
+  ~result () noexcept { this->reset(); }
+
+  result& operator = (result const& that) {
+    result { that }.swap(*this);
+    return *this;
+  }
+
+  result& operator = (result&& that) noexcept(
+    meta::all<
+      ::std::is_nothrow_move_assignable<value_type>,
+      ::std::is_nothrow_move_constructible<value_type>
+    >::value
+  ) {
+    result { ::core::move(that) }.swap(*this);
+    return *this;
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        meta::none<
+          ::std::is_same<decay_t<T>, result>,
+          ::std::is_same<decay_t<T>, ::std::error_condition>
+        >,
+        ::std::is_constructible<value_type, T>,
+        ::std::is_assignable<value_type&, T>
+      >::value
+    >
+  > result& operator = (T&& value) {
+    if (not *this) { this->emplace(::core::forward<T>(value)); }
+    else { **this = ::core::forward<T>(value); }
+    return *this;
+  }
+
+  template <
+    class ErrorConditionEnum,
+    class=enable_if_t<
+      ::std::is_error_condition_enum<ErrorConditionEnum>::value
+    >
+  > result& operator = (ErrorConditionEnum e) {
+    result { e }.swap(*this);
+    return *this;
+  }
+
+  result& operator = (value_type const& value) {
+    if (not *this) { this->emplace(value); }
+    else { **this = value; }
+    return *this;
+  }
+
+  result& operator = (value_type&& value) {
+    if (not *this) { this->emplace(::core::move(value)); }
+    else { **this = ::core::move(value); }
+    return *this;
+  }
+
+  result& operator = (::std::error_condition const& cnd) {
+    if (not cnd) { return *this; }
+    if (not *this) { this->cnd = cnd; }
+    else {
+      this->reset();
+      ::new (::std::addressof(this->cnd)) ::std::error_condition(cnd);
+      this->valid = false;
+    }
+    return *this;
+  }
+
+  void swap (result& that) noexcept(
+    meta::all<
+      is_nothrow_swappable<value_type>,
+      ::std::is_nothrow_move_constructible<value_type>
+    >::value
+  ) {
+    using ::std::swap;
+    if (not *this and not that) {
+      swap(this->cnd, that.cnd);
+      return;
+    }
+
+    if (*this and that) {
+      swap(this->val, that.val);
+      return;
+    }
+
+    auto& to_invalidate = *this ? *this : that;
+    auto& to_validate = *this ? that : *this;
+    auto cnd = to_validate.cnd;
+    to_validate.emplace(::core::move(*to_invalidate));
+    to_invalidate = cnd;
+  }
+
+  explicit operator bool () const noexcept { return this->valid; }
+
+  value_type const& operator * () const noexcept { return this->val; }
+  value_type& operator * () noexcept { return this->val; }
+
+  value_type const* operator -> () const noexcept {
+    return ::std::addressof(this->val);
+  }
+
+  value_type* operator -> () noexcept { return ::std::addressof(this->val); }
+
+  template <class T, class... Args>
+  void emplace (::std::initializer_list<T> il, Args&&... args) {
+    this->reset();
+    ::new (::std::addressof(this->val)) value_type(
+      il,
+      ::core::forward<Args>(args)...
+    );
+    this->valid = true;
+  }
+
+  template <class... Args>
+  void emplace (Args&&... args) {
+    this->reset();
+    ::new (::std::addressof(this->val)) value_type(
+      ::core::forward<Args>(args)...
+    );
+    this->valid = true;
+  }
+
+  value_type const& value () const noexcept(false) {
+    if (*this) { return **this; }
+    throw_system_error(this->cnd);
+  }
+
+  value_type& value () noexcept(false) {
+    if (*this) { return **this; }
+   throw_system_error(this->cnd);
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        ::std::is_copy_constructible<value_type>,
+        ::std::is_convertible<T, value_type>
+      >::value
+    >
+  > value_type value_or (T&& val) const& {
+    return *this ? **this : static_cast<value_type>(::core::forward<T>(val));
+  }
+
+  template <
+    class T,
+    class=enable_if_t<
+      meta::all<
+        ::std::is_move_constructible<value_type>,
+        ::std::is_convertible<T, value_type>
+      >::value
+    >
+  > value_type value_or (T&& val) && {
+    return *this
+      ? value_type { ::core::move(**this) }
+      : static_cast<value_type>(::core::forward<T>(val));
+  }
+
+  ::std::error_condition const& condition () const noexcept(false) {
+    if (*this) { throw_bad_result_condition(); }
+    return this->cnd;
+  }
+
+  /* member function extensions */
+  template <class Visitor, class... Args>
+  constexpr auto visit (Visitor&& visitor, Args&&... args) const -> common_type_t<
+    invoke_of_t<Visitor, value_type const&, Args...>,
+    invoke_of_t<Visitor, ::std::error_condition const&, Args...>
+  > {
+    return *this
+      ? invoke(
+          ::core::forward<Visitor>(visitor),
+          **this,
+          ::core::forward<Args>(args)...)
+      : invoke(
+          ::core::forward<Visitor>(visitor),
+          this->cnd,
+          ::core::forward<Args>(args)...);
+  }
+
+  template <class Visitor, class... Args>
+  auto visit (Visitor&& visitor, Args&&... args) -> common_type_t<
+    invoke_of_t<Visitor, value_type&, Args...>,
+    invoke_of_t<Visitor, ::std::error_condition&, Args...>
+  > {
+    return *this
+      ? invoke(
+          ::core::forward<Visitor>(visitor),
+          **this,
+          ::core::forward<Args>(args)...)
+      : invoke(
+          ::core::forward<Visitor>(visitor),
+          this->cnd,
+          ::core::forward<Args>(args)...);
+  }
+
+  template <class... Visitors>
+  auto match (Visitors&&... visitors) const -> decltype(
+    this->visit(impl::make_overload(::core::forward<Visitors>(visitors)...))
+  ) {
+    return this->visit(
+      impl::make_overload(::core::forward<Visitors>(visitors)...));
+  }
+
+  template <class... Visitors>
+  auto match (Visitors&&... visitors) -> decltype(
+    this->visit(impl::make_overload(::core::forward<Visitors>(visitors)...))
+  ) {
+    return this->visit(
+      impl::make_overload(::core::forward<Visitors>(visitors)...));
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_result<invoke_of_t<F, value_type&>>::value>
+  > auto then (F&& f) -> invoke_of_t<F, value_type&> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f), **this); }
+    return this->cnd;
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_result<invoke_of_t<F, value_type const&>>::value>
+  > auto then (F&& f) const -> invoke_of_t<F, value_type const&> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f), **this); }
+    return this->cnd;
+  }
+
+  template <class F>
+  auto operator >>= (F&& f) -> decltype(
+    ::std::declval<result>().then(::core::forward<F>(f))
+  ) { return this->then(::core::forward<F>(f)); }
+
+  template <class F>
+  auto operator >>= (F&& f) const -> decltype(
+    ::std::declval<add_const_t<result>>().then(::core::forward<F>(f))
+  ) { return this->then(::core::forward<F>(f)); }
+
+private:
+  void reset () {
+    *this ? this->val.~value_type() : this->cnd.~error_condition();
+  }
+
+  union {
+    value_type val;
+    ::std::error_condition cnd;
+  };
+  bool valid { false };
+};
+
+#ifndef CORE_NO_EXCEPTIONS
+template <>
+struct expected<void> final {
+  using value_type = void;
+
+  explicit expected (::std::exception_ptr ptr) noexcept : ptr { ptr } { }
+  expected (expected const&) = default;
+  expected (expected&&) = default;
+  expected () = default;
+  ~expected () = default;
+
+  expected& operator = (::std::exception_ptr ptr) noexcept {
+    expected { ptr }.swap(*this);
+    return *this;
+  }
+
+  expected& operator = (expected const&) = default;
+  expected& operator = (expected&&) = default;
+
+  void swap (expected& that) noexcept {
+    using ::std::swap;
+    swap(this->ptr, that.ptr);
+  }
+
+  explicit operator bool () const noexcept { return not this->ptr; }
+
+  template <class E>
+  E expect () const noexcept(false) {
+    try { this->raise(); }
+    catch (E const& e) { return e; }
+    catch (...) {
+      ::std::throw_with_nested(bad_expected_type { "unexpected exception" });
+    }
+  }
+
+  [[noreturn]] void raise () const noexcept(false) {
+    if (*this) { throw bad_expected_type { "valid expected<void>" }; }
+    ::std::rethrow_exception(this->ptr);
+  }
+
+  ::std::exception_ptr pointer () const noexcept(false) {
+    if (*this) { throw bad_expected_type { "valid expected<void>" }; }
+    return this->ptr;
+  }
+
+  [[gnu::deprecated]] ::std::exception_ptr get_ptr () const noexcept(false) {
+    return this->pointer();
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_expected<result_of_t<F()>>::value>
+  > auto operator >>= (F&& f) -> result_of_t<F()> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f)); }
+    return this->ptr;
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_expected<result_of_t<F()>>::value>
+  > auto operator >>= (F&& f) const -> result_of_t<F()> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f)); }
+    return this->ptr;
+  }
+
+private:
+  ::std::exception_ptr ptr;
+};
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <>
+struct result<void> final {
+  using value_type = void;
+
+  result (int val, ::std::error_category const& cat) :
+    cnd { val, cat }
+  { }
+
+  result (::std::error_condition const& ec) :
+    cnd { ec }
+  { }
+
+  template <
+    class ErrorConditionEnum,
+    class=enable_if_t<
+      ::std::is_error_condition_enum<ErrorConditionEnum>::value
+    >
+  > result (ErrorConditionEnum e) noexcept :
+    cnd { e }
+  { }
+
+  result (result const&) = default;
+  result (result&&) = default;
+  result () = default;
+
+  template <
+    class ErrorConditionEnum,
+    class=enable_if_t<std::is_error_condition_enum<ErrorConditionEnum>::value>
+  > result& operator = (ErrorConditionEnum e) noexcept {
+    result { e }.swap(*this);
+    return *this;
+  }
+
+  result& operator = (::std::error_condition const& ec) {
+    result { ec }.swap(*this);
+    return *this;
+  }
+
+  result& operator = (result const&) = default;
+  result& operator = (result&&) = default;
+
+  void swap (result& that) noexcept {
+    using ::std::swap;
+    swap(this->cnd, that.cnd);
+  }
+
+  explicit operator bool () const noexcept { return not this->cnd; }
+
+  ::std::error_condition const& condition () const noexcept(false) {
+    if (*this) { throw_bad_void_result_condition(); }
+    return this->cnd;
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_result<result_of_t<F()>>::value>
+  > auto operator >>= (F&& f) -> result_of_t<F()> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f)); }
+    return this->cnd;
+  }
+
+  template <
+    class F,
+    class=enable_if_t<is_result<result_of_t<F()>>::value>
+  > auto operator >>= (F&& f) const -> result_of_t<F()> {
+    if (*this) { return ::core::invoke(::core::forward<F>(f)); }
+    return this->cnd;
+  }
+
+private:
+  ::std::error_condition cnd;
+};
+
+/* operator == */
+template <class T>
+constexpr bool operator == (
+  optional<T> const& lhs,
+  optional<T> const& rhs
+) noexcept {
+  return static_cast<bool>(lhs) != static_cast<bool>(rhs)
+    ? false
+    : (not lhs and not rhs) or *lhs == *rhs;
+}
+
+template <class T>
+constexpr bool operator == (optional<T> const& lhs, nullopt_t) noexcept {
+  return not lhs;
+}
+
+template <class T>
+constexpr bool operator == (nullopt_t, optional<T> const& rhs) noexcept {
+  return not rhs;
+}
+
+template <class T>
+constexpr bool operator == (optional<T> const& opt, T const& value) noexcept {
+  return opt and *opt == value;
+}
+
+template <class T>
+constexpr bool operator == (T const& value, optional<T> const& opt) noexcept {
+  return opt and value == *opt;
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class T>
+bool operator == (expected<T> const& lhs, expected<T> const& rhs) noexcept {
+  if (lhs and rhs) { return *lhs == *rhs; }
+  return not lhs and not rhs;
+}
+
+template <class T>
+bool operator == (expected<T> const& lhs, ::std::exception_ptr) noexcept {
+  return not lhs;
+}
+
+template <class T>
+bool operator == (::std::exception_ptr, expected<T> const& rhs) noexcept {
+  return not rhs;
+}
+
+template <class T>
+bool operator == (expected<T> const& lhs, T const& rhs) noexcept {
+  return lhs and *lhs == rhs;
+}
+
+template <class T>
+bool operator == (T const& lhs, expected<T> const& rhs) noexcept {
+  return rhs and lhs == *rhs;
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class T>
+bool operator == (result<T> const& lhs, result<T> const& rhs) noexcept {
+  if (lhs and rhs) { return *lhs == *rhs; }
+  if (not lhs and not rhs) { return lhs.condition() == rhs.condition(); }
+  return false;
+}
+
+template <class T>
+bool operator == (
+  result<T> const& lhs,
+  ::std::error_condition const& rhs
+) noexcept { return not lhs and rhs and lhs.condition() == rhs; }
+
+template <class T>
+bool operator == (
+  ::std::error_condition const& lhs,
+  result<T> const& rhs
+) noexcept { return lhs and not rhs and lhs == rhs.condition(); }
+
+template <class T>
+bool operator == (
+  result<T> const& lhs,
+  ::std::error_code const& rhs
+) noexcept { return not lhs and rhs and lhs.condition() == rhs; }
+
+template <class T>
+bool operator == (
+  ::std::error_code const& lhs,
+  result<T> const& rhs
+) noexcept { return lhs and not rhs and lhs == rhs.condition(); }
+
+template <class T>
+bool operator == (result<T> const& res, T const& value) noexcept {
+  return res and *res == value;
+}
+
+template <class T>
+bool operator == (T const& value, result<T> const& res) noexcept {
+  return res and value == *res;
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+/* void specializations */
+template <>
+inline bool operator == <void> (
+  expected<void> const& lhs,
+  expected<void> const& rhs
+) noexcept {
+  if (not lhs and not rhs) { return lhs.pointer() == rhs.pointer(); }
+  return lhs and rhs;
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <>
+inline bool operator == <void> (
+  result<void> const& lhs,
+  result<void> const& rhs
+) noexcept {
+  if (not lhs and not rhs) { return lhs.condition() == rhs.condition(); }
+  return lhs and rhs;
+}
+
+/* operator < */
+template <class T>
+constexpr bool operator < (
+  optional<T> const& lhs,
+  optional<T> const& rhs
+) noexcept {
+  return static_cast<bool>(rhs) == false ? false : not lhs or *lhs < *rhs;
+}
+
+template <class T>
+constexpr bool operator < (optional<T> const& lhs, nullopt_t) noexcept {
+  return not lhs;
+}
+
+template <class T>
+constexpr bool operator < (nullopt_t, optional<T> const& rhs) noexcept {
+  return static_cast<bool>(rhs);
+}
+
+template <class T>
+constexpr bool operator < (optional<T> const& opt, T const& value) noexcept {
+  return not opt or *opt < value;
+}
+
+template <class T>
+constexpr bool operator < (T const& value, optional<T> const& opt) noexcept {
+  return opt and value < *opt;
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class T>
+bool operator < (expected<T> const& lhs, expected<T> const& rhs) noexcept {
+  if (not rhs) { return false; }
+  return not lhs or *lhs < *rhs;
+}
+
+template <class T>
+bool operator < (expected<T> const& lhs, ::std::exception_ptr) noexcept {
+  return not lhs;
+}
+
+template <class T>
+bool operator < (::std::exception_ptr, expected<T> const& rhs) noexcept {
+  return static_cast<bool>(rhs);
+}
+
+template <class T>
+bool operator < (expected<T> const& exp, T const& value) noexcept {
+  return not exp or *exp < value;
+}
+
+template <class T>
+bool operator < (T const& value, expected<T> const& exp) noexcept {
+  return exp and value < *exp;
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class T>
+bool operator < (result<T> const& lhs, result<T> const& rhs) noexcept {
+  if (not rhs and not lhs) { return lhs.condition() < rhs.condition(); }
+  if (lhs and rhs) { return *lhs < *rhs; }
+  return static_cast<bool>(rhs);
+}
+
+template <class T>
+bool operator < (
+  result<T> const& lhs,
+  ::std::error_condition const& rhs
+) noexcept { return not lhs and lhs.condition() < rhs; }
+
+template <class T>
+bool operator < (
+  ::std::error_condition const& lhs,
+  result<T> const& rhs
+) noexcept { return rhs or lhs < rhs.condition(); }
+
+template <>
+inline bool operator < <void> (
+  result<void> const& lhs,
+  result<void> const& rhs
+) noexcept {
+  if (not lhs and not rhs) { return lhs.condition() < rhs.condition(); }
+  return static_cast<bool>(rhs);
+}
+
+template <class T>
+bool operator < (result<T> const& res, T const& value) noexcept {
+  return not res or *res < value;
+}
+
+template <class T>
+bool operator < (T const& value, result<T> const& res) noexcept {
+  return res and value < *res;
+}
+
+/* operator != */
+template <class T>
+constexpr bool operator != (
+  optional<T> const& lhs,
+  optional<T> const& rhs
+) noexcept { return not (lhs == rhs); }
+
+template <class T>
+constexpr bool operator != (optional<T> const& lhs, nullopt_t) noexcept {
+  return not (lhs == nullopt);
+}
+
+template <class T>
+constexpr bool operator != (nullopt_t, optional<T> const& rhs) noexcept {
+  return not (nullopt == rhs);
+}
+
+template <class T>
+constexpr bool operator != (optional<T> const& opt, T const& value) noexcept {
+  return not (opt == value);
+}
+
+template <class T>
+constexpr bool operator != (T const& value, optional<T> const& opt) noexcept {
+  return not (value == opt);
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class T>
+bool operator != (expected<T> const& lhs, expected<T> const& rhs) noexcept {
+  return not (lhs == rhs);
+}
+
+template <class T>
+bool operator != (expected<T> const& lhs, ::std::exception_ptr rhs) noexcept {
+  return not (lhs == rhs);
+}
+
+template <class T>
+bool operator != (::std::exception_ptr lhs, expected<T> const& rhs) noexcept {
+  return not (lhs == rhs);
+}
+
+template <class T>
+bool operator != (expected<T> const& exp, T const& value) noexcept {
+  return not (exp == value);
+}
+
+template <class T>
+bool operator != (T const& value, expected<T> const& exp) noexcept {
+  return not (value == exp);
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class T>
+bool operator != (result<T> const& lhs, result<T> const& rhs) noexcept {
+  return not (lhs == rhs);
+}
+
+template <class T>
+bool operator != (
+  result<T> const& lhs,
+  ::std::error_condition const& rhs
+) noexcept { return not (lhs == rhs); }
+
+template <class T>
+bool operator != (
+  ::std::error_condition const& lhs,
+  result<T> const& rhs
+) noexcept { return not (lhs == rhs); }
+
+template <class T>
+bool operator != (
+  result<T> const& lhs,
+  ::std::error_code const& rhs
+) noexcept { return not (lhs == rhs); }
+
+template <class T>
+bool operator != (
+  ::std::error_code const& lhs,
+  result<T> const& rhs
+) noexcept { return not (lhs == rhs); }
+
+template <class T>
+bool operator != (result<T> const& res, T const& value) noexcept {
+  return not (res == value);
+}
+
+template <class T>
+bool operator != (T const& value, result<T> const& res) noexcept {
+  return not (value == res);
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+template <>
+inline bool operator != <void> (
+  expected<void> const& lhs,
+  expected<void> const& rhs
+) noexcept { return not (lhs == rhs); }
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <>
+inline bool operator != <void> (
+  result<void> const& lhs,
+  result<void> const& rhs
+) noexcept { return not (lhs == rhs); }
+
+/* optional<T> operator >= */
+template <class T>
+constexpr bool operator >= (
+  optional<T> const& lhs,
+  optional<T> const& rhs
+) noexcept { return not (lhs < rhs); }
+
+template <class T>
+constexpr bool operator >= (optional<T> const&, nullopt_t) noexcept {
+  return true;
+}
+
+template <class T>
+constexpr bool operator >= (nullopt_t, optional<T> const& opt) noexcept {
+  return opt < nullopt;
+}
+
+template <class T>
+constexpr bool operator >= (optional<T> const& opt, T const& value) noexcept {
+  return not (opt < value);
+}
+
+template <class T>
+constexpr bool operator >= (T const& value, optional<T> const& opt) noexcept {
+  return not (value < opt);
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class T>
+bool operator >= (expected<T> const& lhs, expected<T> const& rhs) noexcept {
+  return not (lhs < rhs);
+}
+
+template <class T>
+bool operator >= (expected<T> const&, ::std::exception_ptr) noexcept {
+  return true;
+}
+
+template <class T>
+bool operator >= (::std::exception_ptr ptr, expected<T> const& exp) noexcept {
+  return exp < ptr;
+}
+
+template <class T>
+bool operator >= (expected<T> const& exp, T const& value) noexcept {
+  return not (exp < value);
+}
+
+template <class T>
+bool operator >= (T const& value, expected<T> const& exp) noexcept {
+  return not (value < exp);
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class T>
+bool operator >= (result<T> const& lhs, result<T> const& rhs) noexcept {
+  return not (lhs < rhs);
+}
+
+template <class T>
+bool operator >= (
+  result<T> const& lhs,
+  ::std::error_condition const& rhs
+) noexcept { return not (lhs < rhs); }
+
+template <class T>
+bool operator >= (
+  ::std::error_condition const& lhs,
+  result<T> const& rhs
+) noexcept { return not (lhs < rhs); }
+
+template <class T>
+bool operator >= (result<T> const& res, T const& value) noexcept {
+  return not (res < value);
+}
+
+template <class T>
+bool operator >= (T const& value, result<T> const& res) noexcept {
+  return not (value < res);
+}
+
+template <>
+inline bool operator >= <void> (
+  result<void> const& lhs,
+  result<void> const& rhs
+) noexcept { return not (lhs < rhs); }
+
+/* operator <= */
+template <class T>
+constexpr bool operator <= (
+  optional<T> const& lhs,
+  optional<T> const& rhs
+) noexcept { return not (rhs < lhs); }
+
+template <class T>
+constexpr bool operator <= (optional<T> const& lhs, nullopt_t) noexcept {
+  return not lhs;
+}
+
+template <class T>
+constexpr bool operator <= (nullopt_t, optional<T> const&) noexcept {
+  return true;
+}
+
+template <class T>
+constexpr bool operator <= (optional<T> const& opt, T const& value) noexcept {
+  return not (opt > value);
+}
+
+template <class T>
+constexpr bool operator <= (T const& value, optional<T> const& opt) noexcept {
+  return not (value > opt);
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class T>
+bool operator <= (expected<T> const& lhs, expected<T> const& rhs) noexcept {
+  return not (rhs < lhs);
+}
+
+template <class T>
+bool operator <= (expected<T> const& lhs, ::std::exception_ptr) noexcept {
+  return not lhs;
+}
+
+template <class T>
+bool operator <= (::std::exception_ptr, expected<T> const&) noexcept {
+  return true;
+}
+
+template <class T>
+bool operator <= (expected<T> const& exp, T const& value) noexcept {
+  return not (value < exp);
+}
+
+template <class T>
+bool operator <= (T const& value, expected<T> const& exp) noexcept {
+  return not (exp < value);
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class T>
+bool operator <= (result<T> const& lhs, result<T> const& rhs) noexcept {
+  return not (rhs < lhs);
+}
+
+template <class T>
+bool operator <= (
+  result<T> const& lhs,
+  ::std::error_condition const& rhs
+) noexcept { return not (rhs < lhs); }
+
+template <class T>
+bool operator <= (
+  ::std::error_condition const& lhs,
+  result<T> const& rhs
+) noexcept { return not (rhs < lhs); }
+
+template <class T>
+bool operator <= (result<T> const& res, T const& value) noexcept {
+  return not (value < res);
+}
+
+template <class T>
+bool operator <= (T const& value, result<T> const& res) noexcept {
+  return not (res < value);
+}
+
+/* operator > */
+template <class T>
+constexpr bool operator > (
+  optional<T> const& lhs,
+  optional<T> const& rhs
+) noexcept { return rhs < lhs; }
+
+template <class T>
+constexpr bool operator > (optional<T> const& lhs, nullopt_t) noexcept {
+  return static_cast<bool>(lhs);
+}
+
+template <class T>
+constexpr bool operator > (nullopt_t, optional<T> const&) noexcept {
+  return false;
+}
+
+template <class T>
+constexpr bool operator > (optional<T> const& opt, T const& value) noexcept {
+  return value < opt;
+}
+
+template <class T>
+constexpr bool operator > (T const& value, optional<T> const& opt) noexcept {
+  return opt < value;
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class T>
+bool operator > (expected<T> const& lhs, expected<T> const& rhs) noexcept {
+  return rhs < lhs;
+}
+
+template <class T>
+bool operator > (expected<T> const& exp, T const& value) noexcept {
+  return value < exp;
+}
+
+template <class T>
+bool operator > (T const& value, expected<T> const& exp) noexcept {
+  return exp < value;
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class T>
+bool operator > (result<T> const& lhs, result<T> const& rhs) noexcept {
+  return rhs < lhs;
+}
+
+template <class T>
+bool operator > (
+  result<T> const& lhs,
+  ::std::error_condition const& rhs
+) noexcept { return rhs < lhs; }
+
+template <class T>
+bool operator > (
+  ::std::error_condition const& lhs,
+  result<T> const& rhs
+) noexcept { return rhs < lhs; }
+
+template <class T>
+bool operator > (result<T> const& res, T const& value) noexcept {
+  return value < res;
+}
+
+template <class T>
+bool operator > (T const& value, result<T> const& res) noexcept {
+  return res < value;
+}
+
+/* make_ functions */
+template <class Type>
+auto make_optional (Type&& value) -> optional<decay_t<Type>> {
+  return optional<decay_t<Type>> { ::core::forward<Type>(value) };
+}
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class T>
+auto make_expected (::std::exception_ptr error) -> expected<T> {
+  return expected<T> { error };
+}
+
+template <class T>
+auto make_expected (T&& value) -> enable_if_t<
+  not ::std::is_base_of< ::std::exception, decay_t<T>>::value,
+  expected<decay_t<T>>
+> { return expected<T> { ::core::forward<T>(value) }; }
+
+template <class T, class U>
+auto make_expected (U&& value) -> enable_if_t<
+  ::std::is_base_of< ::std::exception, decay_t<U>>::value,
+  expected<T>
+> {
+  return make_expected<T>(
+    ::std::make_exception_ptr(::core::forward<U>(value))
+  );
+}
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class T>
+auto make_result (::std::error_condition const& e) -> result<T> {
+  return result<T> { e };
+}
+
+template <
+  class T,
+  class ErrorConditionEnum,
+  class=enable_if_t<
+    ::std::is_error_condition_enum<ErrorConditionEnum>::value
+  >
+> auto make_result (ErrorConditionEnum e) -> result<T> {
+  return result<T> { e };
+}
+
+template <class T> auto make_result (T&& value) -> result<decay_t<T>> {
+  return result<T> { ::core::forward<T>(value) };
+}
+
+template <class T>
+result<T> make_result (int val, ::std::error_category const& cat) {
+  return make_result<T>(::std::error_condition { val, cat });
+}
+
+template <class T>
+void swap (optional<T>& lhs, optional<T>& rhs) noexcept(
+  noexcept(lhs.swap(rhs))
+) { lhs.swap(rhs); }
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class T>
+void swap (expected<T>& lhs, expected<T>& rhs) noexcept(
+  noexcept(lhs.swap(rhs))
+) { lhs.swap(rhs); }
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class T>
+void swap (result<T>& lhs, result<T>& rhs) noexcept (
+  noexcept(lhs.swap(rhs))
+) { lhs.swap(rhs); }
+
+}} /* namespace core::v1 */
+
+namespace std {
+
+template <class Type>
+struct hash<::core::v1::optional<Type>> {
+  using result_type = typename hash<Type>::result_type;
+  using argument_type = ::core::v1::optional<Type>;
+
+  result_type operator () (argument_type const& value) const noexcept {
+    return value ? hash<Type> { }(*value) : result_type { };
+  }
+};
+
+#ifndef CORE_NO_EXCEPTIONS
+template <class Type>
+struct hash<::core::v1::expected<Type>> {
+  using result_type = typename hash<Type>::result_type;
+  using argument_type = ::core::v1::expected<Type>;
+
+  result_type operator () (argument_type const& value) const noexcept {
+    return value ? hash<Type> { }(*value) : result_type { };
+  }
+};
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class Type>
+struct hash<::core::v1::result<Type>> {
+  using result_type = typename hash<Type>::result_type;
+  using argument_type = ::core::v1::result<Type>;
+
+  result_type operator () (argument_type const& value) const noexcept {
+    return value ? hash<Type> { }(*value) : result_type { };
+  }
+};
+
+} /* namespace std */
+
+#endif /* CORE_OPTIONAL_HPP */

--- a/core/include/core/range.hpp
+++ b/core/include/core/range.hpp
@@ -1,0 +1,334 @@
+#ifndef CORE_RANGE_HPP
+#define CORE_RANGE_HPP
+
+#include <istream>
+#include <utility>
+#include <memory>
+
+#include <cstdlib>
+
+#include <core/type_traits.hpp>
+#include <core/iterator.hpp>
+
+namespace core {
+inline namespace v1 {
+namespace impl {
+
+using ::std::begin;
+using ::std::end;
+
+template <class T, class=void> struct adl_begin : ::std::false_type { };
+template <class T>
+struct adl_begin<T, deduce_t<decltype(begin(::std::declval<T>()))>> :
+  ::std::true_type
+{ using type = decltype(begin(::std::declval<T>())); };
+
+template <class T, class=void> struct adl_end : ::std::false_type { };
+template <class T>
+struct adl_end<T, deduce_t<decltype(end(::std::declval<T>()))>> :
+  ::std::true_type
+{ using type = decltype(end(::std::declval<T>())); };
+
+template <class T> using begin_t = typename adl_begin<T>::type;
+
+} /* namespace impl */
+
+template <class R>
+struct is_range : meta::all<impl::adl_begin<R>, impl::adl_end<R>> { };
+
+template <class Iterator>
+struct range {
+  using traits = ::std::iterator_traits<Iterator>;
+
+  using iterator_category = typename traits::iterator_category;
+
+  using difference_type = typename traits::difference_type;
+  using value_type = typename traits::value_type;
+
+  using reference = typename traits::reference;
+  using pointer = typename traits::pointer;
+
+  using iterator = Iterator;
+
+  static constexpr bool is_input = ::std::is_convertible<
+    iterator_category,
+    ::std::input_iterator_tag
+  >::value;
+
+  static constexpr bool is_output = ::std::is_convertible<
+    iterator_category,
+    ::std::output_iterator_tag
+  >::value;
+
+  static constexpr bool is_forward = ::std::is_convertible<
+    iterator_category,
+    ::std::forward_iterator_tag
+  >::value;
+
+  static constexpr bool is_bidirectional = ::std::is_convertible<
+    iterator_category,
+    ::std::bidirectional_iterator_tag
+  >::value;
+
+  static constexpr bool is_random_access = ::std::is_convertible<
+    iterator_category,
+    ::std::random_access_iterator_tag
+  >::value;
+
+  template <
+    class Range,
+    class=enable_if_t<
+      meta::all<
+        meta::none<::std::is_pointer<iterator>>,
+        is_range<Range>,
+        ::std::is_convertible<impl::begin_t<Range>, iterator>
+      >::value
+    >
+  > explicit range (Range&& r) noexcept :
+    range { ::std::begin(r), ::std::end(r) }
+  { }
+
+  range (::std::pair<iterator, iterator> pair) noexcept :
+    range { ::std::get<0>(pair), ::std::get<1>(pair) }
+  { }
+
+  range (iterator begin_, iterator end_) noexcept :
+    begin_ { begin_ },
+    end_ { end_ }
+  { }
+
+  range (range const& that) :
+    range { that.begin_, that.end_ }
+  { }
+
+  range (range&& that) noexcept :
+    range { ::std::move(that.begin_), ::std::move(that.end_) }
+  { that.begin_ = that.end_; }
+
+  range () = default;
+  ~range () = default;
+
+  range& operator = (range const& that) {
+    return *this = range { that };
+  }
+
+  range& operator = (range&& that) {
+    range { ::std::move(that) }.swap(*this);
+    return *this;
+  }
+
+  reference operator [](difference_type idx) const {
+    static_assert(is_random_access, "can only subscript into random-access");
+    return idx < 0 ? this->end()[idx] : this->begin()[idx];
+  }
+
+  iterator begin () const { return this->begin_; }
+  iterator end () const { return this->end_; }
+
+  reference front () const { return *this->begin(); }
+  reference back () const {
+    static_assert(is_bidirectional, "can only get back of bidirectional");
+    return *::std::prev(this->end());
+  }
+
+  bool empty () const { return this->begin() == this->end(); }
+
+  difference_type size () const {
+    static_assert(is_forward, "can only get size of forward-range");
+    return ::std::distance(this->begin(), this->end());
+  }
+
+  /* Creates an open-ended range of [start, stop) */
+  range slice (difference_type start, difference_type stop) const {
+    static_assert(is_forward, "can only slice forward-range");
+    /* Behavior is:
+     * if start is negative, the begin marker is this->end() - start
+     * if stop is negative, the end marker is this->end() - stop
+     * if start is positive, the begin marker is this->begin() + start
+     * if stop is positive, the end marker is this->begin() + stop
+     *
+     * if start and stop are positive, and stop is less than or equal to start,
+     * an empty range is returned.
+     *
+     * if start and stop are negative and stop is less than or equal to start,
+     * an empty range is returned.
+     *
+     * if start is positive and stop is negative and abs(stop) + start is
+     * greater than or equal to this->size(), an empty range is returned.
+     *
+     * if start is negative and stop is positive and this->size() + start is
+     * greater or equal to stop, an empty range is returned.
+     *
+     * The first two conditions can be computed cheaply, while the third and
+     * fourth are a bit more expensive, but WILL be required no matter what
+     * iterator type we are. However we don't compute the size until after
+     * we've checked the first two conditions
+     *
+     * An example with python style slicing for each would be:
+     * [4:3] -> empty range
+     * [-4:-4] -> empty range
+     * [7:-4] -> empty range for string of size 11 or more
+     * [-4:15] -> empty range for a string of size 19 or less.
+     */
+    bool const start_positive = start > 0;
+    bool const stop_positive = stop > 0;
+    bool const stop_less = stop < start;
+    bool const first_return_empty =
+      (start_positive and stop_positive and stop_less) or
+      (not start_positive and not stop_positive and stop_less);
+    if (first_return_empty) { return range { }; }
+
+    /* now safe to compute size */
+    auto const size = this->size();
+    auto third_empty = ::std::abs(stop) + start;
+
+    bool const second_return_empty =
+      (start_positive and not stop_positive and third_empty >= size) or
+      (not start_positive and stop_positive and size + start >= stop);
+    if (second_return_empty) { return range { }; }
+
+    /* While the code below technically works for all iterators it is
+     * ineffecient in some cases for bidirectional ranges, where either of
+     * start or stop are negative.
+     * TODO: Specialize for bidirectional operators
+     */
+    if (not start_positive) { start = size + start; }
+    if (not stop_positive) { stop = size + stop; }
+
+    auto begin = this->begin();
+    ::std::advance(begin, start);
+
+    auto end = begin;
+    ::std::advance(end, stop - start);
+
+    return range { begin, end };
+  }
+
+  /* Creates an open-ended range of [start, end()) */
+  range slice (difference_type start) const {
+    static_assert(is_forward, "can only slice forward-range");
+    return range { split(start).second };
+  }
+
+  ::std::pair<range, range> split (difference_type idx) const {
+    static_assert(is_forward,"can only split a forward-range");
+    if (idx >= 0) {
+      range second { *this };
+      second.pop_front_upto(idx);
+      return ::std::make_pair(range { this->begin(), second.begin() }, second);
+    }
+
+    range first { *this };
+    first.pop_back_upto(-idx);
+    return ::std::make_pair(first, range { first.end(), this->end() });
+  }
+
+  /* mutates range */
+  void pop_front (difference_type n) { ::std::advance(this->begin_, n); }
+  void pop_front () { ++this->begin_; }
+
+  void pop_back (difference_type n) {
+    static_assert(is_bidirectional, "can only pop-back bidirectional-range");
+    ::std::advance(this->end_, -n);
+  }
+
+  void pop_back () {
+    static_assert(is_bidirectional, "can only pop-back bidirectional-range");
+    --this->end_;
+  }
+
+  /* Negative argument causes no change */
+  void pop_front_upto (difference_type n) {
+    ::std::advance(
+      this->begin_,
+      ::std::min(::std::max<difference_type>(0, n), this->size())
+    );
+  }
+
+  /* Negative argument causes no change */
+  void pop_back_upto (difference_type n) {
+    static_assert(is_bidirectional, "can only pop-back-upto bidirectional");
+    ::std::advance(
+      this->end_,
+      -::std::min(::std::max<difference_type>(0, n), this->size())
+    );
+  }
+
+  void swap (range& that) noexcept(is_nothrow_swappable<iterator>::value) {
+    using ::std::swap;
+    swap(this->begin_, that.begin_);
+    swap(this->end_, that.end_);
+  }
+
+private:
+  iterator begin_;
+  iterator end_;
+};
+
+template <class T>
+auto make_range (T* ptr, ::std::size_t n) -> range<T*> {
+  return range<T*> { ptr, ptr + n };
+}
+
+template <class Iterator>
+auto make_range (Iterator begin, Iterator end) -> range<Iterator> {
+  return range<Iterator> { begin, end };
+}
+
+template <class Range>
+auto make_range (Range&& value) -> range<decltype(::std::begin(value))> {
+  return make_range(::std::begin(value), ::std::end(value));
+}
+
+/* Used like: core::make_range<char>(::std::cin) */
+template <
+  class T,
+  class CharT,
+  class Traits=::std::char_traits<CharT>
+> auto make_range (::std::basic_istream<CharT, Traits>& stream) -> range<
+  ::std::istream_iterator<T, CharT, Traits>
+> {
+  using iterator = ::std::istream_iterator<T, CharT, Traits>;
+  return make_range(iterator { stream }, iterator { });
+}
+
+template <class CharT, class Traits=::std::char_traits<CharT>>
+auto make_range (::std::basic_streambuf<CharT, Traits>* buffer) -> range<
+  ::std::istreambuf_iterator<CharT, Traits>
+> {
+  using iterator = ::std::istreambuf_iterator<CharT, Traits>;
+  return make_range(iterator { buffer }, iterator { });
+}
+
+template <class Iter>
+range<::std::move_iterator<Iter>> make_move_range (Iter start, Iter stop) {
+  return make_range(
+    ::std::make_move_iterator(start),
+    ::std::make_move_iterator(stop));
+}
+
+template <class T>
+range<::std::move_iterator<T*>> make_move_range (T* ptr, ::std::size_t n) {
+  return make_move_range(ptr, ptr + n);
+}
+
+template <class T>
+range<number_iterator<T>> make_number_range(T start, T stop, T step) noexcept {
+  auto begin = make_number_iterator(start, step);
+  auto end = make_number_iterator(stop, step);
+  return make_range(begin, end);
+}
+
+template <class T>
+range<number_iterator<T>> make_number_range (T start, T stop) noexcept {
+  return make_range(make_number_iterator(start), make_number_iterator(stop));
+}
+
+template <class Iterator>
+void swap (range<Iterator>& lhs, range<Iterator>& rhs) noexcept(
+  noexcept(lhs.swap(rhs))
+) { lhs.swap(rhs); }
+
+}} /* namespace core::v1 */
+
+#endif /* CORE_RANGE_HPP */

--- a/core/include/core/string.hpp
+++ b/core/include/core/string.hpp
@@ -1,0 +1,647 @@
+#ifndef CORE_STRING_HPP
+#define CORE_STRING_HPP
+
+#include <initializer_list>
+#include <functional>
+#include <stdexcept>
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <limits>
+
+#include <cstdlib>
+
+#include <core/internal.hpp>
+
+namespace core {
+inline namespace v1 {
+
+#ifndef CORE_NO_EXCEPTIONS
+[[noreturn]] inline void throw_out_of_range (char const* msg) {
+  throw ::std::out_of_range { msg };
+}
+#else /* CORE_NO_EXCEPTIONS */
+[[noreturn]] inline void throw_out_of_range (char const*) { ::std::abort(); }
+#endif /* CORE_NO_EXCEPTIONS */
+
+template <class CharT, class Traits=::std::char_traits<CharT>>
+struct basic_string_view {
+  using difference_type = ::std::ptrdiff_t;
+  using value_type = CharT;
+  using size_type = ::std::size_t;
+
+  using reference = value_type const&;
+  using pointer = value_type const*;
+
+  using const_reference = reference;
+  using const_pointer = pointer;
+
+  using const_iterator = pointer;
+  using iterator = const_iterator;
+
+  using const_reverse_iterator = ::std::reverse_iterator<const_iterator>;
+  using reverse_iterator = const_reverse_iterator;
+
+  using traits = Traits;
+
+  static constexpr size_type npos = ::std::numeric_limits<size_type>::max();
+
+  template <class Allocator>
+  basic_string_view (
+    ::std::basic_string<CharT, Traits, Allocator> const& that
+  ) : str { that.data() }, len { that.size() } { }
+
+  constexpr basic_string_view (pointer str, size_type len) noexcept :
+    str { str },
+    len { len }
+  { }
+
+  basic_string_view (pointer str) noexcept :
+    basic_string_view { str, traits::length(str) }
+  { }
+
+  constexpr basic_string_view (basic_string_view const& that) noexcept :
+    str { that.str },
+    len { that.len }
+  { }
+
+  constexpr basic_string_view () noexcept :
+    str { nullptr },
+    len { 0 }
+  { }
+
+  basic_string_view& operator = (basic_string_view const& that) noexcept {
+    basic_string_view { that }.swap(*this);
+    return *this;
+  }
+
+  template <class Allocator>
+  explicit operator ::std::basic_string<CharT, Traits, Allocator> () const {
+    return ::std::basic_string<CharT, Traits, Allocator> {
+      this->data(),
+      this->size()
+    };
+  }
+
+  template <class Allocator=std::allocator<CharT>>
+  ::std::basic_string<CharT, Traits, Allocator> to_string (
+    Allocator const& allocator = Allocator()
+  ) const {
+    return ::std::basic_string<CharT, Traits, Allocator> {
+      this->data(),
+      this->size(),
+      allocator
+    };
+  }
+
+  constexpr const_iterator begin () const noexcept { return this->data(); }
+  constexpr const_iterator end () const noexcept {
+    return this->data() + this->size();
+  }
+
+  constexpr const_iterator cbegin () const noexcept { return this->begin(); }
+  constexpr const_iterator cend () const noexcept { return this->end(); }
+
+  const_reverse_iterator rbegin () const noexcept {
+    return const_reverse_iterator { this->end()};
+  }
+
+  const_reverse_iterator rend () const noexcept {
+    return const_reverse_iterator { this->begin() };
+  }
+
+  const_reverse_iterator crbegin () const noexcept { return this->rbegin(); }
+  const_reverse_iterator crend () const noexcept { return this->rend(); }
+
+  constexpr size_type max_size () const noexcept { return this->size(); }
+  constexpr size_type length () const noexcept { return this->size(); }
+  constexpr size_type size () const noexcept { return this->len; }
+
+  constexpr bool empty () const noexcept { return this->size() == 0; }
+
+  constexpr reference operator [] (size_type idx) const {
+    return this->str[idx];
+  }
+
+  constexpr reference front () const { return this->str[0]; }
+  constexpr reference back () const { return this->str[this->size() - 1]; }
+  constexpr pointer data () const { return this->str; }
+
+  void remove_prefix (size_type n) {
+    if (n > this->size()) { n = this->size(); }
+    this->str += n;
+    this->len -= n;
+  }
+
+  void remove_suffix (size_type n) {
+    if (n > this->size()) { n = this->size(); }
+    this->len -= n;
+  }
+
+  void clear () noexcept {
+    this->str = nullptr;
+    this->len = 0;
+  }
+
+  size_type copy (CharT* s, size_type n, size_type pos = 0) const {
+    if (pos > this->size()) {
+      throw_out_of_range("position greater than size");
+    }
+    auto const rlen = std::min(n, this->size() - pos);
+    ::std::copy_n(this->begin() + pos, rlen, s);
+    return rlen;
+  }
+
+  constexpr basic_string_view substr (
+    size_type pos=0,
+    size_type n=npos
+  ) const noexcept {
+    return pos > this->size()
+      ? (throw_out_of_range("start position out of range"), *this)
+      : basic_string_view {
+        this->data() + pos,
+        n == npos or pos + n > this->size()
+          ? (this->size() - pos)
+          : n
+      };
+  }
+
+  bool starts_with (value_type value) const noexcept {
+    return not this->empty() and traits::eq(value, this->front());
+  }
+
+  bool ends_with (value_type value) const noexcept {
+    return not this->empty() and traits::eq(value, this->back());
+  }
+
+  bool starts_with (basic_string_view that) const noexcept {
+    return this->size() >= that.size() and
+      traits::compare(this->data(), that.data(), that.size()) == 0;
+  }
+
+  bool ends_with (basic_string_view that) const noexcept {
+    return this->size() >= that.size() and
+      traits::compare(
+        this->data() + this->size() - that.size(),
+        that.data(),
+        that.size()
+      ) == 0;
+  }
+
+  /* compare */
+  difference_type compare (basic_string_view s) const noexcept {
+    auto cmp = traits::compare(
+      this->data(),
+      s.data(),
+      ::std::min(this->size(), s.size())
+    );
+
+    if (cmp != 0) { return cmp; }
+    if (this->size() == s.size()) { return 0; }
+    if (this->size() < s.size()) { return -1; }
+    return 1;
+  }
+
+  difference_type compare (
+    size_type pos,
+    size_type n,
+    basic_string_view s
+  ) const noexcept { return this->substr(pos, n).compare(s); }
+
+  difference_type compare (
+    size_type pos1,
+    size_type n1,
+    basic_string_view s,
+    size_type pos2,
+    size_type n2
+  ) const noexcept {
+    return this->substr(pos1, n1).compare(s.substr(pos2, n2));
+  }
+
+  difference_type compare (pointer s) const noexcept {
+    return this->compare(basic_string_view { s });
+  }
+
+  difference_type compare (
+    size_type pos,
+    size_type n,
+    pointer s
+  ) const noexcept {
+    return this->substr(pos, n).compare(basic_string_view { s });
+  }
+
+  difference_type compare (
+    size_type pos,
+    size_type n1,
+    pointer s,
+    size_type n2
+  ) const noexcept {
+    return this->substr(pos, n1).compare(basic_string_view { s, n2 });
+  }
+
+  reference at (size_type idx) const {
+    static constexpr auto error = "requested index out of range";
+    if (idx >= this->size()) { throw_out_of_range(error); }
+    return this->str[idx];
+  }
+
+  /* find-first-not-of */
+  size_type find_first_not_of (
+    basic_string_view str,
+    size_type pos = 0) const noexcept {
+    if (pos > this->size()) { return npos; }
+    auto begin = this->begin() + pos;
+    auto end = this->end();
+    auto const predicate = [str] (value_type v) { return str.find(v) == npos; };
+    auto iter = std::find_if(begin, end, predicate);
+    if (iter == end) { return npos; }
+    return static_cast<size_type>(::std::distance(this->begin(), iter));
+  }
+
+  size_type find_first_not_of (
+    pointer s,
+    size_type pos,
+    size_type n) const noexcept {
+      return this->find_first_not_of(basic_string_view { s, n }, pos);
+  }
+
+  size_type find_first_not_of (pointer s, size_type pos = 0) const noexcept {
+    return this->find_first_not_of(basic_string_view { s }, pos);
+  }
+
+  size_type find_first_not_of (value_type c, size_type pos = 0) const noexcept {
+    return this->find_first_not_of(
+      basic_string_view { ::std::addressof(c), 1 },
+      pos);
+  }
+
+  /* find-first-of */
+  size_type find_first_of (
+    basic_string_view str,
+    size_type pos = 0) const noexcept {
+    if (pos > this->size()) { return npos; }
+    auto iter = ::std::find_first_of(
+      this->begin() + pos, this->end(),
+      str.begin(), str.end(),
+      traits::eq);
+    if (iter == this->end()) { return npos; }
+    return static_cast<size_type>(::std::distance(this->begin(), iter));
+  }
+
+  size_type find_first_of (pointer s, size_type p, size_type n) const noexcept {
+    return this->find_first_of(basic_string_view { s, n }, p);
+  }
+
+  size_type find_first_of (pointer s, size_type pos = 0) const noexcept {
+    return this->find_first_of(basic_string_view { s }, pos);
+  }
+
+  size_type find_first_of (value_type c, size_type pos = 0) const noexcept {
+    return this->find_first_of(
+      basic_string_view { ::std::addressof(c), 1 },
+      pos);
+  }
+
+  /* find */
+  size_type find (basic_string_view str, size_type pos = 0) const noexcept {
+    if (pos >= this->size()) { return npos; }
+    auto iter = ::std::search(
+      this->begin() + pos, this->end(),
+      str.begin(), str.end(),
+      traits::eq);
+    if (iter == this->end()) { return npos; }
+    return static_cast<size_type>(::std::distance(this->begin(), iter));
+  }
+
+  size_type find (pointer s, size_type p, size_type n) const noexcept {
+    return this->find(basic_string_view { s, n }, p);
+  }
+
+  size_type find (pointer s, size_type pos = 0) const noexcept {
+    return this->find(basic_string_view { s }, pos);
+  }
+
+  size_type find (value_type c, size_type pos = 0) const noexcept {
+    return this->find(basic_string_view { ::std::addressof(c), 1 }, pos);
+  }
+
+  size_type find_last_not_of (
+    basic_string_view str,
+    size_type pos = npos) const noexcept {
+    auto const offset = this->size() - ::std::min(this->size(), pos);
+    auto begin = this->rbegin() + static_cast<difference_type>(offset);
+    auto end = this->rend();
+    auto const predicate = [str] (value_type v) { return str.find(v) == npos; };
+    auto iter = ::std::find_if(begin, end, predicate);
+    if (iter == end) { return npos; }
+    auto const distance = static_cast<size_type>(
+      ::std::distance(this->rbegin(), iter));
+    return this->size() - distance - 1;
+  }
+
+  size_type find_last_not_of (
+    pointer s,
+    size_type p,
+    size_type n) const noexcept {
+    return this->find_last_not_of(basic_string_view { s, n }, p);
+  }
+
+  size_type find_last_not_of (pointer s, size_type p = npos) const noexcept {
+    return this->find_last_not_of(basic_string_view { s }, p);
+  }
+
+  size_type find_last_not_of (
+    value_type c,
+    size_type pos = npos) const noexcept {
+    return this->find_last_not_of(
+      basic_string_view { ::std::addressof(c), 1 },
+      pos);
+  }
+
+  size_type find_last_of (
+    basic_string_view str,
+    size_type pos = npos) const noexcept {
+    auto const offset = this->size() - ::std::min(this->size(), pos);
+    auto begin = this->rbegin() + static_cast<difference_type>(offset);
+    auto end = this->rend();
+
+    auto iter = ::std::find_first_of(
+      begin, end,
+      str.rbegin(), str.rend(),
+      traits::eq);
+    if (iter == end) { return npos; }
+    auto const distance = static_cast<size_type>(
+      ::std::distance(this->rbegin(), iter));
+    return this->size() - distance - 1;
+  }
+
+  size_type find_last_of (pointer s, size_type p, size_type n) const noexcept {
+    return this->find_last_of(basic_string_view { s, n }, p);
+  }
+
+  size_type find_last_of (pointer s, size_type p=npos) const noexcept {
+    return this->find_last_of(basic_string_view { s }, p);
+  }
+
+  size_type find_last_of (value_type c, size_type p=npos) const noexcept {
+    return this->find_last_of(basic_string_view { ::std::addressof(c), 1 }, p);
+  }
+
+  size_type rfind (basic_string_view str, size_type pos=npos) const noexcept {
+    auto const offset = this->size() - ::std::min(this->size(), pos);
+    auto begin = this->rbegin() + offset;
+    auto end = this->rend();
+    auto iter = ::std::search(
+      begin, end,
+      str.rbegin(), str.rend(),
+      traits::eq);
+    if (iter == end) { return npos; }
+    auto const distance = static_cast<size_type>(
+      ::std::distance(this->rbegin(), iter));
+    return this->size() - distance - 1;
+  }
+
+  size_type rfind (pointer s, size_type p, size_type n) const noexcept {
+    return this->rfind(basic_string_view { s, n }, p);
+  }
+
+  size_type rfind (pointer s, size_type p=npos) const noexcept {
+    return this->rfind(basic_string_view { s }, p);
+  }
+
+  size_type rfind (value_type c, size_type p=npos) const noexcept {
+    return this->rfind(basic_string_view { ::std::addressof(c), 1 }, p);
+  }
+
+  void swap (basic_string_view& that) noexcept {
+    using ::std::swap;
+    swap(this->str, that.str);
+    swap(this->len, that.len);
+  }
+
+private:
+  pointer str;
+  size_type len;
+};
+
+using u32string_view = basic_string_view<char32_t>;
+using u16string_view = basic_string_view<char16_t>;
+using wstring_view = basic_string_view<wchar_t>;
+using string_view = basic_string_view<char>;
+
+/* string_view comparison string_view */
+template <class CharT, typename Traits>
+bool operator == (
+  basic_string_view<CharT, Traits> lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return lhs.size() == rhs.size() and lhs.compare(rhs) == 0; }
+
+template <class CharT, typename Traits>
+bool operator != (
+  basic_string_view<CharT, Traits> lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return lhs.size() != rhs.size() or lhs.compare(rhs) != 0; }
+
+template <class CharT, typename Traits>
+bool operator >= (
+  basic_string_view<CharT, Traits> lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return lhs.compare(rhs) >= 0; }
+
+template <class CharT, typename Traits>
+bool operator <= (
+  basic_string_view<CharT, Traits> lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return lhs.compare(rhs) <= 0; }
+
+template <class CharT, typename Traits>
+bool operator > (
+  basic_string_view<CharT, Traits> lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return lhs.compare(rhs) > 0; }
+
+template <class CharT, typename Traits>
+bool operator < (
+  basic_string_view<CharT, Traits> lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return lhs.compare(rhs) < 0; }
+
+/* string_view comparison string */
+template <class CharT, class Traits, class Allocator>
+bool operator == (
+  basic_string_view<CharT, Traits> lhs,
+  ::std::basic_string<CharT, Traits, Allocator> const& rhs
+) noexcept { return lhs == basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator != (
+  basic_string_view<CharT, Traits> lhs,
+  ::std::basic_string<CharT, Traits, Allocator> const& rhs
+) noexcept { return lhs != basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator >= (
+  basic_string_view<CharT, Traits> lhs,
+  ::std::basic_string<CharT, Traits, Allocator> const& rhs
+) noexcept { return lhs >= basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator <= (
+  basic_string_view<CharT, Traits> lhs,
+  ::std::basic_string<CharT, Traits, Allocator> const& rhs
+) noexcept { return lhs <= basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator > (
+  basic_string_view<CharT, Traits> lhs,
+  ::std::basic_string<CharT, Traits, Allocator> const& rhs
+) noexcept { return lhs > basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator < (
+  basic_string_view<CharT, Traits> lhs,
+  ::std::basic_string<CharT, Traits, Allocator> const& rhs
+) noexcept { return lhs < basic_string_view<CharT, Traits> { rhs }; }
+
+/* string comparison string_view */
+template <class CharT, class Traits, class Allocator>
+bool operator == (
+  ::std::basic_string<CharT, Traits, Allocator> const& lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } == rhs; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator != (
+  ::std::basic_string<CharT, Traits, Allocator> const& lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } != rhs; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator >= (
+  ::std::basic_string<CharT, Traits, Allocator> const& lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } >= rhs; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator <= (
+  ::std::basic_string<CharT, Traits, Allocator> const& lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } <= rhs; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator > (
+  ::std::basic_string<CharT, Traits, Allocator> const& lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } > rhs; }
+
+template <class CharT, class Traits, class Allocator>
+bool operator < (
+  ::std::basic_string<CharT, Traits, Allocator> const& lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } < rhs; }
+
+/* string_view comparison CharT* */
+template <class CharT, class Traits>
+bool operator == (
+  basic_string_view<CharT, Traits> lhs,
+  CharT const* rhs
+) noexcept { return lhs == basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits>
+bool operator != (
+  basic_string_view<CharT, Traits> lhs,
+  CharT const* rhs
+) noexcept { return lhs != basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits>
+bool operator >= (
+  basic_string_view<CharT, Traits> lhs,
+  CharT const* rhs
+) noexcept { return lhs >= basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits>
+bool operator <= (
+  basic_string_view<CharT, Traits> lhs,
+  CharT const* rhs
+) noexcept { return lhs <= basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits>
+bool operator > (
+  basic_string_view<CharT, Traits> lhs,
+  CharT const* rhs
+) noexcept { return lhs > basic_string_view<CharT, Traits> { rhs }; }
+
+template <class CharT, class Traits>
+bool operator < (
+  basic_string_view<CharT, Traits> lhs,
+  CharT const* rhs
+) noexcept { return lhs < basic_string_view<CharT, Traits> { rhs }; }
+
+/* CharT* comparison string_view */
+template <class CharT, class Traits>
+bool operator == (
+  CharT const* lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } == rhs; }
+
+template <class CharT, class Traits>
+bool operator != (
+  CharT const* lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } != rhs; }
+
+template <class CharT, class Traits>
+bool operator >= (
+  CharT const* lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } >= rhs; }
+
+template <class CharT, class Traits>
+bool operator <= (
+  CharT const* lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } <= rhs; }
+
+template <class CharT, class Traits>
+bool operator > (
+  CharT const* lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } > rhs; }
+
+template <class CharT, class Traits>
+bool operator < (
+  CharT const* lhs,
+  basic_string_view<CharT, Traits> rhs
+) noexcept { return basic_string_view<CharT, Traits> { lhs } < rhs; }
+
+template <class CharT, class Traits>
+::std::basic_ostream<CharT, Traits>& operator << (
+  ::std::basic_ostream<CharT, Traits>& os,
+  basic_string_view<CharT, Traits> const& str
+) { return os << str.to_string(); }
+
+template <class CharT, class Traits>
+void swap (
+  basic_string_view<CharT, Traits>& lhs,
+  basic_string_view<CharT, Traits>& rhs
+) noexcept { return lhs.swap(rhs); }
+
+}} /* namespace core::v1 */
+
+namespace std {
+
+template <typename CharT, typename Traits>
+struct hash<core::v1::basic_string_view<CharT, Traits>> {
+  using argument_type = core::v1::basic_string_view<CharT, Traits>;
+  using result_type = size_t;
+
+
+  result_type operator ()(argument_type const& ref) const noexcept {
+    static constexpr core::impl::murmur<sizeof(size_t)> hasher { };
+    return hasher(ref.data(), ref.size());
+  }
+};
+
+} /* namespace std */
+
+#endif /* CORE_STRING_HPP */

--- a/core/include/core/type_traits.hpp
+++ b/core/include/core/type_traits.hpp
@@ -1,0 +1,905 @@
+#ifndef CORE_TYPE_TRAITS_HPP
+#define CORE_TYPE_TRAITS_HPP
+
+#include <type_traits>
+#include <utility>
+#include <tuple>
+
+#include <core/internal.hpp>
+
+namespace core {
+inline namespace v1 {
+
+/* custom type traits and types */
+template <class T> using identity_t = typename meta::identity<T>::type;
+template <class T> using identity = meta::identity<T>;
+
+/* extracts the class of a member function ponter */
+template <class T> using class_of_t = impl::class_of_t<T>;
+template <class T> using class_of = impl::class_of<T>;
+
+template <::std::size_t I, class T>
+using tuple_element_t = typename ::std::tuple_element<I, T>::type;
+template <class T> using tuple_size_t = typename ::std::tuple_size<T>::type;
+
+/* Implementation of N4389 */
+template <bool B> using bool_constant = ::std::integral_constant<bool, B>;
+
+/* This is equivalent to the Boost.TypeTraits dont_care type */
+using ignore_t = decltype(::std::ignore);
+
+/* a 'better named' (personal opinion!) form of the void_t type transformation
+ * alias trait by Walter E. Brown. We provide the void_t form for interop
+ * with other folks code
+ */
+template <class... Ts> using deduce_t = impl::deduce_t<Ts...>;
+template <class... Ts> using void_t = deduce_t<Ts...>;
+
+/* tuple_size is used by unpack, so we expect it to be available.
+ * We also expect ::std::get<N> to be available for the give type T
+ *
+ * This type trait is deprecated
+ */
+template <class T, class=void> struct is_unpackable : ::std::false_type { };
+template <class T>
+struct is_unpackable<T, deduce_t<tuple_size_t<T>>> :
+  ::std::true_type
+{ };
+
+/* Used for types that have a .at(size_type) member function. Used by
+ * invoke for 'runpacking'
+ */
+template <class T, class=void> struct is_runpackable : ::std::false_type { };
+template <class T>
+struct is_runpackable<
+  T,
+  deduce_t<decltype(::std::declval<T>().at(::std::declval<::std::size_t>()))>
+> : ::std::true_type
+{ };
+
+/* forward declaration */
+template <::std::size_t, class...> struct aligned_union;
+template <class...> struct invokable;
+template <class...> struct invoke_of;
+template <class T> struct result_of; /* SFINAE result_of */
+
+/* C++14 style aliases for standard traits */
+template <class T>
+using remove_volatile_t = typename ::std::remove_volatile<T>::type;
+
+template <class T>
+using remove_const_t = typename ::std::remove_const<T>::type;
+template <class T> using remove_cv_t = typename ::std::remove_cv<T>::type;
+
+template <class T>
+using add_volatile_t = typename ::std::add_volatile<T>::type;
+template <class T> using add_const_t = typename ::std::add_const<T>::type;
+template <class T> using add_cv_t = typename ::std::add_cv<T>::type;
+
+template <class T>
+using add_lvalue_reference_t = typename ::std::add_lvalue_reference<T>::type;
+
+template <class T>
+using add_rvalue_reference_t = typename ::std::add_rvalue_reference<T>::type;
+
+template <class T>
+using remove_reference_t = typename ::std::remove_reference<T>::type;
+
+template <class T>
+using remove_pointer_t = typename ::std::remove_pointer<T>::type;
+
+template <class T> using add_pointer_t = typename ::std::add_pointer<T>::type;
+
+template <class T>
+using make_unsigned_t = typename ::std::make_unsigned<T>::type;
+template <class T> using make_signed_t = typename ::std::make_signed<T>::type;
+
+template <class T>
+using remove_extent_t = typename ::std::remove_extent<T>::type;
+
+template <class T>
+using remove_all_extents_t = typename ::std::remove_all_extents<T>::type;
+
+template <
+  ::std::size_t Len,
+  ::std::size_t Align = alignof(typename ::std::aligned_storage<Len>::type)
+> using aligned_storage_t = typename ::std::aligned_storage<Len, Align>::type;
+
+template <::std::size_t Len, class... Types>
+using aligned_union_t = typename aligned_union<Len, Types...>::type;
+
+template <class T> using decay_t = impl::decay_t<T>;
+
+template <bool B, class T = void>
+using enable_if_t = typename ::std::enable_if<B, T>::type;
+
+template <bool B, class T, class F>
+using conditional_t = typename ::std::conditional<B, T, F>::type;
+
+template <class T>
+using underlying_type_t = typename ::std::underlying_type<T>::type;
+
+template <::std::size_t Len, class... Types>
+struct aligned_union {
+  using union_type = impl::discriminate<Types...>;
+  static constexpr ::std::size_t size () noexcept {
+    return Len > sizeof(union_type) ? Len : sizeof(union_type);
+  }
+
+  static constexpr ::std::size_t alignment_value = alignof(
+    impl::discriminate<Types...>
+  );
+
+  using type = aligned_storage_t<size(), alignment_value>;
+};
+
+/* custom type trait specializations */
+template <class... Args> using invoke_of_t = typename invoke_of<Args...>::type;
+
+template <class... Args>
+struct invokable : meta::none<
+  std::is_same<
+    decltype(impl::INVOKE(::std::declval<Args>()...)),
+    impl::undefined
+  >
+> { };
+
+template <class... Args> struct invoke_of :
+  impl::invoke_of<invokable<Args...>::value, Args...>
+{ };
+
+template <class F, class... Args>
+struct result_of<F(Args...)> : invoke_of<F, Args...> { };
+
+template <class T> using result_of_t = typename result_of<T>::type;
+
+template <class... Ts> struct common_type;
+
+template <class T> struct common_type<T> : identity<decay_t<T>> { };
+template <class T, class U>
+struct common_type<T, U> : identity<
+  decay_t<decltype(true ? ::std::declval<T>() : ::std::declval<U>())>
+> { };
+
+template <class T, class U, class... Ts>
+struct common_type<T, U, Ts...> : identity<
+  typename common_type<
+    typename common_type<T, U>::type,
+    Ts...
+  >::type
+> { };
+
+template <class... T> using common_type_t = typename common_type<T...>::type;
+
+/* is_null_pointer */
+template <class T> struct is_null_pointer : ::std::false_type { };
+
+template <>
+struct is_null_pointer<add_cv_t<::std::nullptr_t>> : ::std::true_type { };
+template <>
+struct is_null_pointer<::std::nullptr_t volatile> : ::std::true_type { };
+template <>
+struct is_null_pointer<::std::nullptr_t const> : ::std::true_type { };
+template <>
+struct is_null_pointer<::std::nullptr_t> : ::std::true_type { };
+
+/* is_swappable */
+template <class T, class U=T>
+using is_swappable = impl::is_swappable<T, U>;
+
+/* is_nothrow_swappable - N4426 (implemented before paper was proposed) */
+template <class T, class U=T>
+using is_nothrow_swappable = impl::is_nothrow_swappable<T, U>;
+
+template <class T, ::std::size_t N>
+using is_sizeof = meta::boolean<sizeof(T) == N>;
+
+/* These are now deprecated. Use what they alias to instead */
+template <class... Args> using all_traits = meta::all<Args...>;
+template <class... Args> using any_traits = meta::any<Args...>;
+template <class... Args> using no_traits = meta::none<Args...>;
+
+namespace trait {
+namespace impl {
+
+/* comparison */
+template <class, class, class, class=void> struct eq : ::std::false_type { };
+template <class, class, class, class=void> struct ne : ::std::false_type { };
+template <class, class, class, class=void> struct ge : ::std::false_type { };
+template <class, class, class, class=void> struct le : ::std::false_type { };
+template <class, class, class, class=void> struct gt : ::std::false_type { };
+template <class, class, class, class=void> struct lt : ::std::false_type { };
+
+/* arithmetic */
+template <class, class, class, class=void> struct mul : ::std::false_type { };
+template <class, class, class, class=void> struct div : ::std::false_type { };
+template <class, class, class, class=void> struct mod : ::std::false_type { };
+template <class, class, class, class=void> struct add : ::std::false_type { };
+template <class, class, class, class=void> struct sub : ::std::false_type { };
+
+/* bitwise */
+template <class, class, class, class=void> struct band : ::std::false_type { };
+template <class, class, class, class=void> struct bxor : ::std::false_type { };
+template <class, class, class, class=void> struct bor : ::std::false_type { };
+template <class, class, class, class=void> struct bsl : ::std::false_type { };
+template <class, class, class, class=void> struct bsr : ::std::false_type { };
+template <class, class, class=void> struct bnot : ::std::false_type { };
+
+/* logical */
+template <class, class, class, class=void> struct land : ::std::false_type { };
+template <class, class, class, class=void> struct lor : ::std::false_type { };
+template <class, class, class=void> struct lnot : ::std::false_type { };
+
+/* disgusting */
+template <class, class, class, class=void> struct comma : ::std::false_type { };
+
+/* prefix */
+template <class, class, class=void> struct negate : ::std::false_type { };
+template <class, class, class=void> struct plus : ::std::false_type { };
+
+template <class, class, class=void> struct inc : ::std::false_type { };
+template <class, class, class=void> struct dec : ::std::false_type { };
+
+/* postfix */
+template <class, class, class=void> struct postinc : ::std::false_type { };
+template <class, class, class=void> struct postdec : ::std::false_type { };
+
+/* arithmetic assign */
+template <class, class, class, class=void> struct imul : ::std::false_type { };
+template <class, class, class, class=void> struct idiv : ::std::false_type { };
+template <class, class, class, class=void> struct imod : ::std::false_type { };
+template <class, class, class, class=void> struct iadd : ::std::false_type { };
+template <class, class, class, class=void> struct isub : ::std::false_type { };
+
+/* bitwise assign */
+template <class, class, class, class=void> struct iand : ::std::false_type { };
+template <class, class, class, class=void> struct ixor : ::std::false_type { };
+template <class, class, class, class=void> struct ior : ::std::false_type { };
+template <class, class, class, class=void> struct isl : ::std::false_type { };
+template <class, class, class, class=void> struct isr : ::std::false_type { };
+
+/* special operator overloads */
+template <class, class, class, class=void> struct subscript :
+  ::std::false_type
+{ };
+
+template <class, class, class=void> struct dereference : ::std::false_type { };
+template <class, class, class=void> struct address : ::std::false_type { };
+template <class, class, class=void> struct arrow : ::std::false_type { };
+
+/* comparison - ignore */
+template <class T, class U>
+struct eq<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() == ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct ne<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() != ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct ge<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() >= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct le<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() <= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct gt<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() > ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct lt<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() < ::std::declval<U>())>
+> : ::std::true_type { };
+
+/* arithmetic - ignore */
+template <class T, class U>
+struct mul<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() * ::std::declval<T>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct div<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() / ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct mod<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() % ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct add<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() + ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct sub<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() - ::std::declval<U>())>
+> : ::std::true_type { };
+
+/* bitwise - ignore */
+template <class T, class U>
+struct band<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() & ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct bxor<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() ^ ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct bor<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() | ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct bsl<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() << ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct bsr<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() >> ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T>
+struct bnot<T, ignore_t, deduce_t<decltype(~::std::declval<T>())>> :
+  ::std::true_type
+{ };
+
+/* logic - ignore */
+template <class T, class U>
+struct land<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() and ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct lor<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() or ::std::declval<U>())>
+> : ::std::true_type { };
+
+
+template <class T>
+struct lnot<T, ignore_t, deduce_t<decltype(not ::std::declval<T>())>> :
+  ::std::true_type
+{ };
+
+/* prefix - ignore */
+template <class T>
+struct negate<T, ignore_t, deduce_t<decltype(-::std::declval<T>())>> :
+  ::std::true_type
+{ };
+
+template <class T>
+struct plus<T, ignore_t, deduce_t<decltype(+::std::declval<T>())>> :
+  ::std::true_type
+{ };
+
+template <class T>
+struct inc<T, ignore_t, deduce_t<decltype(++::std::declval<T>())>> :
+  ::std::true_type
+{ };
+
+template <class T>
+struct dec<T, ignore_t, deduce_t<decltype(--::std::declval<T>())>> :
+  ::std::true_type
+{ };
+
+
+/* postfix - ignore */
+template <class T>
+struct postinc<T, ignore_t, deduce_t<decltype(::std::declval<T>()++)>> :
+  ::std::true_type
+{ };
+
+template <class T>
+struct postdec<T, ignore_t, deduce_t<decltype(::std::declval<T>()--)>> :
+  ::std::true_type
+{ };
+
+/* arithmetic assign operators - ignore */
+template <class T, class U>
+struct imul<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() *= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct idiv<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() /= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct imod<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() %= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct iadd<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() += ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct isub<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() -= ::std::declval<U>())>
+> : ::std::true_type { };
+
+/* bitwise assign operators - ignore */
+template <class T, class U>
+struct iand<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() &= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct ixor<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() ^= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct ior<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() |= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct isl<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() <<= ::std::declval<U>())>
+> : ::std::true_type { };
+
+template <class T, class U>
+struct isr<
+  T, U, ignore_t,
+  deduce_t<decltype(::std::declval<T>() >>= ::std::declval<U>())>
+> : ::std::true_type { };
+
+/* special operators - ignore */
+template <class T, class I>
+struct subscript<
+  T, I, ignore_t,
+  deduce_t<decltype(::std::declval<T>()[::std::declval<I>()])>
+> : ::std::true_type { };
+
+template <class T>
+struct dereference<
+  T, ignore_t,
+  deduce_t<decltype(::std::declval<T>().operator*())>
+> : ::std::true_type { };
+
+template <class T>
+struct address<
+  T, ignore_t,
+  deduce_t<decltype(::std::declval<T>().operator&())>
+> : ::std::true_type { };
+
+template <class T>
+struct arrow<
+  T, ignore_t,
+  deduce_t<decltype(::std::declval<T>().operator->())>
+> : ::std::true_type { };
+
+/* comparison */
+template <class T, class U, class R>
+struct eq<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() == ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() == ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct ne<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() != ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() == ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct ge<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() >= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() >= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct le<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() <= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() <= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct gt<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() > ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() > ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct lt<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() < ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() < ::std::declval<U>()),
+  R
+> { };
+
+/* arithmetic */
+template <class T, class U, class R>
+struct mul<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() * ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() * ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct div<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() / ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() / ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct mod<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() % ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() % ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct add<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() + ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() + ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct sub<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() - ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() - ::std::declval<U>()),
+  R
+> { };
+
+/* bitwise */
+template <class T, class U, class R>
+struct band<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() & ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() & ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct bxor<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() ^ ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() & ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct bor<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() | ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() | ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct bsl<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() << ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() << ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct bsr<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() >> ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() >> ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class R>
+struct bnot<T, R, deduce_t<decltype(~::std::declval<T>())>> :
+  ::std::is_convertible<decltype(~::std::declval<T>()), R>
+{ };
+
+/* logical */
+template <class T, class U, class R>
+struct land<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() and ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() and ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct lor<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() or ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() or ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class R>
+struct lnot<T, R, deduce_t<decltype(not ::std::declval<T>())>> :
+  ::std::is_convertible<decltype(not ::std::declval<T>()), R>
+{ };
+
+/* disgusting */
+template <class T, class U, class R>
+struct comma<
+  T, U, R,
+  deduce_t<decltype((::std::declval<T>(), ::std::declval<U>()))>
+> : ::std::is_convertible<
+  decltype((::std::declval<T>(), ::std::declval<U>())),
+  R
+> { };
+
+/* prefix */
+template <class T, class R>
+struct negate<
+  T, R, deduce_t<decltype(-::std::declval<T>())>
+> : ::std::is_convertible<decltype(-::std::declval<T>()), R> { };
+
+template <class T, class R>
+struct plus<
+  T, R, deduce_t<decltype(+::std::declval<T>())>
+> : ::std::is_convertible<decltype(+::std::declval<T>()), R> { };
+
+template <class T, class R>
+struct inc<
+  T, R, deduce_t<decltype(++::std::declval<T>())>
+> : ::std::is_convertible<decltype(++::std::declval<T>()), R> { };
+
+template <class T, class R>
+struct dec<
+  T, R, deduce_t<decltype(--::std::declval<T>())>
+> : ::std::is_convertible<decltype(--::std::declval<T>()), R> { };
+
+/* postfix */
+template <class T, class R>
+struct postinc<
+  T, R, deduce_t<decltype(::std::declval<T>()++)>
+> : ::std::is_convertible<decltype(::std::declval<T>()++), R> { };
+
+template <class T, class R>
+struct postdec<
+  T, R, deduce_t<decltype(::std::declval<T>()--)>
+> : ::std::is_convertible<decltype(::std::declval<T>()--), R> { };
+
+/* arithmetic assign */
+template <class T, class U, class R>
+struct imul<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() *= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() *= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct idiv<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() /= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() /= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct imod<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() %= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() %= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct iadd<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() += ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() += ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct isub<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() -= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() -= ::std::declval<U>()),
+  R
+> { };
+
+/* bitwise assign */
+template <class T, class U, class R>
+struct iand<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() &= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() &= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct ixor<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() ^= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() ^= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct ior<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() |= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() |= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct isl<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() <<= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() <<= ::std::declval<U>()),
+  R
+> { };
+
+template <class T, class U, class R>
+struct isr<
+  T, U, R,
+  deduce_t<decltype(::std::declval<T>() >>= ::std::declval<U>())>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>() >>= ::std::declval<U>()),
+  R
+> { };
+
+/* special operator overloads */
+template <class T, class I, class R>
+struct subscript<
+  T, I, R,
+  deduce_t<decltype(::std::declval<T>()[std::declval<I>()])>
+> : ::std::is_convertible<
+  decltype(::std::declval<T>()[::std::declval<I>()]),
+  R
+> { };
+
+template <class T, class R>
+struct address<T, R, deduce_t<decltype(::std::declval<T>().operator&())>> :
+  std::is_convertible<decltype(::std::declval<T>().operator&()), R>
+{ };
+
+template <class T, class R>
+struct arrow<T, R, deduce_t<decltype(::std::declval<T>().operator->())>> :
+  std::is_convertible<decltype(::std::declval<T>().operator->()), R>
+{ };
+
+} /* namespace impl */
+
+/* comparison */
+template <class T, class U=T, class R=ignore_t> using eq = impl::eq<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using ne = impl::ne<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using ge = impl::ge<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using le = impl::le<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using gt = impl::gt<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using lt = impl::lt<T, U, R>;
+
+/* arithmetic */
+template <class T, class U=T, class R=ignore_t> using mul = impl::mul<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using div = impl::div<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using mod = impl::mod<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using add = impl::add<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using sub = impl::sub<T, U, R>;
+
+/* bitwise */
+template <class T, class U=T, class R=ignore_t>
+using band = impl::band<T, U, R>;
+
+template <class T, class U=T, class R=ignore_t>
+using bxor = impl::bxor<T, U, R>;
+
+template <class T, class U=T, class R=ignore_t> using bor = impl::bor<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using bsl = impl::bsl<T, U, R>;
+template <class T, class U=T, class R=ignore_t> using bsr = impl::bsr<T, U, R>;
+template <class T, class R=ignore_t> using bnot = impl::bnot<T, R>;
+
+/* logical */
+template <class T, class U=T, class R=ignore_t>
+using land = impl::land<T, U, R>;
+
+template <class T, class U=T, class R=ignore_t> using lor = impl::lor<T, U, R>;
+template <class T, class R=ignore_t> using lnot = impl::lnot<T, R>;
+
+/* disgusting (we do not allow ignoring the return type) */
+template <class T, class U, class R> using comma = impl::comma<T, U, R>;
+
+/* prefix */
+template <class T, class R=ignore_t> using negate = impl::negate<T, R>;
+template <class T, class R=ignore_t> using plus = impl::plus<T, R>;
+
+template <class T, class R=ignore_t> using inc = impl::inc<T, R>;
+template <class T, class R=ignore_t> using dec = impl::dec<T, R>;
+
+/* postfix */
+template <class T, class R=ignore_t> using postinc = impl::postinc<T, R>;
+template <class T, class R=ignore_t> using postdec = impl::postdec<T, R>;
+
+/* special operators */
+template <class T, class I, class R=ignore_t>
+using subscript = impl::subscript<T, I, R>;
+
+template <class T, class R=ignore_t>
+using dereference = impl::dereference<T, R>;
+
+template <class T, class R=ignore_t> using address = impl::address<T, R>;
+template <class T, class R> using arrow = impl::arrow<T, R>;
+
+}}} /* namespace core::v1::trait */
+
+#endif /* CORE_TYPE_TRAITS_HPP */

--- a/core/include/core/utility.hpp
+++ b/core/include/core/utility.hpp
@@ -1,0 +1,156 @@
+#ifndef CORE_UTILITY_HPP
+#define CORE_UTILITY_HPP
+
+#include <functional>
+
+#include <cstddef>
+
+#include <core/type_traits.hpp>
+
+namespace core {
+inline namespace v1 {
+
+template <class T>
+constexpr T&& forward (remove_reference_t<T>& t) noexcept {
+  return static_cast<T&&>(t);
+}
+
+template <class T>
+constexpr T&& forward (remove_reference_t<T>&& t) noexcept {
+  return static_cast<T&&>(t);
+}
+
+template <class T>
+constexpr auto move (T&& t) noexcept -> decltype(
+  static_cast<remove_reference_t<T>&&>(t)
+) { return static_cast<remove_reference_t<T>&&>(t); }
+
+
+template <class T, T... I>
+using integer_sequence = meta::integer_sequence<T, I...>;
+
+template <::std::size_t... I>
+using index_sequence = integer_sequence<::std::size_t, I...>;
+
+template <class T, T N>
+using make_integer_sequence = typename meta::iota<T, N, N>::type;
+
+template <::std::size_t N>
+using make_index_sequence = make_integer_sequence<::std::size_t, N>;
+
+template <class... Ts>
+using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+
+/* N3761 (with some additions) */
+template <::std::size_t N, class... Ts>
+struct type_at : meta::element<N, meta::pack<Ts...>> { };
+
+template <::std::size_t N, class... Ts>
+using type_at_t = typename type_at<N, Ts...>::type;
+
+template <::std::size_t N, class T, class... Ts>
+constexpr auto value_at (T&& value, Ts&&...) -> enable_if_t<
+  N == 0 and N < (sizeof...(Ts) + 1),
+  decltype(::core::forward<T>(value))
+> { return ::core::forward<T>(value); }
+
+template <::std::size_t N, class T, class... Ts>
+constexpr auto value_at (T&&, Ts&&... values) -> enable_if_t<
+  N != 0 and N < (sizeof...(Ts) + 1),
+  type_at_t<N, T, Ts...>
+> { return value_at<N - 1, Ts...>(::core::forward<Ts>(values)...); }
+
+template <class Callable>
+struct scope_guard final {
+
+  static_assert(
+    ::std::is_nothrow_move_constructible<Callable>::value,
+    "Given type must be nothrow move constructible"
+  );
+
+  explicit scope_guard (Callable callable) noexcept :
+    callable { ::core::move(callable) },
+    dismissed { false }
+  { }
+
+  scope_guard (scope_guard const&) = delete;
+  scope_guard (scope_guard&&) = default;
+  scope_guard () = delete;
+  ~scope_guard () noexcept { if (not this->dismissed) { callable(); } }
+
+  scope_guard& operator = (scope_guard const&) = delete;
+  scope_guard& operator = (scope_guard&&) = default;
+
+  void dismiss () noexcept { this->dismissed = true; }
+
+private:
+  Callable callable;
+  bool dismissed;
+};
+
+template <class Callable>
+auto make_scope_guard(Callable&& callable) -> scope_guard<decay_t<Callable>> {
+  return scope_guard<decay_t<Callable>> {
+    ::core::forward<Callable>(callable)
+  };
+}
+
+template <class T, class U=T>
+T exchange (T& obj, U&& value) noexcept(
+  meta::all<
+    ::std::is_nothrow_move_constructible<T>,
+    ::std::is_nothrow_assignable<add_lvalue_reference_t<T>, U>
+  >::value
+) {
+  T old = ::core::move(obj);
+  obj = ::core::forward<U>(value);
+  return old;
+}
+
+template <class E>
+constexpr auto to_integral(E e) noexcept -> enable_if_t<
+  std::is_enum<E>::value,
+  underlying_type_t<E>
+> { return static_cast<underlying_type_t<E>>(e); }
+
+template <class T>
+struct capture final {
+  static_assert(::std::is_move_constructible<T>::value, "T must be movable");
+  using value_type = T;
+  using reference = add_lvalue_reference_t<value_type>;
+  using pointer = add_pointer_t<value_type>;
+
+  capture (T&& data) : data { core::move(data) } { }
+
+  capture (capture&&) = default;
+  capture (capture& that) : data { core::move(that.data) } { }
+  capture () = delete;
+
+  capture& operator = (capture const&) = delete;
+  capture& operator = (capture&&) = delete;
+
+  operator reference () const noexcept { return this->get(); }
+  reference operator * () const noexcept { return this->get(); }
+  pointer operator -> () const noexcept {
+    return ::std::addressof(this->get());
+  }
+
+  reference get () const noexcept { return this->data; }
+
+private:
+  value_type data;
+};
+
+template <class T>
+auto make_capture (remove_reference_t<T>& ref) -> capture<T> {
+  return capture<T> { core::move(ref) };
+}
+
+template <class T>
+auto make_capture (remove_reference_t<T>&& ref) -> capture<T> {
+  return capture<T> { core::move(ref) };
+}
+
+}} /* namespace core::v1 */
+
+#endif /* CORE_UTILITY_HPP */

--- a/core/include/core/variant.hpp
+++ b/core/include/core/variant.hpp
@@ -1,0 +1,477 @@
+#ifndef CORE_VARIANT_HPP
+#define CORE_VARIANT_HPP
+
+#include <core/type_traits.hpp>
+#include <core/functional.hpp>
+#include <core/utility.hpp>
+
+#include <stdexcept>
+#include <typeinfo>
+#include <limits>
+
+#include <cstdlib>
+#include <cstdint>
+
+namespace core {
+inline namespace v1 {
+namespace impl {
+
+/* This is used to get around GCC's inability to expand lambdas in variadic
+ * template functions. You make me so sad sometimes, GCC.
+ */
+template <class Visitor, class Type, class Data, class Result, class... Args>
+auto visitor_gen () -> Result {
+  return [](Visitor&& visitor, Data* data, Args&&... args) {
+    return invoke(
+      ::core::forward<Visitor>(visitor),
+      *static_cast<Type*>(data),
+      ::core::forward<Args>(args)...
+    );
+  };
+}
+
+} /* namespace impl */
+
+#ifndef CORE_NO_EXCEPTIONS
+struct bad_variant_get final : ::std::logic_error {
+  using ::std::logic_error::logic_error;
+};
+[[noreturn]] inline void throw_bad_variant_get () {
+  throw bad_variant_get { "incorrect type" };
+}
+#else /* CORE_NO_EXCEPTIONS */
+[[noreturn]] inline void throw_bad_variant_get () { ::std::abort(); }
+#endif /* CORE_NO_EXCEPTIONS */
+
+/* visitation semantics require that, given a callable type C, and variadic
+ * arguments Args... that the return type of the visit will be SFINAE-ified
+ * as common_type_t<invoke_of_t<C, Args>...> (this assumes a variadic
+ * approach can be taken with common_type, which it cannot at this time. A
+ * custom SFINAE-capable version has been written within the type traits
+ * component.
+ *
+ * Obviously if a common type cannot be found, then the visitation function
+ * cannot be generated.
+ *
+ * These same semantics are required for variant<Ts...>::match which simply
+ * calls visit with a generate overload<Lambdas...> type.
+ */
+template <class... Ts>
+class variant final {
+  using pack_type = meta::pack<Ts...>;
+
+  static_assert(
+    pack_type::size() < ::std::numeric_limits<::std::uint8_t>::max(),
+    "Cannot have more elements than variant can containe");
+
+  static_assert(
+    meta::all<
+      meta::boolean<meta::count<Ts, meta::pack<Ts...>>::value == 1>...
+    >::value,
+    "Cannot have duplicate types in variant");
+
+  static_assert(
+    sizeof...(Ts) < ::std::numeric_limits<uint8_t>::max(),
+    "Cannot have more elements than variant can contain"
+  );
+
+  using storage_type = aligned_storage_t<
+    sizeof(impl::discriminate<Ts...>),
+    ::std::alignment_of<impl::discriminate<Ts...>>::value
+  >;
+
+  template <::std::size_t N> using element = meta::element_t<N, pack_type>;
+  template <::std::size_t N> using index = meta::size<N>;
+
+  struct copier final {
+    using data_type = add_pointer_t<void>;
+    data_type data;
+
+    template <class T>
+    void operator ()(T const& value) const { ::new (this->data) T(value); }
+  };
+
+  struct mover final {
+    using data_type = add_pointer_t<void>;
+    data_type data;
+
+    template <class T>
+    void operator () (T&& value) {
+      ::new (this->data) decay_t<T>(::core::move(value));
+    }
+  };
+
+  struct destroyer final {
+    template <class T> void operator ()(T const& value) const { value.~T(); }
+  };
+
+  struct swapper final {
+    using data_type = add_pointer_t<void>;
+    data_type data;
+
+    template <class T> void operator () (T const&) = delete;
+
+    template <class T>
+    void operator ()(T& value) noexcept(is_nothrow_swappable<T>::value) {
+      using ::std::swap;
+      swap(*static_cast<T*>(this->data), value);
+    }
+  };
+
+  struct equality final {
+    using data_type = add_pointer_t<add_const_t<void>>;
+    data_type data;
+
+    template <class T>
+    bool operator ()(T const& value) {
+      return equal_to<> { }(*static_cast<T const*>(this->data), value);
+    }
+  };
+
+  struct less_than final {
+    using data_type = add_pointer_t<add_const_t<void>>;
+    data_type data;
+
+    template <class T>
+    bool operator ()(T const& value) noexcept {
+      return less<> { }(*static_cast<T const*>(this->data), value);
+    }
+  };
+
+#ifndef CORE_NO_RTTI
+  struct type_info final {
+    template <class T>
+    ::std::type_info const* operator ()(T&&) const noexcept {
+      return ::std::addressof(typeid(decay_t<T>));
+    }
+  };
+#endif /* CORE_NO_RTTI */
+
+  template <
+    ::std::size_t N,
+    class=enable_if_t<N < sizeof...(Ts)>,
+    class T
+  > explicit variant (index<N>&&, ::std::false_type&&, T&& value) :
+    variant {
+      index<N + 1> { },
+      ::std::is_constructible<type_at_t<N + 1, Ts...>, T> { },
+      ::core::forward<T>(value)
+    }
+  { }
+
+  template <
+    ::std::size_t N,
+    class=enable_if_t<N < sizeof...(Ts)>,
+    class T
+  > explicit variant (index<N>&&, ::std::true_type&&, T&& value) :
+    data { }, tag { N }
+  { ::new (this->pointer()) type_at_t<N, Ts...> (::core::forward<T>(value)); }
+
+  template <class T>
+  using select_index = conditional_t<
+    meta::count<decay_t<T>, pack_type>::value,
+    meta::index<decay_t<T>, pack_type>,
+    index<0>
+  >;
+
+public:
+
+  /* The conditional_t used here allows us to first check if a given type
+   * is declared in the variant and if it is, we will try to find its
+   * constructor and immediately jump there, otherwise, we go the slower
+   * route of trying to construct something from the value given.
+   *
+   * While this route is 'slower' this is a compile time performance issue and
+   * will not impact runtime performance.
+   *
+   * Unfortunately we *do* instantiate templates several times, but there's
+   * not much we can do about it.
+   */
+  template <
+    class T,
+    class=enable_if_t<not ::std::is_same<decay_t<T>, variant>::value>
+  > variant (T&& value) :
+    variant {
+      select_index<T> { },
+      ::std::is_constructible<type_at_t<select_index<T>::value, Ts...>, T> { },
+      ::core::forward<T>(value)
+    }
+  { }
+
+  variant (variant const& that) :
+    data { }, tag { that.tag }
+  { that.visit(copier { this->pointer() }); }
+
+  variant (variant&& that) noexcept :
+    data { }, tag { that.tag }
+  { that.visit(mover { this->pointer() }); }
+
+  variant () : variant { type_at_t<0, Ts...> { } } { }
+
+  ~variant () { this->visit(destroyer { }); }
+
+  template <
+    class T,
+    class=enable_if_t<not ::std::is_same<decay_t<T>, variant>::value>
+  > variant& operator = (T&& value) {
+    variant { ::core::forward<T>(value) }.swap(*this);
+    return *this;
+  }
+
+  variant& operator = (variant const& that) {
+    variant { that }.swap(*this);
+    return *this;
+  }
+
+  variant& operator = (variant&& that) noexcept {
+    this->visit(destroyer { });
+    this->tag = that.tag;
+    that.visit(mover { this->pointer() });
+    return *this;
+  }
+
+  /* Placing these inside of the variant results in no implicit conversions
+   * occuring
+   */
+  bool operator == (variant const& that) const noexcept {
+    if (this->tag != that.tag) { return false; }
+    return that.visit(equality { this->pointer() });
+  }
+
+  bool operator < (variant const& that) const noexcept {
+    if (this->tag != that.tag) { return this->tag < that.tag; }
+    return that.visit(less_than { this->pointer() });
+  }
+
+  void swap (variant& that) noexcept(
+    all_traits<is_nothrow_swappable<Ts>...>::value
+  ) {
+    if (this->which() == that.which()) {
+      that.visit(swapper { this->pointer() });
+      return;
+    }
+    variant temp { ::core::move(*this) };
+    *this = ::core::move(that);
+    that = ::core::move(temp);
+  }
+
+  template <class Visitor, class... Args>
+  auto visit (Visitor&& visitor, Args&&... args) -> common_type_t<
+    invoke_of_t<Visitor, add_lvalue_reference_t<Ts>, Args...>...
+  > {
+    using return_type = common_type_t<
+      invoke_of_t<
+        Visitor,
+        add_lvalue_reference_t<Ts>,
+        Args...
+      >...
+    >;
+    using function = return_type(*)(Visitor&&, void*, Args&&...);
+    constexpr ::std::size_t size = pack_type::size();
+
+    static function const callers[size] {
+      impl::visitor_gen<Visitor, Ts, void, function, Args...>()...
+    };
+
+    return callers[this->tag](
+      ::core::forward<Visitor>(visitor),
+      this->pointer(),
+      ::core::forward<Args>(args)...
+    );
+  }
+
+  template <class Visitor, class... Args>
+  auto visit (Visitor&& visitor, Args&&... args) const -> common_type_t<
+    invoke_of_t<Visitor, add_lvalue_reference_t<add_const_t<Ts>>, Args...>...
+  > {
+    using return_type = common_type_t<
+      invoke_of_t<
+        Visitor,
+        add_lvalue_reference_t<add_const_t<Ts>>,
+        Args...
+      >...
+    >;
+    using function = return_type(*)(Visitor&&, void const*, Args&&...);
+    constexpr ::std::size_t size = pack_type::size();
+
+    static function const callers[size] = {
+      impl::visitor_gen<
+        Visitor,
+        add_const_t<Ts>,
+        void const,
+        function,
+        Args...
+      >()...
+    };
+
+    return callers[this->tag](
+      ::core::forward<Visitor>(visitor),
+      this->pointer(),
+      ::core::forward<Args>(args)...
+    );
+  }
+
+  template <class... Visitors>
+  auto match (Visitors&&... visitors) -> decltype(
+    this->visit(impl::make_overload(::core::forward<Visitors>(visitors)...))
+  ) {
+    return this->visit(
+      impl::make_overload(::core::forward<Visitors>(visitors)...)
+    );
+  }
+
+  template <class... Visitors>
+  auto match (Visitors&&... visitors) const -> decltype(
+    this->visit(impl::make_overload(::core::forward<Visitors>(visitors)...))
+  ) {
+    return this->visit(
+      impl::make_overload(::core::forward<Visitors>(visitors)...)
+    );
+  }
+
+  /* These functions are undocumented and should not be used outside of core */
+  template <::std::size_t N>
+  add_pointer_t<add_const_t<element<N>>> cast () const noexcept {
+    return static_cast<add_pointer_t<add_const_t<element<N>>>>(this->pointer());
+  }
+
+  template <::std::size_t N>
+  add_pointer_t<element<N>> cast () noexcept {
+    return static_cast<add_pointer_t<element<N>>>(this->pointer());
+  }
+
+#ifndef CORE_NO_RTTI
+  ::std::type_info const& type () const noexcept {
+    return *this->visit(type_info { });
+  }
+#endif /* CORE_NO_RTTI */
+
+  ::std::uint32_t which () const noexcept { return this->tag; }
+  bool empty () const noexcept { return false; }
+
+private:
+  void const* pointer () const noexcept { return ::std::addressof(this->data); }
+  void* pointer () noexcept { return ::std::addressof(this->data); }
+
+  storage_type data;
+  ::std::uint8_t tag;
+};
+
+template <class... Ts>
+void swap (variant<Ts...>& lhs, variant<Ts...>& rhs) noexcept(
+  noexcept(lhs.swap(rhs))
+) { lhs.swap(rhs); }
+
+template <::std::size_t I, class... Ts>
+auto get (variant<Ts...> const* v) noexcept -> enable_if_t<
+  I < sizeof...(Ts),
+  add_pointer_t<add_const_t<meta::element_t<I, meta::pack<Ts...>>>>
+> {
+  using t = add_pointer_t<add_const_t<meta::element_t<I, meta::pack<Ts...>>>>;
+  return v and v->which() == I
+    ? static_cast<t>(v->template cast<I>())
+    : nullptr;
+}
+
+template <::std::size_t I, class... Ts>
+auto get (variant<Ts...>* v) noexcept -> enable_if_t<
+  I < sizeof...(Ts),
+  add_pointer_t<meta::element_t<I, meta::pack<Ts...>>>
+> {
+  using t = add_pointer_t<meta::element_t<I, meta::pack<Ts...>>>;
+  return v and v->which() == I
+    ? static_cast<t>(v->template cast<I>())
+    : nullptr;
+}
+
+template <::std::size_t I, class... Ts>
+auto get (variant<Ts...> const& v) noexcept(false) -> enable_if_t<
+  I < sizeof...(Ts),
+  add_lvalue_reference_t<add_const_t<meta::element_t<I, meta::pack<Ts...>>>>
+> {
+  if (auto ptr = get<I>(::std::addressof(v))) { return *ptr; }
+  throw_bad_variant_get();
+}
+
+template <::std::size_t I, class... Ts>
+auto get (variant<Ts...>&& v) noexcept(false) -> enable_if_t<
+  I < sizeof...(Ts),
+  add_rvalue_reference_t<meta::element_t<I, meta::pack<Ts...>>>
+> {
+  if (auto p = get<I>(::std::addressof(v))) { return ::core::move(*p); }
+  throw_bad_variant_get();
+}
+
+template <::std::size_t I, class... Ts>
+auto get (variant<Ts...>& v) noexcept(false) -> enable_if_t<
+  I < sizeof...(Ts),
+  add_lvalue_reference_t<meta::element_t<I, meta::pack<Ts...>>>
+> {
+  if (auto ptr = get<I>(::std::addressof(v))) { return *ptr; }
+  throw_bad_variant_get();
+}
+
+template <class T, class... Ts>
+auto get (variant<Ts...> const* v) noexcept(false) -> enable_if_t<
+  not meta::find_t<T, meta::pack<Ts...>>::empty(),
+  decltype(get<meta::index<T, meta::pack<Ts...>>::value>(v))
+> { return get<meta::index<T, meta::pack<Ts...>>::value>(v); }
+
+template <class T, class... Ts>
+auto get (variant<Ts...>* v) noexcept(false) -> enable_if_t<
+  not meta::find_t<T, meta::pack<Ts...>>::empty(),
+  decltype(get<meta::index<T, meta::pack<Ts...>>::value>(v))
+> { return get<meta::index<T, meta::pack<Ts...>>::value>(v); }
+
+template <class T, class... Ts>
+auto get (variant<Ts...> const& v) noexcept(false) -> enable_if_t<
+  not meta::find_t<T, meta::pack<Ts...>>::empty(),
+  decltype(get<meta::index<T, meta::pack<Ts...>>::value>(v))
+> { return get<meta::index<T, meta::pack<Ts...>>::value>(v); }
+
+template <class T, class... Ts>
+auto get (variant<Ts...>&& v) noexcept(false) -> enable_if_t<
+  not meta::find_t<T, meta::pack<Ts...>>::empty(),
+  decltype(core::move(get<meta::index<T, meta::pack<Ts...>>::value>(v)))
+> { return core::move(get<meta::index<T, meta::pack<Ts...>>::value>(v)); }
+
+template <class T, class... Ts>
+auto get (variant<Ts...>& v) noexcept(false) -> enable_if_t<
+  not meta::find_t<T, meta::pack<Ts...>>::empty(),
+  decltype(get<meta::index<T, meta::pack<Ts...>>::value>(v))
+> { return get<meta::index<T, meta::pack<Ts...>>::value>(v); }
+
+}} /* namespace core::v1 */
+
+namespace std {
+
+template <class... Ts>
+struct hash<core::v1::variant<Ts...>> {
+  using argument_type = core::v1::variant<Ts...>;
+  using result_type = size_t;
+  result_type operator () (argument_type const& value) const {
+    return value.match(hash<Ts> { }...);
+  }
+};
+
+template <size_t I, class... Ts>
+[[gnu::deprecated]]
+auto get (::core::v1::variant<Ts...> const& v) noexcept(false) -> decltype(
+  ::core::v1::get<I>(v)
+) { return ::core::v1::get<I>(v); }
+
+template <size_t I, class... Ts>
+[[gnu::deprecated]]
+auto get (::core::v1::variant<Ts...>&& v) noexcept(false) -> decltype(
+  ::core::v1::get<I>(v)
+) { return ::core::v1::get<I>(v); }
+
+template <size_t I, class... Ts>
+[[gnu::deprecated]]
+auto get (::core::v1::variant<Ts...>& v) noexcept (false) -> decltype(
+  ::core::v1::get<I>(v)
+) { return ::core::v1::get<I>(v); }
+
+} /* namespace std */
+
+#endif /* CORE_VARIANT_HPP */

--- a/core/include/flyweight/cache.hpp
+++ b/core/include/flyweight/cache.hpp
@@ -1,0 +1,212 @@
+#ifndef FLYWEIGHT_CACHE_HPP
+#define FLYWEIGHT_CACHE_HPP
+
+#include <unordered_map>
+#include <algorithm>
+#include <memory>
+#include <mutex>
+
+#include <flyweight/extractor.hpp>
+#include <core/type_traits.hpp>
+
+namespace flyweight {
+inline namespace v1 {
+namespace impl {
+
+template <class T>
+using const_ref = core::add_lvalue_reference_t<core::add_const_t<T>>;
+
+template <class T, class KeyExtractor, class Allocator>
+struct container_traits final {
+
+  using allocator_type = typename std::allocator_traits<
+    Allocator
+  >::template rebind_alloc<T>;
+
+  using extractor_type = KeyExtractor;
+  using computed_key_type = core::decay_t<
+    decltype(
+      std::declval<const_ref<extractor_type>>()(std::declval<const_ref<T>>())
+    )
+  >;
+
+  using is_associative = std::integral_constant<
+    bool,
+    not std::is_same<
+      core::decay_t<T>,
+      core::decay_t<computed_key_type>
+    >::value
+  >;
+
+  using mapped_type = std::weak_ptr<core::add_const_t<T>>;
+  using key_type = core::conditional_t<
+    sizeof(computed_key_type) <=
+    sizeof(std::reference_wrapper<computed_key_type>) or
+    not is_associative::value,
+    computed_key_type,
+    std::reference_wrapper<core::add_const_t<computed_key_type>>
+  >;
+
+  using container_type = std::unordered_map<
+    key_type,
+    mapped_type,
+    std::hash<computed_key_type>,
+    std::equal_to<computed_key_type>,
+    typename std::allocator_traits<Allocator>::template rebind_alloc<
+      std::pair<core::add_const_t<key_type>, mapped_type>
+    >
+  >;
+};
+
+} /* namespace impl */
+
+template <class... Ts> struct tag final { };
+
+/* The cache acts as the backing store for the flyweight, and is partially
+ * inspired by the 'thread-safe reference counted object cache' suggested
+ * by Herb Sutter.
+ */
+template <
+  class T,
+  class KeyExtractor=extractor<T>,
+  class Allocator=std::allocator<T>,
+  class Tag=tag<>
+> struct cache final {
+
+  using traits = impl::container_traits<T, KeyExtractor, Allocator>;
+
+  /* All of these lining up is entirely a coincidence, I assure you */
+  using container_type = typename traits::container_type;
+  using extractor_type = typename traits::extractor_type;
+  using allocator_type = typename traits::allocator_type;
+  using is_associative = typename traits::is_associative;
+
+  using allocator_traits = std::allocator_traits<allocator_type>;
+  using key_type = typename container_type::key_type;
+  using tag_type = Tag;
+
+  using difference_type = typename container_type::difference_type;
+  using value_type = typename container_type::value_type;
+  using size_type = typename container_type::size_type;
+
+  using const_iterator = typename container_type::const_iterator;
+  using iterator = typename container_type::iterator;
+
+  using const_reference = typename container_type::const_reference;
+  using reference = typename container_type::reference;
+
+  using const_pointer = typename container_type::const_pointer;
+  using pointer = typename container_type::pointer;
+
+  cache (cache const&) = delete;
+  cache (cache&&) = delete;
+
+  cache& operator = (cache const&) = delete;
+  cache& operator = (cache&&) = delete;
+
+  static cache& ref () noexcept {
+    static cache instance;
+    return instance;
+  }
+
+  const_iterator begin () const noexcept { return std::begin(this->container); }
+  const_iterator end () const noexcept { return std::end(this->container); }
+
+  size_type size () const noexcept { return this->container.size(); }
+  bool empty () const noexcept { return this->container.empty(); }
+
+  template <class ValueType>
+  std::shared_ptr<core::add_const_t<T>> find (ValueType&& value) noexcept {
+    std::lock_guard<std::mutex> lock { this->mutex };
+    auto const& key = this->extractor(value);
+    auto iter = this->container.find(key);
+    if (iter != this->end()) { return iter->second.lock(); }
+    return this->insert(::std::forward<ValueType>(value), is_associative { });
+  }
+
+private:
+  iterator begin () noexcept { return std::begin(this->container); }
+  iterator end () noexcept { return std::end(this->container); }
+
+  template <class ValueType>
+  std::shared_ptr<core::add_const_t<T>> insert (
+    ValueType&& value,
+    std::false_type&&
+  ) noexcept {
+    auto result = this->container.emplace(
+      ::std::forward<ValueType>(value),
+      std::shared_ptr<core::add_const_t<T>> { }
+    );
+    auto iter = std::get<0>(result);
+    auto const& key = std::get<0>(*iter);
+    std::shared_ptr<core::add_const_t<T>> shared {
+      std::addressof(key),
+      [this](T const* ptr) { this->remove(ptr, std::false_type { }); }
+    };
+    this->container[key] = shared;
+    return shared;
+  }
+
+  template <class ValueType>
+  std::shared_ptr<core::add_const_t<T>> insert (
+    ValueType&& value,
+    std::true_type&&
+  ) noexcept {
+    auto ptr = allocator_traits::allocate(this->allocator, 1);
+    allocator_traits::construct(
+      this->allocator,
+      ptr,
+      ::std::forward<ValueType>(value)
+    );
+
+    auto const& key = this->extractor(*ptr);
+    std::shared_ptr<T> shared {
+      ptr,
+      [this](T const* ptr) { this->remove(ptr, std::true_type { }); }
+    };
+    auto result = this->container.emplace(key, shared);
+    auto pair = std::get<0>(result);
+    return pair->second.lock();
+  }
+
+  void remove (T const* ptr, std::false_type&&) noexcept {
+    if (not ptr) { return; }
+    std::lock_guard<std::mutex> lock { this->mutex };
+    this->container.erase(*ptr);
+  }
+
+  void remove (T const* ptr, std::true_type&&) noexcept {
+    if (not ptr) { return; }
+    /* We don't want to keep the mutex locked after we've removed the weak_ptr */
+    {
+      std::lock_guard<std::mutex> lock { this->mutex };
+      auto const& key = this->extractor(*ptr);
+      this->container.erase(key);
+    }
+    allocator_traits::destroy(this->allocator, ptr);
+    /* It is OK for us to const_cast here.
+     * Because you CANNOT have an allocator to a T const, this means that it
+     * can ONLY allocate a non-const pointer. And when is it ok to const_cast?
+     * If the original object was declared as non-const (which it was). Now,
+     * granted we've been copying the const pointer from shared_ptr to
+     * shared_ptr, but, the object located at ptr has already been destroyed,
+     * and now we're attempting to inform the allocator that the *mutable*
+     * ptr it allocated is now to be deallocated. HENCE, THIS IS LEGAL.
+     *
+     * *DOINK* *DOINK*
+     */
+    allocator_traits::deallocate(this->allocator, const_cast<T*>(ptr), 1);
+  }
+
+  cache () = default;
+  ~cache () = default;
+
+  container_type container;
+  allocator_type allocator;
+  extractor_type extractor;
+  std::mutex mutex;
+};
+
+}} /* namespace flyweight::v1 */
+
+#endif /* FLYWEIGHT_CACHE_HPP */

--- a/core/include/flyweight/extractor.hpp
+++ b/core/include/flyweight/extractor.hpp
@@ -1,0 +1,18 @@
+#ifndef FLYWEIGHT_EXTRACTOR_HPP
+#define FLYWEIGHT_EXTRACTOR_HPP
+
+#include <core/type_traits.hpp>
+
+namespace flyweight {
+inline namespace v1 {
+
+template <class T>
+struct extractor {
+  constexpr extractor () noexcept { }
+
+  T const& operator () (T const& argument) const noexcept { return argument; }
+};
+
+}} /* namespace flyweight::v1 */
+
+#endif /* FLYWEIGHT_EXTRACTOR_HPP */

--- a/core/include/flyweight/object.hpp
+++ b/core/include/flyweight/object.hpp
@@ -1,0 +1,175 @@
+#ifndef FLYWEIGHT_OBJECT_HPP
+#define FLYWEIGHT_OBJECT_HPP
+
+#include <memory>
+
+#include <flyweight/extractor.hpp>
+#include <flyweight/cache.hpp>
+
+namespace flyweight {
+inline namespace v1 {
+
+template <
+  class T,
+  class KeyExtractor=extractor<T>,
+  class Allocator=std::allocator<T>,
+  class Tag=tag<>
+> struct object final {
+
+  using cache_type = cache<T, KeyExtractor, Allocator, Tag>;
+
+  using value_type = core::add_const_t<T>;
+  using key_type = typename cache_type::key_type;
+
+
+  static_assert(
+    not std::is_reference<value_type>::value,
+    "Cannot have a reference for a value_type"
+  );
+
+  using reference = core::add_lvalue_reference_t<value_type>;
+  using pointer = core::add_pointer_t<value_type>;
+
+  template <
+    class... Args,
+    class=core::enable_if_t<
+      core::all_traits<
+        core::no_traits<std::is_same<core::decay_t<Args>, object>...>,
+        std::is_constructible<value_type, Args...>
+      >::value
+    >
+  > object (Args&&... args) : object {
+    value_type { ::std::forward<Args>(args)... }
+  } { }
+
+  template <
+    class ValueType,
+    class=core::enable_if_t<
+      std::is_same<core::decay_t<ValueType>, core::decay_t<value_type>>::value
+    >
+  > explicit object (ValueType&& value) : handle {
+    cache_type::ref().find(::std::forward<ValueType>(value))
+  } { }
+
+  object (object const&) = default;
+  object (object&&) = delete;
+  object () : object { value_type { } } { }
+  ~object () = default;
+
+  object& operator = (object const&) = default;
+  object& operator = (object&&) = delete;
+
+  template <
+    class ValueType,
+    class=core::enable_if_t<
+      not std::is_same<object, core::decay_t<ValueType>>::value
+    >
+  > object& operator = (ValueType&& value) {
+    object { ::std::forward<ValueType>(value) }.swap(*this);
+    return *this;
+  }
+
+  void swap (object& that) noexcept {
+    using std::swap;
+    swap(this->handle, that.handle);
+  }
+
+  pointer operator -> () const noexcept { return this->handle.get(); }
+  operator reference () const noexcept { return this->get(); }
+
+  reference get () const noexcept { return *this->handle; }
+
+private:
+  std::shared_ptr<value_type> handle;
+};
+
+template <class U, class E, class A, class T>
+bool operator == (
+  object<U, E, A, T> const& lhs,
+  object<U, E, A, T> const& rhs
+) noexcept { return std::equal_to<U> { }(lhs, rhs); }
+
+template <class U, class E, class A, class T>
+bool operator != (
+  object<U, E, A, T> const& lhs,
+  object<U, E, A, T> const& rhs
+) noexcept { return std::not_equal_to<U> { }(lhs, rhs); }
+
+template <class U, class E, class A, class T>
+bool operator >= (
+  object<U, E, A, T> const& lhs,
+  object<U, E, A, T> const& rhs
+) noexcept { return std::greater_equal<U> { }(lhs, rhs); }
+
+template <class U, class E, class A, class T>
+bool operator <= (
+  object<U, E, A, T> const& lhs,
+  object<U, E, A, T> const& rhs
+) noexcept { return std::less_equal<U> { }(lhs, rhs); }
+
+template <class U, class E, class A, class T>
+bool operator > (
+  object<U, E, A, T> const& lhs,
+  object<U, E, A, T> const& rhs
+) noexcept { return std::greater<U> { }(lhs, rhs); }
+
+template <class U, class E, class A, class T>
+bool operator < (
+  object<U, E, A, T> const& lhs,
+  object<U, E, A, T> const& rhs
+) noexcept { return std::less<U> { }(lhs, rhs); }
+
+template <class U, class E, class A, class T>
+bool operator == (object<U, E, A, T> const& lhs, U const& rhs) {
+  return std::equal_to<U> { }(lhs, rhs);
+}
+
+template <class U, class E, class A, class T>
+bool operator != (object<U, E, A, T> const& lhs, U const& rhs) {
+  return std::not_equal_to<U> { }(lhs, rhs);
+}
+
+template <class U, class E, class A, class T>
+bool operator >= (object<U, E, A, T> const& lhs, U const& rhs) {
+  return std::greater_equal<U> { }(lhs, rhs);
+}
+
+template <class U, class E, class A, class T>
+bool operator <= (object<U, E, A, T> const& lhs, U const& rhs) {
+  return std::less_equal<U> { }(lhs, rhs);
+}
+
+template <class U, class E, class A, class T>
+bool operator > (object<U, E, A, T> const& lhs, U const& rhs) {
+  return std::greater<U> { }(lhs, rhs);
+}
+
+template <class U, class E, class A, class T>
+bool operator < (object<U, E, A, T> const& lhs, U const& rhs) {
+  return std::less<U> { }(lhs, rhs);
+}
+
+template <class U, class E, class A, class T>
+void swap (object<U, E, A, T>& lhs, object<U, E, A, T>& rhs) noexcept(
+  noexcept(lhs.swap(rhs))
+) { return lhs.swap(rhs); }
+
+}} /* namespace flyweight::v1 */
+
+namespace std {
+
+template <class U, class E, class A, class T>
+struct hash<flyweight::v1::object<U, E, A, T>> {
+  using argument_type = flyweight::v1::object<U, E, A, T>;
+  using result_type = typename hash<
+    typename argument_type::value_type
+  >::result_type;
+
+  result_type operator ()(argument_type const& value) const noexcept {
+    return hash<typename argument_type::value_type> { }(value);
+  }
+};
+
+} /* namespace std */
+
+#endif /* FLYWEIGHT_OBJECT_HPP */

--- a/core/src/data/filters.h
+++ b/core/src/data/filters.h
@@ -125,15 +125,15 @@ namespace Tangram {
 
             auto ctxIt = ctx.find(key);
             if (ctxIt != ctx.end()) {
-                if (typeid(float) == ctxIt->second.type()) {
-                    float val = core::get<1>(ctxIt->second);
+                if (ctxIt->second.is<float>()) {
+                    float val = ctxIt->second.get<float>();
                     return val >= min && val < max;
                 }
             }
             auto numIt = feat.props.find(key);
             if (numIt != feat.props.end()) {
-                if (typeid(float) == numIt->second.type()) {
-                    float num = core::get<1>(numIt->second);
+                if (numIt->second.is<float>()) {
+                    float num = numIt->second.get<float>();
                     return num >= min && num < max;
                 }
             }

--- a/core/src/data/filters.h
+++ b/core/src/data/filters.h
@@ -7,49 +7,9 @@
 
 namespace Tangram {
 
-    struct Value {
+    using ValueList = std::vector<Value>;
 
-        float num;
-        std::string str;
-
-        virtual bool equals(float f) const = 0;
-        virtual bool equals(const std::string& s) const = 0;
-        virtual bool equals(const Value& v) const = 0;
-
-        virtual ~Value() {};
-
-        Value(float n) : num(n) {}
-        Value(float n, const std::string& s) : num(n), str(s) {}
-        Value(const std::string& s) : str(s) {}
-
-    };
-
-    struct NumValue : public Value {
-
-        NumValue(float n) : Value(n) {}
-        NumValue(float n, const std::string& s) : Value(n, s) {}
-        ~NumValue() {}
-
-        virtual bool equals(const std::string& s) const override { return str.size() != 0 && str == s; }
-        virtual bool equals(float f) const override { return num == f; }
-        virtual bool equals(const Value& v) const override { return v.equals(num); }
-
-    };
-
-    struct StrValue : public Value {
-
-        StrValue(const std::string& s) : Value(s) {}
-        ~StrValue() {}
-
-        virtual bool equals(const std::string& s) const override { return str == s; }
-        virtual bool equals(float f) const override { return false; }
-        virtual bool equals(const Value& v) const override { return v.equals(str); }
-
-    };
-
-    using ValueList = std::vector<Value*>;
-
-    using Context = std::unordered_map<std::string, Value*>;
+    using Context = std::unordered_map<std::string, Value>;
 
     struct Filter {
 
@@ -121,8 +81,7 @@ namespace Tangram {
         virtual bool eval(const Feature& feat, const Context& ctx) const override {
 
             bool found = ctx.find(key) != ctx.end() ||
-                         feat.props.stringProps.find(key) != feat.props.stringProps.end() ||
-                         feat.props.numericProps.find(key) != feat.props.numericProps.end();
+                         feat.props.find(key) != feat.props.end();
 
             return exists == found;
         }
@@ -133,28 +92,21 @@ namespace Tangram {
 
         ValueList values;
 
-        Equality(const std::string& k, const ValueList& v) : Predicate(k), values(v) {}
-        ~Equality() { for (auto* v : values) { delete v; } }
+        Equality(const std::string& k, const ValueList v) : Predicate(k), values(std::move(v)) {}
+        //~Equality() { for (auto* v : values) { delete v; } }
 
         virtual bool eval(const Feature& feat, const Context& ctx) const override {
-
             auto ctxIt = ctx.find(key);
             if (ctxIt != ctx.end()) {
-                for (auto* v : values) {
-                    if (v->equals(*ctxIt->second)) { return true; }
+                for (auto& v : values) {
+                    if (v == ctxIt->second) { return true; }
                 }
                 return false;
             }
-            auto strIt = feat.props.stringProps.find(key);
-            if (strIt != feat.props.stringProps.end()) {
-                for (auto* v : values) {
-                    if (v->equals(strIt->second)) { return true; }
-                }
-            }
-            auto numIt = feat.props.numericProps.find(key);
-            if (numIt != feat.props.numericProps.end()) {
-                for (auto* v : values) {
-                    if (v->equals(numIt->second)) { return true; }
+            auto strIt = feat.props.find(key);
+            if (strIt != feat.props.end()) {
+                for (auto& v : values) {
+                    if (v == strIt->second) { return true; }
                 }
             }
             return false;
@@ -173,14 +125,17 @@ namespace Tangram {
 
             auto ctxIt = ctx.find(key);
             if (ctxIt != ctx.end()) {
-                const auto& val = *ctxIt->second;
-                if (!val.equals(val.num)) { return false; } // only check range for numbers
-                return val.num >= min && val.num < max;
+                if (typeid(float) == ctxIt->second.type()) {
+                    float val = core::get<1>(ctxIt->second);
+                    return val >= min && val < max;
+                }
             }
-            auto numIt = feat.props.numericProps.find(key);
-            if (numIt != feat.props.numericProps.end()) {
-                const auto& num = numIt->second;
-                return num >= min && num < max;
+            auto numIt = feat.props.find(key);
+            if (numIt != feat.props.end()) {
+                if (typeid(float) == numIt->second.type()) {
+                    float num = core::get<1>(numIt->second);
+                    return num >= min && num < max;
+                }
             }
             return false;
         }

--- a/core/src/data/filters.h
+++ b/core/src/data/filters.h
@@ -93,7 +93,6 @@ namespace Tangram {
         ValueList values;
 
         Equality(const std::string& k, const ValueList v) : Predicate(k), values(std::move(v)) {}
-        //~Equality() { for (auto* v : values) { delete v; } }
 
         virtual bool eval(const Feature& feat, const Context& ctx) const override {
             auto ctxIt = ctx.find(key);

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "flyweight/object.hpp"
+
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -63,11 +65,29 @@ typedef std::vector<Point> Line;
 
 typedef std::vector<Line> Polygon;
 
+
+    
+typedef flyweight::object<std::string> TagKey;
+
+static TagKey TAG_KEY_NAME { "name" };
+static TagKey TAG_KEY_HEIGHT { "height" };
+static TagKey TAG_KEY_MIN_HEIGHT { "min_height" };
+static TagKey TAG_KEY_ZOOM { "zoom" };
+static TagKey TAG_KEY_SORT_KEY { "sort_key" };
+
+namespace std
+{
+template <> struct hash<TagKey>
+{
+  std::size_t operator()(const TagKey& str) const {
+    return hash<std::string>()(str);
+    }
+};
+}
+
 struct Properties {
-    
-    std::unordered_map<std::string, std::string> stringProps;
-    std::unordered_map<std::string, float> numericProps;
-    
+    std::unordered_map<TagKey, std::string> stringProps;
+    std::unordered_map<TagKey, float> numericProps;
 };
 
 struct Feature {

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "flyweight/object.hpp"
-#include "core/variant.hpp"
+#include "variant/variant.hpp"
 
 #include <vector>
 #include <string>
@@ -68,7 +68,8 @@ typedef std::vector<Point> Line;
 typedef std::vector<Line> Polygon;
 
 using TagKey = flyweight::object<std::string>;
-using Value = core::variant<std::string, float>;
+
+using Value = mapbox::util::variant<std::string, float>;
 
 static TagKey TAG_KEY_NAME { "name" };
 static TagKey TAG_KEY_HEIGHT { "height" };
@@ -94,26 +95,23 @@ class Props {
     auto it = _props.find(_key);
     if(it == _props.end())
       return _fallback;
-    
-    auto* result = core::get<0>(&it->second);
-    if (!result)
+
+    if (!it->second.is<std::string>())
       return _fallback;
 
-    return *result;
-  };
+    return it->second.get<std::string>();
+  }
 
   static float GetFloat(const Properties& _props, const TagKey& _key, float _fallback) {
     auto it = _props.find(_key);
     if(it == _props.end())
       return _fallback;
-    
-    auto* result = core::get<1>(&it->second);
 
-    if (!result)
+    if (!it->second.is<float>())
       return _fallback;
 
-    return *result;
-  };
+    return it->second.get<float>();
+  }
 };
 
 struct Feature {

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "flyweight/object.hpp"
+#include "core/variant.hpp"
 
 #include <vector>
 #include <string>
 #include <unordered_map>
+
 #include "glm/vec3.hpp"
 
 /* Notes on TileData implementation:
@@ -65,9 +67,8 @@ typedef std::vector<Point> Line;
 
 typedef std::vector<Line> Polygon;
 
-
-    
-typedef flyweight::object<std::string> TagKey;
+using TagKey = flyweight::object<std::string>;
+using Value = core::variant<std::string, float>;
 
 static TagKey TAG_KEY_NAME { "name" };
 static TagKey TAG_KEY_HEIGHT { "height" };
@@ -85,9 +86,34 @@ template <> struct hash<TagKey>
 };
 }
 
-struct Properties {
-    std::unordered_map<TagKey, std::string> stringProps;
-    std::unordered_map<TagKey, float> numericProps;
+typedef std::unordered_map<TagKey, Value> Properties;
+
+class Props {
+ public:
+  static const std::string& GetString(const Properties& _props, const TagKey& _key, const std::string& _fallback) {
+    auto it = _props.find(_key);
+    if(it == _props.end())
+      return _fallback;
+    
+    auto* result = core::get<0>(&it->second);
+    if (!result)
+      return _fallback;
+
+    return *result;
+  };
+
+  static float GetFloat(const Properties& _props, const TagKey& _key, float _fallback) {
+    auto it = _props.find(_key);
+    if(it == _props.end())
+      return _fallback;
+    
+    auto* result = core::get<1>(&it->second);
+
+    if (!result)
+      return _fallback;
+
+    return *result;
+  };
 };
 
 struct Feature {

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -17,6 +17,19 @@ typedef long long jlong;
 void setupJniEnv(JNIEnv* _jniEnv, jobject _tangramInstance, jobject _assetManager);
 void onUrlSuccess(JNIEnv* jniEnv, jbyteArray jFetchedBytes, jlong jCallbackPtr);
 void onUrlFailure(JNIEnv* jniEnv, jlong jCallbackPtr);
+
+// FIXME - this just here for a borken NDK
+#include <sstream>
+namespace std {
+template <typename T>
+std::string to_string(T value)
+{
+    std::ostringstream os ;
+    os << value ;
+    return os.str() ;
+}
+}
+
 #endif
 
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -335,7 +335,7 @@ Filter* SceneLoader::generatePredicate(YAML::Node _node, std::string _key) {
 
     if(_node.IsScalar()) {
         try {
-            return (new Equality(_key, { new NumValue(_node.as<float>(), _node.as<std::string>()) }));
+            return (new Equality(_key, {{_node.as<float>() }}));
         } catch(const BadConversion& e) {
             std::string value = _node.as<std::string>();
             if(value == "true") {
@@ -343,17 +343,17 @@ Filter* SceneLoader::generatePredicate(YAML::Node _node, std::string _key) {
             } else if(value == "false") {
                 return (new Existence(_key, false));
             } else {
-                return (new Equality(_key, {new StrValue(value)}));
+                return (new Equality(_key, {{ value }}));
             }
         }
     } else if(_node.IsSequence()) {
         ValueList values;
         for(YAML::const_iterator valItr = _node.begin(); valItr != _node.end(); ++valItr) {
             try {
-                values.emplace_back(new NumValue(valItr->as<float>(), valItr->as<std::string>()));
+                values.emplace_back(valItr->as<float>());
             } catch(const BadConversion& e) {
                 std::string value = valItr->as<std::string>();
-                values.emplace_back(new StrValue(value));
+                values.emplace_back(value);
             }
         }
         return (new Equality(_key, std::move(values)));

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -92,12 +92,12 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties
     GLfloat layer = params->order;
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::PROXY_COLORS)) {
-        abgr = abgr << (int(_props.numericProps[TAG_KEY_ZOOM]) % 6);
+        abgr = abgr << (int(Props::GetFloat(_props, TAG_KEY_ZOOM, 0.0f)) % 6);
     }
-
-    float height = _props.numericProps[TAG_KEY_HEIGHT]; // Inits to zero if not present in data
-    float minHeight = _props.numericProps[TAG_KEY_MIN_HEIGHT]; // Inits to zero if not present in data
-
+    
+    float height = Props::GetFloat(_props, TAG_KEY_HEIGHT, 0.0f); // Inits to zero if not present in data
+    float minHeight = Props::GetFloat(_props, TAG_KEY_MIN_HEIGHT, 0.0f); // Inits to zero if not present in data
+    
     if (minHeight != height) {
         for (auto& line : _polygon) {
             for (auto& point : line) {

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -92,11 +92,11 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties
     GLfloat layer = params->order;
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::PROXY_COLORS)) {
-        abgr = abgr << (int(_props.numericProps["zoom"]) % 6);
+        abgr = abgr << (int(_props.numericProps[TAG_KEY_ZOOM]) % 6);
     }
 
-    float height = _props.numericProps["height"]; // Inits to zero if not present in data
-    float minHeight = _props.numericProps["min_height"]; // Inits to zero if not present in data
+    float height = _props.numericProps[TAG_KEY_HEIGHT]; // Inits to zero if not present in data
+    float minHeight = _props.numericProps[TAG_KEY_MIN_HEIGHT]; // Inits to zero if not present in data
 
     if (minHeight != height) {
         for (auto& line : _polygon) {

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -113,7 +113,7 @@ void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props
     GLuint abgr = params->color;
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::PROXY_COLORS)) {
-        abgr = abgr << (int(_props.numericProps["zoom"]) % 6);
+        abgr = abgr << (int(_props.numericProps[TAG_KEY_ZOOM]) % 6);
     }
 
     GLfloat layer = _props.numericProps["sort_key"] + params->order;

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -113,13 +113,13 @@ void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props
     GLuint abgr = params->color;
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::PROXY_COLORS)) {
-        abgr = abgr << (int(_props.numericProps[TAG_KEY_ZOOM]) % 6);
+        abgr = abgr << (int(Props::GetFloat(_props, TAG_KEY_ZOOM, 0.0f)) % 6);
     }
-
-    GLfloat layer = _props.numericProps["sort_key"] + params->order;
-
+    
+    GLfloat layer = Props::GetFloat(_props, TAG_KEY_SORT_KEY, 0) + params->order;
+    
     float halfWidth = params->width * .5f;
-
+    
     PolyLineOutput lineOutput = { points, indices, scalingVecs, texcoords };
     PolyLineOptions lineOptions = { params->cap, params->join, halfWidth };
     Builders::buildPolyLine(_line, lineOptions, lineOutput);

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -65,7 +65,7 @@ void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapPr
              *     NOTE: for the time being use layerName as ID for cache
              */
 
-            feature.props.numericProps.emplace("zoom", _tile.getID().z);
+            feature.props.emplace(TAG_KEY_ZOOM, _tile.getID().z);
 
             switch (feature.geometryType) {
                 case GeometryType::POINTS:

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -65,7 +65,7 @@ void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapPr
              *     NOTE: for the time being use layerName as ID for cache
              */
 
-            feature.props.numericProps["zoom"] = _tile.getID().z;
+            feature.props.numericProps.emplace("zoom", _tile.getID().z);
 
             switch (feature.geometryType) {
                 case GeometryType::POINTS:

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -163,9 +163,11 @@ void TextStyle::buildPolygon(Polygon& _polygon, void* _styleParams, Properties& 
         ftContext->setSignedDistanceField(blurSpread);
     }
 
-    for (const auto& prop : _props.stringProps) {
+    for (const auto& prop : _props) {
         if (prop.first == TAG_KEY_NAME) {
-            labelContainer->addLabel(*TextStyle::s_processedTile, m_name, { glm::vec2(centroid), glm::vec2(centroid) }, prop.second, Label::Type::POINT);
+            labelContainer->addLabel(*TextStyle::s_processedTile, m_name,
+                                     { glm::vec2(centroid), glm::vec2(centroid) },
+                                     core::get<0>(prop.second), Label::Type::POINT);
         }
     }
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -163,8 +163,8 @@ void TextStyle::buildPolygon(Polygon& _polygon, void* _styleParams, Properties& 
         ftContext->setSignedDistanceField(blurSpread);
     }
 
-    for (auto& prop : _props.stringProps) {
-        if (prop.first == "name") {
+    for (const auto& prop : _props.stringProps) {
+        if (prop.first == TAG_KEY_NAME) {
             labelContainer->addLabel(*TextStyle::s_processedTile, m_name, { glm::vec2(centroid), glm::vec2(centroid) }, prop.second, Label::Type::POINT);
         }
     }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -163,7 +163,7 @@ void TextStyle::buildPolygon(Polygon& _polygon, void* _styleParams, Properties& 
         ftContext->setSignedDistanceField(blurSpread);
     }
 
-    for (auto prop : _props.stringProps) {
+    for (auto& prop : _props.stringProps) {
         if (prop.first == "name") {
             labelContainer->addLabel(*TextStyle::s_processedTile, m_name, { glm::vec2(centroid), glm::vec2(centroid) }, prop.second, Label::Type::POINT);
         }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -167,7 +167,7 @@ void TextStyle::buildPolygon(Polygon& _polygon, void* _styleParams, Properties& 
         if (prop.first == TAG_KEY_NAME) {
             labelContainer->addLabel(*TextStyle::s_processedTile, m_name,
                                      { glm::vec2(centroid), glm::vec2(centroid) },
-                                     core::get<0>(prop.second), Label::Type::POINT);
+                                     prop.second.get<std::string>(), Label::Type::POINT);
         }
     }
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -96,10 +96,10 @@ void TextStyle::buildLine(Line& _line, void* _styleParams, Properties& _props, V
         ftContext->setSignedDistanceField(blurSpread);
     }
 
-    int lineLength = _line.size();
-    int skipOffset = floor(lineLength / 2);
-    float minLength = 0.15; // default, probably need some more thoughts
-
+    // int lineLength = _line.size();
+    // int skipOffset = floor(lineLength / 2);
+    // float minLength = 0.15; // default, probably need some more thoughts
+    
     // if (_layer == "roads") {
     //     for (auto prop : _props.stringProps) {
     //         if (prop.first.compare("name") == 0) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<TextBuffer> FontContext::getCurrentBuffer() {
     return m_currentBuffer.lock();
 }
 
-bool FontContext::addFont(std::string _fontFile, std::string _name) {
+bool FontContext::addFont(const std::string& _fontFile, const std::string& _name) {
     if (m_fonts.find(_name) != m_fonts.end()) {
         return true;
     }
@@ -73,7 +73,7 @@ bool FontContext::addFont(std::string _fontFile, std::string _name) {
     return true;
 }
 
-void FontContext::setFont(std::string _name, int size) {
+void FontContext::setFont(const std::string& _name, int size) {
     auto it = m_fonts.find(_name);
 
     if (it != m_fonts.end()) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<TextBuffer> FontContext::getCurrentBuffer() {
     return m_currentBuffer.lock();
 }
 
-bool FontContext::addFont(const std::string& _fontFile, const std::string& _name) {
+bool FontContext::addFont(const std::string& _fontFile, std::string _name) {
     if (m_fonts.find(_name) != m_fonts.end()) {
         return true;
     }
@@ -68,7 +68,7 @@ bool FontContext::addFont(const std::string& _fontFile, const std::string& _name
         return false;
     }
 
-    m_fonts[_name] = m_font;
+    m_fonts.emplace(std::move(_name), m_font);
 
     return true;
 }

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -22,10 +22,10 @@ public:
     ~FontContext();
 
     /* adds a font from a .ttf font file with a specific name */
-    bool addFont(std::string _fontFile, std::string _name);
+    bool addFont(const std::string& _fontFile, const std::string& _name);
 
     /* sets the current font for a size in pixels */
-    void setFont(std::string _name, int size);
+    void setFont(const std::string& _name, int size);
 
     /* sets the blur spread when using signed distance field rendering */
     void setSignedDistanceField(float _blurSpread);

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -22,7 +22,7 @@ public:
     ~FontContext();
 
     /* adds a font from a .ttf font file with a specific name */
-    bool addFont(const std::string& _fontFile, const std::string& _name);
+    bool addFont(const std::string& _fontFile, std::string _name);
 
     /* sets the current font for a size in pixels */
     void setFont(const std::string& _name, int size);

--- a/core/src/util/geoJson.cpp
+++ b/core/src/util/geoJson.cpp
@@ -42,20 +42,20 @@ void GeoJson::extractFeature(const rapidjson::Value& _in, Feature& _out, const M
         
         // height and minheight need to be handled separately so that their dimensions are normalized
         if (strcmp(member, "height") == 0) {
-            _out.props.numericProps[member] = prop.GetDouble() * _tile.getInverseScale();
+            _out.props.numericProps.emplace(member, prop.GetDouble() * _tile.getInverseScale());
             continue;
         }
         
         if (strcmp(member, "min_height") == 0) {
-            _out.props.numericProps[member] = prop.GetDouble() * _tile.getInverseScale();
+            _out.props.numericProps.emplace(member, prop.GetDouble() * _tile.getInverseScale());
             continue;
         }
         
         
         if (prop.IsNumber()) {
-            _out.props.numericProps[member] = prop.GetDouble();
+            _out.props.numericProps.emplace(member, prop.GetDouble());
         } else if (prop.IsString()) {
-            _out.props.stringProps[member] = prop.GetString();
+            _out.props.stringProps.emplace(member, prop.GetString());
         }
         
     }

--- a/core/src/util/geoJson.cpp
+++ b/core/src/util/geoJson.cpp
@@ -29,7 +29,6 @@ void GeoJson::extractPoly(const rapidjson::Value& _in, Polygon& _out, const MapT
 }
 
 void GeoJson::extractFeature(const rapidjson::Value& _in, Feature& _out, const MapTile& _tile) {
-    
     // Copy properties into tile data
     
     const rapidjson::Value& properties = _in["properties"];
@@ -42,20 +41,20 @@ void GeoJson::extractFeature(const rapidjson::Value& _in, Feature& _out, const M
         
         // height and minheight need to be handled separately so that their dimensions are normalized
         if (strcmp(member, "height") == 0) {
-            _out.props.numericProps.emplace(member, prop.GetDouble() * _tile.getInverseScale());
+            _out.props.emplace(member, prop.GetDouble() * _tile.getInverseScale());
             continue;
         }
         
         if (strcmp(member, "min_height") == 0) {
-            _out.props.numericProps.emplace(member, prop.GetDouble() * _tile.getInverseScale());
+            _out.props.emplace(member, prop.GetDouble() * _tile.getInverseScale());
             continue;
         }
         
         
         if (prop.IsNumber()) {
-            _out.props.numericProps.emplace(member, prop.GetDouble());
+            _out.props.emplace(member, prop.GetDouble());
         } else if (prop.IsString()) {
-            _out.props.stringProps.emplace(member, prop.GetString());
+            _out.props.emplace(member, prop.GetString());
         }
         
     }
@@ -107,7 +106,6 @@ void GeoJson::extractFeature(const rapidjson::Value& _in, Feature& _out, const M
         }
         
     }
-    
 }
 
 void GeoJson::extractLayer(const rapidjson::Value& _in, Layer& _out, const MapTile& _tile) {

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -108,11 +108,11 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, con
                         if(key.compare("height") == 0 || key.compare("min_height") == 0) {
                             numVal *= _tile.getInverseScale();
                         }
-                        _out.props.numericProps.emplace(key, numVal);
+                        _out.props.emplace(key, numVal);
                         
                     } else {
                         
-                        _out.props.stringProps.emplace(key, strVal);
+                        _out.props.emplace(key, strVal);
                         
                     }
                 }

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -108,11 +108,11 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, con
                         if(key.compare("height") == 0 || key.compare("min_height") == 0) {
                             numVal *= _tile.getInverseScale();
                         }
-                        _out.props.numericProps[key] = numVal;
+                        _out.props.numericProps.emplace(key, numVal);
                         
                     } else {
                         
-                        _out.props.stringProps[key] = strVal;
+                        _out.props.stringProps.emplace(key, strVal);
                         
                     }
                 }

--- a/core/src/util/texture.h
+++ b/core/src/util/texture.h
@@ -37,7 +37,7 @@ public:
     Texture(const std::string& _file,
             TextureOptions _options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}});
 
-    ~Texture();
+    virtual ~Texture();
 
     /* Binds the texture to the specified slot */
     void bind(GLuint _textureSlot);

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -18,39 +18,32 @@ Feature civic, bmw1, bike;
 
 void init() {
 
-    civic.props.stringProps.clear();
-    civic.props.numericProps.clear();
-    civic.props.stringProps["name"] = "civic";
-    civic.props.stringProps["brand"] = "honda";
-    civic.props.numericProps["wheel"] = 4;
-    civic.props.stringProps["drive"] = "fwd";
-    civic.props.stringProps["type"] = "car";
+    civic.props.clear();
+    civic.props.emplace("name", "civic");
+    civic.props.emplace("brand", "honda");
+    civic.props.emplace("wheel", 4);
+    civic.props.emplace("drive", "fwd");
+    civic.props.emplace("type", "car");
 
-    bmw1.props.stringProps.clear();
-    bmw1.props.numericProps.clear();
-    bmw1.props.stringProps["name"] = "bmw320i";
-    bmw1.props.stringProps["brand"] = "bmw";
-    bmw1.props.stringProps["check"] = "false";
-    bmw1.props.stringProps["series"] = "3";
-    bmw1.props.numericProps["wheel"] = 4;
-    bmw1.props.stringProps["drive"] = "all";
-    bmw1.props.stringProps["type"] = "car";
+    bmw1.props.clear();
+    bmw1.props.emplace("name", "bmw320i");
+    bmw1.props.emplace("brand", "bmw");
+    bmw1.props.emplace("check", "false");
+    bmw1.props.emplace("series", "3");
+    bmw1.props.emplace("wheel", 4);
+    bmw1.props.emplace("drive", "all");
+    bmw1.props.emplace("type", "car");
 
-    bike.props.stringProps.clear();
-    bike.props.numericProps.clear();
-    bike.props.stringProps["name"] = "cb1100";
-    bike.props.stringProps["brand"] = "honda";
-    bike.props.numericProps["wheel"] = 2;
-    bike.props.stringProps["type"] = "bike";
-    bike.props.stringProps["series"] = "CB";
-    bike.props.stringProps["check"] = "available";
+    bike.props.clear();
+    bike.props.emplace("name", "cb1100");
+    bike.props.emplace("brand", "honda");
+    bike.props.emplace("wheel", 2);
+    bike.props.emplace("type", "bike");
+    bike.props.emplace("series", "CB");
+    bike.props.emplace("check", "available");
 
-    for (auto& it : ctx) {
-        delete it.second;
-        it.second = nullptr;
-    }
-    ctx["$vroom"] = new NumValue(1);
-    ctx["$zooooom"] = new StrValue("false");
+    ctx.emplace("$vroom", 1.0f);
+    ctx.emplace("$zooooom", "false");
 }
 
 

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -29,7 +29,8 @@ void init() {
     bmw1.props.emplace("name", "bmw320i");
     bmw1.props.emplace("brand", "bmw");
     bmw1.props.emplace("check", "false");
-    bmw1.props.emplace("series", "3");
+    //bmw1.props.emplace("series", "3");
+    bmw1.props.emplace("series", 3);
     bmw1.props.emplace("wheel", 4);
     bmw1.props.emplace("drive", "all");
     bmw1.props.emplace("type", "car");

--- a/toolchains/android.toolchain.cmake
+++ b/toolchains/android.toolchain.cmake
@@ -29,7 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # ------------------------------------------------------------------------------
-#  Android CMake toolchain file, for use with the Android NDK r5-r10d
+#  Android CMake toolchain file, for use with the Android NDK r5-r10e
 #  Requires cmake 2.6.3 or newer (2.8.9 or newer is recommended).
 #  See home page: https://github.com/taka-no-me/android-cmake
 #
@@ -216,7 +216,7 @@ set( CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "" )
 set( CMAKE_SKIP_RPATH TRUE CACHE BOOL "If set, runtime paths are not added when using shared libraries." )
 
 # NDK search paths
-set( ANDROID_SUPPORTED_NDK_VERSIONS ${ANDROID_EXTRA_NDK_VERSIONS} -r10d -r10c -r10b -r10 -r9d -r9c -r9b -r9 -r8e -r8d -r8c -r8b -r8 -r7c -r7b -r7 -r6b -r6 -r5c -r5b -r5 "" )
+set( ANDROID_SUPPORTED_NDK_VERSIONS ${ANDROID_EXTRA_NDK_VERSIONS} -r10e -r10d -r10c -r10b -r10 -r9d -r9c -r9b -r9 -r8e -r8d -r8c -r8b -r8 -r7c -r7b -r7 -r6b -r6 -r5c -r5b -r5 "" )
 if( NOT DEFINED ANDROID_NDK_SEARCH_PATHS )
  if( CMAKE_HOST_WIN32 )
   file( TO_CMAKE_PATH "$ENV{PROGRAMFILES}" ANDROID_NDK_SEARCH_PATHS )
@@ -598,7 +598,7 @@ if( BUILD_WITH_ANDROID_NDK )
  endif()
  if( NOT __availableToolchains )
   file( GLOB __availableToolchainsLst RELATIVE "${ANDROID_NDK_TOOLCHAINS_PATH}" "${ANDROID_NDK_TOOLCHAINS_PATH}/*" )
-  if( __availableToolchains )
+  if( __availableToolchainsLst )
    list(SORT __availableToolchainsLst) # we need clang to go after gcc
   endif()
   __LIST_FILTER( __availableToolchainsLst "^[.]" )
@@ -833,7 +833,7 @@ set( ANDROID_STL_FORCE_FEATURES ON CACHE BOOL "automatically configure rtti and 
 mark_as_advanced( ANDROID_STL ANDROID_STL_FORCE_FEATURES )
 
 if( BUILD_WITH_ANDROID_NDK )
- if( NOT "${ANDROID_STL}" MATCHES "^(none|system|system_re|gabi\\+\\+_static|gabi\\+\\+_shared|stlport_static|stlport_shared|gnustl_static|gnustl_shared|c\\+\\+_shared)$")
+ if( NOT "${ANDROID_STL}" MATCHES "^(none|system|system_re|gabi\\+\\+_static|gabi\\+\\+_shared|c\\+\\+_static|c\\+\\+_shared|stlport_static|stlport_shared|gnustl_static|gnustl_shared)$")
   message( FATAL_ERROR "ANDROID_STL is set to invalid value \"${ANDROID_STL}\".
 The possible values are:
   none           -> Do not configure the runtime.
@@ -845,6 +845,8 @@ The possible values are:
   stlport_shared -> Use the STLport runtime as a shared library.
   gnustl_static  -> (default) Use the GNU STL as a static library.
   gnustl_shared  -> Use the GNU STL as a shared library.
+  c++_static     -> Use the libc++ (llvm) runtime as a static library.
+  c++_shared     -> Use the libc++ (llvm) runtime as a shared library.
 " )
  endif()
 elseif( BUILD_WITH_STANDALONE_TOOLCHAIN )
@@ -942,8 +944,6 @@ if( BUILD_WITH_STANDALONE_TOOLCHAIN )
    elseif( EXISTS "${ANDROID_STANDALONE_TOOLCHAIN}/${ANDROID_TOOLCHAIN_MACHINE_NAME}/lib/libgnustl_shared.so" )
     set( __libstl "${ANDROID_STANDALONE_TOOLCHAIN}/${ANDROID_TOOLCHAIN_MACHINE_NAME}/lib/libgnustl_shared.so" )
    endif()
-   elseif( ANDROID_STL STREQUAL "c\\+\\+_shared" )
-        # TODO : build with standalone c++_shared toolchain
   endif()
  endif()
 endif()
@@ -989,12 +989,24 @@ if( BUILD_WITH_ANDROID_NDK )
   set( ANDROID_STL_INCLUDE_DIRS "${ANDROID_NDK}/sources/cxx-stl/system/include" )
  elseif( ANDROID_STL MATCHES "gabi" )
   if( ANDROID_NDK_RELEASE_NUM LESS 7000 ) # before r7
-   message( FATAL_ERROR "gabi++ is not awailable in your NDK. You have to upgrade to NDK r7 or newer to use gabi++.")
+   message( FATAL_ERROR "gabi++ is not available in your NDK. You have to upgrade to NDK r7 or newer to use gabi++.")
   endif()
   set( ANDROID_RTTI             ON )
   set( ANDROID_EXCEPTIONS       OFF )
   set( ANDROID_STL_INCLUDE_DIRS "${ANDROID_NDK}/sources/cxx-stl/gabi++/include" )
   set( __libstl                 "${ANDROID_NDK}/sources/cxx-stl/gabi++/libs/${ANDROID_NDK_ABI_NAME}/libgabi++_static.a" )
+elseif( ANDROID_STL MATCHES "c\\+\\+" )
+  # if( ANDROID_NDK_RELEASE STRLESS "r9" )
+  #   message( FATAL_ERROR "c++ is not awailable in your NDK. You have to upgrade to NDK r9 or newer to use gabi++.")
+  # endif()
+  set( ANDROID_RTTI             ON )
+  set( ANDROID_EXCEPTIONS       ON )
+  set( ANDROID_STL_INCLUDE_DIRS
+    "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libcxx/include"
+    "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++abi/libcxxabi/include"
+    "${ANDROID_NDK}/sources/android/support/include")
+  set( __libstl
+    "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_NDK_ABI_NAME}/libc++_static.a" )
  elseif( ANDROID_STL MATCHES "stlport" )
   if( NOT ANDROID_NDK_RELEASE_NUM LESS 8004 ) # before r8d
    set( ANDROID_EXCEPTIONS       ON )
@@ -1028,24 +1040,6 @@ if( BUILD_WITH_ANDROID_NDK )
   else()
    set( __libstl                "${__libstl}/libs/${ANDROID_NDK_ABI_NAME}/libstdc++.a" )
   endif()
- elseif( ANDROID_STL MATCHES "c\\+\\+_shared" )
-    set( ANDROID_EXCEPTIONS       ON )
-    set( ANDROID_RTTI             ON )
-    set( ANDROID_CXX_ROOT     "${ANDROID_NDK}/sources/cxx-stl/" )
-    set( ANDROID_LLVM_ROOT    "${ANDROID_CXX_ROOT}/llvm-libc++" )
-    if( X86 ) 
-        set( ANDROID_ABI_INCLUDE_DIRS "${ANDROID_CXX_ROOT}/gabi++/include" )
-    else()
-        set( ANDROID_ABI_INCLUDE_DIRS "${ANDROID_CXX_ROOT}/llvm-libc++abi/include" )
-    endif()
-    set( ANDROID_STL_INCLUDE_DIRS     "${ANDROID_LLVM_ROOT}/libcxx/include" "${ANDROID_ABI_INCLUDE_DIRS}" )
-    # android support sfiles
-    include_directories ( SYSTEM ${ANDROID_NDK}/sources/android/support/include )
-    if( EXISTS "${ANDROID_LLVM_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/libc++_shared.so" )
-        set( __libstl                           "${ANDROID_LLVM_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/libc++_shared.so" )
-    else()
-        message( "c++ shared library doesn't exist" )
-    endif()
  else()
   message( FATAL_ERROR "Unknown runtime: ${ANDROID_STL}" )
  endif()
@@ -1118,7 +1112,12 @@ if( NOT CMAKE_C_COMPILER )
  endif()
  set( CMAKE_ASM_COMPILER "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-gcc${TOOL_OS_SUFFIX}"     CACHE PATH "assembler" )
  set( CMAKE_STRIP        "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-strip${TOOL_OS_SUFFIX}"   CACHE PATH "strip" )
- set( CMAKE_AR           "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-ar${TOOL_OS_SUFFIX}"      CACHE PATH "archive" )
+ if( EXISTS "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-gcc-ar${TOOL_OS_SUFFIX}" )
+  # Use gcc-ar if we have it for better LTO support.
+  set( CMAKE_AR           "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-gcc-ar${TOOL_OS_SUFFIX}"      CACHE PATH "archive" )
+ else()
+  set( CMAKE_AR           "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-ar${TOOL_OS_SUFFIX}"      CACHE PATH "archive" )
+ endif()
  set( CMAKE_LINKER       "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-ld${TOOL_OS_SUFFIX}"      CACHE PATH "linker" )
  set( CMAKE_NM           "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-nm${TOOL_OS_SUFFIX}"      CACHE PATH "nm" )
  set( CMAKE_OBJCOPY      "${ANDROID_TOOLCHAIN_ROOT}/bin/${ANDROID_TOOLCHAIN_MACHINE_NAME}-objcopy${TOOL_OS_SUFFIX}" CACHE PATH "objcopy" )
@@ -1508,9 +1507,9 @@ endif()
 set( CMAKE_INSTALL_PREFIX "${ANDROID_TOOLCHAIN_ROOT}/user" CACHE STRING "path for installing" )
 
 if( DEFINED LIBRARY_OUTPUT_PATH_ROOT
-      OR EXISTS "${CMAKE_SOURCE_DIR}/android/AndroidManifest.xml"
+      OR EXISTS "${CMAKE_SOURCE_DIR}/AndroidManifest.xml"
       OR (EXISTS "${CMAKE_SOURCE_DIR}/../AndroidManifest.xml" AND EXISTS "${CMAKE_SOURCE_DIR}/../jni/") )
-  set( LIBRARY_OUTPUT_PATH_ROOT ${CMAKE_SOURCE_DIR}/android CACHE PATH "Root for binaries output, set this to change where Android libs are installed to" )
+  set( LIBRARY_OUTPUT_PATH_ROOT ${CMAKE_SOURCE_DIR} CACHE PATH "Root for binaries output, set this to change where Android libs are installed to" )
   if( NOT _CMAKE_IN_TRY_COMPILE )
     if( EXISTS "${CMAKE_SOURCE_DIR}/jni/CMakeLists.txt" )
       set( EXECUTABLE_OUTPUT_PATH "${LIBRARY_OUTPUT_PATH_ROOT}/bin/${ANDROID_NDK_ABI_NAME}" CACHE PATH "Output directory for applications" )

--- a/toolchains/linux.tests.cmake
+++ b/toolchains/linux.tests.cmake
@@ -1,0 +1,41 @@
+# options
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
+
+add_definitions(-DPLATFORM_LINUX)
+
+# include headers for homebrew-installed libraries
+include_directories(/usr/local/include)
+
+# load core library
+add_subdirectory(${PROJECT_SOURCE_DIR}/core)
+include_directories(${CORE_INCLUDE_DIRS})
+include_directories(${CORE_LIBRARIES_INCLUDE_DIRS})
+
+set(LINUX_PLATFORM_SRC
+  ${PROJECT_SOURCE_DIR}/linux/src/platform_linux.cpp
+  ${PROJECT_SOURCE_DIR}/linux/src/urlWorker.cpp
+)
+
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GLFW REQUIRED glfw3)
+
+file(GLOB TEST_SOURCES tests/unit/*.cpp)
+
+# create an executable per test
+foreach(_src_file_path ${TEST_SOURCES})
+    string(REPLACE ".cpp" "" test_case ${_src_file_path})
+    string(REGEX MATCH "([^/]*)$" test_name ${test_case})
+
+    set(EXECUTABLE_NAME "${test_name}.out")
+
+    add_executable(${EXECUTABLE_NAME} ${_src_file_path} ${LINUX_PLATFORM_SRC})
+
+    target_link_libraries(${EXECUTABLE_NAME} -lcurl)
+    target_link_libraries(${EXECUTABLE_NAME} core ${GLFW_STATIC_LIBRARIES})
+endforeach(_src_file_path ${TEST_SOURCES})
+
+# copy resources in order to make tests with resources dependency
+file(GLOB_RECURSE RESOURCES ${PROJECT_SOURCE_DIR}/core/resources/*)
+foreach(_resource ${RESOURCES})
+    file(COPY ${_resource} DESTINATION ${PROJECT_SOURCE_DIR}/build/tests/unit/bin)
+endforeach()


### PR DESCRIPTION
These are just some experiments so far:
The idea is to avoid the many string copies for feature tag-keys  by using flyweight objects as string wrapper (aka intern String in Java). This also allows to test equality by object IDs for performance.

I've changed Properties to use variant for having a single Value type for both tag- and filter-values. The mnmlstc implementation works nicely, but the mapbox implementation has a slightly better api and would also support complex tag values (recursive types).
  
