### PR TITLE
Dynamic meshes

### DIFF
--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -16,8 +16,8 @@ void SpriteStyle::constructVertexLayout() {
     // 32 bytes, good for memory aligments
     m_vertexLayout = std::shared_ptr<VertexLayout>(new VertexLayout({
         {"a_position", 2, GL_FLOAT, false, 0},
-        {"a_screenPosition", 2, GL_FLOAT, false, 0},
         {"a_uv", 2, GL_FLOAT, false, 0},
+        {"a_screenPosition", 2, GL_FLOAT, false, 0},
         {"a_alpha", 1, GL_FLOAT, false, 0},
         {"a_rotation", 1, GL_FLOAT, false, 0},
     }));
@@ -46,12 +46,12 @@ void* SpriteStyle::parseStyleParams(const std::string& _layerNameID, const Style
 void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const {
     // TODO : make this configurable
     SpriteNode planeSprite = m_spriteAtlas->getSpriteNode("tree");
-    std::vector<PosUVVertex> vertices;
-    GLvoid* memStart;
+    std::vector<BufferVert> vertices;
+    GLint memOffset = 0;
     
     SpriteBuilder builder = {
         [&](const glm::vec2& coord, const glm::vec2& screenPos, const glm::vec2& uv) {
-            vertices.push_back({ coord, screenPos, uv, 0.5f, M_PI_2 });
+            vertices.push_back({ coord, uv, screenPos, 0.5f, M_PI_2 });
         }
     };
     
@@ -64,20 +64,17 @@ void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _prop
             Label::Transform t = {glm::vec2(_point), glm::vec2(_point)};
             
             SpriteLabel::AttributeOffsets attribOffsets = {
-                m_vertexLayout->getStride(),
-                memStart,
-                m_vertexLayout->getOffset("a_screenPosition"),
-                m_vertexLayout->getOffset("a_rotation"),
-                m_vertexLayout->getOffset("a_alpha"),
+                (GLintptr) m_vertexLayout->getOffset("a_screenPosition"),
+                (GLintptr) m_vertexLayout->getOffset("a_rotation"),
+                (GLintptr) m_vertexLayout->getOffset("a_alpha"),
             };
             
             auto label = m_labels->addSpriteLabel(_tile, m_name, t, planeSprite.size * spriteScale, offset, attribOffsets);
             
             if (label) {
                 Builders::buildQuadAtPoint(label->getTransform().m_screenPosition + offset, planeSprite.size * spriteScale, planeSprite.uvBL, planeSprite.uvTR, builder);
+                memOffset++;
             }
-            
-            memStart = vertices.data() + vertices.size();
         }
     }
     

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -47,7 +47,6 @@ void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _prop
     // TODO : make this configurable
     SpriteNode planeSprite = m_spriteAtlas->getSpriteNode("tree");
     std::vector<BufferVert> vertices;
-    GLint memOffset = 0;
     
     SpriteBuilder builder = {
         [&](const glm::vec2& coord, const glm::vec2& screenPos, const glm::vec2& uv) {
@@ -64,6 +63,7 @@ void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _prop
             Label::Transform t = {glm::vec2(_point), glm::vec2(_point)};
             
             SpriteLabel::AttributeOffsets attribOffsets = {
+                _mesh.numVertices() * m_vertexLayout->getStride(),
                 (GLintptr) m_vertexLayout->getOffset("a_screenPosition"),
                 (GLintptr) m_vertexLayout->getOffset("a_rotation"),
                 (GLintptr) m_vertexLayout->getOffset("a_alpha"),
@@ -73,7 +73,6 @@ void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _prop
             
             if (label) {
                 Builders::buildQuadAtPoint(label->getTransform().m_screenPosition + offset, planeSprite.size * spriteScale, planeSprite.uvBL, planeSprite.uvTR, builder);
-                memOffset++;
             }
         }
     }

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -9,16 +9,6 @@ class SpriteStyle : public Style {
 
 protected:
 
-    struct PosUVVertex {
-        // Position Data
-        glm::vec2 pos;
-        glm::vec2 screenPos;
-        // UV Data
-        glm::vec2 uv;
-        float alpha;
-        float rotation;
-    };
-
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
     virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh, MapTile& _tile) const override;
@@ -27,7 +17,7 @@ protected:
 
     virtual void* parseStyleParams(const std::string& _layerNameID, const StyleParamMap& _styleParamMap) override;
 
-    typedef TypedMesh<PosUVVertex> Mesh;
+    typedef TypedMesh<BufferVert> Mesh;
 
     virtual VboMesh* newMesh() const override {
         return new Mesh(m_vertexLayout, m_drawMode, GL_DYNAMIC_DRAW);

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -25,8 +25,8 @@ protected:
     
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;
     std::shared_ptr<Labels> m_labels;
+    unsigned int m_spriteGeneration;
     
-
 public:
 
     virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -22,16 +22,14 @@ protected:
     virtual VboMesh* newMesh() const override {
         return new Mesh(m_vertexLayout, m_drawMode, GL_DYNAMIC_DRAW);
     };
-    
+
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;
     std::shared_ptr<Labels> m_labels;
-    
+
 public:
 
     virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
     virtual void onEndDrawFrame() override;
-    
-    void setSpriteAtlas(std::unique_ptr<SpriteAtlas> _atlas);
 
     SpriteStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);
 

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -25,7 +25,6 @@ protected:
     
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;
     std::shared_ptr<Labels> m_labels;
-    unsigned int m_spriteGeneration;
     
 public:
 

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -2,9 +2,9 @@
 #include "fontContext.h"
 
 TextBuffer::TextBuffer(std::shared_ptr<FontContext> _fontContext, std::shared_ptr<VertexLayout> _vertexLayout)
-    : TypedMesh<TextVert>(_vertexLayout, GL_TRIANGLES, GL_DYNAMIC_DRAW) {
+    : TypedMesh<BufferVert>(_vertexLayout, GL_TRIANGLES, GL_DYNAMIC_DRAW) {
         
-    m_dirty = false;
+    m_dirtyTransform = false;
     m_fontContext = _fontContext;
     m_bound = false;
 }
@@ -42,11 +42,11 @@ bool TextBuffer::rasterize(const std::string& _text, fsuint _id) {
 }
 
 void TextBuffer::pushBuffer() {
-    if (m_dirty) {
+    if (m_dirtyTransform) {
         bind();
         glfonsUpdateBuffer(m_fontContext->getFontContext(), this);
         unbind();
-        m_dirty = false;
+        m_dirtyTransform = false;
     }
 }
 
@@ -54,7 +54,7 @@ void TextBuffer::transformID(fsuint _textID, float _x, float _y, float _rot, flo
     bind();
     glfonsTransform(m_fontContext->getFontContext(), _textID, _x, _y, _rot, _alpha);
     unbind();
-    m_dirty = true;
+    m_dirtyTransform = true;
 }
 
 glm::vec4 TextBuffer::getBBox(fsuint _textID) {
@@ -66,7 +66,7 @@ glm::vec4 TextBuffer::getBBox(fsuint _textID) {
 }
 
 void TextBuffer::addBufferVerticesToMesh() {
-    std::vector<TextVert> vertices;
+    std::vector<BufferVert> vertices;
     int bufferSize = getVerticesSize();
     
     if (bufferSize == 0) {

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -4,9 +4,9 @@
 #include "glfontstash.h"
 #include "util/typedMesh.h"
 
-struct TextVert {
+struct BufferVert {
     glm::vec2 pos;
-    glm::vec2 uvs;
+    glm::vec2 uv;
     glm::vec2 screenPos;
     float alpha;
     float rotation;
@@ -17,7 +17,7 @@ class FontContext;
 /*
  * This class represents a text buffer, each text buffer has several text ids
  */
-class TextBuffer : public TypedMesh<TextVert> {
+class TextBuffer : public TypedMesh<BufferVert> {
 
 public:
 
@@ -57,7 +57,7 @@ private:
     void unbind();
     
     bool m_bound;
-    bool m_dirty;
+    bool m_dirtyTransform;
     fsuint m_fsBuffer;
     std::shared_ptr<FontContext> m_fontContext;
 

--- a/core/src/tile/labels/spriteLabel.cpp
+++ b/core/src/tile/labels/spriteLabel.cpp
@@ -9,7 +9,12 @@ SpriteLabel::SpriteLabel(Label::Transform _transform, const glm::vec2& _size, co
 }
 
 void SpriteLabel::pushTransform(VboMesh& _mesh) {
-    // TODO: update the mesh
+    if (m_dirty) {
+        TypedMesh<BufferVert>& mesh = static_cast<TypedMesh<BufferVert>&>(_mesh);
+        mesh.updateAttribute(m_attribOffsets.m_position, 4, glm::vec2(m_transform.m_screenPosition.x, m_transform.m_screenPosition.y));
+        mesh.updateAttribute(m_attribOffsets.m_alpha, 4, m_transform.m_alpha);
+        mesh.updateAttribute(m_attribOffsets.m_rotation, 4, m_transform.m_rotation);
+    }
 }
 
 void SpriteLabel::updateBBoxes() {

--- a/core/src/tile/labels/spriteLabel.cpp
+++ b/core/src/tile/labels/spriteLabel.cpp
@@ -11,9 +11,10 @@ SpriteLabel::SpriteLabel(Label::Transform _transform, const glm::vec2& _size, co
 void SpriteLabel::pushTransform(VboMesh& _mesh) {
     if (m_dirty) {
         TypedMesh<BufferVert>& mesh = static_cast<TypedMesh<BufferVert>&>(_mesh);
-        mesh.updateAttribute(m_attribOffsets.m_position, 4, glm::vec2(m_transform.m_screenPosition.x, m_transform.m_screenPosition.y));
-        mesh.updateAttribute(m_attribOffsets.m_alpha, 4, m_transform.m_alpha);
-        mesh.updateAttribute(m_attribOffsets.m_rotation, 4, m_transform.m_rotation);
+        int memOffset = m_attribOffsets.memOffset;
+        mesh.updateAttribute(m_attribOffsets.m_position + memOffset, 4, glm::vec2(m_transform.m_screenPosition.x, m_transform.m_screenPosition.y));
+        mesh.updateAttribute(m_attribOffsets.m_alpha + memOffset, 4, m_transform.m_alpha);
+        mesh.updateAttribute(m_attribOffsets.m_rotation + memOffset, 4, m_transform.m_rotation);
     }
 }
 

--- a/core/src/tile/labels/spriteLabel.cpp
+++ b/core/src/tile/labels/spriteLabel.cpp
@@ -12,6 +12,7 @@ void SpriteLabel::pushTransform(VboMesh& _mesh) {
     if (m_dirty) {
         TypedMesh<BufferVert>& mesh = static_cast<TypedMesh<BufferVert>&>(_mesh);
         int memOffset = m_attribOffsets.memOffset;
+        
         mesh.updateAttribute(m_attribOffsets.m_position + memOffset, 4, glm::vec2(m_transform.m_screenPosition.x, m_transform.m_screenPosition.y));
         mesh.updateAttribute(m_attribOffsets.m_alpha + memOffset, 4, m_transform.m_alpha);
         mesh.updateAttribute(m_attribOffsets.m_rotation + memOffset, 4, m_transform.m_rotation);

--- a/core/src/tile/labels/spriteLabel.cpp
+++ b/core/src/tile/labels/spriteLabel.cpp
@@ -13,7 +13,7 @@ void SpriteLabel::pushTransform(VboMesh& _mesh) {
         TypedMesh<BufferVert>& mesh = static_cast<TypedMesh<BufferVert>&>(_mesh);
         int memOffset = m_attribOffsets.memOffset;
         
-        mesh.updateAttribute(m_attribOffsets.m_position + memOffset, 4, glm::vec2(m_transform.m_screenPosition.x, m_transform.m_screenPosition.y));
+        mesh.updateAttribute(m_attribOffsets.m_position + memOffset, 4, glm::vec2(m_transform.m_screenPosition.x, m_transform.m_screenPosition.y) + m_offset);
         mesh.updateAttribute(m_attribOffsets.m_alpha + memOffset, 4, m_transform.m_alpha);
         mesh.updateAttribute(m_attribOffsets.m_rotation + memOffset, 4, m_transform.m_rotation);
     }

--- a/core/src/tile/labels/spriteLabel.cpp
+++ b/core/src/tile/labels/spriteLabel.cpp
@@ -4,18 +4,30 @@ SpriteLabel::SpriteLabel(Label::Transform _transform, const glm::vec2& _size, co
     Label(_transform, Label::Type::POINT),
     m_offset(_offset),
     m_attribOffsets(_attribOffsets) {
-        
+
     m_dim = _size;
 }
 
 void SpriteLabel::pushTransform(VboMesh& _mesh) {
     if (m_dirty) {
         TypedMesh<BufferVert>& mesh = static_cast<TypedMesh<BufferVert>&>(_mesh);
-        int memOffset = m_attribOffsets.memOffset;
-        
-        mesh.updateAttribute(m_attribOffsets.m_position + memOffset, 4, glm::vec2(m_transform.m_screenPosition.x, m_transform.m_screenPosition.y) + m_offset);
-        mesh.updateAttribute(m_attribOffsets.m_alpha + memOffset, 4, m_transform.m_alpha);
-        mesh.updateAttribute(m_attribOffsets.m_rotation + memOffset, 4, m_transform.m_rotation);
+
+        // used to write all attributes memory at once, good for caching
+        struct VertexAttributes {
+            glm::vec2 screenPos;
+            float alpha;
+            float rot;
+        };
+
+        GLintptr stride = std::min<GLintptr>(m_attribOffsets.m_position, std::min<GLintptr>(m_attribOffsets.m_alpha, m_attribOffsets.m_rotation));
+
+        VertexAttributes newAttributes {
+            m_transform.m_screenPosition + m_offset,
+            m_transform.m_alpha,
+            m_transform.m_rotation,
+        };
+
+        mesh.updateAttribute(stride + m_attribOffsets.memOffset, 4, newAttributes);
     }
 }
 

--- a/core/src/tile/labels/spriteLabel.h
+++ b/core/src/tile/labels/spriteLabel.h
@@ -6,6 +6,7 @@ class SpriteLabel : public Label {
 public:
     
     struct AttributeOffsets {
+        int memOffset;
         GLintptr m_position;
         GLintptr m_rotation;
         GLintptr m_alpha;

--- a/core/src/tile/labels/spriteLabel.h
+++ b/core/src/tile/labels/spriteLabel.h
@@ -6,11 +6,9 @@ class SpriteLabel : public Label {
 public:
     
     struct AttributeOffsets {
-        GLint m_size;
-        GLvoid* m_memStart;
-        GLvoid* m_position;
-        GLvoid* m_rotation;
-        GLvoid* m_alpha;
+        GLintptr m_position;
+        GLintptr m_rotation;
+        GLintptr m_alpha;
     };
     
     SpriteLabel(Label::Transform _transform, const glm::vec2& _size, const glm::vec2& _offset, AttributeOffsets _attribOffsets);

--- a/core/src/tile/labels/textLabel.cpp
+++ b/core/src/tile/labels/textLabel.cpp
@@ -33,11 +33,9 @@ bool TextLabel::rasterize(TextBuffer& _buffer) {
 }
 
 void TextLabel::pushTransform(VboMesh& _mesh) {
-    if (m_dirty && typeid(_mesh) == typeid(TextBuffer)) {
+    if (m_dirty) {
         TextBuffer& buffer = static_cast<TextBuffer&>(_mesh);
-        
-        buffer.transformID(m_id, m_transform.m_screenPosition.x, m_transform.m_screenPosition.y,
-                           m_transform.m_rotation, m_transform.m_alpha);
+        buffer.transformID(m_id, m_transform.m_screenPosition.x, m_transform.m_screenPosition.y, m_transform.m_rotation, m_transform.m_alpha);
         m_dirty = false;
     }
 }

--- a/core/src/tile/labels/textLabel.cpp
+++ b/core/src/tile/labels/textLabel.cpp
@@ -33,9 +33,11 @@ bool TextLabel::rasterize(TextBuffer& _buffer) {
 }
 
 void TextLabel::pushTransform(VboMesh& _mesh) {
-    if (m_dirty) {
+    if (m_dirty && typeid(_mesh) == typeid(TextBuffer)) {
         TextBuffer& buffer = static_cast<TextBuffer&>(_mesh);
-        buffer.transformID(m_id, m_transform.m_screenPosition.x, m_transform.m_screenPosition.y, m_transform.m_rotation, m_transform.m_alpha);
+        
+        buffer.transformID(m_id, m_transform.m_screenPosition.x, m_transform.m_screenPosition.y,
+                           m_transform.m_rotation, m_transform.m_alpha);
         m_dirty = false;
     }
 }

--- a/core/src/tile/mapTile.cpp
+++ b/core/src/tile/mapTile.cpp
@@ -64,13 +64,15 @@ void MapTile::updateLabels(float _dt, const Style& _style, const View& _view) {
 void MapTile::pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _labels) {
     std::shared_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
     
-    if (styleMesh && typeid(*styleMesh) == typeid(TextBuffer)) {
+    if (styleMesh) {
         for(auto& label : m_labels[_style.getName()]) {
             label->pushTransform(*styleMesh);
         }
     
-        TextBuffer& buffer = static_cast<TextBuffer&>(*styleMesh);
-        buffer.pushBuffer();
+        if (typeid(*styleMesh) == typeid(TextBuffer)) {
+            TextBuffer& buffer = static_cast<TextBuffer&>(*styleMesh);
+            buffer.pushBuffer();
+        }
     }
 }
 

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -23,8 +23,16 @@ public:
         compile(vertices, indices);
     }
     
+    /*
+     * Update _nVerts vertices in the mesh with the new T value _newVertexValue starting after 
+     * _byteOffset in the mesh vertex data memory
+     */
     void updateVertices(GLintptr _byteOffset, unsigned int _nVerts, const T& _newVertexValue);
     
+    /*
+     * Update _nVerts vertices in the mesh with the new attribute A _newAttributeValue starting 
+     * after _byteOffset in the mesh vertex data memory
+     */
     template<class A>
     void updateAttribute(GLintptr _byteOffset, unsigned int _nVerts, const A& _newAttributeValue) {
         if (!m_isCompiled) {
@@ -34,7 +42,7 @@ public:
         size_t aSize = sizeof(A);
         size_t tSize = sizeof(T);
         
-        // update the vertices
+        // update the vertices attributes
         for (int i = 0; i < _nVerts; ++i) {
             std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newAttributeValue, aSize);
         }
@@ -53,7 +61,8 @@ protected:
 
 template<class T>
 void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
-    // not dirty, init the dirtyness of the buffer
+    
+    // not dirty at all, init the dirtyness of the buffer
     if(!m_dirty) {
         m_dirtySize = _byteSize;
         m_dirtyOffset = _byteOffset;
@@ -65,7 +74,7 @@ void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
         long oldEnd = m_dirtySize + m_dirtyOffset;
         
         if(_byteOffset < m_dirtyOffset) {
-            // update from left part of the buffer
+            // update before the old buffer offset (left part of the buffer)
             m_dirtyOffset = _byteOffset;
             
             // merge sizes
@@ -74,9 +83,10 @@ void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
             } else {
                 m_dirtySize += dBytes;
             }
+            
             m_dirty = true;
         } else if(newEnd > oldEnd) {
-            // update from right part of the buffer
+            // update starting after the old buffer offset (right part of the buffer)
             m_dirtySize = dBytes + _byteSize;
             m_dirty = true;
         }

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -60,7 +60,7 @@ void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
         m_dirty = true;
     } else {
         // distance in bytes
-        long dBytes = std::abs((long double)_byteOffset - m_dirtyOffset);
+        long dBytes = std::abs(_byteOffset - m_dirtyOffset);
         long newEnd = _byteOffset + _byteSize;
         long oldEnd = m_dirtySize + m_dirtyOffset;
         

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "vboMesh.h"
+#include <cstdlib> // std::abs
 
 template<class T>
 class TypedMesh : public VboMesh {
 
 public:
-    
+
     TypedMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode, GLenum _hint = GL_STATIC_DRAW)
         : VboMesh(_vertexLayout, _drawMode, _hint) {};
 
@@ -22,15 +23,15 @@ public:
     virtual void compileVertexBuffer() override {
         compile(vertices, indices);
     }
-    
+
     /*
-     * Update _nVerts vertices in the mesh with the new T value _newVertexValue starting after 
+     * Update _nVerts vertices in the mesh with the new T value _newVertexValue starting after
      * _byteOffset in the mesh vertex data memory
      */
     void updateVertices(GLintptr _byteOffset, unsigned int _nVerts, const T& _newVertexValue);
-    
+
     /*
-     * Update _nVerts vertices in the mesh with the new attribute A _newAttributeValue starting 
+     * Update _nVerts vertices in the mesh with the new attribute A _newAttributeValue starting
      * after _byteOffset in the mesh vertex data memory
      */
     template<class A>
@@ -38,68 +39,68 @@ public:
         if (!m_isCompiled) {
             return;
         }
-        
+
         if (m_hint == GL_STATIC_DRAW) {
             logMsg("WARNING: wrong usage hint provided to the Vbo\n");
         }
-        
+
         size_t aSize = sizeof(A);
         size_t tSize = sizeof(T);
-        
+
         // update the vertices attributes
         for (int i = 0; i < _nVerts; ++i) {
             std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newAttributeValue, aSize);
         }
-        
+
         setDirty(_byteOffset + aSize, _nVerts * tSize + aSize);
     }
 
 protected:
-    
+
     void setDirty(GLintptr _byteOffset, GLsizei _byteSize);
-    
+
     std::vector<std::vector<T>> vertices;
     std::vector<std::vector<int>> indices;
-    
+
 };
 
 template<class T>
 void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
-    
-    // not dirty at all, init the dirtyness of the buffer
+
+    // not dirty at all, init the dirtiness of the buffer
     if (!m_dirty) {
-        
+
         m_dirtySize = _byteSize;
         m_dirtyOffset = _byteOffset;
         m_dirty = true;
-        
+
     } else {
         GLsizei dBytes = std::abs(_byteOffset - m_dirtyOffset); // distance in bytes
         GLintptr nOff = _byteOffset + _byteSize; // new offset
         GLintptr pOff = m_dirtySize + m_dirtyOffset; // previous offset
-        
+
         if (_byteOffset < m_dirtyOffset) { // left part of the buffer
-            
+
             // update before the old buffer offset
             m_dirtyOffset = _byteOffset;
-            
+
             // merge sizes
             if (nOff > pOff) {
                 m_dirtySize = _byteSize;
             } else {
                 m_dirtySize += dBytes;
             }
-            
+
             m_dirty = true;
-            
+
         } else if (nOff > pOff) { // right part of the buffer
-            
+
             // update starting after the old buffer offset
             m_dirtySize = dBytes + _byteSize;
             m_dirty = true;
         }
     }
-    
+
 }
 
 template<class T>
@@ -107,17 +108,17 @@ void TypedMesh<T>::updateVertices(GLintptr _byteOffset, unsigned int _nVerts, co
     if (!m_isCompiled) {
         return;
     }
-    
+
     if (m_hint == GL_STATIC_DRAW) {
         logMsg("WARNING: wrong usage hint provided to the Vbo\n");
     }
-    
+
     size_t tSize = sizeof(T);
-    
+
     // update the vertices
     for (int i = 0; i < _nVerts; ++i) {
         std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newVertexValue, tSize);
     }
-    
+
     setDirty(_byteOffset, _nVerts * tSize);
 }

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -39,6 +39,10 @@ public:
             return;
         }
         
+        if (m_hint == GL_STATIC_DRAW) {
+            logMsg("WARNING: wrong usage hint provided to the Vbo\n");
+        }
+        
         size_t aSize = sizeof(A);
         size_t tSize = sizeof(T);
         
@@ -63,40 +67,49 @@ template<class T>
 void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
     
     // not dirty at all, init the dirtyness of the buffer
-    if(!m_dirty) {
+    if (!m_dirty) {
+        
         m_dirtySize = _byteSize;
         m_dirtyOffset = _byteOffset;
         m_dirty = true;
-    } else {
-        // distance in bytes
-        long dBytes = std::abs(_byteOffset - m_dirtyOffset);
-        long newEnd = _byteOffset + _byteSize;
-        long oldEnd = m_dirtySize + m_dirtyOffset;
         
-        if(_byteOffset < m_dirtyOffset) {
-            // update before the old buffer offset (left part of the buffer)
+    } else {
+        GLsizei dBytes = std::abs(_byteOffset - m_dirtyOffset); // distance in bytes
+        GLintptr nOff = _byteOffset + _byteSize; // new offset
+        GLintptr pOff = m_dirtySize + m_dirtyOffset; // previous offset
+        
+        if (_byteOffset < m_dirtyOffset) { // left part of the buffer
+            
+            // update before the old buffer offset
             m_dirtyOffset = _byteOffset;
             
             // merge sizes
-            if(newEnd > oldEnd) {
+            if (nOff > pOff) {
                 m_dirtySize = _byteSize;
             } else {
                 m_dirtySize += dBytes;
             }
             
             m_dirty = true;
-        } else if(newEnd > oldEnd) {
-            // update starting after the old buffer offset (right part of the buffer)
+            
+        } else if (nOff > pOff) { // right part of the buffer
+            
+            // update starting after the old buffer offset
             m_dirtySize = dBytes + _byteSize;
             m_dirty = true;
         }
     }
+    
 }
 
 template<class T>
 void TypedMesh<T>::updateVertices(GLintptr _byteOffset, unsigned int _nVerts, const T& _newVertexValue) {
     if (!m_isCompiled) {
         return;
+    }
+    
+    if (m_hint == GL_STATIC_DRAW) {
+        logMsg("WARNING: wrong usage hint provided to the Vbo\n");
     }
     
     size_t tSize = sizeof(T);

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -40,10 +40,6 @@ public:
             return;
         }
 
-        if (m_hint == GL_STATIC_DRAW) {
-            logMsg("WARNING: wrong usage hint provided to the Vbo\n");
-        }
-
         size_t aSize = sizeof(A);
         size_t tSize = sizeof(T);
 
@@ -107,10 +103,6 @@ template<class T>
 void TypedMesh<T>::updateVertices(GLintptr _byteOffset, unsigned int _nVerts, const T& _newVertexValue) {
     if (!m_isCompiled) {
         return;
-    }
-
-    if (m_hint == GL_STATIC_DRAW) {
-        logMsg("WARNING: wrong usage hint provided to the Vbo\n");
     }
 
     size_t tSize = sizeof(T);

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -22,10 +22,84 @@ public:
     virtual void compileVertexBuffer() override {
         compile(vertices, indices);
     }
+    
+    void updateVertices(GLintptr _byteOffset, unsigned int _nVerts, const T& _newVertexValue);
+    
+    template<class A>
+    void updateAttribute(GLintptr _byteOffset, unsigned int _nVerts, const A& _newAttributeValue) {
+        if (!m_isCompiled) {
+            return;
+        }
+        
+        size_t aSize = sizeof(A);
+        size_t tSize = sizeof(T);
+        
+        // update the vertices
+        for (int i = 0; i < _nVerts; ++i) {
+            std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newAttributeValue, aSize);
+        }
+        
+        //setDirty(_byteOffset + aSize, _byteOffset + _nVerts * tSize + aSize);
+        
+        // hack for now
+        m_dirtySize = m_nVertices * m_vertexLayout->getStride();
+        m_dirtyOffset = 0;
+        m_dirty = true;
+    }
 
 protected:
+    
+    void setDirty(GLintptr _byteOffset, GLsizei _byteSize);
     
     std::vector<std::vector<T>> vertices;
     std::vector<std::vector<int>> indices;
     
 };
+
+template<class T>
+void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
+    // not dirty, init the dirtyness of the buffer
+    if(!m_dirty) {
+        m_dirtySize = _byteSize;
+        m_dirtyOffset = _byteOffset;
+        m_dirty = true;
+    } else {
+        // distance in bytes
+        long dBytes = std::abs((long double)_byteOffset - m_dirtyOffset);
+        long newEnd = _byteOffset + _byteSize;
+        long oldEnd = m_dirtySize + m_dirtyOffset;
+        
+        if(_byteOffset < m_dirtyOffset) {
+            // update from left part of the buffer
+            m_dirtyOffset = _byteOffset;
+            
+            // merge sizes
+            if(newEnd > oldEnd) {
+                m_dirtySize = _byteSize;
+            } else {
+                m_dirtySize += dBytes;
+            }
+            m_dirty = true;
+        } else if(newEnd > oldEnd) {
+            // update from right part of the buffer
+            m_dirtySize = dBytes + _byteSize;
+            m_dirty = true;
+        }
+    }
+}
+
+template<class T>
+void TypedMesh<T>::updateVertices(GLintptr _byteOffset, unsigned int _nVerts, const T& _newVertexValue) {
+    if (!m_isCompiled) {
+        return;
+    }
+    
+    size_t tSize = sizeof(T);
+    
+    // update the vertices
+    for (int i = 0; i < _nVerts; ++i) {
+        std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newVertexValue, tSize);
+    }
+    
+    setDirty(_byteOffset, _byteOffset + _nVerts * tSize);
+}

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -39,12 +39,7 @@ public:
             std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newAttributeValue, aSize);
         }
         
-        //setDirty(_byteOffset + aSize, _byteOffset + _nVerts * tSize + aSize);
-        
-        // hack for now
-        m_dirtySize = m_nVertices * m_vertexLayout->getStride();
-        m_dirtyOffset = 0;
-        m_dirty = true;
+        setDirty(_byteOffset + aSize, _nVerts * tSize + aSize);
     }
 
 protected:
@@ -101,5 +96,5 @@ void TypedMesh<T>::updateVertices(GLintptr _byteOffset, unsigned int _nVerts, co
         std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newVertexValue, tSize);
     }
     
-    setDirty(_byteOffset, _byteOffset + _nVerts * tSize);
+    setDirty(_byteOffset, _nVerts * tSize);
 }

--- a/core/src/util/typedMesh.h
+++ b/core/src/util/typedMesh.h
@@ -48,7 +48,7 @@ public:
             std::memcpy(m_glVertexData + _byteOffset + i * tSize, &_newAttributeValue, aSize);
         }
 
-        setDirty(_byteOffset + aSize, _nVerts * tSize + aSize);
+        setDirty(_byteOffset, (_nVerts - 1) * tSize + aSize);
     }
 
 protected:

--- a/core/src/util/vboMesh.cpp
+++ b/core/src/util/vboMesh.cpp
@@ -57,10 +57,6 @@ void VboMesh::setDrawMode(GLenum _drawMode) {
 }
 
 void VboMesh::update(GLintptr _offset, GLsizei _size, unsigned char* _data) {
-    if (m_hint == GL_STATIC_DRAW) {
-        logMsg("WARNING: wrong usage hint provided to the Vbo\n");
-    }
-
     std::memcpy(m_glVertexData + _offset, _data, _size);
 
     m_dirtyOffset = _offset;
@@ -71,6 +67,11 @@ void VboMesh::update(GLintptr _offset, GLsizei _size, unsigned char* _data) {
 
 void VboMesh::subDataUpload() {
     if (m_dirtySize != 0) {
+        
+        if (m_hint == GL_STATIC_DRAW) {
+            logMsg("WARNING: wrong usage hint provided to the Vbo\n");
+        }
+        
         glBindBuffer(GL_ARRAY_BUFFER, m_glVertexBuffer);
 
         long vertexBytes = m_nVertices * m_vertexLayout->getStride();

--- a/core/src/util/vboMesh.h
+++ b/core/src/util/vboMesh.h
@@ -24,7 +24,7 @@ public:
      */
     VboMesh(std::shared_ptr<VertexLayout> _vertexlayout, GLenum _drawMode = GL_TRIANGLES, GLenum _hint = GL_STATIC_DRAW);
     VboMesh();
-    
+
     /*
      * Set Vertex Layout for the vboMesh object
      */
@@ -62,14 +62,17 @@ public:
      * been uploaded it will be uploaded at this point
      */
     void draw(const std::shared_ptr<ShaderProgram> _shader);
-    
+
     void update(GLintptr _offset, GLsizei _size, unsigned char* _data);
-    
+
     static void addManagedVBO(VboMesh* _vbo);
-    
+
     static void removeManagedVBO(VboMesh* _vbo);
-    
+
     static void invalidateAllVBOs();
+
+    GLsizei getDirtySize() const { return m_dirtySize; }
+    GLintptr getDirtyOffset() const { return m_dirtyOffset; }
 
 protected:
 
@@ -98,10 +101,10 @@ protected:
     bool m_isUploaded;
     bool m_isCompiled;
     bool m_dirty;
-    
+
     GLsizei m_dirtySize;
     GLintptr m_dirtyOffset;
-    
+
     void checkValidity();
 
     template <typename T>

--- a/tests/unit/meshTests.cpp
+++ b/tests/unit/meshTests.cpp
@@ -73,7 +73,7 @@ TEST_CASE( "Right merge on vertices dirtiness", "[Core][TypedMesh]" ) {
 TEST_CASE( "Update on second attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
     auto mesh = newMesh(10);
     int nVert = 5;
-    size_t stride_b = 1 * sizeof(float); // stride of a in the struct
+    size_t stride_b = sizeof(float); // stride of a in the struct
 
     mesh->updateAttribute(stride_b + sizeof(Vertex), nVert, 0.f);
 
@@ -83,17 +83,17 @@ TEST_CASE( "Update on second attribute of the mesh for n vertices", "[Core][Type
 
 TEST_CASE( "Update on second attribute of the mesh for 1 vertices", "[Core][TypedMesh]" ) {
     auto mesh = newMesh(10);
-    size_t stride_a = 1 * sizeof(float); // stride of a in the struct
+    size_t stride_b = sizeof(float); // stride of a in the struct
 
-    mesh->updateAttribute(stride_a, 1, 0.f);
+    mesh->updateAttribute(stride_b, 1, 0.f);
 
-    REQUIRE(mesh->getDirtyOffset() == stride_a);
+    REQUIRE(mesh->getDirtyOffset() == stride_b);
     REQUIRE(mesh->getDirtySize() == sizeof(float));
 }
 
 TEST_CASE( "Update on second and third attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
     auto mesh = newMesh(10);
-    size_t stride_b = 1 * sizeof(float); // stride of b in the struct
+    size_t stride_b = sizeof(float); // stride of b in the struct
     size_t stride_c = 2 * sizeof(float); // stride of c in the struct
     short c = 0;
 
@@ -107,7 +107,7 @@ TEST_CASE( "Update on second and third attribute of the mesh for n vertices", "[
 
 TEST_CASE( "Update on second and fourth attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
     auto mesh = newMesh(10);
-    size_t stride_b = 1 * sizeof(float); // stride of b in the struct
+    size_t stride_b = sizeof(float); // stride of b in the struct
     size_t stride_d = 2 * sizeof(float) + sizeof(short); // stride of c in the struct
     char d = 0;
 

--- a/tests/unit/meshTests.cpp
+++ b/tests/unit/meshTests.cpp
@@ -73,11 +73,11 @@ TEST_CASE( "Right merge on vertices dirtiness", "[Core][TypedMesh]" ) {
 TEST_CASE( "Update on second attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
     auto mesh = newMesh(10);
     int nVert = 5;
-    size_t stride_a = 1 * sizeof(float); // stride of a in the struct
+    size_t stride_b = 1 * sizeof(float); // stride of a in the struct
 
-    mesh->updateAttribute(stride_a + sizeof(Vertex), nVert, 0.f);
+    mesh->updateAttribute(stride_b + sizeof(Vertex), nVert, 0.f);
 
-    REQUIRE(mesh->getDirtyOffset() == stride_a + sizeof(Vertex));
+    REQUIRE(mesh->getDirtyOffset() == stride_b + sizeof(Vertex));
     REQUIRE(mesh->getDirtySize() == (nVert - 1) * sizeof(Vertex) + sizeof(float));
 }
 

--- a/tests/unit/meshTests.cpp
+++ b/tests/unit/meshTests.cpp
@@ -1,0 +1,120 @@
+#define CATCH_CONFIG_MAIN
+#include "catch/catch.hpp"
+
+#include <iostream>
+#include "typedMesh.h"
+
+struct Vertex {
+    float a;
+    float b;
+    short c;
+    char d;
+};
+
+std::shared_ptr<VertexLayout> layout = std::shared_ptr<VertexLayout>(new VertexLayout({
+    {"ab", 2, GL_FLOAT, false, 0},
+    {"c",  1, GL_SHORT, false, 0},
+    {"d",  1, GL_BYTE,  false, 0},
+}));
+
+std::shared_ptr<TypedMesh<Vertex>> newMesh(unsigned int size) {
+    auto mesh = std::shared_ptr<TypedMesh<Vertex>>(new TypedMesh<Vertex>(layout, GL_TRIANGLES));
+    std::vector<Vertex> vertices;
+    for (int i = 0; i < size; ++i) {
+        vertices.push_back({0,0,0,0});
+    }
+    mesh->addVertices(std::move(vertices), {});
+    mesh->compileVertexBuffer();
+    return mesh;
+}
+
+TEST_CASE( "Simple update on vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+
+    REQUIRE(mesh->getDirtyOffset() == 0);
+    REQUIRE(mesh->getDirtySize() == 0);
+
+    mesh->updateVertices(0, 4, Vertex());
+
+    REQUIRE(mesh->getDirtyOffset() == 0);
+    REQUIRE(mesh->getDirtySize() == 4 * sizeof(Vertex));
+}
+
+TEST_CASE( "Left merge on vertices with bigger left size", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+
+    mesh->updateVertices(2 * sizeof(Vertex), 2, Vertex());
+    mesh->updateVertices(0 * sizeof(Vertex), 8, Vertex());
+
+    REQUIRE(mesh->getDirtyOffset() == 0);
+    REQUIRE(mesh->getDirtySize() == 8 * sizeof(Vertex));
+}
+
+TEST_CASE( "Left merge on vertices with smaller left size", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+
+    mesh->updateVertices(2 * sizeof(Vertex), 2, Vertex());
+    mesh->updateVertices(0 * sizeof(Vertex), 1, Vertex());
+
+    REQUIRE(mesh->getDirtyOffset() == 0);
+    REQUIRE(mesh->getDirtySize() == 4 * sizeof(Vertex));
+}
+
+TEST_CASE( "Right merge on vertices dirtiness", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+
+    mesh->updateVertices(2 * sizeof(Vertex), 2, Vertex());
+    mesh->updateVertices(4 * sizeof(Vertex), 2, Vertex());
+
+    REQUIRE(mesh->getDirtyOffset() == 2 * sizeof(Vertex));
+    REQUIRE(mesh->getDirtySize() == 4 * sizeof(Vertex));
+}
+
+TEST_CASE( "Update on second attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+    int nVert = 5;
+    size_t stride_a = 1 * sizeof(float); // stride of a in the struct
+
+    mesh->updateAttribute(stride_a + sizeof(Vertex), nVert, 0.f);
+
+    REQUIRE(mesh->getDirtyOffset() == stride_a + sizeof(Vertex));
+    REQUIRE(mesh->getDirtySize() == (nVert - 1) * sizeof(Vertex) + sizeof(float));
+}
+
+TEST_CASE( "Update on second attribute of the mesh for 1 vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+    size_t stride_a = 1 * sizeof(float); // stride of a in the struct
+
+    mesh->updateAttribute(stride_a, 1, 0.f);
+
+    REQUIRE(mesh->getDirtyOffset() == stride_a);
+    REQUIRE(mesh->getDirtySize() == sizeof(float));
+}
+
+TEST_CASE( "Update on second and third attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+    size_t stride_b = 1 * sizeof(float); // stride of b in the struct
+    size_t stride_c = 2 * sizeof(float); // stride of c in the struct
+    short c = 0;
+
+    mesh->updateAttribute(stride_b, 5, 0.f);
+    mesh->updateAttribute(stride_c + sizeof(Vertex), 8, c);
+
+    REQUIRE(mesh->getDirtyOffset() == stride_b);
+    int dist = stride_c - stride_b; // distance between b and c
+    REQUIRE(mesh->getDirtySize() == 8 * sizeof(Vertex) + dist + sizeof(short));
+}
+
+TEST_CASE( "Update on second and fourth attribute of the mesh for n vertices", "[Core][TypedMesh]" ) {
+    auto mesh = newMesh(10);
+    size_t stride_b = 1 * sizeof(float); // stride of b in the struct
+    size_t stride_d = 2 * sizeof(float) + sizeof(short); // stride of c in the struct
+    char d = 0;
+
+    mesh->updateAttribute(stride_b, 1, 0.f);
+    mesh->updateAttribute(stride_d + sizeof(Vertex), 7, d);
+
+    REQUIRE(mesh->getDirtyOffset() == stride_b);
+    int dist = stride_d - stride_b; // distance between b and c
+    REQUIRE(mesh->getDirtySize() == 7 * sizeof(Vertex) + dist + sizeof(char));
+}


### PR DESCRIPTION
Following the work on the transformation of the text buffer to a mesh. 

This PR introduces dynamic mesh updates, it basically adds the possibility to update an attribute/vertex on a specific location inside the mesh, useful for text/sprites. 

Once you have updated an attribute/vertex, the dirtiness is then computed in order to send only the most efficient part to update to OpenGL, some sync could still happen while buffering the data since the vbo could be in use on current frame but I have some thoughts on how to fix that if it becomes an issue in render time.
`updateAttribute` method is not cache-friendly, we'd have to consolidate that.

Once this gets merged in text-buffer-mesh branch, I'd follow up with the sprites PR.