### PR TITLE
avoid void* casting: move parseStyleParams to style subclasses

### DIFF
--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -29,9 +29,7 @@ void DebugStyle::constructShaderProgram() {
 
 }
 
-void* DebugStyle::parseStyleParams(const StyleParamMap& _styleParamMap) const {
-    return nullptr;
-}
+void DebugStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {}
 
 void DebugStyle::addData(TileData &_data, MapTile &_tile) {
 
@@ -60,19 +58,19 @@ void DebugStyle::addData(TileData &_data, MapTile &_tile) {
 
 }
 
-void DebugStyle::buildPoint(Point &_point, void* _styleParams, Properties &_props, VboMesh &_mesh) const {
+void DebugStyle::buildPoint(Point &_point, const StyleParamMap& _styleParamMap, Properties &_props, VboMesh &_mesh) const {
 
     // No-op
 
 }
 
-void DebugStyle::buildLine(Line &_line, void* _styleParams, Properties &_props, VboMesh &_mesh) const {
+void DebugStyle::buildLine(Line &_line, const StyleParamMap& _styleParamMap, Properties &_props, VboMesh &_mesh) const {
 
     // No-op
 
 }
 
-void DebugStyle::buildPolygon(Polygon &_polygon, void* _styleParams, Properties &_props, VboMesh &_mesh) const {
+void DebugStyle::buildPolygon(Polygon &_polygon, const StyleParamMap& _styleParamMap, Properties &_props, VboMesh &_mesh) const {
 
     // No-op
 

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -29,8 +29,6 @@ void DebugStyle::constructShaderProgram() {
 
 }
 
-void DebugStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {}
-
 void DebugStyle::addData(TileData &_data, MapTile &_tile) {
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::tile_bounds)) {

--- a/core/src/style/debugStyle.h
+++ b/core/src/style/debugStyle.h
@@ -21,8 +21,6 @@ protected:
     virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void addData(TileData& _data, MapTile& _tile) override;
 
-    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
-
     typedef TypedMesh<PosColVertex> Mesh;
 
     virtual VboMesh* newMesh() const override {

--- a/core/src/style/debugStyle.h
+++ b/core/src/style/debugStyle.h
@@ -16,12 +16,12 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void addData(TileData& _data, MapTile& _tile) override;
 
-    virtual void* parseStyleParams(const StyleParamMap& _styleParamMap) const override;
+    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
 
     typedef TypedMesh<PosColVertex> Mesh;
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -28,24 +28,22 @@ void PolygonStyle::constructShaderProgram() {
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 }
 
-void* PolygonStyle::parseStyleParams(const StyleParamMap& _styleParamMap) const {
+void PolygonStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {
 
-    StyleParams* params = new StyleParams();
+    StyleParams* params = static_cast<StyleParams*>(_styleParams);
     if(_styleParamMap.find("order") != _styleParamMap.end()) {
         params->order = std::stof(_styleParamMap.at("order"));
     }
     if(_styleParamMap.find("color") != _styleParamMap.end()) {
         params->color = parseColorProp(_styleParamMap.at("color"));
     }
-
-    return static_cast<void*>(params);
 }
 
-void PolygonStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolygonStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
     // No-op
 }
 
-void PolygonStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolygonStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
     std::vector<PosNormColVertex> vertices;
 
     PolyLineBuilder builder = {
@@ -64,13 +62,15 @@ void PolygonStyle::buildLine(Line& _line, void* _styleParam, Properties& _props,
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
 }
 
-void PolygonStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const {
+void PolygonStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
 
     std::vector<PosNormColVertex> vertices;
 
-    StyleParams* params = static_cast<StyleParams*>(_styleParam);
-    GLuint abgr = params->color;
-    GLfloat layer = params->order;
+    StyleParams params;
+    parseStyleParams(_styleParamMap, static_cast<void*>(&params));
+
+    GLuint abgr = params.color;
+    GLfloat layer = params.order;
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::proxy_colors)) {
         abgr = abgr << (int(_props.numericProps["zoom"]) % 6);

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -28,15 +28,16 @@ void PolygonStyle::constructShaderProgram() {
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 }
 
-void PolygonStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {
+auto PolygonStyle::parseStyleParams(const StyleParamMap& _styleParamMap) const -> StyleParams {
 
-    StyleParams* params = static_cast<StyleParams*>(_styleParams);
+    StyleParams params;
     if(_styleParamMap.find("order") != _styleParamMap.end()) {
-        params->order = std::stof(_styleParamMap.at("order"));
+        params.order = std::stof(_styleParamMap.at("order"));
     }
     if(_styleParamMap.find("color") != _styleParamMap.end()) {
-        params->color = parseColorProp(_styleParamMap.at("color"));
+        params.color = parseColorProp(_styleParamMap.at("color"));
     }
+    return params;
 }
 
 void PolygonStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
@@ -66,8 +67,7 @@ void PolygonStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _stylePa
 
     std::vector<PosNormColVertex> vertices;
 
-    StyleParams params;
-    parseStyleParams(_styleParamMap, static_cast<void*>(&params));
+    StyleParams params(parseStyleParams(_styleParamMap));
 
     GLuint abgr = params.color;
     GLfloat layer = params.order;

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -31,10 +31,10 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void* parseStyleParams(const StyleParamMap& _styleParamMap) const override;
+    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
 
     typedef TypedMesh<PosNormColVertex> Mesh;
 

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -34,7 +34,8 @@ protected:
     virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
-    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
+
+    auto parseStyleParams(const StyleParamMap& _styleParamMap) const -> StyleParams;
 
     typedef TypedMesh<PosNormColVertex> Mesh;
 

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -28,60 +28,62 @@ void PolylineStyle::constructShaderProgram() {
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 }
 
-void PolylineStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {
+auto PolylineStyle::parseStyleParams(const StyleParamMap& _styleParamMap) const -> StyleParams {
 
-    StyleParams* params = static_cast<StyleParams*>(_styleParams);
+    StyleParams params;
 
     if(_styleParamMap.find("order") != _styleParamMap.end()) {
-        params->order = std::stof(_styleParamMap.at("order"));
+        params.order = std::stof(_styleParamMap.at("order"));
     }
 
     if(_styleParamMap.find("color") != _styleParamMap.end()) {
-        params->color = parseColorProp(_styleParamMap.at("color"));
+        params.color = parseColorProp(_styleParamMap.at("color"));
     }
 
     if(_styleParamMap.find("width") != _styleParamMap.end()) {
-        params->width = std::stof(_styleParamMap.at("width"));
+        params.width = std::stof(_styleParamMap.at("width"));
     }
 
     if(_styleParamMap.find("cap") != _styleParamMap.end()) {
         std::string capStr = _styleParamMap.at("cap");
-        if(capStr == "butt") { params->cap = CapTypes::butt; }
-        else if(capStr == "square") { params->cap = CapTypes::square; }
-        else if(capStr == "round") { params->cap = CapTypes::round; }
+        if(capStr == "butt") { params.cap = CapTypes::butt; }
+        else if(capStr == "square") { params.cap = CapTypes::square; }
+        else if(capStr == "round") { params.cap = CapTypes::round; }
     }
 
     if(_styleParamMap.find("join") != _styleParamMap.end()) {
         std::string joinStr = _styleParamMap.at("join");
-        if(joinStr == "bevel") { params->join = JoinTypes::bevel; }
-        else if(joinStr == "miter") { params->join = JoinTypes::miter; }
-        else if(joinStr == "round") { params->join = JoinTypes::round; }
+        if(joinStr == "bevel") { params.join = JoinTypes::bevel; }
+        else if(joinStr == "miter") { params.join = JoinTypes::miter; }
+        else if(joinStr == "round") { params.join = JoinTypes::round; }
     }
 
     if(_styleParamMap.find("outline:width") != _styleParamMap.end()) {
-        params->outlineOn = true;
-        params->outlineWidth = std::stof(_styleParamMap.at("outline:width"));
+        params.outlineOn = true;
+        params.outlineWidth = std::stof(_styleParamMap.at("outline:width"));
     }
 
     if(_styleParamMap.find("outline:color") != _styleParamMap.end()) {
-        params->outlineColor =  parseColorProp(_styleParamMap.at("outline:color"));
+        params.outlineColor =  parseColorProp(_styleParamMap.at("outline:color"));
     }
 
     if(_styleParamMap.find("outline:cap") != _styleParamMap.end()) {
-        params->outlineOn = true;
+        params.outlineOn = true;
         std::string capStr = _styleParamMap.at("outline:cap");
-        if(capStr == "butt") { params->outlineCap = CapTypes::butt; }
-        else if(capStr == "square") { params->outlineCap = CapTypes::square; }
-        else if(capStr == "round") { params->outlineCap = CapTypes::round; }
+        if(capStr == "butt") { params.outlineCap = CapTypes::butt; }
+        else if(capStr == "square") { params.outlineCap = CapTypes::square; }
+        else if(capStr == "round") { params.outlineCap = CapTypes::round; }
     }
 
     if( _styleParamMap.find("outline:join") != _styleParamMap.end()) {
-        params->outlineOn = true;
+        params.outlineOn = true;
         std::string joinStr = _styleParamMap.at("outline:join");
-        if(joinStr == "bevel") { params->outlineJoin = JoinTypes::bevel; }
-        else if(joinStr == "miter") { params->outlineJoin = JoinTypes::miter; }
-        else if(joinStr == "round") { params->outlineJoin = JoinTypes::round; }
+        if(joinStr == "bevel") { params.outlineJoin = JoinTypes::bevel; }
+        else if(joinStr == "miter") { params.outlineJoin = JoinTypes::miter; }
+        else if(joinStr == "round") { params.outlineJoin = JoinTypes::round; }
     }
+
+    return params;
 }
 
 void PolylineStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
@@ -91,8 +93,7 @@ void PolylineStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMa
 void PolylineStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
     std::vector<PosNormEnormColVertex> vertices;
 
-    StyleParams params;
-    parseStyleParams(_styleParamMap, static_cast<void*>(&params));
+    StyleParams params(parseStyleParams(_styleParamMap));
     GLuint abgr = params.color;
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::proxy_colors)) {

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -44,7 +44,8 @@ protected:
     virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
-    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
+
+    auto parseStyleParams(const StyleParamMap& _styleParamMap) const -> StyleParams;
 
     typedef TypedMesh<PosNormEnormColVertex> Mesh;
 

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -41,10 +41,10 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void* parseStyleParams(const StyleParamMap& _styleParamMap) const override;
+    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
 
     typedef TypedMesh<PosNormEnormColVertex> Mesh;
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -27,8 +27,6 @@ void SpriteStyle::constructShaderProgram() {
     m_texture = std::shared_ptr<Texture>(new Texture("mapzen-logo.png"));
 }
 
-void SpriteStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {}
-
 void SpriteStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {}
 
 void SpriteStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {}

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -27,15 +27,13 @@ void SpriteStyle::constructShaderProgram() {
     m_texture = std::shared_ptr<Texture>(new Texture("mapzen-logo.png"));
 }
 
-void* SpriteStyle::parseStyleParams(const StyleParamMap& _styleParamMap) const {
-    return nullptr;
-}
+void SpriteStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {}
 
-void SpriteStyle::buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const {}
+void SpriteStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {}
 
-void SpriteStyle::buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const {}
+void SpriteStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {}
 
-void SpriteStyle::buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const {}
+void SpriteStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {}
 
 void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
     m_texture->update(0);

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -25,8 +25,6 @@ protected:
     virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void addData(TileData& _data, MapTile& _tile) override;
 
-    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
-
     typedef TypedMesh<PosUVVertex> Mesh;
 
     virtual VboMesh* newMesh() const override {

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -20,12 +20,12 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void addData(TileData& _data, MapTile& _tile) override;
 
-    virtual void* parseStyleParams(const StyleParamMap& _styleParamMap) const override;
+    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
 
     typedef TypedMesh<PosUVVertex> Mesh;
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -155,19 +155,19 @@ void Style::addData(TileData& _data, MapTile& _tile) {
                     case GeometryType::points:
                         // Build points
                         for (auto& point : feature.points) {
-                            buildPoint(point, parseStyleParams(styleParamMapMix), feature.props, *mesh);
+                            buildPoint(point, styleParamMapMix, feature.props, *mesh);
                         }
                         break;
                     case GeometryType::lines:
                         // Build lines
                         for (auto& line : feature.lines) {
-                            buildLine(line, parseStyleParams(styleParamMapMix), feature.props, *mesh);
+                            buildLine(line, styleParamMapMix, feature.props, *mesh);
                         }
                         break;
                     case GeometryType::polygons:
                         // Build polygons
                         for (auto& polygon : feature.polygons) {
-                            buildPolygon(polygon, parseStyleParams(styleParamMapMix), feature.props, *mesh);
+                            buildPolygon(polygon, styleParamMapMix, feature.props, *mesh);
                         }
                         break;
                     default:

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -80,18 +80,18 @@ protected:
     virtual void constructShaderProgram() = 0;
 
     /* Build styled vertex data for point geometry and add it to the given <VboMesh> */
-    virtual void buildPoint(Point& _point, void* _styleParam, Properties& _props, VboMesh& _mesh) const = 0;
+    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const = 0;
 
     /* Build styled vertex data for line geometry and add it to the given <VboMesh> */
-    virtual void buildLine(Line& _line, void* _styleParam, Properties& _props, VboMesh& _mesh) const = 0;
+    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const = 0;
 
     /* Build styled vertex data for polygon geometry and add it to the given <VboMesh> */
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParam, Properties& _props, VboMesh& _mesh) const = 0;
+    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const = 0;
 
     /*
-     * Parse StyleParamMap to apt Style property parameters
+     * Parse StyleParamMap to individual style's StyleParam structure.
      */
-    virtual void* parseStyleParams(const StyleParamMap& _styleParamMap) const = 0;
+    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const = 0;
 
     static std::unordered_map<std::bitset<MAX_LAYERS>, StyleParamMap> s_styleParamMapCache;
     static std::mutex s_cacheMutex;
@@ -100,6 +100,8 @@ protected:
     /*
      * filter what layer(s) a features match and get style paramaters for this feature based on all subLayers it
      * matches. Matching is cached for other features to use.
+     * Parameter maps for a set of layers is determined by merging parameters maps for individual layers matching the
+     * filters and keyed based on a uniqueID defined by the id of the matching layers.
      */
     void applyLayerFiltering(const Feature& _feature, const Tangram::Context& _ctx, std::bitset<MAX_LAYERS>& _uniqueID,
                                         StyleParamMap& _styleParamMapMix, std::weak_ptr<Tangram::SceneLayer> _uberLayer) const;

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -88,11 +88,6 @@ protected:
     /* Build styled vertex data for polygon geometry and add it to the given <VboMesh> */
     virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const = 0;
 
-    /*
-     * Parse StyleParamMap to individual style's StyleParam structure.
-     */
-    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const = 0;
-
     static std::unordered_map<std::bitset<MAX_LAYERS>, StyleParamMap> s_styleParamMapCache;
     static std::mutex s_cacheMutex;
     static uint32_t parseColorProp(const std::string& _colorPropStr) ;

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -43,8 +43,6 @@ void TextStyle::constructShaderProgram() {
     m_shaderProgram->addSourceBlock("defines", defines);
 }
 
-void TextStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {}
-
 void TextStyle::addVertices(TextBuffer& _buffer, VboMesh& _mesh) const {
     std::vector<TextVert> vertices;
     int bufferSize = _buffer.getVerticesSize();

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -42,9 +42,8 @@ void TextStyle::constructShaderProgram() {
 
     m_shaderProgram->addSourceBlock("defines", defines);
 }
-void* TextStyle::parseStyleParams(const StyleParamMap& _styleParamMap) const {
-    return nullptr;
-}
+
+void TextStyle::parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const {}
 
 void TextStyle::addVertices(TextBuffer& _buffer, VboMesh& _mesh) const {
     std::vector<TextVert> vertices;
@@ -62,7 +61,7 @@ void TextStyle::addVertices(TextBuffer& _buffer, VboMesh& _mesh) const {
     }
 }
 
-void TextStyle::buildPoint(Point& _point, void* _styleParams, Properties& _props, VboMesh& _mesh) const {
+void TextStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
     for (auto prop : _props.stringProps) {
         if (prop.first == "name") {
             m_labels->addLabel(*TextStyle::s_processedTile, m_name, { glm::vec2(_point), glm::vec2(_point) }, prop.second, Label::Type::point);
@@ -70,7 +69,7 @@ void TextStyle::buildPoint(Point& _point, void* _styleParams, Properties& _props
     }
 }
 
-void TextStyle::buildLine(Line& _line, void* _styleParams, Properties& _props, VboMesh& _mesh) const {
+void TextStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
     int lineLength = _line.size();
     int skipOffset = floor(lineLength / 2);
     float minLength = 0.15; // default, probably need some more thoughts
@@ -95,7 +94,7 @@ void TextStyle::buildLine(Line& _line, void* _styleParams, Properties& _props, V
     }
 }
 
-void TextStyle::buildPolygon(Polygon& _polygon, void* _styleParams, Properties& _props, VboMesh& _mesh) const {
+void TextStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const {
     glm::vec3 centroid;
     int n = 0;
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -20,13 +20,13 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildLine(Line& _line, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
-    virtual void buildPolygon(Polygon& _polygon, void* _styleParams, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
+    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh) const override;
     virtual void onBeginBuildTile(MapTile& _tile) const override;
     virtual void onEndBuildTile(MapTile& _tile, std::shared_ptr<VboMesh> _mesh) const override;
 
-    virtual void* parseStyleParams(const StyleParamMap& _styleParamMap) const override;
+    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
 
     typedef TypedMesh<TextVert> Mesh;
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -26,8 +26,6 @@ protected:
     virtual void onBeginBuildTile(MapTile& _tile) const override;
     virtual void onEndBuildTile(MapTile& _tile, std::shared_ptr<VboMesh> _mesh) const override;
 
-    virtual void parseStyleParams(const StyleParamMap& _styleParamMap, void* _styleParams) const override;
-
     typedef TypedMesh<TextVert> Mesh;
 
     virtual VboMesh* newMesh() const override {


### PR DESCRIPTION
+ some c++11 specials for brief return type naming