### PR TITLE
Off viewport labels

### DIFF
--- a/core/src/tile/labels/label.cpp
+++ b/core/src/tile/labels/label.cpp
@@ -127,12 +127,16 @@ void Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _d
 }
 
 bool Label::offViewport(const glm::vec2& _screenSize) {
-    const glm::vec2& screenPosition = m_transform.m_screenPosition;
-
-    bool outOfScreen = screenPosition.x > _screenSize.x || screenPosition.x < 0;
-    outOfScreen = outOfScreen || screenPosition.y > _screenSize.y || screenPosition.y < 0;
-
-    return outOfScreen;
+    const isect2d::Vec2* quad = m_obb.getQuad();
+    
+    for (int i = 0; i < 4; ++i) {
+        const auto& p = quad[i];
+        if (p.x < _screenSize.x && p.y < _screenSize.y && p.x > 0 && p.y > 0) {
+            return false;
+        }
+    }
+    
+    return true;
 }
 
 void Label::setOcclusion(bool _occlusion) {

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -2,20 +2,19 @@
 #include "catch/catch.hpp"
 #include "tangram.h"
 #include "tile/labels/label.h"
+#include "glm/mat4x4.hpp"
 #include "glm/gtc/matrix_transform.hpp"
 
 #define EPSILON 0.00001
 
-glm::mat4 mvp;
-glm::vec2 screen;
+glm::vec2 screenSize(500.f, 500.f);
 
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
-    Label l({}, "label", 0, Label::Type::LINE);
+    Label l({screenSize/2.f}, "label", 0, Label::Type::POINT);
 
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
-
     l.setOcclusion(true);
-    l.update(mvp, screen, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
 
     REQUIRE(l.getState() != Label::State::SLEEP);
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
@@ -23,93 +22,88 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
 
     l.setOcclusion(true);
     l.occlusionSolved();
-    l.update(mvp, screen, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
 
     REQUIRE(l.getState() == Label::State::SLEEP);
     REQUIRE(!l.canOcclude());
 }
 
 TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens", "[Core][Label]" ) {
-    Label l({}, "label", 0, Label::Type::LINE);
+    Label l({screenSize/2.f}, "label", 0, Label::Type::POINT);
 
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
 
     l.setOcclusion(false);
-    l.update(mvp, screen, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
 
     REQUIRE(l.getState() != Label::State::SLEEP);
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
 
     l.setOcclusion(false);
     l.occlusionSolved();
-    l.update(mvp, screen, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
 
     REQUIRE(l.getState() == Label::State::FADING_IN);
     REQUIRE(l.canOcclude());
 
-    l.update(mvp, screen, 1.0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 1.f);
     REQUIRE(l.getState() == Label::State::VISIBLE);
     REQUIRE(l.canOcclude());
 }
 
 TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]" ) {
-    Label l({}, "label", 0, Label::Type::LINE);
+    Label l({screenSize/2.f}, "label", 0, Label::Type::POINT);
 
     l.setOcclusion(false);
     l.occlusionSolved();
-    l.update(mvp, screen, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f);
 
     REQUIRE(l.getState() == Label::State::FADING_IN);
     REQUIRE(l.canOcclude());
 
     l.setOcclusion(true);
     l.occlusionSolved();
-    l.update(mvp, screen, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f);
 
     REQUIRE(l.getState() == Label::State::SLEEP);
     REQUIRE(!l.canOcclude());
 }
 
 TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
-    Label l({ glm::vec2(500.0) }, "label", 0, Label::Type::POINT);
+    Label l({screenSize*2.f}, "label", 0, Label::Type::POINT);
 
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
 
-    double screenWidth = 250.0, screenHeight = 250.0;
-
-    glm::mat4 p = glm::ortho(0.0, screenWidth, screenHeight, 0.0, 0.0, 1000.0);
-
-    l.update(p, glm::vec2(screenWidth, screenHeight), 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f);
 
     REQUIRE(l.getState() == Label::State::OUT_OF_SCREEN);
     REQUIRE(!l.canOcclude());
 
-    p = glm::ortho(0.0, screenWidth * 4.0, screenHeight * 4.0, 0.0, 0.0, 1000.0);
-
-    l.update(p, glm::vec2(screenWidth * 4.0, screenHeight * 4.0), 0);
+    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0.f);
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
     REQUIRE(l.canOcclude());
 
     l.setOcclusion(false);
     l.occlusionSolved();
-    l.update(mvp, screen, 0);
+    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0.f);
+    REQUIRE(l.getState() != Label::State::WAIT_OCC);
 
     REQUIRE(l.getState() == Label::State::FADING_IN);
     REQUIRE(l.canOcclude());
 
-    l.update(mvp, screen, 1.0);
+    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 1.f);
 
     REQUIRE(l.getState() == Label::State::VISIBLE);
     REQUIRE(l.canOcclude());
 }
 
 TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][Label]" ) {
-    Label l({}, "label", 0, Label::Type::DEBUG);
+    Label l({screenSize/2.f}, "label", 0, Label::Type::DEBUG);
 
     REQUIRE(l.getState() == Label::State::VISIBLE);
     REQUIRE(!l.canOcclude());
 
-    l.update(mvp, screen, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 1.f);
 
     REQUIRE(l.getState() == Label::State::VISIBLE);
     REQUIRE(!l.canOcclude());
@@ -162,8 +156,8 @@ TEST_CASE( "Pow interpolation", "[Core][Label][Fade]" ) {
 TEST_CASE( "Sine interpolation", "[Core][Label][Fade]" ) {
     FadeEffect fadeOut(false, FadeEffect::Interpolation::SINE, 1.0);
 
-    REQUIRE(abs(fadeOut.update(0.0) - 1.0) < EPSILON);
-    REQUIRE(abs(fadeOut.update(1.0) - 0.0) < EPSILON);
+    REQUIRE(std::fabs(fadeOut.update(0.0) - 1.0) < EPSILON);
+    REQUIRE(std::fabs(fadeOut.update(1.0) - 0.0) < EPSILON);
 
     fadeOut.update(0.01);
 
@@ -171,8 +165,8 @@ TEST_CASE( "Sine interpolation", "[Core][Label][Fade]" ) {
 
     FadeEffect fadeIn(true, FadeEffect::Interpolation::SINE, 1.0);
 
-    REQUIRE(abs(fadeIn.update(0.0) - 0.0) < EPSILON);
-    REQUIRE(abs(fadeIn.update(1.0) - 1.0) < EPSILON);
+    REQUIRE(std::fabs(fadeIn.update(0.0) - 0.0) < EPSILON);
+    REQUIRE(std::fabs(fadeIn.update(1.0) - 1.0) < EPSILON);
 
     fadeIn.update(0.01);
 


### PR DESCRIPTION
This fits with the new text vbo structure, vertices can now be offscreen since their translations are not encoded in a byte.