### PR TITLE
Make sure sublayers are valid for all drawGroups

### DIFF
--- a/core/src/scene/sceneLayer.cpp
+++ b/core/src/scene/sceneLayer.cpp
@@ -4,7 +4,7 @@ namespace Tangram {
 
     uint8_t SceneLayer::s_layerCount = 0;
 
-    SceneLayer::SceneLayer(const std::vector<std::shared_ptr<SceneLayer>>&& _subLayers, const StyleParamMap&& _styleParamMap, const std::string _name, Filter* _filter) :
+    SceneLayer::SceneLayer(std::vector<std::shared_ptr<SceneLayer>> _subLayers, const StyleParamMap&& _styleParamMap, const std::string _name, std::shared_ptr<Filter> _filter) :
         m_subLayers(std::move(_subLayers)), m_styleParams(std::move(_styleParamMap)), m_name(_name), m_filter(_filter) {
 
         m_id = s_layerCount++;

--- a/core/src/scene/sceneLayer.h
+++ b/core/src/scene/sceneLayer.h
@@ -22,14 +22,14 @@ namespace Tangram {
         static uint8_t s_layerCount;
 
     public:
-        SceneLayer(const std::vector<std::shared_ptr<SceneLayer>>&& _subLayers, const StyleParamMap&& _styleParamMap, const std::string _name, Filter* _filter);
+        SceneLayer(const std::vector<std::shared_ptr<SceneLayer>> _subLayers, const StyleParamMap&& _styleParamMap, const std::string _name, std::shared_ptr<Filter> _filter);
         ~SceneLayer();
 
         uint8_t getID() const { return m_id; }
         Filter* getFilter() const { return m_filter; }
         std::string getName() const { return m_name; }
         StyleParamMap& getStyleParamMap() { return m_styleParams; }
-        std::vector<std::shared_ptr<SceneLayer>>& getSublayers() { return m_subLayers; }
+        std::vector< std::shared_ptr<SceneLayer> >& getSublayers() { return m_subLayers; }
     };
 
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -778,7 +778,7 @@ void SceneLoader::loadSublayers(YAML::Node layer, std::vector<std::shared_ptr<Sc
                 // TODO: multiple draw groups for a subLayer, NOTE: only one draw for now
                 // TODO: subLayers can have different base style than the parent layer
                 parseStyleProps(groupIt.second, paramMap);
-                subLayers.push_back(std::make_shared<SceneLayer>(std::move(ssubLayers), std::move(paramMap), subLayerName,
+                subLayers.push_back(std::make_shared<SceneLayer>(ssubLayers, std::move(paramMap), subLayerName,
                             subLayerFilter));
             }
         }
@@ -816,7 +816,7 @@ void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager
             // match layer to the style in scene with the given name
             for (const auto& style : scene.getStyles()) {
                 if (style->getName() == styleName) {
-                    style->addLayer(std::make_shared<SceneLayer>(std::move(subLayers), std::move(paramMap),
+                    style->addLayer(std::make_shared<SceneLayer>(subLayers, std::move(paramMap),
                                 name, layerFilter));
                 }
 			}


### PR DESCRIPTION
- previously subLayers vector was "moved" for first drawGroup, but all drawGroups must have the layers.

(was not noticed because we were not having a layer with multiple drawGroups in our example scene yaml)