### PR TITLE
Saving some kb

### DIFF
--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -43,7 +43,7 @@ Texture::Texture(const std::string& _file, TextureOptions _options, bool _genera
 }
 
 Texture::~Texture() {
-    for (size_t i = 0; i < GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS; i++) {
+    for (size_t i = 0; i < TANGRAM_MAX_TEXTURE_UNIT; i++) {
         if (s_boundTextures[i] == m_glHandle) { s_boundTextures[i] = 0; }
     }
     if (m_glHandle) { glDeleteTextures(1, &m_glHandle); }
@@ -51,7 +51,7 @@ Texture::~Texture() {
 
 void Texture::bind(GLuint _textureSlot) {
 
-    if (_textureSlot >= GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS) {
+    if (_textureSlot >= TANGRAM_MAX_TEXTURE_UNIT) {
 
         // Trying to access an invalid texture unit
         return;
@@ -194,14 +194,14 @@ size_t Texture::bytesPerPixel() {
 }
 
 GLuint Texture::getTextureUnit(GLuint _unit) {
-    if (_unit >= GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS) { logMsg("Warning: trying to access unavailable texture unit"); }
+    if (_unit >= TANGRAM_MAX_TEXTURE_UNIT) { logMsg("Warning: trying to access unavailable texture unit"); }
 
     return GL_TEXTURE0 + _unit;
 }
 
 void Texture::invalidateAllTextures() {
 
-    for (GLuint i = 0; i < GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS; ++i) {
+    for (GLuint i = 0; i < TANGRAM_MAX_TEXTURE_UNIT; ++i) {
         s_boundTextures[i] = 0;
     }
     s_activeSlot = GL_TEXTURE0;

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -24,6 +24,8 @@ struct TextureOptions {
     TextureWrapping m_wrapping;
 };
 
+#define TANGRAM_MAX_TEXTURE_UNIT 4
+
 class Texture {
 
 public:
@@ -109,5 +111,5 @@ private:
     static GLuint s_activeSlot;
 
     // if (s_boundTextures[s] == h) then the texture with handle 'h' is currently bound at slot 's'
-    static GLuint s_boundTextures[GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS];
+    static GLuint s_boundTextures[TANGRAM_MAX_TEXTURE_UNIT];
 };


### PR DESCRIPTION
By using the define `GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS`, we are allocating an array 35660 ints for the array `s_boundTextures`, which is the actual driver define value on my computer. If we wanted to use this value, we would need to use `glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &s_maxCombinedTextureUnits)` to get the actual driver value.
I prefer to define this value to 4 for now (most of the devices would be able to handle that), and we could increase this value in the future.