### PR TITLE
change shared_ptr parameter to pass by ref

### DIFF
--- a/core/src/scene/ambientLight.cpp
+++ b/core/src/scene/ambientLight.cpp
@@ -19,7 +19,7 @@ AmbientLight::~AmbientLight() {
 
 }
 
-void AmbientLight::setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _shader ) {
+void AmbientLight::setupProgram(const View& _view, ShaderProgram& _shader ) {
     if (m_dynamic) {
         Light::setupProgram(_view, _shader);
     }

--- a/core/src/scene/ambientLight.h
+++ b/core/src/scene/ambientLight.h
@@ -10,7 +10,7 @@ public:
     AmbientLight(const std::string& _name, bool _dynamic = false);
     virtual ~AmbientLight();
     
-    virtual void setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _program) override;
+    virtual void setupProgram(const View& _view, ShaderProgram& _program) override;
     
 protected:
 

--- a/core/src/scene/directionalLight.cpp
+++ b/core/src/scene/directionalLight.cpp
@@ -25,16 +25,16 @@ void DirectionalLight::setDirection(const glm::vec3 &_dir) {
     m_direction = glm::normalize(_dir);
 }
 
-void DirectionalLight::setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _shader ) {
+void DirectionalLight::setupProgram(const View& _view, ShaderProgram& _shader ) {
 
     glm::vec3 direction = m_direction;
     if (m_origin == LightOrigin::world) {
-        direction = _view->getNormalMatrix() * direction;
+        direction = _view.getNormalMatrix() * direction;
     }
 
 	if (m_dynamic) {
 		Light::setupProgram(_view, _shader);
-		_shader->setUniformf(getUniformName()+".direction", direction);
+		_shader.setUniformf(getUniformName()+".direction", direction);
 	}
 }
 

--- a/core/src/scene/directionalLight.h
+++ b/core/src/scene/directionalLight.h
@@ -14,7 +14,7 @@ public:
     /*	Set the direction of the light */
     virtual void setDirection(const glm::vec3& _dir);
     
-    virtual void setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _program) override;
+    virtual void setupProgram(const View& _view, ShaderProgram& _program) override;
     
 protected:
 

--- a/core/src/scene/light.cpp
+++ b/core/src/scene/light.cpp
@@ -42,22 +42,22 @@ void Light::setOrigin( LightOrigin _origin ) {
     m_origin = _origin;
 }
 
-void Light::injectOnProgram(std::shared_ptr<ShaderProgram> _shader) {
+void Light::injectOnProgram(ShaderProgram& _shader) {
 
     // Inject all needed #defines for this light instance
-    _shader->addSourceBlock("defines", getInstanceDefinesBlock(), false);
+    _shader.addSourceBlock("defines", getInstanceDefinesBlock(), false);
 
-    _shader->addSourceBlock("__lighting", getClassBlock(), false);
-    _shader->addSourceBlock("__lighting", getInstanceBlock());
-    _shader->addSourceBlock("__lights_to_compute", getInstanceComputeBlock());
+    _shader.addSourceBlock("__lighting", getClassBlock(), false);
+    _shader.addSourceBlock("__lighting", getInstanceBlock());
+    _shader.addSourceBlock("__lights_to_compute", getInstanceComputeBlock());
 
 }
 
-void Light::setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _shader) {
+void Light::setupProgram(const View& _view, ShaderProgram& _shader) {
     if (m_dynamic) {
-        _shader->setUniformf(getUniformName()+".ambient", m_ambient);
-        _shader->setUniformf(getUniformName()+".diffuse", m_diffuse);
-        _shader->setUniformf(getUniformName()+".specular", m_specular);
+        _shader.setUniformf(getUniformName()+".ambient", m_ambient);
+        _shader.setUniformf(getUniformName()+".diffuse", m_diffuse);
+        _shader.setUniformf(getUniformName()+".specular", m_specular);
     }
 }
 

--- a/core/src/scene/light.h
+++ b/core/src/scene/light.h
@@ -62,10 +62,10 @@ public:
     virtual std::string getInstanceComputeBlock();
 
     /*  Inject the needed lines of GLSL code on the shader to make this light work */
-    virtual void injectOnProgram( std::shared_ptr<ShaderProgram> _shader);
+    virtual void injectOnProgram(ShaderProgram& _shader);
 
     /*  Pass the uniforms for this particular DYNAMICAL light on the passed shader */
-    virtual void setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _shader );
+    virtual void setupProgram(const View& _view, ShaderProgram& _shader );
 
     /*  STATIC Function that compose sourceBlocks with Lights on a ProgramShader */
     static void assembleLights(std::map<std::string, std::vector<std::string>>& _sourceBlocks);

--- a/core/src/scene/pointLight.cpp
+++ b/core/src/scene/pointLight.cpp
@@ -46,7 +46,7 @@ void PointLight::setRadius(float _inner, float _outer){
     m_outerRadius = _outer;
 }
 
-void PointLight::setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _shader) {
+void PointLight::setupProgram(const View& _view, ShaderProgram& _shader) {
     if (m_dynamic) {
         Light::setupProgram(_view, _shader);
 
@@ -56,34 +56,34 @@ void PointLight::setupProgram(const std::shared_ptr<View>& _view, std::shared_pt
             // For world origin, format is: [longitude, latitude, meters (default) or pixels w/px units]
 
             // Move light's world position into camera space
-            glm::dvec2 camSpace = _view->getMapProjection().LonLatToMeters(glm::dvec2(m_position.x, m_position.y));
-            position.x = camSpace.x - _view->getPosition().x;
-            position.y = camSpace.y - _view->getPosition().y;
-            position.z = position.z - _view->getPosition().z;
+            glm::dvec2 camSpace = _view.getMapProjection().LonLatToMeters(glm::dvec2(m_position.x, m_position.y));
+            position.x = camSpace.x - _view.getPosition().x;
+            position.y = camSpace.y - _view.getPosition().y;
+            position.z = position.z - _view.getPosition().z;
 
         } else if (m_origin == LightOrigin::ground) {
             // Leave light's xy in camera space, but z needs to be moved relative to ground plane
-            position.z = position.z - _view->getPosition().z;
+            position.z = position.z - _view.getPosition().z;
         }
 
         if (m_origin == LightOrigin::world || m_origin == LightOrigin::ground) {
             // Light position is a vector from the camera to the light in world space;
             // we can transform this vector into camera space the same way we would with normals
-            position = _view->getViewMatrix() * position;
+            position = _view.getViewMatrix() * position;
         }
 
-        _shader->setUniformf(getUniformName()+".position", position);
+        _shader.setUniformf(getUniformName()+".position", position);
 
         if (m_attenuation!=0.0) {
-            _shader->setUniformf(getUniformName()+".attenuation", m_attenuation);
+            _shader.setUniformf(getUniformName()+".attenuation", m_attenuation);
         }
 
         if (m_innerRadius!=0.0) {
-            _shader->setUniformf(getUniformName()+".innerRadius", m_innerRadius);
+            _shader.setUniformf(getUniformName()+".innerRadius", m_innerRadius);
         }
 
         if (m_outerRadius!=0.0) {
-            _shader->setUniformf(getUniformName()+".outerRadius", m_outerRadius);
+            _shader.setUniformf(getUniformName()+".outerRadius", m_outerRadius);
         }
     }
 }

--- a/core/src/scene/pointLight.h
+++ b/core/src/scene/pointLight.h
@@ -20,7 +20,7 @@ public:
     virtual void setRadius(float _outer);
     virtual void setRadius(float _inner, float _outer);
     
-    virtual void setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _program) override;
+    virtual void setupProgram(const View& _view, ShaderProgram& _program) override;
     
 protected:
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -24,8 +24,8 @@ public:
     void addStyle(std::unique_ptr<Style> _style);
     void addLight(std::unique_ptr<Light> _light);
 
-    std::vector<std::unique_ptr<Style>>& getStyles() { return m_styles; };
-    std::vector<std::unique_ptr<Light>>& getLights() { return m_lights; };
+    const std::vector<std::unique_ptr<Style>>& getStyles() const { return m_styles; };
+    const std::vector<std::unique_ptr<Light>>& getLights() const { return m_lights; };
 
     std::unordered_map<std::string, std::shared_ptr<Texture>>& getTextures() { return m_textures; };
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -279,12 +279,12 @@ void SceneLoader::loadTextures(YAML::Node textures, Scene& scene) {
 void SceneLoader::loadStyles(YAML::Node styles, Scene& scene) {
 
     // Instantiate built-in styles
-    scene.getStyles().emplace_back(new PolygonStyle("polygons"));
-    scene.getStyles().emplace_back(new PolylineStyle("lines"));
-    scene.getStyles().emplace_back(new TextStyle("FiraSans", "text", 15.0f, 0xF7F0E1, true, true));
-    scene.getStyles().emplace_back(new DebugTextStyle("FiraSans", "debugtext", 30.0f, 0xDC3522, true));
-    scene.getStyles().emplace_back(new DebugStyle("debug"));
-    scene.getStyles().emplace_back(new SpriteStyle("sprites"));
+    scene.addStyle(std::unique_ptr<Style>(new PolygonStyle("polygons")));
+    scene.addStyle(std::unique_ptr<Style>(new PolylineStyle("lines")));
+    scene.addStyle(std::unique_ptr<Style>(new TextStyle("FiraSans", "text", 15.0f, 0xF7F0E1, true, true)));
+    scene.addStyle(std::unique_ptr<Style>(new DebugTextStyle("FiraSans", "debugtext", 30.0f, 0xDC3522, true)));
+    scene.addStyle(std::unique_ptr<Style>(new DebugStyle("debug")));
+    scene.addStyle(std::unique_ptr<Style>(new SpriteStyle("sprites")));
 
     if (!styles) {
         return;

--- a/core/src/scene/spotLight.cpp
+++ b/core/src/scene/spotLight.cpp
@@ -38,18 +38,18 @@ void SpotLight::setCutoffExponent(float _exponent) {
     m_spotExponent = _exponent;
 }
 
-void SpotLight::setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _shader ) {
+void SpotLight::setupProgram(const View& _view, ShaderProgram& _shader ) {
     if (m_dynamic) {
         PointLight::setupProgram(_view, _shader);
 
         glm::vec3 direction = m_direction;
         if (m_origin == LightOrigin::world) {
-            direction = glm::normalize(_view->getNormalMatrix() * direction);
+            direction = glm::normalize(_view.getNormalMatrix() * direction);
         }
 
-        _shader->setUniformf(getUniformName()+".direction", direction);
-        _shader->setUniformf(getUniformName()+".spotCosCutoff", m_spotCosCutoff);
-        _shader->setUniformf(getUniformName()+".spotExponent", m_spotExponent);
+        _shader.setUniformf(getUniformName()+".direction", direction);
+        _shader.setUniformf(getUniformName()+".spotCosCutoff", m_spotCosCutoff);
+        _shader.setUniformf(getUniformName()+".spotExponent", m_spotExponent);
     }
 }
 

--- a/core/src/scene/spotLight.h
+++ b/core/src/scene/spotLight.h
@@ -19,7 +19,7 @@ public:
     
     virtual void setCutoffExponent(float _exponent);
     
-    virtual void setupProgram(const std::shared_ptr<View>& _view, std::shared_ptr<ShaderProgram> _program) override;
+    virtual void setupProgram(const View& _view, ShaderProgram& _program) override;
     
 protected:
     /*  GLSL block code with structs and need functions for this light type */

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -144,64 +144,64 @@ std::string Material::getClassBlock() {
     return stringFromResource("material.glsl") + "\n";
 }
 
-void Material::injectOnProgram(std::shared_ptr<ShaderProgram> _shader ) {
-    _shader->addSourceBlock("defines", getDefinesBlock(), false);
-    _shader->addSourceBlock("material", getClassBlock(), false);
+void Material::injectOnProgram(ShaderProgram& _shader ) {
+    _shader.addSourceBlock("defines", getDefinesBlock(), false);
+    _shader.addSourceBlock("material", getClassBlock(), false);
 }
 
-void Material::setupProgram(std::shared_ptr<ShaderProgram> _shader) {
+void Material::setupProgram(ShaderProgram& _shader) {
 
     if (m_bEmission) {
-        _shader->setUniformf("u_material.emission", m_emission);
+        _shader.setUniformf("u_material.emission", m_emission);
 
         if (m_emission_texture.tex) {
             m_emission_texture.tex->update(1);
             m_emission_texture.tex->bind(1);
-            _shader->setUniformi("u_material_emission_texture", 1);
-            _shader->setUniformf("u_material.emissionScale", m_emission_texture.scale);
+            _shader.setUniformi("u_material_emission_texture", 1);
+            _shader.setUniformf("u_material.emissionScale", m_emission_texture.scale);
         }
     }
 
     if (m_bAmbient) {
-        _shader->setUniformf("u_material.ambient", m_ambient);
+        _shader.setUniformf("u_material.ambient", m_ambient);
 
         if (m_ambient_texture.tex) {
             m_ambient_texture.tex->update(2);
             m_ambient_texture.tex->bind(2);
-            _shader->setUniformi("u_material_ambient_texture", 2);
-            _shader->setUniformf("u_material.ambientScale", m_ambient_texture.scale);
+            _shader.setUniformi("u_material_ambient_texture", 2);
+            _shader.setUniformf("u_material.ambientScale", m_ambient_texture.scale);
         }
     }
 
     if (m_bDiffuse) {
-        _shader->setUniformf("u_material.diffuse", m_diffuse);
+        _shader.setUniformf("u_material.diffuse", m_diffuse);
 
         if (m_diffuse_texture.tex) {
             m_diffuse_texture.tex->update(3);
             m_diffuse_texture.tex->bind(3);
-            _shader->setUniformi("u_material_diffuse_texture", 3);
-            _shader->setUniformf("u_material.diffuseScale", m_diffuse_texture.scale);
+            _shader.setUniformi("u_material_diffuse_texture", 3);
+            _shader.setUniformf("u_material.diffuseScale", m_diffuse_texture.scale);
         }
     }
 
     if (m_bSpecular) {
-        _shader->setUniformf("u_material.specular", m_specular);
-        _shader->setUniformf("u_material.shininess", m_shininess);
+        _shader.setUniformf("u_material.specular", m_specular);
+        _shader.setUniformf("u_material.shininess", m_shininess);
 
         if (m_diffuse_texture.tex) {
             m_diffuse_texture.tex->update(4);
             m_diffuse_texture.tex->bind(4);
-            _shader->setUniformi("u_material_specular_texture", 4);
-            _shader->setUniformf("u_material.specularScale", m_specular_texture.scale);
+            _shader.setUniformi("u_material_specular_texture", 4);
+            _shader.setUniformf("u_material.specularScale", m_specular_texture.scale);
         }
     }
 
     if (m_normal_texture.tex) {
         m_normal_texture.tex->update(5);
         m_normal_texture.tex->bind(5);
-        _shader->setUniformi("u_material_normal_texture", 5);
-        _shader->setUniformf("u_material.normalScale", m_normal_texture.scale);
-        _shader->setUniformf("u_material.normalAmount", m_normal_texture.amount);
+        _shader.setUniformi("u_material_normal_texture", 5);
+        _shader.setUniformf("u_material.normalScale", m_normal_texture.scale);
+        _shader.setUniformf("u_material.normalAmount", m_normal_texture.amount);
     }
 }
 

--- a/core/src/style/material.h
+++ b/core/src/style/material.h
@@ -74,10 +74,10 @@ public:
     void setNormal(MaterialTexture _normalTexture);
 
     /*  Inject the needed lines of GLSL code on the shader to make this material work */
-    virtual void injectOnProgram(std::shared_ptr<ShaderProgram> _shader);
+    virtual void injectOnProgram(ShaderProgram& _shader);
 
     /*  Method to pass it self as a uniform to the shader program */
-    virtual void setupProgram(std::shared_ptr<ShaderProgram> _shader);
+    virtual void setupProgram(ShaderProgram& _shader);
 
 private:
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -97,11 +97,11 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
     mesh.addLabel(std::move(label));
 }
 
-void SpriteStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
+void SpriteStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
     m_spriteAtlas->bind();
 
     m_shaderProgram->setUniformi("u_tex", 0);
-    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view->getOrthoViewportMatrix()));
+    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getOrthoViewportMatrix()));
 
     RenderState::blending(GL_TRUE);
     RenderState::blendingFunc({GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA});

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -30,7 +30,7 @@ public:
 
     bool isOpaque() const override { return false; }
 
-    virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
+    virtual void onBeginDrawFrame(const View& _view, const Scene& _scene) override;
 
     SpriteStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -57,10 +57,10 @@ void Style::build(const std::vector<std::unique_ptr<Light>>& _lights) {
             break;
     }
 
-    m_material->injectOnProgram(m_shaderProgram);
+    m_material->injectOnProgram(*m_shaderProgram);
 
     for (auto& light : _lights) {
-        light->injectOnProgram(m_shaderProgram);
+        light->injectOnProgram(*m_shaderProgram);
     }
 
 }
@@ -191,16 +191,16 @@ void Style::addData(TileData& _data, Tile& _tile) {
     }
 }
 
-void Style::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
+void Style::onBeginDrawFrame(const View& _view, const Scene& _scene) {
 
-    m_material->setupProgram(m_shaderProgram);
+    m_material->setupProgram(*m_shaderProgram);
 
     // Set up lights
-    for (const auto& light : _scene->getLights()) {
-        light->setupProgram(_view, m_shaderProgram);
+    for (const auto& light : _scene.getLights()) {
+        light->setupProgram(_view, *m_shaderProgram);
     }
 
-    m_shaderProgram->setUniformf("u_zoom", _view->getZoom());
+    m_shaderProgram->setUniformf("u_zoom", _view.getZoom());
     
     // default capabilities
     RenderState::blending(GL_FALSE);

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -130,7 +130,7 @@ public:
     virtual void addData(TileData& _data, Tile& _tile);
 
     /* Perform any setup needed before drawing each frame */
-    virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene);
+    virtual void onBeginDrawFrame(const View& _view, const Scene& _scene);
 
     /* Perform any unsetup needed after drawing each frame */
     virtual void onEndDrawFrame() {}

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -134,20 +134,19 @@ void TextStyle::onEndBuildTile(VboMesh& _mesh) const {
     buffer.addBufferVerticesToMesh();
 }
 
-void TextStyle::onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) {
-    auto ftContext = FontContext::GetInstance();
+void TextStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
 
-    ftContext->bindAtlas(1);
+    FontContext::GetInstance()->bindAtlas(1);
 
     m_shaderProgram->setUniformi("u_tex", 1);
-    m_shaderProgram->setUniformf("u_resolution", _view->getWidth(), _view->getHeight());
+    m_shaderProgram->setUniformf("u_resolution", _view.getWidth(), _view.getHeight());
 
     float r = (m_color >> 16 & 0xff) / 255.0;
     float g = (m_color >> 8  & 0xff) / 255.0;
     float b = (m_color       & 0xff) / 255.0;
 
     m_shaderProgram->setUniformf("u_color", r, g, b);
-    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view->getOrthoViewportMatrix()));
+    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getOrthoViewportMatrix()));
 
     RenderState::blending(GL_TRUE);
     RenderState::blendingFunc({GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA});

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -43,7 +43,7 @@ public:
     TextStyle(const std::string& _fontName, std::string _name, float _fontSize, unsigned int _color = 0xffffff,
               bool _sdf = false, bool _sdfMultisampling = false, GLenum _drawMode = GL_TRIANGLES);
 
-    virtual void onBeginDrawFrame(const std::shared_ptr<View>& _view, const std::shared_ptr<Scene>& _scene) override;
+    virtual void onBeginDrawFrame(const View& _view, const Scene& _scene) override;
 
     virtual ~TextStyle();
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -124,7 +124,7 @@ void render() {
 
     // Loop over all styles
     for (const auto& style : m_scene->getStyles()) {
-        style->onBeginDrawFrame(m_view, m_scene);
+        style->onBeginDrawFrame(*m_view, *m_scene);
 
         // Loop over all tiles in m_tileSet
         for (const auto& mapIDandTile : m_tileManager->getVisibleTiles()) {

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -125,7 +125,7 @@ public:
     
     constexpr static float s_maxZoom = 18.0;
 
-    const glm::mat4& getOrthoViewportMatrix() { return m_orthoViewport; };
+    const glm::mat4& getOrthoViewportMatrix() const { return m_orthoViewport; };
 
 protected:
     


### PR DESCRIPTION
- no need to copy shared_ptr unless the callee should be able to store it.
- pass view as *const* reference
- 'const std::shared_ptr\<X\>' is not that useful, it does *not* mean std::share_ptr\<const X\>