### PR TITLE
Measuring label buffer updates

### DIFF
--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -5,7 +5,6 @@
 #include "tile/tileID.h"
 #include "tile/tile.h"
 #include "tile/tileManager.h"
-#include "labels/labels.h"
 
 namespace Tangram {
 

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -131,8 +131,11 @@ void Label::enterState(State _state, float _alpha) {
 }
 
 void Label::setAlpha(float _alpha) {
-    m_transform.state.alpha = CLAMP(_alpha, 0.0, 1.0);
-    m_dirty = true;
+    float alpha = CLAMP(_alpha, 0.0, 1.0);
+    if (m_transform.state.alpha != alpha) {
+        m_transform.state.alpha = alpha;
+        m_dirty = true;
+    }
 }
 
 void Label::setScreenPosition(const glm::vec2& _screenPosition) {

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -4,8 +4,6 @@
 
 namespace Tangram {
 
-bool Label::s_needUpdate = false;
-
 Label::Label(Label::Transform _transform, Type _type) :
     m_type(_type),
     m_transform(_transform) {
@@ -90,10 +88,11 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
     return true;
 }
 
-void Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt) {
-    updateState(_mvp, _screenSize, _dt);
-
+bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt) {
+    bool animate =  updateState(_mvp, _screenSize, _dt);
     m_occlusionSolved = false;
+
+    return animate;
 }
 
 bool Label::offViewport(const glm::vec2& _screenSize) {
@@ -148,11 +147,11 @@ void Label::setRotation(float _rotation) {
     m_dirty = true;
 }
 
-void Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt) {
+bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt) {
     if (m_currentState == State::sleep) {
         // no-op state for now, when label-collision has less complexity, this state
         // would lead to FADE_IN state if no collision occured
-        return;
+        return false;
     }
 
     bool occludedLastFrame = m_occludedLastFrame;
@@ -162,7 +161,7 @@ void Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
 
     if (!ruleSatisfied) { // one of the label rules not satisfied
         enterState(State::sleep, 0.0);
-        return;
+        return false;
     }
 
     // update the view-space bouding box
@@ -172,6 +171,8 @@ void Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
     if (offViewport(_screenSize)) {
         enterState(State::out_of_screen, 0.0);
     }
+
+    bool animate = false;
 
     switch (m_currentState) {
         case State::visible:
@@ -186,13 +187,13 @@ void Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
                 break;
             }
             setAlpha(m_fade.update(_dt));
-            s_needUpdate = true;
+            animate = true;
             if (m_fade.isFinished())
                 enterState(State::visible, 1.0);
             break;
         case State::fading_out:
             setAlpha(m_fade.update(_dt));
-            s_needUpdate = true;
+            animate = true;
             if (m_fade.isFinished())
                 enterState(State::sleep, 0.0);
             break;
@@ -211,6 +212,8 @@ void Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
         case State::sleep:;
             // dead state
     }
+
+    return animate;
 }
 
 }

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -205,12 +205,15 @@ bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
                 enterState(State::wait_occ, 0.0);
             break;
         case State::wait_occ:
-            if (!occludedLastFrame && m_occlusionSolved) {
-                m_fade = FadeEffect(true, FadeEffect::Interpolation::pow, 0.2);
-                enterState(State::fading_in, 0.0);
-            } else if (occludedLastFrame && m_occlusionSolved) {
-                enterState(State::sleep, 0.0);
+            if (m_occlusionSolved) {
+                if (occludedLastFrame) {
+                    enterState(State::sleep, 0.0);
+                }  else {
+                    m_fade = FadeEffect(true, FadeEffect::Interpolation::pow, 0.2);
+                    enterState(State::fading_in, 0.0);
+                }
             }
+
             break;
         case State::sleep:;
             // dead state

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -56,7 +56,7 @@ public:
     bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt);
 
     /* Push the pending transforms to the vbo by updating the vertices */
-    virtual void pushTransform(VboMesh& _mesh) = 0;
+    virtual void pushTransform() = 0;
     
     /* Update the screen position of the label */
     bool updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize);
@@ -105,7 +105,6 @@ protected:
     bool m_dirty;
     Transform m_transform;
     glm::vec2 m_dim;
-
 };
 
 }

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -86,6 +86,8 @@ public:
 
     static bool s_needUpdate;
 
+    size_t debugSize = 4 * sizeof(Label::Vertex);
+    
 private:
 
     void enterState(State _state, float _alpha = 1.0f);

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -29,7 +29,7 @@ public:
         wait_occ        = 1 << 5, // state waiting for first occlusion result
     };
 
-    struct BufferVert {
+    struct Vertex {
         glm::vec2 pos;
         glm::vec2 uv;
         struct State {
@@ -44,7 +44,7 @@ public:
         glm::vec2 modelPosition2;
         glm::vec2 offset;
 
-        BufferVert::State state;
+        Vertex::State state;
     };
 
     Label(Transform _transform, Type _type);

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -53,7 +53,7 @@ public:
     /* Gets the extent of the oriented bounding box of the label */
     const isect2d::AABB& getAABB() const { return m_aabb; }
 
-    void update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt);
+    bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt);
 
     /* Push the pending transforms to the vbo by updating the vertices */
     virtual void pushTransform(VboMesh& _mesh) = 0;
@@ -81,7 +81,7 @@ private:
 
     void enterState(State _state, float _alpha = 1.0f);
 
-    void updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt);
+    bool updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt);
 
     void setAlpha(float _alpha);
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -4,7 +4,6 @@
 #include "glm/mat4x4.hpp"
 #include <climits> // needed in aabb.h
 #include "isect2d.h"
-#include "text/textBuffer.h"
 #include "fadeEffect.h"
 
 #include <string>
@@ -28,6 +27,16 @@ public:
         sleep           = 1 << 3,
         out_of_screen   = 1 << 4,
         wait_occ        = 1 << 5, // state waiting for first occlusion result
+    };
+
+    struct BufferVert {
+        glm::vec2 pos;
+        glm::vec2 uv;
+        struct State {
+            glm::vec2 screenPos;
+            float alpha;
+            float rotation;
+        } state;
     };
 
     struct Transform {

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -4,7 +4,7 @@
 namespace Tangram {
 
 LabelMesh::LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
-    : TypedMesh<Label::BufferVert>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW) {
+    : TypedMesh<Label::Vertex>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW) {
 }
 
 LabelMesh::~LabelMesh() {}

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -1,0 +1,16 @@
+#include "labels/labelMesh.h"
+#include "labels/label.h"
+
+namespace Tangram {
+
+LabelMesh::LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
+    : TypedMesh<Label::BufferVert>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW) {
+}
+
+LabelMesh::~LabelMesh() {}
+
+void LabelMesh::addLabel(std::unique_ptr<Label> _label) {
+    m_labels.push_back(std::move(_label));
+}
+
+}

--- a/core/src/labels/labelMesh.h
+++ b/core/src/labels/labelMesh.h
@@ -8,7 +8,7 @@
 
 namespace Tangram {
 
-class LabelMesh : public TypedMesh<Label::BufferVert> {
+class LabelMesh : public TypedMesh<Label::Vertex> {
 public:
     LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode);
 

--- a/core/src/labels/labelMesh.h
+++ b/core/src/labels/labelMesh.h
@@ -1,42 +1,27 @@
 #pragma once
 
 #include "gl/typedMesh.h"
-//#include "labels/label.h"
-#include "glm/vec2.hpp"
+#include "labels/label.h"
 
 #include <memory>
 #include <vector>
 
 namespace Tangram {
 
-class Label;
-
-struct BufferVert {
-    glm::vec2 pos;
-    glm::vec2 uv;
-    struct State {
-        glm::vec2 screenPos;
-        float alpha;
-        float rotation;
-    } state;
-};
-
-class LabelMesh : public TypedMesh<BufferVert> {
+class LabelMesh : public TypedMesh<Label::BufferVert> {
 public:
-    LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
-        : TypedMesh<BufferVert>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW) {
-    }
+    LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode);
 
-    void addLabel(std::shared_ptr<Label> _label) {
-        m_labels.push_back(std::move(_label));
-    }
+    virtual ~LabelMesh();
 
-    std::vector<std::shared_ptr<Label>>& getLabels() {
+    void addLabel(std::unique_ptr<Label> _label);
+
+    std::vector<std::unique_ptr<Label>>& getLabels() {
         return m_labels;
     }
 
 protected:
-    std::vector<std::shared_ptr<Label>> m_labels;
+    std::vector<std::unique_ptr<Label>> m_labels;
 };
 
 }

--- a/core/src/labels/labelMesh.h
+++ b/core/src/labels/labelMesh.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "gl/typedMesh.h"
+//#include "labels/label.h"
+#include "glm/vec2.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace Tangram {
+
+class Label;
+
+struct BufferVert {
+    glm::vec2 pos;
+    glm::vec2 uv;
+    struct State {
+        glm::vec2 screenPos;
+        float alpha;
+        float rotation;
+    } state;
+};
+
+class LabelMesh : public TypedMesh<BufferVert> {
+public:
+    LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
+        : TypedMesh<BufferVert>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW) {
+    }
+
+    void addLabel(std::shared_ptr<Label> _label) {
+        m_labels.push_back(std::move(_label));
+    }
+
+    std::vector<std::shared_ptr<Label>>& getLabels() {
+        return m_labels;
+    }
+
+protected:
+    std::vector<std::shared_ptr<Label>> m_labels;
+};
+
+}

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -55,7 +55,6 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
             auto labelMesh = dynamic_cast<LabelMesh*>(mesh.get());
             if (!labelMesh) { continue; }
 
-
             for (auto& label : labelMesh->getLabels()) {
                 m_needUpdate |= label->update(mvp, screenSize, _dt);
 
@@ -104,29 +103,7 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
 
     for (auto label : m_labels) {
         label->occlusionSolved();
-    }
-
-    //// update meshes
-    for (const auto& mapIDandTile : _tiles) {
-        const auto& tile = mapIDandTile.second;
-
-        if (!tile->isReady()) { continue; }
-
-        if ((zoom - tile->getID().z) > LODDiscardFunc(View::s_maxZoom, zoom)) {
-            continue;
-        }
-
-        for (const auto& style : _styles) {
-            auto mesh = tile->getMesh(*style);
-            if (!mesh) { continue; }
-
-            auto labelMesh = dynamic_cast<LabelMesh*>(mesh.get());
-            if (!labelMesh) { continue; }
-
-            for (auto& label : labelMesh->getLabels()) {
-                label->pushTransform(*labelMesh);
-            }
-        }
+        label->pushTransform();
     }
 
     // Request for render if labels are in fading in/out states

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -63,7 +63,7 @@ void Labels::addLabel(Tile& _tile, const std::string& _styleName, std::shared_pt
     const auto& viewOrigin = m_view->getPosition();
     modelMatrix[3][2] = -viewOrigin.z;
 
-    _label->update(m_view->getViewProjectionMatrix() * modelMatrix, m_screenSize, 0);
+    _label->update(m_view->getViewProjectionMatrix() * modelMatrix, {m_view->getWidth(), m_view->getHeight()}, 0);
     _tile.addLabel(_styleName, _label);
 
     // lock concurrent collection

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -1,7 +1,6 @@
 #include "labels.h"
 #include "tangram.h"
 #include "tile/tile.h"
-#include "text/fontContext.h"
 #include "gl/primitives.h"
 #include "view/view.h"
 #include "style/style.h"

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -90,12 +90,8 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
             }
         }
         if (!pair.second->occludedLastFrame()) {
-            if (pair.first->getState() == Label::State::wait_occ) {
-                pair.first->setOcclusion(true);
-            }
+            pair.first->setOcclusion(true);
         }
-
-        if (!pair.second->occludedLastFrame()) { pair.first->setOcclusion(true); }
     }
 
     //// Update label meshes

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -95,11 +95,42 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
     }
 
     //// Update label meshes
+    size_t sumLabelBytes = 0;
 
     for (auto label : m_labels) {
         label->occlusionSolved();
         label->pushTransform();
+        if (label->getState() & (Label::State::fading_in | Label::State::fading_out | Label::State::visible))
+            sumLabelBytes += label->debugSize;
     }
+
+
+    size_t dirtyBuffers = 0;
+
+    for (const auto& mapIDandTile : _tiles) {
+        const auto& tile = mapIDandTile.second;
+
+        if (!tile->isReady()) { continue; }
+
+        // discard based on level of detail
+        if ((zoom - tile->getID().z) > LODDiscardFunc(View::s_maxZoom, zoom)) {
+            continue;
+        }
+
+        glm::mat4 mvp = _view.getViewProjectionMatrix() * tile->getModelMatrix();
+
+        for (const auto& style : _styles) {
+            auto mesh = tile->getMesh(*style);
+            if (!mesh) { continue; }
+
+            auto labelMesh = dynamic_cast<LabelMesh*>(mesh.get());
+            if (!labelMesh) { continue; }
+
+            dirtyBuffers += labelMesh->getDirtySize();
+        }
+    }
+
+    logMsg("Active %f / Dirty %f\n", double(sumLabelBytes) / (1024 * 1024),  double(dirtyBuffers) / (1024 * 1024));
 
     // Request for render if labels are in fading in/out states
     if (m_needUpdate)

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -18,12 +18,12 @@ int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
 }
 
 
-void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
+void Labels::update(const View& _view, float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
                     const std::map<TileID, std::shared_ptr<Tile>>& _tiles) {
 
     m_needUpdate = false;
 
-    float zoom = m_view->getZoom();
+    float zoom = _view.getZoom();
 
     std::set<std::pair<Label*, Label*>> occlusions;
 
@@ -31,7 +31,7 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
     m_labels.clear();
     m_aabbs.clear();
 
-    glm::vec2 screenSize = glm::vec2(m_view->getWidth(), m_view->getHeight());
+    glm::vec2 screenSize = glm::vec2(_view.getWidth(), _view.getHeight());
 
     //// Collect labels from visible tiles
 
@@ -45,7 +45,7 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
             continue;
         }
 
-        glm::mat4 mvp = m_view->getViewProjectionMatrix() * tile->getModelMatrix();
+        glm::mat4 mvp = _view.getViewProjectionMatrix() * tile->getModelMatrix();
 
         for (const auto& style : _styles) {
             auto mesh = tile->getMesh(*style);
@@ -69,7 +69,7 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
     //// Manage occlusions
 
     // broad phase
-    auto pairs = intersect(m_aabbs, {4, 4}, {m_view->getWidth(), m_view->getHeight()});
+    auto pairs = intersect(m_aabbs, {4, 4}, {_view.getWidth(), _view.getHeight()});
 
     for (auto pair : pairs) {
         const auto& aabb1 = m_aabbs[pair.first];
@@ -110,7 +110,7 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
         requestRender();
 }
 
-void Labels::drawDebug() {
+void Labels::drawDebug(const View& _view) {
 
     if (!Tangram::getDebugFlag(Tangram::DebugFlags::labels)) {
         return;
@@ -119,12 +119,12 @@ void Labels::drawDebug() {
     for (auto label : m_labels) {
         if (label->canOcclude()) {
             Primitives::drawPoly(reinterpret_cast<const glm::vec2*>(label->getOBB().getQuad()),
-                                 4, { m_view->getWidth(), m_view->getHeight() });
+                                 4, { _view.getWidth(), _view.getHeight() });
         }
     }
 
     glm::vec2 split(4, 4);
-    glm::vec2 res(m_view->getWidth(), m_view->getHeight());
+    glm::vec2 res(_view.getWidth(), _view.getHeight());
     const short xpad = short(ceilf(res.x / split.x));
     const short ypad = short(ceilf(res.y / split.y));
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -71,7 +71,7 @@ void Labels::addLabel(Tile& _tile, const std::string& _styleName, std::shared_pt
 void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
                     const std::map<TileID, std::shared_ptr<Tile>>& _tiles) {
 
-    Label::s_needUpdate = false;
+    m_needUpdate = false;
 
     // FIXME value is used on tile-worker thread (see addTextLabel)
     m_currentZoom = m_view->getZoom();
@@ -95,7 +95,7 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
         for (const auto& style : _styles) {
 
             for (auto& label : tile->getLabels(*style)) {
-                label->update(mvp, screenSize, _dt);
+                m_needUpdate |= label->update(mvp, screenSize, _dt);
 
                 if (label->canOcclude()) {
                     m_aabbs.push_back(label->getAABB());
@@ -153,13 +153,10 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
             }
         }
     }
-}
 
-void Labels::lazyRenderRequest() {
-
-    if (Label::s_needUpdate) {
+    // Request for render if labels are in fading in/out states
+    if (m_needUpdate)
         requestRender();
-    }
 }
 
 void Labels::drawDebug() {

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -105,6 +105,7 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
     }
 
 
+    size_t dirtyBytes = 0;
     size_t dirtyBuffers = 0;
 
     for (const auto& mapIDandTile : _tiles) {
@@ -126,11 +127,17 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
             auto labelMesh = dynamic_cast<LabelMesh*>(mesh.get());
             if (!labelMesh) { continue; }
 
-            dirtyBuffers += labelMesh->getDirtySize();
+            if (labelMesh->getDirtySize() > 0)
+                dirtyBuffers++;
+
+            dirtyBytes += labelMesh->getDirtySize();
         }
     }
 
-    logMsg("Active %f / Dirty %f\n", double(sumLabelBytes) / (1024 * 1024),  double(dirtyBuffers) / (1024 * 1024));
+    logMsg("Buffers %d / Dirty %fMB - Active %fMB\n",
+           dirtyBuffers,
+           double(dirtyBytes) / (1024 * 1024),
+           double(sumLabelBytes) / (1024 * 1024));
 
     // Request for render if labels are in fading in/out states
     if (m_needUpdate)

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -49,7 +49,14 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
         glm::mat4 mvp = m_view->getViewProjectionMatrix() * tile->getModelMatrix();
 
         for (const auto& style : _styles) {
-            for (auto& label : tile->getLabels(*style)) {
+            auto mesh = tile->getMesh(*style);
+            if (!mesh) { continue; }
+
+            auto labelMesh = dynamic_cast<LabelMesh*>(mesh.get());
+            if (!labelMesh) { continue; }
+
+
+            for (auto& label : labelMesh->getLabels()) {
                 m_needUpdate |= label->update(mvp, screenSize, _dt);
 
                 if (label->canOcclude()) {
@@ -110,7 +117,15 @@ void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _style
         }
 
         for (const auto& style : _styles) {
-            tile->pushLabelTransforms(*style);
+            auto mesh = tile->getMesh(*style);
+            if (!mesh) { continue; }
+
+            auto labelMesh = dynamic_cast<LabelMesh*>(mesh.get());
+            if (!labelMesh) { continue; }
+
+            for (auto& label : labelMesh->getLabels()) {
+                label->pushTransform(*labelMesh);
+            }
         }
     }
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -18,34 +18,6 @@ int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
     return (int) MIN(floor(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5)), MAX_LOD);
 }
 
-std::shared_ptr<Label> Labels::addTextLabel(Tile& _tile, TextBuffer& _buffer, const std::string& _styleName,
-                                            Label::Transform _transform, std::string _text, Label::Type _type) {
-
-    fsuint textID = _buffer.genTextID();
-
-    std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, textID, _type));
-
-    // raterize the text label
-    if (!label->rasterize(_buffer)) {
-
-        label.reset();
-        return nullptr;
-    }
-
-    _tile.addLabel(_styleName, label);
-
-    return label;
-}
-
-std::shared_ptr<Label> Labels::addSpriteLabel(Tile& _tile, const std::string& _styleName, Label::Transform _transform,
-                                              const glm::vec2& _size, size_t _bufferOffset) {
-
-    auto label = std::shared_ptr<Label>(new SpriteLabel(_transform, _size, _bufferOffset));
-
-    _tile.addLabel(_styleName, label);
-
-    return label;
-}
 
 void Labels::update(float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
                     const std::map<TileID, std::shared_ptr<Tile>>& _tiles) {

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -29,11 +29,9 @@ public:
 
     virtual ~Labels();
 
-    void setView(std::shared_ptr<View> _view) { m_view = _view; }
+    void drawDebug(const View& _view);
 
-    void drawDebug();
-
-    void update(float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
+    void update(const View& _view, float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
                 const std::map<TileID, std::shared_ptr<Tile>>& _tiles);
 
     bool needUpdate() { return m_needUpdate; }
@@ -42,7 +40,6 @@ private:
 
     int LODDiscardFunc(float _maxZoom, float _zoom);
 
-    std::shared_ptr<View> m_view;
     bool m_needUpdate;
 
     // temporary data used in update()

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -65,23 +65,21 @@ public:
 
 private:
 
-    void updateOcclusions();
-
     void addLabel(Tile& _tile, const std::string& _styleName, std::shared_ptr<Label> _label);
 
     int LODDiscardFunc(float _maxZoom, float _zoom);
 
     Labels();
-    std::vector<std::weak_ptr<Label>> m_labels;
-    std::vector<std::weak_ptr<Label>> m_pendingLabels;
+    std::vector<Label*> m_labels;
 
     // reference to the <FontContext>
     std::shared_ptr<FontContext> m_ftContext;
 
-    std::mutex m_mutex;
-
     std::shared_ptr<View> m_view;
     float m_currentZoom;
+
+
+    std::vector<isect2d::AABB> m_aabbs;
 
 };
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -25,36 +25,22 @@ class Style;
 class Labels {
 
 public:
-
-    static std::shared_ptr<Labels> GetInstance() {
-        static std::shared_ptr<Labels> instance(new Labels());
-        return instance;
-    }
+    Labels();
 
     virtual ~Labels();
-
-    void setFontContext(std::shared_ptr<FontContext> _ftContext) { m_ftContext = _ftContext; }
-
-    /* Returns a const reference to a pointer of the font context */
-    const std::shared_ptr<FontContext>& getFontContext() { return m_ftContext; }
-
 
     void setView(std::shared_ptr<View> _view) { m_view = _view; }
 
     void drawDebug();
 
-    void update(float _dt, const std::vector<std::unique_ptr<Style>>& _styles, const std::map<TileID, std::shared_ptr<Tile>>& _tiles);
+    void update(float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
+                const std::map<TileID, std::shared_ptr<Tile>>& _tiles);
 
     bool needUpdate() { return m_needUpdate; }
 
 private:
 
     int LODDiscardFunc(float _maxZoom, float _zoom);
-
-    Labels();
-
-    // reference to the <FontContext>
-    std::shared_ptr<FontContext> m_ftContext;
 
     std::shared_ptr<View> m_view;
     bool m_needUpdate;

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -33,20 +33,6 @@ public:
 
     virtual ~Labels();
 
-    /*
-     * Creates a text slabel for and associate it with the current processed <MapTile> TileID for a specific syle name
-     * Returns the created label
-     */
-    std::shared_ptr<Label> addTextLabel(Tile& _tile, TextBuffer& _buffer, const std::string& _styleName,
-                                        Label::Transform _transform, std::string _text, Label::Type _type);
-
-    /*
-     * Creates a sprite slabel for and associate it with the current processed <MapTile> TileID for a specific syle name
-     * Returns the created labe
-     */
-    std::shared_ptr<Label> addSpriteLabel(Tile& _tile, const std::string& _styleName, Label::Transform _transform,
-                                          const glm::vec2& _size, size_t _bufferOffset);
-
     void setFontContext(std::shared_ptr<FontContext> _ftContext) { m_ftContext = _ftContext; }
 
     /* Returns a const reference to a pointer of the font context */

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -54,8 +54,6 @@ public:
 
     void setView(std::shared_ptr<View> _view) { m_view = _view; }
 
-    void setScreenSize(int _width, int _height) { m_screenSize = glm::vec2(_width, _height); }
-
     void drawDebug();
 
 private:
@@ -73,7 +71,6 @@ private:
 
     std::mutex m_mutex;
 
-    glm::vec2 m_screenSize;
     std::shared_ptr<View> m_view;
     float m_currentZoom;
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -8,12 +8,14 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include <map>
 
 namespace Tangram {
 
 class FontContext;
 class Tile;
 class View;
+class Style;
 
 
 /*
@@ -50,13 +52,20 @@ public:
     /* Returns a const reference to a pointer of the font context */
     const std::shared_ptr<FontContext>& getFontContext() { return m_ftContext; }
 
-    void updateOcclusions();
 
     void setView(std::shared_ptr<View> _view) { m_view = _view; }
 
     void drawDebug();
 
+    void update(float _dt, const std::vector<std::unique_ptr<Style>>& _styles, const std::map<TileID, std::shared_ptr<Tile>>& _tiles);
+
+    void lazyRenderRequest();
+
+    bool needUpdate() { return Label::s_needUpdate; }
+
 private:
+
+    void updateOcclusions();
 
     void addLabel(Tile& _tile, const std::string& _styleName, std::shared_ptr<Label> _label);
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -59,9 +59,7 @@ public:
 
     void update(float _dt, const std::vector<std::unique_ptr<Style>>& _styles, const std::map<TileID, std::shared_ptr<Tile>>& _tiles);
 
-    void lazyRenderRequest();
-
-    bool needUpdate() { return Label::s_needUpdate; }
+    bool needUpdate() { return m_needUpdate; }
 
 private:
 
@@ -70,17 +68,17 @@ private:
     int LODDiscardFunc(float _maxZoom, float _zoom);
 
     Labels();
-    std::vector<Label*> m_labels;
 
     // reference to the <FontContext>
     std::shared_ptr<FontContext> m_ftContext;
 
     std::shared_ptr<View> m_view;
     float m_currentZoom;
+    bool m_needUpdate;
 
-
+    // temporary data used in update()
+    std::vector<Label*> m_labels;
     std::vector<isect2d::AABB> m_aabbs;
-
 };
 
 }

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -63,8 +63,6 @@ public:
 
 private:
 
-    void addLabel(Tile& _tile, const std::string& _styleName, std::shared_ptr<Label> _label);
-
     int LODDiscardFunc(float _maxZoom, float _zoom);
 
     Labels();
@@ -73,7 +71,6 @@ private:
     std::shared_ptr<FontContext> m_ftContext;
 
     std::shared_ptr<View> m_view;
-    float m_currentZoom;
     bool m_needUpdate;
 
     // temporary data used in update()

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -13,7 +13,9 @@ void SpriteLabel::pushTransform() {
     if (m_dirty) {
 
         // update all attributes screenPosition/rotation/alpha for the 4 quad vertices in the mesh
-        m_mesh.updateAttribute(m_bufferOffset, 4, m_transform.state);
+        size_t attribOffset = offsetof(Label::Vertex, state);
+
+        m_mesh.updateAttribute(m_bufferOffset + attribOffset, 4, m_transform.state);
     }
 }
 

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -2,19 +2,18 @@
 
 namespace Tangram {
 
-SpriteLabel::SpriteLabel(Label::Transform _transform, const glm::vec2& _size, size_t _bufferOffset) :
+SpriteLabel::SpriteLabel(LabelMesh& _mesh, Label::Transform _transform, const glm::vec2& _size, size_t _bufferOffset) :
     Label(_transform, Label::Type::point),
+    m_mesh(_mesh),
     m_bufferOffset(_bufferOffset) {
-
     m_dim = _size;
 }
 
-void SpriteLabel::pushTransform(VboMesh& _mesh) {
+void SpriteLabel::pushTransform() {
     if (m_dirty) {
-        TypedMesh<BufferVert>& mesh = static_cast<TypedMesh<BufferVert>&>(_mesh);
 
         // update all attributes screenPosition/rotation/alpha for the 4 quad vertices in the mesh
-        mesh.updateAttribute(m_bufferOffset, 4, m_transform.state);
+        m_mesh.updateAttribute(m_bufferOffset, 4, m_transform.state);
     }
 }
 

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -7,14 +7,18 @@ namespace Tangram {
 class SpriteLabel : public Label {
 public:
 
-    SpriteLabel(Label::Transform _transform, const glm::vec2& _size, size_t _bufferOffset);
+    SpriteLabel(LabelMesh& _mesh, Label::Transform _transform, const glm::vec2& _size, size_t _bufferOffset);
 
-    void pushTransform(VboMesh& _mesh) override;
+    void pushTransform() override;
 
 protected:
 
     void updateBBoxes() override;
 
+    // Back-pointer to owning container
+    LabelMesh& m_mesh;
+
+    // byte-offset in m_mesh vertices
     size_t m_bufferOffset;
 };
 

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "label.h"
+#include "labels/label.h"
+#include "labels/labelMesh.h"
 
 namespace Tangram {
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -26,6 +26,9 @@ bool TextLabel::rasterize() {
     if (m_numGlyphs == 0) {
         return false;
     }
+
+    debugSize = m_numGlyphs * 6 * sizeof(Label::Vertex);
+
     return true;
 }
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -12,33 +12,38 @@ void TextLabel::updateBBoxes() {
     glm::vec2 t = glm::vec2(cos(m_transform.state.rotation), sin(m_transform.state.rotation));
     glm::vec2 tperp = glm::vec2(-t.y, t.x);
     glm::vec2 obbCenter;
-    
+
     obbCenter = m_transform.state.screenPos + t * m_dim.x * 0.5f - tperp * (m_dim.y / 8);
-    
+
     m_obb = isect2d::OBB(obbCenter.x, obbCenter.y, m_transform.state.rotation, m_dim.x, m_dim.y);
     m_aabb = m_obb.getExtent();
 }
 
 bool TextLabel::rasterize(TextBuffer& _buffer) {
-    bool res = _buffer.rasterize(m_text, m_id);
-    
-    if (!res) {
+
+    m_numGlyphs = _buffer.rasterize(m_text, m_id, m_bufferOffset);
+
+    if (m_numGlyphs == 0) {
         return false;
     }
-    
+
     glm::vec4 bbox = _buffer.getBBox(m_id);
-    
+
     m_dim.x = std::abs(bbox.z - bbox.x);
     m_dim.y = std::abs(bbox.w - bbox.y);
-    
+
     return true;
 }
 
 void TextLabel::pushTransform(VboMesh& _mesh) {
     if (m_dirty) {
-        TextBuffer& buffer = static_cast<TextBuffer&>(_mesh);
-        buffer.transformID(m_id, m_transform.state);
         m_dirty = false;
+        TextBuffer& buffer = static_cast<TextBuffer&>(_mesh);
+
+        int numVerts = m_numGlyphs * 6;
+        size_t attribOffset = 16;
+
+        buffer.updateAttribute(m_bufferOffset + attribOffset, numVerts, m_transform.state);
     }
 }
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -2,10 +2,9 @@
 
 namespace Tangram {
 
-TextLabel::TextLabel(Label::Transform _transform, std::string _text, fsuint _id, Type _type) :
+TextLabel::TextLabel(Label::Transform _transform, std::string _text, Type _type) :
     Label(_transform, _type),
-    m_text(_text),
-    m_id(_id)
+    m_text(_text)
 {}
 
 void TextLabel::updateBBoxes() {
@@ -21,17 +20,11 @@ void TextLabel::updateBBoxes() {
 
 bool TextLabel::rasterize(TextBuffer& _buffer) {
 
-    m_numGlyphs = _buffer.rasterize(m_text, m_id, m_bufferOffset);
+    m_numGlyphs = _buffer.rasterize(m_text, m_dim, m_bufferOffset);
 
     if (m_numGlyphs == 0) {
         return false;
     }
-
-    glm::vec4 bbox = _buffer.getBBox(m_id);
-
-    m_dim.x = std::abs(bbox.z - bbox.x);
-    m_dim.y = std::abs(bbox.w - bbox.y);
-
     return true;
 }
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -2,9 +2,10 @@
 
 namespace Tangram {
 
-TextLabel::TextLabel(Label::Transform _transform, std::string _text, Type _type) :
+TextLabel::TextLabel(TextBuffer& _mesh, Label::Transform _transform, std::string _text, Type _type) :
     Label(_transform, _type),
-    m_text(_text)
+    m_text(_text),
+    m_mesh(_mesh)
 {}
 
 void TextLabel::updateBBoxes() {
@@ -18,9 +19,9 @@ void TextLabel::updateBBoxes() {
     m_aabb = m_obb.getExtent();
 }
 
-bool TextLabel::rasterize(TextBuffer& _buffer) {
+bool TextLabel::rasterize() {
 
-    m_numGlyphs = _buffer.rasterize(m_text, m_dim, m_bufferOffset);
+    m_numGlyphs = m_mesh.rasterize(m_text, m_dim, m_bufferOffset);
 
     if (m_numGlyphs == 0) {
         return false;
@@ -28,15 +29,14 @@ bool TextLabel::rasterize(TextBuffer& _buffer) {
     return true;
 }
 
-void TextLabel::pushTransform(VboMesh& _mesh) {
+void TextLabel::pushTransform() {
     if (m_dirty) {
         m_dirty = false;
-        TextBuffer& buffer = static_cast<TextBuffer&>(_mesh);
 
         int numVerts = m_numGlyphs * 6;
         size_t attribOffset = 16;
 
-        buffer.updateAttribute(m_bufferOffset + attribOffset, numVerts, m_transform.state);
+        m_mesh.updateAttribute(m_bufferOffset + attribOffset, numVerts, m_transform.state);
     }
 }
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -32,9 +32,8 @@ bool TextLabel::rasterize() {
 void TextLabel::pushTransform() {
     if (m_dirty) {
         m_dirty = false;
-
+        size_t attribOffset = offsetof(Label::Vertex, state);
         int numVerts = m_numGlyphs * 6;
-        size_t attribOffset = 16;
 
         m_mesh.updateAttribute(m_bufferOffset + attribOffset, numVerts, m_transform.state);
     }

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -8,7 +8,7 @@ namespace Tangram {
 class TextLabel : public Label {
 
 public:
-    TextLabel(Label::Transform _transform, std::string _text, fsuint _id, Type _type);
+    TextLabel(Label::Transform _transform, std::string _text, Type _type);
     
     /* Call the font context to rasterize the label string */
     bool rasterize(TextBuffer& _buffer);
@@ -20,7 +20,6 @@ public:
 private:
     
     std::string m_text;
-    fsuint m_id;
 
     size_t m_bufferOffset;
     int m_numGlyphs;

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -21,6 +21,9 @@ private:
     
     std::string m_text;
     fsuint m_id;
+
+    size_t m_bufferOffset;
+    int m_numGlyphs;
     
 protected:
     

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -8,22 +8,27 @@ namespace Tangram {
 class TextLabel : public Label {
 
 public:
-    TextLabel(Label::Transform _transform, std::string _text, Type _type);
+    TextLabel(TextBuffer& _mesh, Label::Transform _transform, std::string _text, Type _type);
     
     /* Call the font context to rasterize the label string */
-    bool rasterize(TextBuffer& _buffer);
+    bool rasterize();
     
     std::string getText() { return m_text; }
     
-    void pushTransform(VboMesh& _mesh) override;
+    void pushTransform() override;
     
 private:
     
     std::string m_text;
 
-    size_t m_bufferOffset;
     int m_numGlyphs;
-    
+
+    // Back-pointer to owning container
+    TextBuffer& m_mesh;
+
+    // byte-offset in m_mesh vertices
+    size_t m_bufferOffset;
+
 protected:
     
     void updateBBoxes() override;

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -52,7 +52,7 @@ void DebugStyle::addData(TileData &_data, Tile &_tile) {
         mesh->addVertices(std::move(vertices), { 0, 1, 2, 3, 0 });
         mesh->compileVertexBuffer();
 
-        _tile.addGeometry(*this, std::unique_ptr<VboMesh>(mesh));
+        _tile.addMesh(*this, std::unique_ptr<VboMesh>(mesh));
 
     }
 }

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -18,7 +18,7 @@ void DebugTextStyle::addData(TileData& _data, Tile& _tile) {
         
         onBeginBuildTile(*mesh);
         
-        auto ftContext = m_labels->getFontContext();
+        auto ftContext = Labels::GetInstance()->getFontContext();
         
         ftContext->setFont(m_fontName, m_fontSize * m_pixelScale);
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -28,12 +28,12 @@ void DebugTextStyle::addData(TileData& _data, Tile& _tile) {
         }
 
         std::string tileID = std::to_string(_tile.getID().x) + "/" + std::to_string(_tile.getID().y) + "/" + std::to_string(_tile.getID().z);
-        addTextLabel(_tile, buffer, { glm::vec2(0), glm::vec2(0) }, tileID, Label::Type::debug);
+        addTextLabel(buffer, { glm::vec2(0), glm::vec2(0) }, tileID, Label::Type::debug);
 
         onEndBuildTile(*mesh);
 
         mesh->compileVertexBuffer();
-        _tile.addGeometry(*this, mesh);
+        _tile.addMesh(*this, mesh);
     }
 
 }

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -18,15 +18,6 @@ void DebugTextStyle::addData(TileData& _data, Tile& _tile) {
         
         onBeginBuildTile(*mesh);
         
-        auto ftContext = Labels::GetInstance()->getFontContext();
-        
-        ftContext->setFont(m_fontName, m_fontSize * m_pixelScale);
-
-        if (m_sdf) {
-            float blurSpread = 2.5;
-            ftContext->setSignedDistanceField(blurSpread);
-        }
-
         std::string tileID = std::to_string(_tile.getID().x) + "/" + std::to_string(_tile.getID().y) + "/" + std::to_string(_tile.getID().z);
         addTextLabel(buffer, { glm::vec2(0), glm::vec2(0) }, tileID, Label::Type::debug);
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -28,7 +28,7 @@ void DebugTextStyle::addData(TileData& _data, Tile& _tile) {
         }
 
         std::string tileID = std::to_string(_tile.getID().x) + "/" + std::to_string(_tile.getID().y) + "/" + std::to_string(_tile.getID().z);
-        m_labels->addTextLabel(_tile, buffer, m_name, { glm::vec2(0), glm::vec2(0) }, tileID, Label::Type::debug);
+        addTextLabel(_tile, buffer, { glm::vec2(0), glm::vec2(0) }, tileID, Label::Type::debug);
 
         onEndBuildTile(*mesh);
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -89,9 +89,9 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
 
     size_t bufferOffset = _mesh.numVertices() * m_vertexLayout->getStride() + m_stateAttribOffset;
 
-    auto label = m_labels->addSpriteLabel(_tile, m_name, t,
-                                          spriteNode.m_size * spriteScale,
-                                          bufferOffset);
+    auto label = addSpriteLabel(_tile, t,
+                                spriteNode.m_size * spriteScale,
+                                bufferOffset);
 
     if (label) {
         Builders::buildQuadAtPoint(label->getTransform().state.screenPos + offset,
@@ -101,6 +101,16 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
 
     auto& mesh = static_cast<SpriteStyle::Mesh&>(_mesh);
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
+}
+
+std::shared_ptr<Label> SpriteStyle::addSpriteLabel(Tile& _tile, Label::Transform _transform,
+                                                   const glm::vec2& _size, size_t _bufferOffset) const {
+
+    auto label = std::shared_ptr<Label>(new SpriteLabel(_transform, _size, _bufferOffset));
+
+    _tile.addLabel(m_name, label);
+
+    return label;
 }
 
 void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -7,6 +7,7 @@
 #include "gl/vertexLayout.h"
 #include "util/builders.h"
 #include "view/view.h"
+#include "labels/spriteLabel.h"
 
 #include "glm/gtc/type_ptr.hpp"
 
@@ -87,28 +88,15 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
 
     size_t bufferOffset = _mesh.numVertices() * m_vertexLayout->getStride() + m_stateAttribOffset;
 
-    auto label = addSpriteLabel(_tile, t,
-                                spriteNode.m_size * spriteScale,
-                                bufferOffset);
+    auto label = std::make_shared<SpriteLabel>(t, spriteNode.m_size * spriteScale, bufferOffset);
 
-    if (label) {
-        Builders::buildQuadAtPoint(label->getTransform().state.screenPos + offset,
-                                   spriteNode.m_size * spriteScale,
-                                   spriteNode.m_uvBL, spriteNode.m_uvTR, builder);
-    }
+    Builders::buildQuadAtPoint(label->getTransform().state.screenPos + offset,
+                               spriteNode.m_size * spriteScale,
+                               spriteNode.m_uvBL, spriteNode.m_uvTR, builder);
 
-    auto& mesh = static_cast<SpriteStyle::Mesh&>(_mesh);
+    auto& mesh = static_cast<LabelMesh&>(_mesh);
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
-}
-
-std::shared_ptr<Label> SpriteStyle::addSpriteLabel(Tile& _tile, Label::Transform _transform,
-                                                   const glm::vec2& _size, size_t _bufferOffset) const {
-
-    auto label = std::shared_ptr<Label>(new SpriteLabel(_transform, _size, _bufferOffset));
-
-    _tile.addLabel(m_name, label);
-
-    return label;
+    mesh.addLabel(std::move(label));
 }
 
 void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -8,8 +8,8 @@
 #include "util/builders.h"
 #include "view/view.h"
 
-#include "glm/gtc/matrix_transform.hpp"
 #include "glm/gtc/type_ptr.hpp"
+#include "glm/gtc/matrix_transform.hpp"
 
 namespace Tangram {
 
@@ -108,8 +108,7 @@ void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std
     m_spriteAtlas->bind();
 
     m_shaderProgram->setUniformi("u_tex", 0);
-    // top-left screen axis, y pointing down
-    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(glm::ortho(0.f, _view->getWidth(), _view->getHeight(), 0.f, -1.f, 1.f)));
+    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view->getOrthoViewportMatrix()));
 
     RenderState::blending(GL_TRUE);
     RenderState::blendingFunc({GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA});

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -9,7 +9,6 @@
 #include "view/view.h"
 
 #include "glm/gtc/type_ptr.hpp"
-#include "glm/gtc/matrix_transform.hpp"
 
 namespace Tangram {
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -28,9 +28,6 @@ void SpriteStyle::constructVertexLayout() {
         {"a_alpha", 1, GL_FLOAT, false, 0},
         {"a_rotation", 1, GL_FLOAT, false, 0},
     }));
-
-    // NB: byte offset into BufferVert 'state'
-    m_stateAttribOffset = m_vertexLayout->getOffset("a_screenPosition");
 }
 
 void SpriteStyle::constructShaderProgram() {
@@ -86,7 +83,7 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
     SpriteNode spriteNode = m_spriteAtlas->getSpriteNode(kind);
     Label::Transform t = { glm::vec2(_point), glm::vec2(_point), offset };
 
-    size_t bufferOffset = _mesh.numVertices() * m_vertexLayout->getStride() + m_stateAttribOffset;
+    size_t bufferOffset = _mesh.numVertices() * m_vertexLayout->getStride();
 
     auto& mesh = static_cast<LabelMesh&>(_mesh);
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -88,13 +88,14 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
 
     size_t bufferOffset = _mesh.numVertices() * m_vertexLayout->getStride() + m_stateAttribOffset;
 
-    auto label = std::make_shared<SpriteLabel>(t, spriteNode.m_size * spriteScale, bufferOffset);
+    auto& mesh = static_cast<LabelMesh&>(_mesh);
+
+    auto label = std::make_shared<SpriteLabel>(mesh, t, spriteNode.m_size * spriteScale, bufferOffset);
 
     Builders::buildQuadAtPoint(label->getTransform().state.screenPos + offset,
                                spriteNode.m_size * spriteScale,
                                spriteNode.m_uvBL, spriteNode.m_uvTR, builder);
 
-    auto& mesh = static_cast<LabelMesh&>(_mesh);
     mesh.addVertices(std::move(vertices), std::move(builder.indices));
     mesh.addLabel(std::move(label));
 }

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -61,7 +61,7 @@ void SpriteStyle::constructShaderProgram() {
 
 void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     // TODO : make this configurable
-    std::vector<Label::BufferVert> vertices;
+    std::vector<Label::Vertex> vertices;
 
     SpriteBuilder builder = {
         [&](const glm::vec2& coord, const glm::vec2& screenPos, const glm::vec2& uv) {

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -61,7 +61,7 @@ void SpriteStyle::constructShaderProgram() {
 
 void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     // TODO : make this configurable
-    std::vector<BufferVert> vertices;
+    std::vector<Label::BufferVert> vertices;
 
     SpriteBuilder builder = {
         [&](const glm::vec2& coord, const glm::vec2& screenPos, const glm::vec2& uv) {
@@ -90,7 +90,7 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
 
     auto& mesh = static_cast<LabelMesh&>(_mesh);
 
-    auto label = std::make_shared<SpriteLabel>(mesh, t, spriteNode.m_size * spriteScale, bufferOffset);
+    std::unique_ptr<SpriteLabel> label(new SpriteLabel(mesh, t, spriteNode.m_size * spriteScale, bufferOffset));
 
     Builders::buildQuadAtPoint(label->getTransform().state.screenPos + offset,
                                spriteNode.m_size * spriteScale,

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -13,8 +13,6 @@
 namespace Tangram {
 
 SpriteStyle::SpriteStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
-
-    m_labels = Labels::GetInstance();
 }
 
 SpriteStyle::~SpriteStyle() {}

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -32,7 +32,6 @@ protected:
     };
 
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;
-    std::shared_ptr<Labels> m_labels;
     size_t m_stateAttribOffset;
 
 public:

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -4,7 +4,8 @@
 #include "glm/vec2.hpp"
 #include "glm/vec3.hpp"
 #include "gl/typedMesh.h"
-#include "labels/labels.h"
+#include "labels/labelMesh.h"
+#include "labels/label.h"
 #include "labels/spriteAtlas.h"
 
 namespace Tangram {
@@ -19,16 +20,8 @@ protected:
     virtual void constructShaderProgram() override;
     virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
 
-    /*
-     * Creates a sprite slabel for and associate it with the current processed <MapTile> TileID for a specific syle name
-     * Returns the created labe
-     */
-    std::shared_ptr<Label> addSpriteLabel(Tile& _tile, Label::Transform _transform, const glm::vec2& _size, size_t _bufferOffset) const;
-
-    typedef TypedMesh<BufferVert> Mesh;
-
     virtual VboMesh* newMesh() const override {
-        return new Mesh(m_vertexLayout, m_drawMode, GL_DYNAMIC_DRAW);
+        return new LabelMesh(m_vertexLayout, m_drawMode);
     };
 
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -19,6 +19,12 @@ protected:
     virtual void constructShaderProgram() override;
     virtual void buildPoint(Point& _point, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
 
+    /*
+     * Creates a sprite slabel for and associate it with the current processed <MapTile> TileID for a specific syle name
+     * Returns the created labe
+     */
+    std::shared_ptr<Label> addSpriteLabel(Tile& _tile, Label::Transform _transform, const glm::vec2& _size, size_t _bufferOffset) const;
+
     typedef TypedMesh<BufferVert> Mesh;
 
     virtual VboMesh* newMesh() const override {

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -25,7 +25,6 @@ protected:
     };
 
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;
-    size_t m_stateAttribOffset;
 
 public:
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -187,7 +187,7 @@ void Style::addData(TileData& _data, Tile& _tile) {
     } else {
         mesh->compileVertexBuffer();
 
-        _tile.addGeometry(*this, mesh);
+        _tile.addMesh(*this, mesh);
     }
 }
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -112,9 +112,7 @@ void TextStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParam
 std::shared_ptr<Label> TextStyle::addTextLabel(Tile& _tile, TextBuffer& _buffer, Label::Transform _transform,
                                                std::string _text, Label::Type _type) const {
 
-    fsuint textID = _buffer.genTextID();
-
-    std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, textID, _type));
+    std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, _type));
 
     // raterize the text label
     if (!label->rasterize(_buffer)) {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -111,9 +111,9 @@ void TextStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParam
 
 void TextStyle::addTextLabel(TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const {
 
-    std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, _type));
+    std::shared_ptr<TextLabel> label(new TextLabel(_buffer, _transform, _text, _type));
 
-    if (label->rasterize(_buffer)) {
+    if (label->rasterize()) {
         _buffer.addLabel(label);
     }
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -120,15 +120,10 @@ void TextStyle::addTextLabel(TextBuffer& _buffer, Label::Transform _transform, s
 
 void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
-    buffer.init();
-
-    // FIXME: unsynced access - font might be changed by another tile-worker
     auto ftContext = Labels::GetInstance()->getFontContext();
-    ftContext->setFont(m_fontName, m_fontSize * m_pixelScale);
-    if (m_sdf) {
-        float blurSpread = 2.5;
-        ftContext->setSignedDistanceField(blurSpread);
-    }
+    auto font = ftContext->getFontID(m_fontName);
+
+    buffer.init(font, m_fontSize * m_pixelScale, m_sdf ? 2.5 : 0);
 }
 
 void TextStyle::onEndBuildTile(VboMesh& _mesh) const {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -52,7 +52,7 @@ void TextStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, P
     }
 
     Label::Transform t { glm::vec2(_point), glm::vec2(_point), glm::vec2(0) };
-    addTextLabel(_tile, buffer, t, text, Label::Type::point);
+    addTextLabel(buffer, t, text, Label::Type::point);
 }
 
 void TextStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
@@ -79,7 +79,7 @@ void TextStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Prop
             continue;
         }
 
-        addTextLabel(_tile, buffer, { p1, p2, glm::vec2(0) }, text, Label::Type::line);
+        addTextLabel(buffer, { p1, p2, glm::vec2(0) }, text, Label::Type::line);
     }
 }
 
@@ -106,24 +106,16 @@ void TextStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParam
 
     Label::Transform t { centroid, centroid, glm::vec2(0) };
 
-    addTextLabel(_tile, buffer, t, text, Label::Type::point);
+    addTextLabel(buffer, t, text, Label::Type::point);
 }
 
-std::shared_ptr<Label> TextStyle::addTextLabel(Tile& _tile, TextBuffer& _buffer, Label::Transform _transform,
-                                               std::string _text, Label::Type _type) const {
+void TextStyle::addTextLabel(TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const {
 
     std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, _type));
 
-    // raterize the text label
-    if (!label->rasterize(_buffer)) {
-
-        label.reset();
-        return nullptr;
+    if (label->rasterize(_buffer)) {
+        _buffer.addLabel(label);
     }
-
-    _tile.addLabel(m_name, label);
-
-    return label;
 }
 
 void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -11,7 +11,6 @@ namespace Tangram {
 
 TextStyle::TextStyle(const std::string& _fontName, std::string _name, float _fontSize, unsigned int _color, bool _sdf, bool _sdfMultisampling, GLenum _drawMode)
 : Style(_name, _drawMode), m_fontName(_fontName), m_fontSize(_fontSize), m_color(_color), m_sdf(_sdf), m_sdfMultisampling(_sdfMultisampling)  {
-    m_labels = Labels::GetInstance();
 }
 
 TextStyle::~TextStyle() {
@@ -133,7 +132,7 @@ void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
     buffer.init();
 
-    auto ftContext = m_labels->getFontContext();
+    auto ftContext = Labels::GetInstance()->getFontContext();
 
     ftContext->setFont(m_fontName, m_fontSize * m_pixelScale);
     if (m_sdf) {
@@ -149,7 +148,7 @@ void TextStyle::onEndBuildTile(VboMesh& _mesh) const {
 }
 
 void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
-    auto ftContext = m_labels->getFontContext();
+    auto ftContext = Labels::GetInstance()->getFontContext();
     const auto& atlas = ftContext->getAtlas();
 
     atlas->update(1);

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -5,6 +5,7 @@
 #include "gl/shaderProgram.h"
 #include "gl/vboMesh.h"
 #include "view/view.h"
+#include "glm/gtc/type_ptr.hpp"
 
 namespace Tangram {
 
@@ -131,10 +132,8 @@ void TextStyle::onEndBuildTile(VboMesh& _mesh) const {
 void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
     auto ftContext = m_labels->getFontContext();
     const auto& atlas = ftContext->getAtlas();
-    float projectionMatrix[16] = {0};
 
     ftContext->setScreenSize(_view->getWidth(), _view->getHeight());
-    ftContext->getProjection(projectionMatrix);
 
     atlas->update(1);
     atlas->bind(1);
@@ -147,7 +146,7 @@ void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::
     float b = (m_color       & 0xff) / 255.0;
 
     m_shaderProgram->setUniformf("u_color", r, g, b);
-    m_shaderProgram->setUniformMatrix4f("u_proj", projectionMatrix);
+    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view->getOrthoViewportMatrix()));
 
     RenderState::blending(GL_TRUE);
     RenderState::blendingFunc({GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA});

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -5,6 +5,7 @@
 #include "gl/shaderProgram.h"
 #include "gl/vboMesh.h"
 #include "view/view.h"
+#include "labels/textLabel.h"
 #include "glm/gtc/type_ptr.hpp"
 
 namespace Tangram {
@@ -120,7 +121,7 @@ void TextStyle::addTextLabel(TextBuffer& _buffer, Label::Transform _transform, s
 
 void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
-    auto ftContext = Labels::GetInstance()->getFontContext();
+    auto ftContext = FontContext::GetInstance();
     auto font = ftContext->getFontID(m_fontName);
 
     buffer.init(font, m_fontSize * m_pixelScale, m_sdf ? 2.5 : 0);
@@ -134,7 +135,7 @@ void TextStyle::onEndBuildTile(VboMesh& _mesh) const {
 }
 
 void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
-    auto ftContext = Labels::GetInstance()->getFontContext();
+    auto ftContext = FontContext::GetInstance();
 
     const auto& atlas = ftContext->getAtlas();
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -133,8 +133,6 @@ void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::
     auto ftContext = m_labels->getFontContext();
     const auto& atlas = ftContext->getAtlas();
 
-    ftContext->setScreenSize(_view->getWidth(), _view->getHeight());
-
     atlas->update(1);
     atlas->bind(1);
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -111,10 +111,10 @@ void TextStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParam
 
 void TextStyle::addTextLabel(TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const {
 
-    std::shared_ptr<TextLabel> label(new TextLabel(_buffer, _transform, _text, _type));
+    std::unique_ptr<TextLabel> label(new TextLabel(_buffer, _transform, _text, _type));
 
     if (label->rasterize()) {
-        _buffer.addLabel(label);
+        _buffer.addLabel(std::move(label));
     }
 }
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -53,7 +53,7 @@ void TextStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, P
     }
 
     Label::Transform t { glm::vec2(_point), glm::vec2(_point), glm::vec2(0) };
-    m_labels->addTextLabel(_tile, buffer, m_name, t, text, Label::Type::point);
+    addTextLabel(_tile, buffer, t, text, Label::Type::point);
 }
 
 void TextStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
@@ -80,7 +80,7 @@ void TextStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Prop
             continue;
         }
 
-        m_labels->addTextLabel(_tile, buffer, m_name, { p1, p2, glm::vec2(0) }, text, Label::Type::line);
+        addTextLabel(_tile, buffer, { p1, p2, glm::vec2(0) }, text, Label::Type::line);
     }
 }
 
@@ -107,7 +107,26 @@ void TextStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParam
 
     Label::Transform t { centroid, centroid, glm::vec2(0) };
 
-    m_labels->addTextLabel(_tile, buffer, m_name, t, text, Label::Type::point);
+    addTextLabel(_tile, buffer, t, text, Label::Type::point);
+}
+
+std::shared_ptr<Label> TextStyle::addTextLabel(Tile& _tile, TextBuffer& _buffer, Label::Transform _transform,
+                                               std::string _text, Label::Type _type) const {
+
+    fsuint textID = _buffer.genTextID();
+
+    std::shared_ptr<TextLabel> label(new TextLabel(_transform, _text, textID, _type));
+
+    // raterize the text label
+    if (!label->rasterize(_buffer)) {
+
+        label.reset();
+        return nullptr;
+    }
+
+    _tile.addLabel(m_name, label);
+
+    return label;
 }
 
 void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -3,7 +3,6 @@
 #include "style.h"
 #include "gl/typedMesh.h"
 #include "glfontstash.h"
-#include "labels/labels.h"
 #include "text/fontContext.h"
 #include "text/textBuffer.h"
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -28,6 +28,12 @@ protected:
         return new TextBuffer(m_labels->getFontContext(), m_vertexLayout);
     };
 
+    /*
+     * Creates a text slabel for and associate it with the current processed <MapTile> TileID for a specific syle name
+     * Returns the created label
+     */
+    std::shared_ptr<Label> addTextLabel(Tile& _tile, TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const;
+
     std::string m_fontName;
     float m_fontSize;
     int m_color;

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "style.h"
-#include "gl/typedMesh.h"
-#include "glfontstash.h"
 #include "text/fontContext.h"
 #include "text/textBuffer.h"
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -25,7 +25,7 @@ protected:
     virtual void onEndBuildTile(VboMesh& _mesh) const override;
 
     virtual VboMesh* newMesh() const override {
-        return new TextBuffer(m_labels->getFontContext(), m_vertexLayout);
+        return new TextBuffer(m_vertexLayout);
     };
 
     /*
@@ -39,8 +39,6 @@ protected:
     int m_color;
     bool m_sdf;
     bool m_sdfMultisampling = true;
-
-    std::shared_ptr<Labels> m_labels;
 
 public:
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -29,10 +29,9 @@ protected:
     };
 
     /*
-     * Creates a text slabel for and associate it with the current processed <MapTile> TileID for a specific syle name
-     * Returns the created label
+     * Creates a text label and add it to the processed <TextBuffer>.
      */
-    std::shared_ptr<Label> addTextLabel(Tile& _tile, TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const;
+    void addTextLabel(TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const;
 
     std::string m_fontName;
     float m_fontSize;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -114,9 +114,6 @@ void update(float _dt) {
         m_labels->update(_dt, m_scene->getStyles(), tileSet);
     }
 
-    // Request for render if labels are in fading in/out states
-    m_labels->lazyRenderRequest();
-
     if (m_scene) {
         // Update lights and styles
     }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -23,7 +23,7 @@ namespace Tangram {
 std::unique_ptr<TileManager> m_tileManager;
 std::shared_ptr<Scene> m_scene;
 std::shared_ptr<View> m_view;
-std::shared_ptr<Labels> m_labels;
+std::unique_ptr<Labels> m_labels;
 std::shared_ptr<FontContext> m_ftContext;
 std::shared_ptr<Skybox> m_skybox;
 std::unique_ptr<InputHandler> m_inputHandler;
@@ -57,10 +57,9 @@ void initialize() {
         m_tileManager->setScene(m_scene);
 
         // Font and label setup
-        m_ftContext = std::make_shared<FontContext>();
+        m_ftContext = FontContext::GetInstance();
         m_ftContext->addFont("FiraSans-Medium.ttf", "FiraSans");
-        m_labels = Labels::GetInstance();
-        m_labels->setFontContext(m_ftContext);
+        m_labels = std::unique_ptr<Labels>(new Labels());
         m_labels->setView(m_view);
 
         SceneLoader loader;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -60,7 +60,6 @@ void initialize() {
         m_ftContext = FontContext::GetInstance();
         m_ftContext->addFont("FiraSans-Medium.ttf", "FiraSans");
         m_labels = std::unique_ptr<Labels>(new Labels());
-        m_labels->setView(m_view);
 
         SceneLoader loader;
         loader.loadScene("config.yaml", *m_scene, *m_tileManager, *m_view);
@@ -110,7 +109,7 @@ void update(float _dt) {
             }
         }
 
-        m_labels->update(_dt, m_scene->getStyles(), tileSet);
+        m_labels->update(*m_view, _dt, m_scene->getStyles(), tileSet);
     }
 
     if (m_scene) {
@@ -141,7 +140,7 @@ void render() {
 
     m_skybox->draw(*m_view);
 
-    m_labels->drawDebug();
+    m_labels->drawDebug(*m_view);
 
     while (Error::hadGlError("Tangram::render()")) {}
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -86,11 +86,6 @@ void resize(int _newWidth, int _newHeight) {
         m_view->setSize(_newWidth, _newHeight);
     }
 
-    if (m_ftContext) {
-        m_ftContext->setScreenSize(m_view->getWidth(), m_view->getHeight());
-        m_labels->setScreenSize(m_view->getWidth(), m_view->getHeight());
-    }
-
     while (Error::hadGlError("Tangram::resize()")) {}
 
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -65,6 +65,17 @@ void FontContext::setFont(const std::string& _name, int size) {
     }
 }
 
+fsuint FontContext::getFontID(const std::string& _name) {
+    auto it = m_fonts.find(_name);
+
+    if (it != m_fonts.end()) {
+        return it->second;
+    } else {
+        logMsg("[FontContext] Could not find font %s\n", _name.c_str());
+        return 0;
+    }
+}
+
 void updateAtlas(void* _userPtr, unsigned int _xoff, unsigned int _yoff,
                  unsigned int _width, unsigned int _height, const unsigned int* _pixels) {
 

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -6,7 +6,7 @@ namespace Tangram {
 
 FontContext::FontContext() : FontContext(512) {}
 
-FontContext::FontContext(int _atlasSize) : m_contextMutex(std_patch::make_unique<std::mutex>()) {
+FontContext::FontContext(int _atlasSize) {
     initFontContext(_atlasSize);
 }
 
@@ -28,11 +28,11 @@ void FontContext::setSignedDistanceField(float _blurSpread) {
 }
 
 void FontContext::lock() {
-    m_contextMutex->lock();
+    m_contextMutex.lock();
 }
 
 void FontContext::unlock() {
-    m_contextMutex->unlock();
+    m_contextMutex.unlock();
 }
 
 bool FontContext::addFont(const std::string& _fontFile, std::string _name) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -18,10 +18,6 @@ const std::unique_ptr<Texture>& FontContext::getAtlas() const {
     return m_atlas;
 }
 
-void FontContext::getProjection(float* _projectionMatrix) const {
-    glfonsProjection(m_fsContext, _projectionMatrix);
-}
-
 void FontContext::setScreenSize(int _width, int _height) {
     glfonsScreenSize(m_fsContext, _width, _height);
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -72,17 +72,9 @@ void updateAtlas(void* _userPtr, unsigned int _xoff, unsigned int _yoff,
     fontContext->getAtlas()->setSubData(static_cast<const GLuint*>(_pixels), _xoff, _yoff, _width, _height);
 }
 
-void updateBuffer(void* _userPtr, GLintptr _offset, GLsizei _size, float* _newData, void* _owner) {
-    auto buffer = static_cast<TextBuffer*>(_owner);
-    
-    if (buffer) {
-        buffer->update(_offset, _size, reinterpret_cast<unsigned char*>(_newData));
-    }
-}
-
 void FontContext::initFontContext(int _atlasSize) {
     m_atlas = std::unique_ptr<Texture>(new Texture(_atlasSize, _atlasSize));
-    m_fsContext = glfonsCreate(_atlasSize, _atlasSize, FONS_ZERO_TOPLEFT, { false, updateBuffer, updateAtlas }, (void*) this);
+    m_fsContext = glfonsCreate(_atlasSize, _atlasSize, FONS_ZERO_TOPLEFT, { false, nullptr, updateAtlas }, (void*) this);
 }
 
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -18,10 +18,6 @@ const std::unique_ptr<Texture>& FontContext::getAtlas() const {
     return m_atlas;
 }
 
-void FontContext::setScreenSize(int _width, int _height) {
-    glfonsScreenSize(m_fsContext, _width, _height);
-}
-
 void FontContext::clearState() {
     fonsClearState(m_fsContext);
 }

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -30,6 +30,8 @@ public:
     /* sets the current font for a size in pixels */
     void setFont(const std::string& _name, int size);
 
+    fsuint getFontID(const std::string& _name);
+
     /* sets the blur spread when using signed distance field rendering */
     void setSignedDistanceField(float _blurSpread);
 

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -20,6 +20,11 @@ class FontContext {
 
 public:
 
+    static std::shared_ptr<FontContext> GetInstance() {
+        static std::shared_ptr<FontContext> instance(new FontContext());
+        return instance;
+    }
+
     FontContext();
     FontContext(int _atlasSize);
     ~FontContext();

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -36,9 +36,6 @@ public:
     /* sets the screen size, this size is used when transforming text ids in the text buffers */
     void setScreenSize(int _width, int _height);
 
-    /* fills the orthographic projection matrix related to the current screen size */
-    void getProjection(float* _projectionMatrix) const;
-
     void clearState();
     
     /* lock thread access to this font context */

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -58,7 +58,7 @@ private:
 
     std::map<std::string, int> m_fonts;
     std::unique_ptr<Texture> m_atlas;
-    std::unique_ptr<std::mutex> m_contextMutex;
+    std::mutex m_contextMutex;
     FONScontext* m_fsContext;
 
 };

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -33,9 +33,6 @@ public:
     /* sets the blur spread when using signed distance field rendering */
     void setSignedDistanceField(float _blurSpread);
 
-    /* sets the screen size, this size is used when transforming text ids in the text buffers */
-    void setScreenSize(int _width, int _height);
-
     void clearState();
     
     /* lock thread access to this font context */

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -3,15 +3,17 @@
 
 #include "gl/texture.h"
 #include "gl/vboMesh.h"
+#include "labels/labels.h"
 
 namespace Tangram {
 
-TextBuffer::TextBuffer(std::shared_ptr<FontContext> _fontContext, std::shared_ptr<VertexLayout> _vertexLayout)
+TextBuffer::TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout)
     : TypedMesh<BufferVert>(_vertexLayout, GL_TRIANGLES, GL_DYNAMIC_DRAW) {
 
     m_dirtyTransform = false;
-    m_fontContext = _fontContext;
     m_bound = false;
+
+    m_fontContext = Labels::GetInstance()->getFontContext();
 }
 
 void TextBuffer::init() {

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -60,7 +60,7 @@ int TextBuffer::rasterize(const std::string& _text, glm::vec2& _size, size_t& _b
 }
 
 void TextBuffer::addBufferVerticesToMesh() {
-    std::vector<Label::BufferVert> vertices;
+    std::vector<Label::Vertex> vertices;
 
     m_fontContext->lock();
     auto ctx = m_fontContext->getFontContext();

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -16,7 +16,11 @@ TextBuffer::TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout)
     m_fontContext = Labels::GetInstance()->getFontContext();
 }
 
-void TextBuffer::init() {
+void TextBuffer::init(fsuint _fontID, float _size, float _blurSpread) {
+    m_fontID = _fontID;
+    m_fontSize = _size;
+    m_fontBlurSpread = _blurSpread;
+
     m_fontContext->lock();
     glfonsBufferCreate(m_fontContext->getFontContext(), &m_fsBuffer);
     m_fontContext->unlock();
@@ -38,6 +42,16 @@ int TextBuffer::rasterize(const std::string& _text, glm::vec2& _size, size_t& _b
 
     fsuint textID;
     glfonsGenText(ctx, 1, &textID);
+
+    fonsSetSize(ctx, m_fontSize);
+    fonsSetFont(ctx, m_fontID);
+
+    if (m_fontBlurSpread > 0){
+        fonsSetBlur(ctx, m_fontBlurSpread);
+        fonsSetBlurType(ctx, FONS_EFFECT_DISTANCE_FIELD);
+    } else {
+        fonsSetBlurType(ctx, FONS_EFFECT_NONE);
+    }
 
     int status = glfonsRasterize(ctx, textID, _text.c_str());
     if (status == GLFONS_VALID) {

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -60,7 +60,7 @@ int TextBuffer::rasterize(const std::string& _text, glm::vec2& _size, size_t& _b
 }
 
 void TextBuffer::addBufferVerticesToMesh() {
-    std::vector<BufferVert> vertices;
+    std::vector<Label::BufferVert> vertices;
 
     m_fontContext->lock();
     auto ctx = m_fontContext->getFontContext();

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -8,7 +8,7 @@
 namespace Tangram {
 
 TextBuffer::TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout)
-    : TypedMesh<BufferVert>(_vertexLayout, GL_TRIANGLES, GL_DYNAMIC_DRAW) {
+    : LabelMesh(_vertexLayout, GL_TRIANGLES) {
 
     m_dirtyTransform = false;
     m_bufferPosition = 0;

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -44,9 +44,6 @@ private:
     bool m_dirtyTransform;
     fsuint m_fsBuffer;
     int m_bufferPosition;
-
-    std::shared_ptr<FontContext> m_fontContext;
-
 };
 
 }

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "gl.h"
-#include "glfontstash.h"
 #include "gl/typedMesh.h"
 #include "glm/vec4.hpp"
 #include "glm/vec2.hpp"
+
+#include "glfontstash.h" // for fsuint
 
 #include <memory>
 
@@ -32,29 +33,20 @@ public:
     TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout);
     ~TextBuffer();
 
-    /* generates a text id */
-    fsuint genTextID();
-
     /* creates a text buffer and bind it */
     void init();
 
-    /* ask the font rasterizer to rasterize a specific text for a text id */
-    int rasterize(const std::string& _text, fsuint _id, size_t& bufferOffset);
-
-    int getVerticesSize();
-
-    /* get the axis aligned bounding box for a text */
-    glm::vec4 getBBox(fsuint _textID);
+    /* ask the font rasterizer to rasterize a specific text.
+     * Returns number of glyphs > 0 on success.
+     * @_size is set to the text extents
+     * @_bufferOffset is set to the byteOffset of the first glyph-vertex */
+    int rasterize(const std::string& _text, glm::vec2& _size, size_t& bufferOffset);
 
     /* get the vertices from the font context and add them as vbo mesh data */
     void addBufferVerticesToMesh();
 
 private:
 
-    void bind();
-    void unbind();
-
-    bool m_bound;
     bool m_dirtyTransform;
     fsuint m_fsBuffer;
     int m_bufferPosition;

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -24,7 +24,7 @@ public:
     ~TextBuffer();
 
     /* creates a text buffer and bind it */
-    void init();
+    void init(fsuint _fontID, float _size, float _blurSpread);
 
     /* ask the font rasterizer to rasterize a specific text.
      * Returns number of glyphs > 0 on success.
@@ -36,6 +36,10 @@ public:
     void addBufferVerticesToMesh();
 
 private:
+
+    fsuint m_fontID;
+    float m_fontSize;
+    float m_fontBlurSpread;
 
     bool m_dirtyTransform;
     fsuint m_fsBuffer;

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -29,7 +29,7 @@ class TextBuffer : public TypedMesh<BufferVert> {
 
 public:
 
-    TextBuffer(std::shared_ptr<FontContext> _fontContext, std::shared_ptr<VertexLayout> _vertexLayout);
+    TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout);
     ~TextBuffer();
 
     /* generates a text id */

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -39,17 +39,7 @@ public:
     void init();
 
     /* ask the font rasterizer to rasterize a specific text for a text id */
-    bool rasterize(const std::string& _text, fsuint _id);
-
-    /*
-     * transform a text id in screen space coordinate
-     *  x, y in screen space
-     *  rotation is in radians
-     *  alpha should be in [0..1]
-     */
-    void transformID(fsuint _textID, const BufferVert::State& _state);
-
-    void pushBuffer();
+    int rasterize(const std::string& _text, fsuint _id, size_t& bufferOffset);
 
     int getVerticesSize();
 
@@ -67,6 +57,8 @@ private:
     bool m_bound;
     bool m_dirtyTransform;
     fsuint m_fsBuffer;
+    int m_bufferPosition;
+
     std::shared_ptr<FontContext> m_fontContext;
 
 };

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "gl.h"
-#include "gl/typedMesh.h"
+#include "labels/labelMesh.h"
 #include "glm/vec4.hpp"
 #include "glm/vec2.hpp"
 
@@ -11,22 +11,12 @@
 
 namespace Tangram {
 
-struct BufferVert {
-    glm::vec2 pos;
-    glm::vec2 uv;
-    struct State {
-        glm::vec2 screenPos;
-        float alpha;
-        float rotation;
-    } state;
-};
-
 class FontContext;
 
 /*
  * This class represents a text buffer, each text buffer has several text ids
  */
-class TextBuffer : public TypedMesh<BufferVert> {
+class TextBuffer : public LabelMesh {
 
 public:
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -5,8 +5,6 @@
 #include "tile/tileID.h"
 #include "gl/vboMesh.h"
 #include "gl/shaderProgram.h"
-#include "text/fontContext.h"
-#include "labels/labels.h"
 
 #include "glm/gtc/matrix_transform.hpp"
 #include "glm/gtc/type_ptr.hpp"

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -50,13 +50,8 @@ void Tile::update(float _dt, const View& _view) {
 
 }
 
-void Tile::updateLabels(float _dt, const Style& _style, const View& _view) {
-    glm::mat4 mvp = _view.getViewProjectionMatrix() * m_modelMatrix;
-    glm::vec2 screenSize = glm::vec2(_view.getWidth(), _view.getHeight());
-    
-    for (auto& label : m_labels[_style.getName()]) {
-        label->update(mvp, screenSize, _dt);
-    }
+std::vector<std::shared_ptr<Label>>& Tile::getLabels(const Style& _style) {
+    return m_labels[_style.getName()];
 }
 
 void Tile::pushLabelTransforms(const Style& _style) {

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -34,10 +34,16 @@ Tile::~Tile() {
 
 }
 
-void Tile::addGeometry(const Style& _style, std::shared_ptr<VboMesh> _mesh) {
+void Tile::addMesh(const Style& _style, std::shared_ptr<VboMesh> _mesh) {
+    m_geometry[_style.getName()] = std::move(_mesh);
+}
 
-    m_geometry[_style.getName()] = std::move(_mesh); // Move-construct a unique_ptr at the value associated with the given style
+std::shared_ptr<VboMesh> Tile::getMesh(const Style& _style) {
+    auto it = m_geometry.find(_style.getName());
+    if (it != m_geometry.end())
+        return it->second;
 
+    return nullptr;
 }
 
 void Tile::update(float _dt, const View& _view) {
@@ -48,20 +54,6 @@ void Tile::update(float _dt, const View& _view) {
     m_modelMatrix[3][1] = m_tileOrigin.y - viewOrigin.y;
     m_modelMatrix[3][2] = -viewOrigin.z;
 
-}
-
-std::vector<std::shared_ptr<Label>>& Tile::getLabels(const Style& _style) {
-    return m_labels[_style.getName()];
-}
-
-void Tile::pushLabelTransforms(const Style& _style) {
-    std::shared_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
-    
-    if (styleMesh) {
-        for(auto& label : m_labels[_style.getName()]) {
-            label->pushTransform(*styleMesh);
-        }
-    }
 }
 
 void Tile::draw(const Style& _style, const View& _view) {
@@ -84,14 +76,6 @@ void Tile::draw(const Style& _style, const View& _view) {
 
         styleMesh->draw(shader);
     }
-}
-
-std::shared_ptr<VboMesh>& Tile::getGeometry(const Style& _style) {
-    return m_geometry.at(_style.getName());
-}
-
-void Tile::addLabel(const std::string& _styleName, std::shared_ptr<Label> _label) {
-    m_labels[_styleName].push_back(std::move(_label));
 }
 
 }

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -59,7 +59,7 @@ void Tile::updateLabels(float _dt, const Style& _style, const View& _view) {
     }
 }
 
-void Tile::pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _labels) {
+void Tile::pushLabelTransforms(const Style& _style) {
     std::shared_ptr<VboMesh>& styleMesh = m_geometry[_style.getName()];
     
     if (styleMesh) {

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -61,11 +61,6 @@ void Tile::pushLabelTransforms(const Style& _style) {
         for(auto& label : m_labels[_style.getName()]) {
             label->pushTransform(*styleMesh);
         }
-    
-        if (typeid(*styleMesh) == typeid(TextBuffer)) {
-            TextBuffer& buffer = static_cast<TextBuffer&>(*styleMesh);
-            buffer.pushBuffer();
-        }
     }
 }
 

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -13,8 +13,6 @@
 
 namespace Tangram {
 
-class Label;
-class Labels;
 class MapProjection;
 class Style;
 class TextBuffer;

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -73,7 +73,7 @@ public:
     void updateLabels(float _dt, const Style& _style, const View& _view);
     
     /* Push the label transforms to the font rendering context */
-    void pushLabelTransforms(const Style& _style, std::shared_ptr<Labels> _labels);
+    void pushLabelTransforms(const Style& _style);
 
     /* Draws the geometry associated with the provided <Style> and view-projection matrix */
     void draw(const Style& _style, const View& _view);

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -60,19 +60,12 @@ public:
      * Use std::move to pass in the mesh by move semantics; Geometry in the mesh
      * must have coordinates relative to the tile origin.
      */
-    void addGeometry(const Style& _style, std::shared_ptr<VboMesh> _mesh);
+    void addMesh(const Style& _style, std::shared_ptr<VboMesh> _mesh);
     
-    void addLabel(const std::string& _styleName, std::shared_ptr<Label> _label);
-    
-    std::shared_ptr<VboMesh>& getGeometry(const Style& _style);
+    std::shared_ptr<VboMesh> getMesh(const Style& _style);
 
     /* uUdate the Tile considering the current view */
     void update(float _dt, const View& _view);
-
-    std::vector<std::shared_ptr<Label>>& getLabels(const Style& _style);
-    
-    /* Push the label transforms to the font rendering context */
-    void pushLabelTransforms(const Style& _style);
 
     /* Draws the geometry associated with the provided <Style> and view-projection matrix */
     void draw(const Style& _style, const View& _view);
@@ -183,7 +176,6 @@ private:
     // relative translation from the view origin to the model origin immediately before drawing the tile.
 
     std::unordered_map<std::string, std::shared_ptr<VboMesh>> m_geometry; // Map of <Style>s and their associated <VboMesh>es
-    std::unordered_map<std::string, std::vector<std::shared_ptr<Label>>> m_labels;
 
 };
 

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -69,8 +69,7 @@ public:
     /* uUdate the Tile considering the current view */
     void update(float _dt, const View& _view);
 
-    /* Update labels position considering the tile transform */
-    void updateLabels(float _dt, const Style& _style, const View& _view);
+    std::vector<std::shared_ptr<Label>>& getLabels(const Style& _style);
     
     /* Push the label transforms to the font rendering context */
     void pushLabelTransforms(const Style& _style);

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -63,6 +63,9 @@ void View::setSize(int _width, int _height) {
     m_aspect = (float)_width / (float)_height;
     m_dirty = true;
 
+    // Screen space orthographic projection matrix, top left origin, y pointing down
+    m_orthoViewport = glm::ortho(0.f, (float)m_vpWidth, (float)m_vpHeight, 0.f, -1.f, 1.f);
+
 }
 
 void View::setPosition(double _x, double _y) {

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -125,6 +125,8 @@ public:
     
     constexpr static float s_maxZoom = 18.0;
 
+    const glm::mat4& getOrthoViewportMatrix() { return m_orthoViewport; };
+
 protected:
     
     void updateMatrices();
@@ -136,6 +138,7 @@ protected:
     glm::dvec3 m_pos;
 
     glm::mat4 m_view;
+    glm::mat4 m_orthoViewport;
     glm::mat4 m_proj;
     glm::mat4 m_viewProj;
     glm::mat4 m_invViewProj;

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -11,9 +11,10 @@
 using namespace Tangram;
 
 glm::vec2 screenSize(500.f, 500.f);
+TextBuffer dummy(nullptr);
 
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", Label::Type::point);
+    TextLabel l(dummy, {screenSize/2.f}, "label", Label::Type::point);
 
     REQUIRE(l.getState() == Label::State::wait_occ);
     l.setOcclusion(true);
@@ -32,7 +33,7 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
 }
 
 TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", Label::Type::point);
+    TextLabel l(dummy, {screenSize/2.f}, "label", Label::Type::point);
 
     REQUIRE(l.getState() == Label::State::wait_occ);
 
@@ -55,7 +56,7 @@ TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens
 }
 
 TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", Label::Type::point);
+    TextLabel l(dummy, {screenSize/2.f}, "label", Label::Type::point);
 
     l.setOcclusion(false);
     l.occlusionSolved();
@@ -73,7 +74,7 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
 }
 
 TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
-    TextLabel l({screenSize*2.f}, "label", Label::Type::point);
+    TextLabel l(dummy, {screenSize*2.f}, "label", Label::Type::point);
 
     REQUIRE(l.getState() == Label::State::wait_occ);
 
@@ -101,7 +102,7 @@ TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
 }
 
 TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", Label::Type::debug);
+    TextLabel l(dummy, {screenSize/2.f}, "label", Label::Type::debug);
 
     REQUIRE(l.getState() == Label::State::visible);
     REQUIRE(!l.canOcclude());

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -13,7 +13,7 @@ using namespace Tangram;
 glm::vec2 screenSize(500.f, 500.f);
 
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::point);
+    TextLabel l({screenSize/2.f}, "label", Label::Type::point);
 
     REQUIRE(l.getState() == Label::State::wait_occ);
     l.setOcclusion(true);
@@ -32,7 +32,7 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
 }
 
 TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::point);
+    TextLabel l({screenSize/2.f}, "label", Label::Type::point);
 
     REQUIRE(l.getState() == Label::State::wait_occ);
 
@@ -55,7 +55,7 @@ TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens
 }
 
 TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::point);
+    TextLabel l({screenSize/2.f}, "label", Label::Type::point);
 
     l.setOcclusion(false);
     l.occlusionSolved();
@@ -73,7 +73,7 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
 }
 
 TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
-    TextLabel l({screenSize*2.f}, "label", 0, Label::Type::point);
+    TextLabel l({screenSize*2.f}, "label", Label::Type::point);
 
     REQUIRE(l.getState() == Label::State::wait_occ);
 
@@ -101,7 +101,7 @@ TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
 }
 
 TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][Label]" ) {
-    TextLabel l({screenSize/2.f}, "label", 0, Label::Type::debug);
+    TextLabel l({screenSize/2.f}, "label", Label::Type::debug);
 
     REQUIRE(l.getState() == Label::State::visible);
     REQUIRE(!l.canOcclude());


### PR DESCRIPTION
(Edit: this is not a pull request)

I've added some logging to compare the number of used label vertices with the number of vertices that are uploaded for each frame:
It shows that roughly 4 times more vertices are updated than being using in general. The screenshot shows a case with  a tilted view where the updated buffer are 16 times larger than what is actually used (5.8 vs 0.36 MB), with up to 60 meshes being updated.

http://www.enlightenment.org/ss/e-55b60fd612e225.04695096.jpg

I would propose to use one VboMesh per Text- and SpriteStyle that only hold the currently active labels. 

- this should decrease size and number of buffer uploads
- and reduce the number of vertices processed by the shader (instead of processing all label vertices and discard inactive ones).  
