### PR TITLE
Text buffer as mesh

### DIFF
--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -58,19 +58,19 @@ void DebugStyle::addData(TileData &_data, MapTile &_tile, const MapProjection &_
 
 }
 
-void DebugStyle::buildPoint(Point &_point, void* _styleParams, Properties &_props, VboMesh &_mesh) const {
+void DebugStyle::buildPoint(Point &_point, void* _styleParams, Properties &_props, VboMesh &_mesh, MapTile& _tile) const {
 
     // No-op
 
 }
 
-void DebugStyle::buildLine(Line &_line, void* _styleParams, Properties &_props, VboMesh &_mesh) const {
+void DebugStyle::buildLine(Line &_line, void* _styleParams, Properties &_props, VboMesh &_mesh, MapTile& _tile) const {
 
     // No-op
 
 }
 
-void DebugStyle::buildPolygon(Polygon &_polygon, void* _styleParams, Properties &_props, VboMesh &_mesh) const {
+void DebugStyle::buildPolygon(Polygon &_polygon, void* _styleParams, Properties &_props, VboMesh &_mesh, MapTile& _tile) const {
 
     // No-op
 

--- a/core/src/style/debugStyle.h
+++ b/core/src/style/debugStyle.h
@@ -16,9 +16,9 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPoint(Point& _point, void* _styleParams, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildLine(Line& _line, void* _styleParams, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildPolygon(Polygon& _polygon, void* _styleParams, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
     virtual void addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) override;
 
     virtual void* parseStyleParams(const std::string& _layerNameID, const StyleParamMap& _styleParamMap) override;

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -9,13 +9,13 @@ DebugTextStyle::DebugTextStyle(const std::string& _fontName, std::string _name, 
 void DebugTextStyle::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) {
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::TILE_INFOS)) {
-        onBeginBuildTile(_tile);
-
-        std::shared_ptr<VboMesh> mesh(new Mesh(m_vertexLayout, m_drawMode));
+        std::shared_ptr<VboMesh> mesh(newMesh());
+        auto& buffer = static_cast<TextBuffer&>(*mesh);
+        
+        onBeginBuildTile(*mesh);
         
         auto ftContext = m_labels->getFontContext();
-        auto textBuffer = _tile.getTextBuffer(*this);
-
+        
         ftContext->setFont(m_fontName, m_fontSize * m_pixelScale);
 
         if (m_sdf) {
@@ -24,9 +24,9 @@ void DebugTextStyle::addData(TileData& _data, MapTile& _tile, const MapProjectio
         }
 
         std::string tileID = std::to_string(_tile.getID().x) + "/" + std::to_string(_tile.getID().y) + "/" + std::to_string(_tile.getID().z);
-        m_labels->addTextLabel(_tile, m_name, { glm::vec2(0), glm::vec2(0) }, tileID, Label::Type::DEBUG);
+        m_labels->addTextLabel(_tile, buffer, m_name, { glm::vec2(0), glm::vec2(0) }, tileID, Label::Type::DEBUG);
 
-        onEndBuildTile(_tile, mesh);
+        onEndBuildTile(*mesh);
 
         mesh->compileVertexBuffer();
         _tile.addGeometry(*this, mesh);

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -49,11 +49,11 @@ void* PolygonStyle::parseStyleParams(const std::string& _layerNameID, const Styl
     return static_cast<void*>(params);
 }
 
-void PolygonStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolygonStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     // No-op
 }
 
-void PolygonStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolygonStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     std::vector<PosNormColVertex> vertices;
 
     PolyLineBuilder builder = {
@@ -72,7 +72,7 @@ void PolygonStyle::buildLine(Line& _line, void* _styleParam, Properties& _props,
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
 }
 
-void PolygonStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolygonStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
 
     std::vector<PosNormColVertex> vertices;
 

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -29,9 +29,9 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
     virtual void* parseStyleParams(const std::string& _layerNameID, const StyleParamMap& _styleParamMap) override;
 
     typedef TypedMesh<PosNormColVertex> Mesh;

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -95,11 +95,11 @@ void* PolylineStyle::parseStyleParams(const std::string& _layerNameID, const Sty
     return static_cast<void*>(params);
 }
 
-void PolylineStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolylineStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     // No-op
 }
 
-void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     std::vector<PosNormEnormColVertex> vertices;
 
     StyleParams* params = static_cast<StyleParams*>(_styleParam);
@@ -151,6 +151,6 @@ void PolylineStyle::buildLine(Line& _line, void* _styleParam, Properties& _props
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
 }
 
-void PolylineStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolylineStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     // No-op
 }

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -38,9 +38,9 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
     virtual void* parseStyleParams(const std::string& _layerNameID, const StyleParamMap& _styleParamMap) override;
 
     typedef TypedMesh<PosNormEnormColVertex> Mesh;

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -16,8 +16,8 @@ void SpriteStyle::constructVertexLayout() {
     // 32 bytes, good for memory aligments
     m_vertexLayout = std::shared_ptr<VertexLayout>(new VertexLayout({
         {"a_position", 2, GL_FLOAT, false, 0},
-        {"a_screenPosition", 2, GL_FLOAT, false, 0},
         {"a_uv", 2, GL_FLOAT, false, 0},
+        {"a_screenPosition", 2, GL_FLOAT, false, 0},
         {"a_alpha", 1, GL_FLOAT, false, 0},
         {"a_rotation", 1, GL_FLOAT, false, 0},
     }));
@@ -46,12 +46,11 @@ void* SpriteStyle::parseStyleParams(const std::string& _layerNameID, const Style
 void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     // TODO : make this configurable
     SpriteNode planeSprite = m_spriteAtlas->getSpriteNode("tree");
-    std::vector<PosUVVertex> vertices;
-    GLvoid* memStart;
+    std::vector<BufferVert> vertices;
     
     SpriteBuilder builder = {
         [&](const glm::vec2& coord, const glm::vec2& screenPos, const glm::vec2& uv) {
-            vertices.push_back({ coord, screenPos, uv, 0.5f, M_PI_2 });
+            vertices.push_back({ coord, uv, screenPos, 0.5f, M_PI_2 });
         }
     };
     
@@ -64,11 +63,10 @@ void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _prop
             Label::Transform t = {glm::vec2(_point), glm::vec2(_point)};
             
             SpriteLabel::AttributeOffsets attribOffsets = {
-                m_vertexLayout->getStride(),
-                memStart,
-                m_vertexLayout->getOffset("a_screenPosition"),
-                m_vertexLayout->getOffset("a_rotation"),
-                m_vertexLayout->getOffset("a_alpha"),
+                _mesh.numVertices() * m_vertexLayout->getStride(),
+                (GLintptr) m_vertexLayout->getOffset("a_screenPosition"),
+                (GLintptr) m_vertexLayout->getOffset("a_rotation"),
+                (GLintptr) m_vertexLayout->getOffset("a_alpha"),
             };
             
             auto label = m_labels->addSpriteLabel(_tile, m_name, t, planeSprite.size * spriteScale, offset, attribOffsets);
@@ -76,8 +74,6 @@ void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _prop
             if (label) {
                 Builders::buildQuadAtPoint(label->getTransform().m_screenPosition + offset, planeSprite.size * spriteScale, planeSprite.uvBL, planeSprite.uvTR, builder);
             }
-            
-            memStart = vertices.data() + vertices.size();
         }
     }
     

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -4,8 +4,6 @@
 #include "glm/gtc/matrix_transform.hpp"
 #include "glm/gtc/type_ptr.hpp"
 
-MapTile* SpriteStyle::s_processedTile = nullptr;
-
 SpriteStyle::SpriteStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
     
     m_labels = Labels::GetInstance();
@@ -45,16 +43,14 @@ void* SpriteStyle::parseStyleParams(const std::string& _layerNameID, const Style
     return nullptr;
 }
 
-void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     // TODO : make this configurable
     SpriteNode planeSprite = m_spriteAtlas->getSpriteNode("tree");
     std::vector<PosUVVertex> vertices;
-    
-    // a pointer to the current start of the vertex in the array of vertices
-    GLvoid* memStart = &vertices;
+    GLvoid* memStart;
     
     SpriteBuilder builder = {
-        [&](const glm::vec2& coord, const glm::vec2 screenPos, const glm::vec2& uv) {
+        [&](const glm::vec2& coord, const glm::vec2& screenPos, const glm::vec2& uv) {
             vertices.push_back({ coord, screenPos, uv, 0.5f, M_PI_2 });
         }
     };
@@ -68,13 +64,14 @@ void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _prop
             Label::Transform t = {glm::vec2(_point), glm::vec2(_point)};
             
             SpriteLabel::AttributeOffsets attribOffsets = {
-                nullptr,
+                m_vertexLayout->getStride(),
+                memStart,
                 m_vertexLayout->getOffset("a_screenPosition"),
                 m_vertexLayout->getOffset("a_rotation"),
                 m_vertexLayout->getOffset("a_alpha"),
             };
             
-            auto label = m_labels->addSpriteLabel(*SpriteStyle::s_processedTile, m_name, t, planeSprite.size * spriteScale, offset, attribOffsets);
+            auto label = m_labels->addSpriteLabel(_tile, m_name, t, planeSprite.size * spriteScale, offset, attribOffsets);
             
             if (label) {
                 Builders::buildQuadAtPoint(label->getTransform().m_screenPosition + offset, planeSprite.size * spriteScale, planeSprite.uvBL, planeSprite.uvTR, builder);
@@ -88,23 +85,12 @@ void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _prop
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
 }
 
-void SpriteStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void SpriteStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     // NO-OP
 }
 
-void SpriteStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void SpriteStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     // NO-OP
-}
-
-void SpriteStyle::onBeginBuildTile(MapTile& _tile) const {
-
-    // FIXME: concurrency makes this processed tile unreliable
-    SpriteStyle::s_processedTile = &_tile;
-}
-
-void SpriteStyle::onEndBuildTile(MapTile &_tile, std::shared_ptr<VboMesh> _mesh) const {
-
-    SpriteStyle::s_processedTile = nullptr;
 }
 
 void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -21,11 +21,9 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void onBeginBuildTile(MapTile& _tile) const override;
-    virtual void onEndBuildTile(MapTile& _tile, std::shared_ptr<VboMesh> _mesh) const override;
+    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
 
     virtual void* parseStyleParams(const std::string& _layerNameID, const StyleParamMap& _styleParamMap) override;
 
@@ -49,8 +47,5 @@ public:
     SpriteStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);
 
     virtual ~SpriteStyle();
-    
-    // FIXME : only one sprite tile can be processed at a time
-    static MapTile* s_processedTile;
 
 };

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -9,16 +9,6 @@ class SpriteStyle : public Style {
 
 protected:
 
-    struct PosUVVertex {
-        // Position Data
-        glm::vec2 pos;
-        glm::vec2 screenPos;
-        // UV Data
-        glm::vec2 uv;
-        float alpha;
-        float rotation;
-    };
-
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
     virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
@@ -27,22 +17,19 @@ protected:
 
     virtual void* parseStyleParams(const std::string& _layerNameID, const StyleParamMap& _styleParamMap) override;
 
-    typedef TypedMesh<PosUVVertex> Mesh;
+    typedef TypedMesh<BufferVert> Mesh;
 
     virtual VboMesh* newMesh() const override {
         return new Mesh(m_vertexLayout, m_drawMode, GL_DYNAMIC_DRAW);
     };
-    
+
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;
     std::shared_ptr<Labels> m_labels;
-    
 
 public:
 
     virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
     virtual void onEndDrawFrame() override;
-    
-    void setSpriteAtlas(std::unique_ptr<SpriteAtlas> _atlas);
 
     SpriteStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -69,9 +69,10 @@ void Style::addLayer(const std::pair<std::string, StyleParamMap>&& _layer) {
 }
 
 void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapProjection) {
-    onBeginBuildTile(_tile);
-
+    
     std::shared_ptr<VboMesh> mesh(newMesh());
+    
+    onBeginBuildTile(*mesh);
 
     for (auto& layer : _data.layers) {
 
@@ -96,19 +97,19 @@ void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapPr
                 case GeometryType::POINTS:
                     // Build points
                     for (auto& point : feature.points) {
-                        buildPoint(point, parseStyleParams(it->first, it->second), feature.props, *mesh);
+                        buildPoint(point, parseStyleParams(it->first, it->second), feature.props, *mesh, _tile);
                     }
                     break;
                 case GeometryType::LINES:
                     // Build lines
                     for (auto& line : feature.lines) {
-                        buildLine(line, parseStyleParams(it->first, it->second), feature.props, *mesh);
+                        buildLine(line, parseStyleParams(it->first, it->second), feature.props, *mesh, _tile);
                     }
                     break;
                 case GeometryType::POLYGONS:
                     // Build polygons
                     for (auto& polygon : feature.polygons) {
-                        buildPolygon(polygon, parseStyleParams(it->first, it->second), feature.props, *mesh);
+                        buildPolygon(polygon, parseStyleParams(it->first, it->second), feature.props, *mesh, _tile);
                     }
                     break;
                 default:
@@ -117,7 +118,7 @@ void Style::addData(TileData& _data, MapTile& _tile, const MapProjection& _mapPr
         }
     }
 
-    onEndBuildTile(_tile, mesh);
+    onEndBuildTile(*mesh);
 
     if (mesh->numVertices() == 0) {
         mesh.reset();
@@ -141,10 +142,10 @@ void Style::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shar
 
 }
 
-void Style::onBeginBuildTile(MapTile& _tile) const {
+void Style::onBeginBuildTile(VboMesh& _mesh) const {
     // No-op by default
 }
 
-void Style::onEndBuildTile(MapTile& _tile, std::shared_ptr<VboMesh> _mesh) const {
+void Style::onEndBuildTile(VboMesh& _mesh) const {
     // No-op by default
 }

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -73,13 +73,13 @@ protected:
     virtual void constructShaderProgram() = 0;
 
     /* Build styled vertex data for point geometry and add it to the given <VboMesh> */
-    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const = 0;
+    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const = 0;
 
     /* Build styled vertex data for line geometry and add it to the given <VboMesh> */
-    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const = 0;
+    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const = 0;
 
     /* Build styled vertex data for polygon geometry and add it to the given <VboMesh> */
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const = 0;
+    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const = 0;
 
     /* Parse StyleParamMap to apt Style property parameters, and puts in the styleParamCache
      * NOTE: layerNameID will be replaced by unique ID for a set of filter matches*/
@@ -89,10 +89,10 @@ protected:
     static uint32_t parseColorProp(const std::string& _colorPropStr) ;
 
     /* Perform any needed setup to process the data for a tile */
-    virtual void onBeginBuildTile(MapTile& _tile) const;
+    virtual void onBeginBuildTile(VboMesh& _mesh) const;
 
     /* Perform any needed teardown after processing data for a tile */
-    virtual void onEndBuildTile(MapTile& _tile, std::shared_ptr<VboMesh> _mesh) const;
+    virtual void onEndBuildTile(VboMesh& _mesh) const;
 
     /* Create a new mesh object using the vertex layout corresponding to this style */
     virtual VboMesh* newMesh() const = 0;

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -114,7 +114,7 @@ void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {
 void TextStyle::onEndBuildTile(VboMesh& _mesh) const {
     auto& buffer = static_cast<TextStyle::Mesh&>(_mesh);
 
-    buffer.finish();
+    buffer.addBufferVerticesToMesh();
 }
 
 void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -113,10 +113,8 @@ void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {
 
 void TextStyle::onEndBuildTile(VboMesh& _mesh) const {
     auto& buffer = static_cast<TextStyle::Mesh&>(_mesh);
-    
+
     buffer.finish();
-    
-    m_labels->getFontContext()->clearState();
 }
 
 void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -4,34 +4,26 @@
 #include "typedMesh.h"
 #include "glfontstash.h"
 #include "tile/labels/labels.h"
+#include "text/fontContext.h"
 #include <memory>
 
 class TextStyle : public Style {
 
 protected:
 
-    struct TextVert {
-        glm::vec2 pos;
-        glm::vec2 uvs;
-        glm::vec2 screenPos;
-        float alpha;
-        float rotation;
-    };
-
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void onBeginBuildTile(MapTile& _tile) const override;
-    virtual void onEndBuildTile(MapTile& _tile, std::shared_ptr<VboMesh> _mesh) const override;
+    virtual void buildPoint(Point& _point, void* _styleParams, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void buildLine(Line& _line, void* _styleParams, Properties& _props, VboMesh& _meshm, MapTile& _tile) const override;
+    virtual void buildPolygon(Polygon& _polygon, void* _styleParams, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
+    virtual void onBeginBuildTile(VboMesh& _mesh) const override;
+    virtual void onEndBuildTile(VboMesh& _mesh) const override;
     
     virtual void* parseStyleParams(const std::string& _layerNameID, const StyleParamMap& _styleParamMap) override;
-
-    typedef TypedMesh<TextVert> Mesh;
-
+    
+    typedef TextBuffer Mesh;
     virtual VboMesh* newMesh() const override {
-        return new Mesh(m_vertexLayout, m_drawMode, GL_DYNAMIC_DRAW);
+        return new TextBuffer(m_labels->getFontContext(), m_vertexLayout);
     };
 
     std::string m_fontName;
@@ -41,8 +33,6 @@ protected:
     bool m_sdfMultisampling = true;
     
     std::shared_ptr<Labels> m_labels;
-    
-    void addVertices(TextBuffer& _buffer, VboMesh& _mesh) const;
 
 public:
 
@@ -53,11 +43,5 @@ public:
     virtual void onEndDrawFrame() override;
 
     virtual ~TextStyle();
-
-    /*
-     * A pointer to the tile being currently processed, e.g. the tile which data is being added to
-     * nullptr if no tile is being processed
-     */
-    static MapTile* s_processedTile;
 
 };

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -79,13 +79,12 @@ void updateAtlas(void* _userPtr, unsigned int _xoff, unsigned int _yoff,
     fontContext->getAtlas()->setSubData(static_cast<const GLuint*>(_pixels), _xoff, _yoff, _width, _height);
 }
 
-void updateBuffer(void* _userPtr, GLintptr _offset, GLsizei _size, float* _newData) {
-    FontContext* fontContext = static_cast<FontContext*>(_userPtr);
-    //auto buffer = fontContext->getCurrentBuffer();
+void updateBuffer(void* _userPtr, GLintptr _offset, GLsizei _size, float* _newData, void* _owner) {
+    auto buffer = static_cast<TextBuffer*>(_owner);
     
-    //if (buffer->hasData()) {
-    //    buffer->getWeakMesh()->update(_offset, _size, reinterpret_cast<unsigned char*>(_newData));
-    //}
+    if (buffer) {
+        buffer->update(_offset, _size, reinterpret_cast<unsigned char*>(_newData));
+    }
 }
 
 void FontContext::initFontContext(int _atlasSize) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -13,10 +13,6 @@ FontContext::~FontContext() {
     glfonsDelete(m_fsContext);
 }
 
-std::shared_ptr<TextBuffer> FontContext::genTextBuffer() {
-    return std::shared_ptr<TextBuffer>(new TextBuffer(m_fsContext));
-}
-
 const std::unique_ptr<Texture>& FontContext::getAtlas() const {
     return m_atlas;
 }
@@ -33,14 +29,6 @@ void FontContext::clearState() {
     fonsClearState(m_fsContext);
 }
 
-void FontContext::useBuffer(const std::shared_ptr<TextBuffer>& _textBuffer) {
-    if (_textBuffer) {
-        _textBuffer->bind();
-    }
-
-    m_currentBuffer = _textBuffer;
-}
-
 void FontContext::setSignedDistanceField(float _blurSpread) {
     fonsSetBlur(m_fsContext, _blurSpread);
     fonsSetBlurType(m_fsContext, FONS_EFFECT_DISTANCE_FIELD);
@@ -52,10 +40,6 @@ void FontContext::lock() {
 
 void FontContext::unlock() {
     m_contextMutex->unlock();
-}
-
-std::shared_ptr<TextBuffer> FontContext::getCurrentBuffer() {
-    return m_currentBuffer.lock();
 }
 
 bool FontContext::addFont(const std::string& _fontFile, std::string _name) {
@@ -97,11 +81,11 @@ void updateAtlas(void* _userPtr, unsigned int _xoff, unsigned int _yoff,
 
 void updateBuffer(void* _userPtr, GLintptr _offset, GLsizei _size, float* _newData) {
     FontContext* fontContext = static_cast<FontContext*>(_userPtr);
-    auto buffer = fontContext->getCurrentBuffer();
+    //auto buffer = fontContext->getCurrentBuffer();
     
-    if (buffer->hasData()) {
-        buffer->getWeakMesh()->update(_offset, _size, reinterpret_cast<unsigned char*>(_newData));
-    }
+    //if (buffer->hasData()) {
+    //    buffer->getWeakMesh()->update(_offset, _size, reinterpret_cast<unsigned char*>(_newData));
+    //}
 }
 
 void FontContext::initFontContext(int _atlasSize) {

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -37,17 +37,8 @@ public:
     /* fills the orthographic projection matrix related to the current screen size */
     void getProjection(float* _projectionMatrix) const;
 
-    /* asks to generate an uninitialized text buffer */
-    std::shared_ptr<TextBuffer> genTextBuffer();
-
-    /* use a buffer : all callbacks related to text buffer would be done on this buffer */
-    void useBuffer(const std::shared_ptr<TextBuffer>& _textBuffer);
-
-    /* gets the currently used buffer by the font context */
-    std::shared_ptr<TextBuffer> getCurrentBuffer(); 
-
     void clearState();
-
+    
     /* lock thread access to this font context */
     void lock();
     
@@ -56,12 +47,13 @@ public:
 
     const std::unique_ptr<Texture>& getAtlas() const;
     
+    FONScontext* getFontContext() const { return m_fsContext; }
+    
 private:
 
     void initFontContext(int _atlasSize);
 
     std::map<std::string, int> m_fonts;
-    std::weak_ptr<TextBuffer> m_currentBuffer;
     std::unique_ptr<Texture> m_atlas;
     std::unique_ptr<std::mutex> m_contextMutex;
     FONScontext* m_fsContext;

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -1,7 +1,11 @@
 #include "textBuffer.h"
+#include "fontContext.h"
 
-TextBuffer::TextBuffer(FONScontext* _fsContext) : m_fsContext(_fsContext) {
+TextBuffer::TextBuffer(std::shared_ptr<FontContext> _fontContext, std::shared_ptr<VertexLayout> _vertexLayout)
+    : TypedMesh<TextVert>(_vertexLayout, GL_TRIANGLES, GL_DYNAMIC_DRAW) {
+        
     m_dirty = false;
+    m_fsContext = _fontContext->getFontContext();
 }
 
 void TextBuffer::init() {
@@ -13,59 +17,61 @@ TextBuffer::~TextBuffer() {
 }
 
 int TextBuffer::getVerticesSize() {
+    glfonsBindBuffer(m_fsContext, m_fsBuffer);
     return glfonsVerticesSize(m_fsContext);
 }
 
 bool TextBuffer::getVertices(float* _vertices) {
-    return glfonsVertices(m_fsContext, _vertices);
-}
-
-void TextBuffer::bind() {
     glfonsBindBuffer(m_fsContext, m_fsBuffer);
+    return glfonsVertices(m_fsContext, _vertices);
 }
 
 fsuint TextBuffer::genTextID() {
     fsuint id;
+    glfonsBindBuffer(m_fsContext, m_fsBuffer);
     glfonsGenText(m_fsContext, 1, &id);
     return id;
 }
     
 bool TextBuffer::rasterize(const std::string& _text, fsuint _id) {
+    glfonsBindBuffer(m_fsContext, m_fsBuffer);
     int status = glfonsRasterize(m_fsContext, _id, _text.c_str());
     return status == GLFONS_VALID;
 }
 
 void TextBuffer::pushBuffer() {
     if (m_dirty) {
+        glfonsBindBuffer(m_fsContext, m_fsBuffer);
         glfonsUpdateBuffer(m_fsContext);
         m_dirty = false;
     }
 }
 
 void TextBuffer::transformID(fsuint _textID, float _x, float _y, float _rot, float _alpha) {
+    glfonsBindBuffer(m_fsContext, m_fsBuffer);
     glfonsTransform(m_fsContext, _textID, _x, _y, _rot, _alpha);
 
     m_dirty = true;
 }
 
-void TextBuffer::unbind() {
-    glfonsBindBuffer(m_fsContext, 0);
-}
-
 glm::vec4 TextBuffer::getBBox(fsuint _textID) {
     glm::vec4 bbox;
+    glfonsBindBuffer(m_fsContext, m_fsBuffer);
     glfonsGetBBox(m_fsContext, _textID, &bbox.x, &bbox.y, &bbox.z, &bbox.w);
     return bbox;
 }
 
-bool TextBuffer::hasData() {
-    auto mesh = getWeakMesh();
-    if (mesh == nullptr) {
-        return false;
+void TextBuffer::finish() {
+    std::vector<TextVert> vertices;
+    int bufferSize = getVerticesSize();
+    
+    if (bufferSize == 0) {
+        return;
     }
-    return mesh->numVertices() > 0;
-}
-
-std::shared_ptr<VboMesh> TextBuffer::getWeakMesh() {
-    return m_mesh.lock();
+    
+    vertices.resize(bufferSize);
+    
+    if (getVertices(reinterpret_cast<float*>(vertices.data()))) {
+        addVertices(std::move(vertices), {});
+    }
 }

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -2,9 +2,9 @@
 #include "fontContext.h"
 
 TextBuffer::TextBuffer(std::shared_ptr<FontContext> _fontContext, std::shared_ptr<VertexLayout> _vertexLayout)
-    : TypedMesh<TextVert>(_vertexLayout, GL_TRIANGLES, GL_DYNAMIC_DRAW) {
+    : TypedMesh<BufferVert>(_vertexLayout, GL_TRIANGLES, GL_DYNAMIC_DRAW) {
 
-    m_dirty = false;
+    m_dirtyTransform = false;
     m_fontContext = _fontContext;
     m_bound = false;
 }
@@ -44,11 +44,11 @@ bool TextBuffer::rasterize(const std::string& _text, fsuint _id) {
 }
 
 void TextBuffer::pushBuffer() {
-    if (m_dirty) {
+    if (m_dirtyTransform) {
         bind();
         glfonsUpdateBuffer(m_fontContext->getFontContext(), this);
         unbind();
-        m_dirty = false;
+        m_dirtyTransform = false;
     }
 }
 
@@ -56,7 +56,7 @@ void TextBuffer::transformID(fsuint _textID, float _x, float _y, float _rot, flo
     bind();
     glfonsTransform(m_fontContext->getFontContext(), _textID, _x, _y, _rot, _alpha);
     unbind();
-    m_dirty = true;
+    m_dirtyTransform = true;
 }
 
 glm::vec4 TextBuffer::getBBox(fsuint _textID) {
@@ -68,7 +68,7 @@ glm::vec4 TextBuffer::getBBox(fsuint _textID) {
 }
 
 void TextBuffer::addBufferVerticesToMesh() {
-    std::vector<TextVert> vertices;
+    std::vector<BufferVert> vertices;
     int bufferSize = getVerticesSize();
 
     if (bufferSize == 0) {

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -3,7 +3,7 @@
 
 TextBuffer::TextBuffer(std::shared_ptr<FontContext> _fontContext, std::shared_ptr<VertexLayout> _vertexLayout)
     : TypedMesh<TextVert>(_vertexLayout, GL_TRIANGLES, GL_DYNAMIC_DRAW) {
-        
+
     m_dirty = false;
     m_fontContext = _fontContext;
     m_bound = false;
@@ -16,7 +16,9 @@ void TextBuffer::init() {
 }
 
 TextBuffer::~TextBuffer() {
+    m_fontContext->lock();
     glfonsBufferDelete(m_fontContext->getFontContext(), m_fsBuffer);
+    m_fontContext->unlock();
 }
 
 int TextBuffer::getVerticesSize() {
@@ -33,7 +35,7 @@ fsuint TextBuffer::genTextID() {
     unbind();
     return id;
 }
-    
+
 bool TextBuffer::rasterize(const std::string& _text, fsuint _id) {
     bind();
     int status = glfonsRasterize(m_fontContext->getFontContext(), _id, _text.c_str());
@@ -68,17 +70,17 @@ glm::vec4 TextBuffer::getBBox(fsuint _textID) {
 void TextBuffer::addBufferVerticesToMesh() {
     std::vector<TextVert> vertices;
     int bufferSize = getVerticesSize();
-    
+
     if (bufferSize == 0) {
         return;
     }
-    
+
     vertices.resize(bufferSize);
-    
+
     bind();
     bool res = glfonsVertices(m_fontContext->getFontContext(), reinterpret_cast<float*>(vertices.data()));
     unbind();
-    
+
     if (res) {
         addVertices(std::move(vertices), {});
     }

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -51,7 +51,7 @@ bool TextBuffer::rasterize(const std::string& _text, fsuint _id) {
 void TextBuffer::pushBuffer() {
     if (m_dirty) {
         bind();
-        glfonsUpdateBuffer(m_fontContext->getFontContext());
+        glfonsUpdateBuffer(m_fontContext->getFontContext(), this);
         unbind();
         m_dirty = false;
     }

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -26,13 +26,6 @@ int TextBuffer::getVerticesSize() {
     return size;
 }
 
-bool TextBuffer::getVertices(float* _vertices) {
-    bind();
-    bool res = glfonsVertices(m_fontContext->getFontContext(), _vertices);
-    unbind();
-    return res;
-}
-
 fsuint TextBuffer::genTextID() {
     fsuint id;
     bind();
@@ -72,7 +65,7 @@ glm::vec4 TextBuffer::getBBox(fsuint _textID) {
     return bbox;
 }
 
-void TextBuffer::finish() {
+void TextBuffer::addBufferVerticesToMesh() {
     std::vector<TextVert> vertices;
     int bufferSize = getVerticesSize();
     
@@ -82,7 +75,11 @@ void TextBuffer::finish() {
     
     vertices.resize(bufferSize);
     
-    if (getVertices(reinterpret_cast<float*>(vertices.data()))) {
+    bind();
+    bool res = glfonsVertices(m_fontContext->getFontContext(), reinterpret_cast<float*>(vertices.data()));
+    unbind();
+    
+    if (res) {
         addVertices(std::move(vertices), {});
     }
 }

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -59,8 +59,13 @@ public:
     void finish();
 
 private:
+    
+    void bind();
+    void unbind();
+    
+    bool m_bound;
     bool m_dirty;
     fsuint m_fsBuffer;
-    FONScontext* m_fsContext;
+    std::shared_ptr<FontContext> m_fontContext;
 
 };

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -4,9 +4,9 @@
 #include "glfontstash.h"
 #include "util/typedMesh.h"
 
-struct TextVert {
+struct BufferVert {
     glm::vec2 pos;
-    glm::vec2 uvs;
+    glm::vec2 uv;
     glm::vec2 screenPos;
     float alpha;
     float rotation;
@@ -17,7 +17,7 @@ class FontContext;
 /*
  * This class represents a text buffer, each text buffer has several text ids
  */
-class TextBuffer : public TypedMesh<TextVert> {
+class TextBuffer : public TypedMesh<BufferVert> {
 
 public:
 
@@ -57,7 +57,7 @@ private:
     void unbind();
     
     bool m_bound;
-    bool m_dirty;
+    bool m_dirtyTransform;
     fsuint m_fsBuffer;
     std::shared_ptr<FontContext> m_fontContext;
 

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -27,6 +27,7 @@ public:
     /* generates a text id */
     fsuint genTextID();
 
+    /* creates a text buffer and bind it */
     void init();
 
     /* ask the font rasterizer to rasterize a specific text for a text id */
@@ -42,19 +43,13 @@ public:
 
     void pushBuffer();
     
-    /* 
-     * fills the vector of float with the rasterized text ids linked to the text buffer 
-     * nVerts is the number of vertices inside the vector
-     */
-    bool getVertices(float* _vertices);
-    
     int getVerticesSize();
     
     /* get the axis aligned bounding box for a text */
     glm::vec4 getBBox(fsuint _textID);
-    
+
     /* get the vertices from the font context and add them as vbo mesh data */
-    void finish();
+    void addBufferVerticesToMesh();
 
 private:
     

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -50,8 +50,6 @@ public:
     
     int getVerticesSize();
     
-    bool hasData();
-    
     /* get the axis aligned bounding box for a text */
     glm::vec4 getBBox(fsuint _textID);
     

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -2,16 +2,26 @@
 
 #include "texture.h"
 #include "glfontstash.h"
-#include "util/vboMesh.h"
+#include "util/typedMesh.h"
 
-/* 
+struct TextVert {
+    glm::vec2 pos;
+    glm::vec2 uvs;
+    glm::vec2 screenPos;
+    float alpha;
+    float rotation;
+};
+
+class FontContext;
+
+/*
  * This class represents a text buffer, each text buffer has several text ids
  */
-class TextBuffer {
+class TextBuffer : public TypedMesh<TextVert> {
 
 public:
 
-    TextBuffer(FONScontext* _fsContext);
+    TextBuffer(std::shared_ptr<FontContext> _fontContext, std::shared_ptr<VertexLayout> _vertexLayout);
     ~TextBuffer();
     
     /* generates a text id */
@@ -29,10 +39,6 @@ public:
      *  alpha should be in [0..1]
      */
     void transformID(fsuint _textID, float _x, float _y, float _rot, float _alpha);
-    
-    void setMesh(std::shared_ptr<VboMesh> _mesh) { m_mesh = _mesh; }
-    
-    std::shared_ptr<VboMesh> getWeakMesh();
 
     void pushBuffer();
     
@@ -49,13 +55,12 @@ public:
     /* get the axis aligned bounding box for a text */
     glm::vec4 getBBox(fsuint _textID);
     
-    void bind();
-    void unbind();
+    /* get the vertices from the font context and add them as vbo mesh data */
+    void finish();
 
 private:
     bool m_dirty;
     fsuint m_fsBuffer;
     FONScontext* m_fsContext;
-    std::weak_ptr<VboMesh> m_mesh;
 
 };

--- a/core/src/tile/labels/label.h
+++ b/core/src/tile/labels/label.h
@@ -93,7 +93,7 @@ public:
 
     void update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt);
 
-    virtual void pushTransform() = 0;
+    virtual void pushTransform(VboMesh& _mesh) = 0;
     
     bool updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize);
     

--- a/core/src/tile/labels/labels.cpp
+++ b/core/src/tile/labels/labels.cpp
@@ -15,30 +15,33 @@ int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
     return (int) MIN(floor(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5)), MAX_LOD);
 }
 
-std::shared_ptr<Label> Labels::addTextLabel(MapTile& _tile, const std::string& _styleName, Label::Transform _transform, std::string _text, Label::Type _type) {
+std::shared_ptr<Label> Labels::addTextLabel(MapTile& _tile, TextBuffer& _buffer, const std::string& _styleName,
+                                            Label::Transform _transform, std::string _text, Label::Type _type) {
+    
     // discard based on level of detail
     if ((m_currentZoom - _tile.getID().z) > LODDiscardFunc(View::s_maxZoom, m_currentZoom)) {
         return nullptr;
     }
     
-    auto currentBuffer = m_ftContext->getCurrentBuffer();
+    fsuint textID = _buffer.genTextID();
     
-    if (currentBuffer) {
-        fsuint textID = currentBuffer->genTextID();
-        std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, textID, _type, currentBuffer));
+    std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, textID, _type));
 
-        // raterize the text label
-        if (!label->rasterize(currentBuffer)) {
-            label.reset();
-            return nullptr;
-        }
+    m_ftContext->lock();
+    
+    // raterize the text label
+    if (!label->rasterize(_buffer)) {
+        m_ftContext->unlock();
         
-        addLabel(_tile, _styleName, std::dynamic_pointer_cast<Label>(label));
-
-        return label;
+        label.reset();
+        return nullptr;
     }
+    
+    m_ftContext->unlock();
+    
+    addLabel(_tile, _styleName, std::dynamic_pointer_cast<Label>(label));
 
-    return nullptr;
+    return label;
 }
 
 void Labels::addLabel(MapTile& _tile, const std::string& _styleName, std::shared_ptr<Label> _label) {

--- a/core/src/tile/labels/labels.cpp
+++ b/core/src/tile/labels/labels.cpp
@@ -27,17 +27,12 @@ std::shared_ptr<Label> Labels::addTextLabel(MapTile& _tile, TextBuffer& _buffer,
     
     std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, textID, _type));
 
-    m_ftContext->lock();
-    
     // raterize the text label
     if (!label->rasterize(_buffer)) {
-        m_ftContext->unlock();
         
         label.reset();
         return nullptr;
     }
-    
-    m_ftContext->unlock();
     
     addLabel(_tile, _styleName, std::dynamic_pointer_cast<Label>(label));
 

--- a/core/src/tile/labels/labels.h
+++ b/core/src/tile/labels/labels.h
@@ -60,7 +60,7 @@ public:
      * Creates a text slabel for and associate it with the current processed <MapTile> TileID for a specific syle name
      * Returns the created label
      */
-    std::shared_ptr<Label> addTextLabel(MapTile& _tile, const std::string& _styleName, Label::Transform _transform, std::string _text, Label::Type _type);
+    std::shared_ptr<Label> addTextLabel(MapTile& _tile, TextBuffer& _buffer, const std::string& _styleName, Label::Transform _transform, std::string _text, Label::Type _type);
     
     /*
      * Creates a sprite slabel for and associate it with the current processed <MapTile> TileID for a specific syle name

--- a/core/src/tile/labels/spriteLabel.cpp
+++ b/core/src/tile/labels/spriteLabel.cpp
@@ -8,8 +8,7 @@ SpriteLabel::SpriteLabel(Label::Transform _transform, const glm::vec2& _size, co
     m_dim = _size;
 }
 
-void SpriteLabel::pushTransform() {
-    // TODO : update vbo mesh
+void SpriteLabel::pushTransform(VboMesh& _mesh) {
 }
 
 void SpriteLabel::updateBBoxes() {

--- a/core/src/tile/labels/spriteLabel.cpp
+++ b/core/src/tile/labels/spriteLabel.cpp
@@ -4,12 +4,31 @@ SpriteLabel::SpriteLabel(Label::Transform _transform, const glm::vec2& _size, co
     Label(_transform, Label::Type::POINT),
     m_offset(_offset),
     m_attribOffsets(_attribOffsets) {
-        
+
     m_dim = _size;
 }
 
 void SpriteLabel::pushTransform(VboMesh& _mesh) {
-    // TODO: update the mesh
+    if (m_dirty) {
+        TypedMesh<BufferVert>& mesh = static_cast<TypedMesh<BufferVert>&>(_mesh);
+
+        // used to write all attributes memory at once, good for caching
+        struct VertexAttributes {
+            glm::vec2 screenPos;
+            float alpha;
+            float rot;
+        };
+
+        GLintptr stride = std::min<GLintptr>(m_attribOffsets.m_position, std::min<GLintptr>(m_attribOffsets.m_alpha, m_attribOffsets.m_rotation));
+
+        VertexAttributes newAttributes {
+            m_transform.m_screenPosition + m_offset,
+            m_transform.m_alpha,
+            m_transform.m_rotation,
+        };
+
+        mesh.updateAttribute(stride + m_attribOffsets.memOffset, 4, newAttributes);
+    }
 }
 
 void SpriteLabel::updateBBoxes() {

--- a/core/src/tile/labels/spriteLabel.cpp
+++ b/core/src/tile/labels/spriteLabel.cpp
@@ -9,6 +9,7 @@ SpriteLabel::SpriteLabel(Label::Transform _transform, const glm::vec2& _size, co
 }
 
 void SpriteLabel::pushTransform(VboMesh& _mesh) {
+    // TODO: update the mesh
 }
 
 void SpriteLabel::updateBBoxes() {

--- a/core/src/tile/labels/spriteLabel.h
+++ b/core/src/tile/labels/spriteLabel.h
@@ -6,6 +6,7 @@ class SpriteLabel : public Label {
 public:
     
     struct AttributeOffsets {
+        GLint m_size;
         GLvoid* m_memStart;
         GLvoid* m_position;
         GLvoid* m_rotation;
@@ -14,7 +15,7 @@ public:
     
     SpriteLabel(Label::Transform _transform, const glm::vec2& _size, const glm::vec2& _offset, AttributeOffsets _attribOffsets);
     
-    void pushTransform() override;
+    void pushTransform(VboMesh& _mesh) override;
     
 protected:
     

--- a/core/src/tile/labels/spriteLabel.h
+++ b/core/src/tile/labels/spriteLabel.h
@@ -6,11 +6,10 @@ class SpriteLabel : public Label {
 public:
     
     struct AttributeOffsets {
-        GLint m_size;
-        GLvoid* m_memStart;
-        GLvoid* m_position;
-        GLvoid* m_rotation;
-        GLvoid* m_alpha;
+        int memOffset;
+        GLintptr m_position;
+        GLintptr m_rotation;
+        GLintptr m_alpha;
     };
     
     SpriteLabel(Label::Transform _transform, const glm::vec2& _size, const glm::vec2& _offset, AttributeOffsets _attribOffsets);

--- a/core/src/tile/labels/textLabel.cpp
+++ b/core/src/tile/labels/textLabel.cpp
@@ -1,12 +1,10 @@
 #include "textLabel.h"
 
-TextLabel::TextLabel(Label::Transform _transform, std::string _text, fsuint _id, Type _type, std::weak_ptr<TextBuffer> _textBuffer) :
+TextLabel::TextLabel(Label::Transform _transform, std::string _text, fsuint _id, Type _type) :
     Label(_transform, _type),
     m_text(_text),
-    m_id(_id),
-    m_textBuffer(_textBuffer) {
-    
-}
+    m_id(_id)
+{}
 
 void TextLabel::updateBBoxes() {
     glm::vec2 t = glm::vec2(cos(m_transform.m_rotation), sin(m_transform.m_rotation));
@@ -19,14 +17,14 @@ void TextLabel::updateBBoxes() {
     m_aabb = m_obb.getExtent();
 }
 
-bool TextLabel::rasterize(std::shared_ptr<TextBuffer>& _buffer) {
-    bool res = _buffer->rasterize(m_text, m_id);
+bool TextLabel::rasterize(TextBuffer& _buffer) {
+    bool res = _buffer.rasterize(m_text, m_id);
     
     if (!res) {
         return false;
     }
     
-    glm::vec4 bbox = _buffer->getBBox(m_id);
+    glm::vec4 bbox = _buffer.getBBox(m_id);
     
     m_dim.x = std::abs(bbox.z - bbox.x);
     m_dim.y = std::abs(bbox.w - bbox.y);
@@ -34,14 +32,10 @@ bool TextLabel::rasterize(std::shared_ptr<TextBuffer>& _buffer) {
     return true;
 }
 
-void TextLabel::pushTransform() {
+void TextLabel::pushTransform(VboMesh& _mesh) {
     if (m_dirty) {
-        auto buffer = m_textBuffer.lock();
-        
-        if (buffer) {
-            buffer->transformID(m_id, m_transform.m_screenPosition.x, m_transform.m_screenPosition.y, m_transform.m_rotation, m_transform.m_alpha);
-        }
-        
+        TextBuffer& buffer = static_cast<TextBuffer&>(_mesh);
+        buffer.transformID(m_id, m_transform.m_screenPosition.x, m_transform.m_screenPosition.y, m_transform.m_rotation, m_transform.m_alpha);
         m_dirty = false;
     }
 }

--- a/core/src/tile/labels/textLabel.h
+++ b/core/src/tile/labels/textLabel.h
@@ -6,20 +6,19 @@
 class TextLabel : public Label {
 
 public:
-    TextLabel(Label::Transform _transform, std::string _text, fsuint _id, Type _type, std::weak_ptr<TextBuffer> _textBuffer);
+    TextLabel(Label::Transform _transform, std::string _text, fsuint _id, Type _type);
     
     /* Call the font context to rasterize the label string */
-    bool rasterize(std::shared_ptr<TextBuffer>& _buffer);
+    bool rasterize(TextBuffer& _buffer);
     
     std::string getText() { return m_text; }
     
-    void pushTransform() override;
+    void pushTransform(VboMesh& _mesh) override;
     
 private:
     
     std::string m_text;
     fsuint m_id;
-    std::weak_ptr<TextBuffer> m_textBuffer;
     
 protected:
     

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -65,8 +65,15 @@ void MapTile::pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _
     std::shared_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
     
     if (styleMesh) {
+        bool hasLabels = false;
         for(auto& label : m_labels[_style.getName()]) {
             label->pushTransform(*styleMesh);
+            hasLabels = true;
+        }
+        
+        // FIXME
+        if (styleMesh->numVertices() > 0 && _style.getName() == "text") {
+            (static_cast<TextBuffer*>(styleMesh.get()))->pushBuffer();
         }
     }
 }

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -64,11 +64,9 @@ void MapTile::updateLabels(float _dt, const Style& _style, const View& _view) {
 void MapTile::pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _labels) {
     std::shared_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
     
-    if (styleMesh) {
-        bool hasLabels = false;
+    if (styleMesh) {s
         for(auto& label : m_labels[_style.getName()]) {
             label->pushTransform(*styleMesh);
-            hasLabels = true;
         }
         
         // FIXME

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -64,15 +64,13 @@ void MapTile::updateLabels(float _dt, const Style& _style, const View& _view) {
 void MapTile::pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _labels) {
     std::shared_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
     
-    if (styleMesh) {
+    if (styleMesh && typeid(*styleMesh) == typeid(TextBuffer)) {
         for(auto& label : m_labels[_style.getName()]) {
             label->pushTransform(*styleMesh);
         }
-        
-        if (typeid(*styleMesh) == typeid(TextBuffer)) {
-            TextBuffer& buffer = static_cast<TextBuffer&>(*styleMesh);
-            buffer.pushBuffer();
-        }
+    
+        TextBuffer& buffer = static_cast<TextBuffer&>(*styleMesh);
+        buffer.pushBuffer();
     }
 }
 

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -64,7 +64,7 @@ void MapTile::updateLabels(float _dt, const Style& _style, const View& _view) {
 void MapTile::pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _labels) {
     std::shared_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
     
-    if (styleMesh) {s
+    if (styleMesh) {
         for(auto& label : m_labels[_style.getName()]) {
             label->pushTransform(*styleMesh);
         }

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -64,13 +64,15 @@ void MapTile::updateLabels(float _dt, const Style& _style, const View& _view) {
 void MapTile::pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _labels) {
     std::shared_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
     
-    if (styleMesh && typeid(*styleMesh) == typeid(TextBuffer)) {
+    if (styleMesh) {
         for(auto& label : m_labels[_style.getName()]) {
             label->pushTransform(*styleMesh);
         }
     
-        TextBuffer& buffer = static_cast<TextBuffer&>(*styleMesh);
-        buffer.pushBuffer();
+        if (typeid(*styleMesh) == typeid(TextBuffer)) {
+            TextBuffer& buffer = static_cast<TextBuffer&>(*styleMesh);
+            buffer.pushBuffer();
+        }
     }
 }
 

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -69,9 +69,9 @@ void MapTile::pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _
             label->pushTransform(*styleMesh);
         }
         
-        // FIXME
-        if (styleMesh->numVertices() > 0 && _style.getName() == "text") {
-            (static_cast<TextBuffer*>(styleMesh.get()))->pushBuffer();
+        if (typeid(*styleMesh) == typeid(TextBuffer)) {
+            TextBuffer& buffer = static_cast<TextBuffer&>(*styleMesh);
+            buffer.pushBuffer();
         }
     }
 }

--- a/core/src/tile/mapTile.h
+++ b/core/src/tile/mapTile.h
@@ -76,9 +76,6 @@ public:
     /* Push the label transforms to the font rendering context */
     void pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _labels);
 
-    void setTextBuffer(const Style& _style, std::shared_ptr<TextBuffer> _buffer);
-    std::shared_ptr<TextBuffer> getTextBuffer(const Style& _style) const;
-
     /* Draws the geometry associated with the provided <Style> and view-projection matrix */
     void draw(const Style& _style, const View& _view);
     
@@ -114,6 +111,5 @@ private:
 
     std::unordered_map<std::string, std::shared_ptr<VboMesh>> m_geometry; // Map of <Style>s and their associated <VboMesh>es
     std::unordered_map<std::string, std::vector<std::shared_ptr<Label>>> m_labels;
-    std::map<std::string, std::shared_ptr<TextBuffer>> m_buffers; // Map of <Style>s and the associated text buffer
 
 };

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -43,6 +43,10 @@ public:
         size_t aSize = sizeof(A);
         size_t tSize = sizeof(T);
 
+        if (_nVerts * tSize + _byteOffset > m_nVertices * tSize) {
+            return;
+        }
+
         // update the vertices attributes
         for (int i = 0; i < _nVerts; ++i) {
             std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newAttributeValue, aSize);
@@ -106,6 +110,10 @@ void TypedMesh<T>::updateVertices(GLintptr _byteOffset, unsigned int _nVerts, co
     }
 
     size_t tSize = sizeof(T);
+
+    if (_nVerts * tSize + _byteOffset > m_nVertices * tSize) {
+            return;
+    }
 
     // update the vertices
     for (int i = 0; i < _nVerts; ++i) {

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "vboMesh.h"
+#include <cstdlib> // std::abs
 
 template<class T>
 class TypedMesh : public VboMesh {
 
 public:
-    
+
     TypedMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode, GLenum _hint = GL_STATIC_DRAW)
         : VboMesh(_vertexLayout, _drawMode, _hint) {};
 
@@ -23,9 +24,93 @@ public:
         compile(vertices, indices);
     }
 
+    /*
+     * Update _nVerts vertices in the mesh with the new T value _newVertexValue starting after
+     * _byteOffset in the mesh vertex data memory
+     */
+    void updateVertices(GLintptr _byteOffset, unsigned int _nVerts, const T& _newVertexValue);
+
+    /*
+     * Update _nVerts vertices in the mesh with the new attribute A _newAttributeValue starting
+     * after _byteOffset in the mesh vertex data memory
+     */
+    template<class A>
+    void updateAttribute(GLintptr _byteOffset, unsigned int _nVerts, const A& _newAttributeValue) {
+        if (!m_isCompiled) {
+            return;
+        }
+
+        size_t aSize = sizeof(A);
+        size_t tSize = sizeof(T);
+
+        // update the vertices attributes
+        for (int i = 0; i < _nVerts; ++i) {
+            std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newAttributeValue, aSize);
+        }
+
+        setDirty(_byteOffset, (_nVerts - 1) * tSize + aSize);
+    }
+
 protected:
-    
+
+    void setDirty(GLintptr _byteOffset, GLsizei _byteSize);
+
     std::vector<std::vector<T>> vertices;
     std::vector<std::vector<int>> indices;
-    
+
 };
+
+template<class T>
+void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
+
+    // not dirty at all, init the dirtiness of the buffer
+    if (!m_dirty) {
+
+        m_dirtySize = _byteSize;
+        m_dirtyOffset = _byteOffset;
+        m_dirty = true;
+
+    } else {
+        GLsizei dBytes = std::abs(_byteOffset - m_dirtyOffset); // distance in bytes
+        GLintptr nOff = _byteOffset + _byteSize; // new offset
+        GLintptr pOff = m_dirtySize + m_dirtyOffset; // previous offset
+
+        if (_byteOffset < m_dirtyOffset) { // left part of the buffer
+
+            // update before the old buffer offset
+            m_dirtyOffset = _byteOffset;
+
+            // merge sizes
+            if (nOff > pOff) {
+                m_dirtySize = _byteSize;
+            } else {
+                m_dirtySize += dBytes;
+            }
+
+            m_dirty = true;
+
+        } else if (nOff > pOff) { // right part of the buffer
+
+            // update starting after the old buffer offset
+            m_dirtySize = dBytes + _byteSize;
+            m_dirty = true;
+        }
+    }
+
+}
+
+template<class T>
+void TypedMesh<T>::updateVertices(GLintptr _byteOffset, unsigned int _nVerts, const T& _newVertexValue) {
+    if (!m_isCompiled) {
+        return;
+    }
+
+    size_t tSize = sizeof(T);
+
+    // update the vertices
+    for (int i = 0; i < _nVerts; ++i) {
+        std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newVertexValue, tSize);
+    }
+
+    setDirty(_byteOffset, _nVerts * tSize);
+}

--- a/core/src/util/vboMesh.cpp
+++ b/core/src/util/vboMesh.cpp
@@ -57,10 +57,6 @@ void VboMesh::setDrawMode(GLenum _drawMode) {
 }
 
 void VboMesh::update(GLintptr _offset, GLsizei _size, unsigned char* _data) {
-    if (m_hint == GL_STATIC_DRAW) {
-        logMsg("WARNING: wrong usage hint provided to the Vbo\n");
-    }
-
     std::memcpy(m_glVertexData + _offset, _data, _size);
 
     m_dirtyOffset = _offset;
@@ -71,6 +67,11 @@ void VboMesh::update(GLintptr _offset, GLsizei _size, unsigned char* _data) {
 
 void VboMesh::subDataUpload() {
     if (m_dirtySize != 0) {
+        
+        if (m_hint == GL_STATIC_DRAW) {
+            logMsg("WARNING: wrong usage hint provided to the Vbo\n");
+        }
+        
         glBindBuffer(GL_ARRAY_BUFFER, m_glVertexBuffer);
 
         long vertexBytes = m_nVertices * m_vertexLayout->getStride();

--- a/core/src/util/vboMesh.h
+++ b/core/src/util/vboMesh.h
@@ -24,7 +24,7 @@ public:
      */
     VboMesh(std::shared_ptr<VertexLayout> _vertexlayout, GLenum _drawMode = GL_TRIANGLES, GLenum _hint = GL_STATIC_DRAW);
     VboMesh();
-    
+
     /*
      * Set Vertex Layout for the vboMesh object
      */
@@ -62,14 +62,17 @@ public:
      * been uploaded it will be uploaded at this point
      */
     void draw(const std::shared_ptr<ShaderProgram> _shader);
-    
+
     void update(GLintptr _offset, GLsizei _size, unsigned char* _data);
-    
+
     static void addManagedVBO(VboMesh* _vbo);
-    
+
     static void removeManagedVBO(VboMesh* _vbo);
-    
+
     static void invalidateAllVBOs();
+
+    GLsizei getDirtySize() const { return m_dirtySize; }
+    GLintptr getDirtyOffset() const { return m_dirtyOffset; }
 
 protected:
 
@@ -98,10 +101,10 @@ protected:
     bool m_isUploaded;
     bool m_isCompiled;
     bool m_dirty;
-    
+
     GLsizei m_dirtySize;
     GLintptr m_dirtyOffset;
-    
+
     void checkValidity();
 
     template <typename T>

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -9,10 +9,9 @@
 #define EPSILON 0.00001
 
 glm::vec2 screenSize(500.f, 500.f);
-std::weak_ptr<TextBuffer> ptr;
 
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::POINT, ptr);
+    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::POINT);
 
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
     l.setOcclusion(true);
@@ -31,7 +30,7 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
 }
 
 TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::POINT, ptr);
+    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::POINT);
 
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
 
@@ -54,7 +53,7 @@ TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens
 }
 
 TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::POINT, ptr);
+    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::POINT);
 
     l.setOcclusion(false);
     l.occlusionSolved();
@@ -72,7 +71,7 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
 }
 
 TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
-    TextLabel l({screenSize*2.f}, "label", 0, Label::Type::POINT, ptr);
+    TextLabel l({screenSize*2.f}, "label", 0, Label::Type::POINT);
 
     REQUIRE(l.getState() == Label::State::WAIT_OCC);
 
@@ -100,7 +99,7 @@ TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
 }
 
 TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::DEBUG, ptr);
+    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::DEBUG);
 
     REQUIRE(l.getState() == Label::State::VISIBLE);
     REQUIRE(!l.canOcclude());

--- a/tests/unit/meshTests.cpp
+++ b/tests/unit/meshTests.cpp
@@ -1,0 +1,120 @@
+#define CATCH_CONFIG_MAIN
+#include "catch/catch.hpp"
+
+#include <iostream>
+#include "typedMesh.h"
+
+struct Vertex {
+    float a;
+    float b;
+    short c;
+    char d;
+};
+
+std::shared_ptr<VertexLayout> layout = std::shared_ptr<VertexLayout>(new VertexLayout({
+    {"ab", 2, GL_FLOAT, false, 0},
+    {"c",  1, GL_SHORT, false, 0},
+    {"d",  1, GL_BYTE,  false, 0},
+}));
+
+std::shared_ptr<TypedMesh<Vertex>> newMesh(unsigned int size) {
+    auto mesh = std::shared_ptr<TypedMesh<Vertex>>(new TypedMesh<Vertex>(layout, GL_TRIANGLES));
+    std::vector<Vertex> vertices;
+    for (int i = 0; i < size; ++i) {
+        vertices.push_back({0,0,0,0});
+    }
+    mesh->addVertices(std::move(vertices), {});
+    mesh->compileVertexBuffer();
+    return mesh;
+}
+
+TEST_CASE( "Simple update on vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+
+    REQUIRE(mesh->getDirtyOffset() == 0);
+    REQUIRE(mesh->getDirtySize() == 0);
+
+    mesh->updateVertices(0, 4, Vertex());
+
+    REQUIRE(mesh->getDirtyOffset() == 0);
+    REQUIRE(mesh->getDirtySize() == 4 * sizeof(Vertex));
+}
+
+TEST_CASE( "Left merge on vertices with bigger left size", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+
+    mesh->updateVertices(2 * sizeof(Vertex), 2, Vertex());
+    mesh->updateVertices(0 * sizeof(Vertex), 8, Vertex());
+
+    REQUIRE(mesh->getDirtyOffset() == 0);
+    REQUIRE(mesh->getDirtySize() == 8 * sizeof(Vertex));
+}
+
+TEST_CASE( "Left merge on vertices with smaller left size", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+
+    mesh->updateVertices(2 * sizeof(Vertex), 2, Vertex());
+    mesh->updateVertices(0 * sizeof(Vertex), 1, Vertex());
+
+    REQUIRE(mesh->getDirtyOffset() == 0);
+    REQUIRE(mesh->getDirtySize() == 4 * sizeof(Vertex));
+}
+
+TEST_CASE( "Right merge on vertices dirtiness", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+
+    mesh->updateVertices(2 * sizeof(Vertex), 2, Vertex());
+    mesh->updateVertices(4 * sizeof(Vertex), 2, Vertex());
+
+    REQUIRE(mesh->getDirtyOffset() == 2 * sizeof(Vertex));
+    REQUIRE(mesh->getDirtySize() == 4 * sizeof(Vertex));
+}
+
+TEST_CASE( "Update on second attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+    int nVert = 5;
+    size_t stride_b = sizeof(float); // stride of a in the struct
+
+    mesh->updateAttribute(stride_b + sizeof(Vertex), nVert, 0.f);
+
+    REQUIRE(mesh->getDirtyOffset() == stride_b + sizeof(Vertex));
+    REQUIRE(mesh->getDirtySize() == (nVert - 1) * sizeof(Vertex) + sizeof(float));
+}
+
+TEST_CASE( "Update on second attribute of the mesh for 1 vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+    size_t stride_b = sizeof(float); // stride of a in the struct
+
+    mesh->updateAttribute(stride_b, 1, 0.f);
+
+    REQUIRE(mesh->getDirtyOffset() == stride_b);
+    REQUIRE(mesh->getDirtySize() == sizeof(float));
+}
+
+TEST_CASE( "Update on second and third attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+    size_t stride_b = sizeof(float); // stride of b in the struct
+    size_t stride_c = 2 * sizeof(float); // stride of c in the struct
+    short c = 0;
+
+    mesh->updateAttribute(stride_b, 5, 0.f);
+    mesh->updateAttribute(stride_c + sizeof(Vertex), 8, c);
+
+    REQUIRE(mesh->getDirtyOffset() == stride_b);
+    int dist = stride_c - stride_b; // distance between b and c
+    REQUIRE(mesh->getDirtySize() == 8 * sizeof(Vertex) + dist + sizeof(short));
+}
+
+TEST_CASE( "Update on second and fourth attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+    size_t stride_b = sizeof(float); // stride of b in the struct
+    size_t stride_d = 2 * sizeof(float) + sizeof(short); // stride of c in the struct
+    char d = 0;
+
+    mesh->updateAttribute(stride_b, 1, 0.f);
+    mesh->updateAttribute(stride_d + sizeof(Vertex), 7, d);
+
+    REQUIRE(mesh->getDirtyOffset() == stride_b);
+    int dist = stride_d - stride_b; // distance between b and c
+    REQUIRE(mesh->getDirtySize() == 7 * sizeof(Vertex) + dist + sizeof(char));
+}


### PR DESCRIPTION
Make the text buffer inherits from the mesh. 
This makes the data ownership easier, also reduces the thread lock of the font context from building tile time lapse to a label rasterization time, which makes tile building faster when text rendering is needed, or text buffer binding.
This will also helps updating the vertex buffer objects in the sprite system.