### PR TITLE
Blend/Opaque style ordering

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -8,7 +8,13 @@ Scene::Scene() {
 }
 
 void Scene::addStyle(std::unique_ptr<Style> _style) {
-    m_styles.push_back(std::move(_style));
+    // opaque styles go first in drawing loop
+    if (_style->isOpaque()) {
+        m_styles.insert(m_styles.begin(), std::move(_style));
+    } else {
+        // styles that uses blending operations
+        m_styles.push_back(std::move(_style));
+    }
 }
 
 void Scene::addLight(std::unique_ptr<Light> _light) {

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -30,6 +30,8 @@ protected:
 
 public:
 
+    bool isOpaque() const override { return false; }
+
     virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
 
     SpriteStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -115,6 +115,9 @@ public:
 
     virtual ~Style();
 
+    /* Whether or not the style uses blending operation for drawing */
+    virtual bool isOpaque() const { return true; };
+
     /* Make this style ready to be used (call after all needed properties are set) */
     virtual void build(const std::vector<std::unique_ptr<Light>>& _lights);
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -35,6 +35,8 @@ protected:
 
 public:
 
+    bool isOpaque() const override { return false; }
+
     TextStyle(const std::string& _fontName, std::string _name, float _fontSize, unsigned int _color = 0xffffff,
               bool _sdf = false, bool _sdfMultisampling = false, GLenum _drawMode = GL_TRIANGLES);
 


### PR DESCRIPTION
This fixes styles that uses blending (sprite & text for now) that are drawn in arbitrary order. 
PR for #196 