### PR TITLE
Cache screenspace proj matrix

### DIFF
--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -61,7 +61,7 @@ void Labels::addLabel(Tile& _tile, const std::string& _styleName, std::shared_pt
     const auto& viewOrigin = m_view->getPosition();
     modelMatrix[3][2] = -viewOrigin.z;
 
-    _label->update(m_view->getViewProjectionMatrix() * modelMatrix, m_screenSize, 0);
+    _label->update(m_view->getViewProjectionMatrix() * modelMatrix, {m_view->getWidth(), m_view->getHeight()}, 0);
     _tile.addLabel(_styleName, _label);
 
     // lock concurrent collection

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -52,8 +52,6 @@ public:
 
     void setView(std::shared_ptr<View> _view) { m_view = _view; }
 
-    void setScreenSize(int _width, int _height) { m_screenSize = glm::vec2(_width, _height); }
-
     void drawDebug();
 
 private:
@@ -71,7 +69,6 @@ private:
 
     std::mutex m_mutex;
 
-    glm::vec2 m_screenSize;
     std::shared_ptr<View> m_view;
     float m_currentZoom;
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -9,7 +9,6 @@
 #include "view/view.h"
 
 #include "glm/gtc/type_ptr.hpp"
-#include "glm/gtc/matrix_transform.hpp"
 
 SpriteStyle::SpriteStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -8,8 +8,8 @@
 #include "util/builders.h"
 #include "view/view.h"
 
-#include "glm/gtc/matrix_transform.hpp"
 #include "glm/gtc/type_ptr.hpp"
+#include "glm/gtc/matrix_transform.hpp"
 
 SpriteStyle::SpriteStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
 
@@ -106,8 +106,7 @@ void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std
     m_spriteAtlas->bind();
 
     m_shaderProgram->setUniformi("u_tex", 0);
-    // top-left screen axis, y pointing down
-    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(glm::ortho(0.f, _view->getWidth(), _view->getHeight(), 0.f, -1.f, 1.f)));
+    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view->getOrthoViewportMatrix()));
 
     RenderState::blending(GL_TRUE);
     RenderState::blendingFunc({GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA});

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -131,8 +131,6 @@ void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::
     auto ftContext = m_labels->getFontContext();
     const auto& atlas = ftContext->getAtlas();
 
-    ftContext->setScreenSize(_view->getWidth(), _view->getHeight());
-
     atlas->update(1);
     atlas->bind(1);
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -5,6 +5,7 @@
 #include "gl/shaderProgram.h"
 #include "gl/vboMesh.h"
 #include "view/view.h"
+#include "glm/gtc/type_ptr.hpp"
 
 TextStyle::TextStyle(const std::string& _fontName, std::string _name, float _fontSize, unsigned int _color, bool _sdf, bool _sdfMultisampling, GLenum _drawMode)
 : Style(_name, _drawMode), m_fontName(_fontName), m_fontSize(_fontSize), m_color(_color), m_sdf(_sdf), m_sdfMultisampling(_sdfMultisampling)  {
@@ -129,10 +130,8 @@ void TextStyle::onEndBuildTile(VboMesh& _mesh) const {
 void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
     auto ftContext = m_labels->getFontContext();
     const auto& atlas = ftContext->getAtlas();
-    float projectionMatrix[16] = {0};
 
     ftContext->setScreenSize(_view->getWidth(), _view->getHeight());
-    ftContext->getProjection(projectionMatrix);
 
     atlas->update(1);
     atlas->bind(1);
@@ -145,7 +144,7 @@ void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::
     float b = (m_color       & 0xff) / 255.0;
 
     m_shaderProgram->setUniformf("u_color", r, g, b);
-    m_shaderProgram->setUniformMatrix4f("u_proj", projectionMatrix);
+    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view->getOrthoViewportMatrix()));
 
     RenderState::blending(GL_TRUE);
     RenderState::blendingFunc({GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA});

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -80,11 +80,6 @@ namespace Tangram {
             m_view->setSize(_newWidth, _newHeight);
         }
 
-        if (m_ftContext) {
-            m_ftContext->setScreenSize(m_view->getWidth(), m_view->getHeight());
-            m_labels->setScreenSize(m_view->getWidth(), m_view->getHeight());
-        }
-
         while (Error::hadGlError("Tangram::resize()")) {}
 
     }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -16,10 +16,6 @@ const std::unique_ptr<Texture>& FontContext::getAtlas() const {
     return m_atlas;
 }
 
-void FontContext::setScreenSize(int _width, int _height) {
-    glfonsScreenSize(m_fsContext, _width, _height);
-}
-
 void FontContext::clearState() {
     fonsClearState(m_fsContext);
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -16,10 +16,6 @@ const std::unique_ptr<Texture>& FontContext::getAtlas() const {
     return m_atlas;
 }
 
-void FontContext::getProjection(float* _projectionMatrix) const {
-    glfonsProjection(m_fsContext, _projectionMatrix);
-}
-
 void FontContext::setScreenSize(int _width, int _height) {
     glfonsScreenSize(m_fsContext, _width, _height);
 }

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -31,9 +31,6 @@ public:
     /* sets the blur spread when using signed distance field rendering */
     void setSignedDistanceField(float _blurSpread);
 
-    /* sets the screen size, this size is used when transforming text ids in the text buffers */
-    void setScreenSize(int _width, int _height);
-
     void clearState();
     
     /* lock thread access to this font context */

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -34,9 +34,6 @@ public:
     /* sets the screen size, this size is used when transforming text ids in the text buffers */
     void setScreenSize(int _width, int _height);
 
-    /* fills the orthographic projection matrix related to the current screen size */
-    void getProjection(float* _projectionMatrix) const;
-
     void clearState();
     
     /* lock thread access to this font context */

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -61,6 +61,9 @@ void View::setSize(int _width, int _height) {
     m_aspect = (float)_width / (float)_height;
     m_dirty = true;
 
+    // Screen space orthographic projection matrix, top left origin, y pointing down
+    m_orthoViewport = glm::ortho(0.f, (float)m_vpWidth, (float)m_vpHeight, 0.f, -1.f, 1.f);
+
 }
 
 void View::setPosition(double _x, double _y) {

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -123,6 +123,8 @@ public:
     
     constexpr static float s_maxZoom = 18.0;
 
+    const glm::mat4& getOrthoViewportMatrix() { return m_orthoViewport; };
+
 protected:
     
     void updateMatrices();
@@ -134,6 +136,7 @@ protected:
     glm::dvec3 m_pos;
 
     glm::mat4 m_view;
+    glm::mat4 m_orthoViewport;
     glm::mat4 m_proj;
     glm::mat4 m_viewProj;
     glm::mat4 m_invViewProj;


### PR DESCRIPTION
Sprites and text now uses the same projection matrix so it's better to move it to the view module and cache it when viewport changes.