### PR TITLE
Specify glfw3>=3.1 in pkg-config check

### DIFF
--- a/toolchains/darwin.cmake
+++ b/toolchains/darwin.cmake
@@ -6,7 +6,7 @@ set(EXECUTABLE_NAME "tangram")
 add_definitions(-DPLATFORM_OSX)
 
 find_package(PkgConfig REQUIRED)
-pkg_search_module(GLFW REQUIRED glfw3)
+pkg_search_module(GLFW REQUIRED glfw3>=3.1)
 
 if(NOT GLFW_FOUND)
     message(SEND_ERROR "GLFW not found")

--- a/toolchains/linux.cmake
+++ b/toolchains/linux.cmake
@@ -23,7 +23,7 @@ include_recursive_dirs(${PROJECT_SOURCE_DIR}/core/src/*.h)
 function(link_libraries)
 
     find_package(PkgConfig REQUIRED)
-    pkg_search_module(GLFW REQUIRED glfw3)
+    pkg_search_module(GLFW REQUIRED glfw3>=3.1)
     include_directories(${GLFW_INCLUDE_DIRS})
     target_link_libraries(${EXECUTABLE_NAME} -lcurl) #use system libcurl
     target_link_libraries(${EXECUTABLE_NAME} core ${GLFW_STATIC_LIBRARIES})

--- a/toolchains/unitTests.cmake
+++ b/toolchains/unitTests.cmake
@@ -14,7 +14,7 @@ include_directories(${CORE_LIBRARIES_INCLUDE_DIRS})
 set(OSX_PLATFORM_SRC ${PROJECT_SOURCE_DIR}/osx/src/platform_osx.mm)
 
 find_package(PkgConfig REQUIRED)
-pkg_search_module(GLFW REQUIRED glfw3)
+pkg_search_module(GLFW REQUIRED glfw3>=3.1)
 
 list(APPEND GLFW_LDFLAGS
         "-framework OpenGL" 


### PR DESCRIPTION
Versions of glfw3 < 3.1, such as Debian's which is currently stuck at 3.0.4, can't build tangram-es as they lack glfwPostEmptyEvent, so in such cases it's better to fail the build at config time with a comprehensible error.