### PR TITLE
provide default for build* methods

### DIFF
--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -53,23 +53,4 @@ void DebugStyle::addData(TileData &_data, Tile &_tile) {
         _tile.addGeometry(*this, std::unique_ptr<VboMesh>(mesh));
 
     }
-
-}
-
-void DebugStyle::buildPoint(Point &_point, const StyleParamMap& _styleParamMap, Properties &_props, VboMesh &_mesh, Tile& _tile) const {
-
-    // No-op
-
-}
-
-void DebugStyle::buildLine(Line &_line, const StyleParamMap& _styleParamMap, Properties &_props, VboMesh &_mesh, Tile& _tile) const {
-
-    // No-op
-
-}
-
-void DebugStyle::buildPolygon(Polygon &_polygon, const StyleParamMap& _styleParamMap, Properties &_props, VboMesh &_mesh, Tile& _tile) const {
-
-    // No-op
-
 }

--- a/core/src/style/debugStyle.h
+++ b/core/src/style/debugStyle.h
@@ -16,10 +16,6 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-
-    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     virtual void addData(TileData& _data, Tile& _tile) override;
 
     typedef TypedMesh<PosColVertex> Mesh;

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -38,10 +38,6 @@ void PolygonStyle::parseStyleParams(const StyleParamMap& _styleParamMap, StylePa
     }
 }
 
-void PolygonStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
-    // No-op
-}
-
 void PolygonStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     std::vector<PosNormColVertex> vertices;
 

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -31,7 +31,6 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     /*

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -82,10 +82,6 @@ void PolylineStyle::parseStyleParams(const StyleParamMap& _styleParamMap, StyleP
     }
 }
 
-void PolylineStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
-    // No-op
-}
-
 void PolylineStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     std::vector<PosNormEnormColVertex> vertices;
 
@@ -137,8 +133,4 @@ void PolylineStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, 
 
     auto& mesh = static_cast<PolylineStyle::Mesh&>(_mesh);
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
-}
-
-void PolylineStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
-    // No-op
 }

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -41,9 +41,7 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     /*
      * Parse StyleParamMap to individual style's StyleParam structure.
      */

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -100,14 +100,6 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
 }
 
-void SpriteStyle::buildLine(Line& _line, const StyleParamMap&, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
-    // NO-OP
-}
-
-void SpriteStyle::buildPolygon(Polygon& _polygon, const StyleParamMap&, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
-    // NO-OP
-}
-
 void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
     m_spriteAtlas->bind();
 

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -15,10 +15,7 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-
     virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
 
     typedef TypedMesh<BufferVert> Mesh;
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -213,3 +213,15 @@ void Style::onBeginBuildTile(VboMesh& _mesh) const {
 void Style::onEndBuildTile(VboMesh& _mesh) const {
     // No-op by default
 }
+
+void Style::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
+    // No-op by default
+}
+
+void Style::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
+    // No-op by default
+}
+
+void Style::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
+    // No-op by default
+}

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -80,13 +80,13 @@ protected:
     virtual void constructShaderProgram() = 0;
 
     /* Build styled vertex data for point geometry and add it to the given <VboMesh> */
-    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const = 0;
+    virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const;
 
     /* Build styled vertex data for line geometry and add it to the given <VboMesh> */
-    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const = 0;
+    virtual void buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const;
 
     /* Build styled vertex data for polygon geometry and add it to the given <VboMesh> */
-    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const = 0;
+    virtual void buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const;
 
     static std::unordered_map<std::bitset<MAX_LAYERS>, StyleParamMap> s_styleParamMapCache;
     static std::mutex s_cacheMutex;


### PR DESCRIPTION
- reduces the refactoring PITA, chances are small that
  one forget to provide an implementation for a style
  which should provide it