### PR TITLE
Add clang-format auto-routine in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,3 +193,6 @@ ifndef ANDROID_NDK
 	$(error ANDROID_NDK is undefined)
 endif
 
+format:
+	clang-format -i `git diff --name-only -- '*.cpp' '*.h'` 
+	@echo "format done on `git diff --name-only -- '*.cpp' '*.h'`"

--- a/Makefile
+++ b/Makefile
@@ -194,5 +194,7 @@ ifndef ANDROID_NDK
 endif
 
 format:
-	clang-format -i `git diff --name-only -- '*.cpp' '*.h'` 
-	@echo "format done on `git diff --name-only -- '*.cpp' '*.h'`"
+	@for file in `git diff --diff-filter=ACMRTUXB --name-only -- '*.cpp' '*.h'`; do \
+		if [[ -e $$file ]]; then clang-format -i $$file; fi \
+	done
+	@echo "format done on `git diff --diff-filter=ACMRTUXB --name-only -- '*.cpp' '*.h'`"


### PR DESCRIPTION
Few lines @karimnaaji asks me to help with. There is an auto selection of last modified .cpp and .h files using git diff, on which clang-format is applied.