### PR TITLE
Labels

### DIFF
--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -56,15 +56,6 @@ void VboMesh::setDrawMode(GLenum _drawMode) {
     }
 }
 
-void VboMesh::update(GLintptr _offset, GLsizei _size, unsigned char* _data) {
-    std::memcpy(m_glVertexData + _offset, _data, _size);
-
-    m_dirtyOffset = _offset;
-    m_dirtySize = _size;
-
-    m_dirty = true;
-}
-
 bool VboMesh::subDataUpload() {
     if (!m_dirty) {
         return false;

--- a/core/src/gl/vboMesh.h
+++ b/core/src/gl/vboMesh.h
@@ -56,8 +56,8 @@ public:
      * Returns true if the upload results in a buffer binding
      */
     bool upload();
-    
-    /* 
+
+    /*
      * Sub data upload of the mesh, returns true if this results in a buffer binding
      */
     bool subDataUpload();
@@ -67,8 +67,6 @@ public:
      * been uploaded it will be uploaded at this point
      */
     virtual void draw(ShaderProgram& _shader);
-
-    void update(GLintptr _offset, GLsizei _size, unsigned char* _data);
 
     static void addManagedVBO(VboMesh* _vbo);
 

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -127,7 +127,7 @@ bool Label::canOcclude() {
 
 bool Label::visibleState() const {
     int visibleFlags = (State::visible | State::fading_in | State::fading_out);
-    return (visibleFlags & visibleFlags);
+    return (visibleFlags & m_currentState);
 }
 
 void Label::occlusionSolved() {
@@ -160,6 +160,7 @@ void Label::setRotation(float _rotation) {
 }
 
 void Label::pushTransform() {
+
     // update the buffer on valid states
     if (m_dirty && visibleState()) {
         static size_t attribOffset = offsetof(Label::Vertex, state);

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -8,7 +8,10 @@
 
 #include <string>
 
+
 namespace Tangram {
+
+class LabelMesh;
 
 class Label {
 
@@ -47,7 +50,7 @@ public:
         Vertex::State state;
     };
 
-    Label(Transform _transform, Type _type);
+    Label(Transform _transform, LabelMesh& _mesh, Type _type, size_t _bufferOffset, unsigned int _nVerts);
 
     ~Label();
 
@@ -65,28 +68,30 @@ public:
     bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt);
 
     /* Push the pending transforms to the vbo by updating the vertices */
-    virtual void pushTransform() = 0;
-    
+    void pushTransform();
+
     /* Update the screen position of the label */
     bool updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize);
 
-    Type getType() const { return m_type; }
-
+    /* Sets the occlusion */
     void setOcclusion(bool _occlusion);
 
+    /* Checks whether the label is in a state where it can occlusion */
     bool canOcclude();
 
-    bool offViewport(const glm::vec2& _screenSize);
-
+    /* Mark the label as resolved */
     void occlusionSolved();
 
     bool occludedLastFrame() { return m_occludedLastFrame; }
 
     State getState() const { return m_currentState; }
 
-    static bool s_needUpdate;
+    /* Checks whether the label is in a visible state */
+    bool visibleState() const;
 
 private:
+
+    bool offViewport(const glm::vec2& _screenSize);
 
     void enterState(State _state, float _alpha = 1.0f);
 
@@ -99,21 +104,28 @@ private:
     void setRotation(float _rotation);
 
     State m_currentState;
-
     Type m_type;
     bool m_occludedLastFrame;
     bool m_occlusionSolved;
     FadeEffect m_fade;
-    
+
 protected:
-    
+
     virtual void updateBBoxes() = 0;
-    
+
     isect2d::OBB m_obb;
     isect2d::AABB m_aabb;
     bool m_dirty;
     Transform m_transform;
     glm::vec2 m_dim;
+    unsigned int m_nVerts;
+
+    // Back-pointer to owning container
+    LabelMesh& m_mesh;
+
+    // byte-offset in m_mesh vertices
+    size_t m_bufferOffset;
+
 };
 
 }

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -108,6 +108,7 @@ private:
     bool m_occludedLastFrame;
     bool m_occlusionSolved;
     FadeEffect m_fade;
+    bool m_updateMeshVisibility;
 
 protected:
 

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -1,22 +1,11 @@
-#include "spriteLabel.h"
+#include "labels/spriteLabel.h"
 
 namespace Tangram {
 
 SpriteLabel::SpriteLabel(LabelMesh& _mesh, Label::Transform _transform, const glm::vec2& _size, size_t _bufferOffset) :
-    Label(_transform, Label::Type::point),
-    m_mesh(_mesh),
-    m_bufferOffset(_bufferOffset) {
+    Label(_transform, _mesh, Label::Type::point, _bufferOffset, 4)
+{
     m_dim = _size;
-}
-
-void SpriteLabel::pushTransform() {
-    if (m_dirty) {
-
-        // update all attributes screenPosition/rotation/alpha for the 4 quad vertices in the mesh
-        size_t attribOffset = offsetof(Label::Vertex, state);
-
-        m_mesh.updateAttribute(m_bufferOffset + attribOffset, 4, m_transform.state);
-    }
 }
 
 void SpriteLabel::updateBBoxes() {

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "labels/label.h"
-#include "labels/labelMesh.h"
 
 namespace Tangram {
 
@@ -10,17 +9,10 @@ public:
 
     SpriteLabel(LabelMesh& _mesh, Label::Transform _transform, const glm::vec2& _size, size_t _bufferOffset);
 
-    void pushTransform() override;
-
 protected:
 
     void updateBBoxes() override;
 
-    // Back-pointer to owning container
-    LabelMesh& m_mesh;
-
-    // byte-offset in m_mesh vertices
-    size_t m_bufferOffset;
 };
 
 }

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -1,11 +1,10 @@
-#include "textLabel.h"
+#include "labels/textLabel.h"
 
 namespace Tangram {
 
 TextLabel::TextLabel(TextBuffer& _mesh, Label::Transform _transform, std::string _text, Type _type) :
-    Label(_transform, _type),
-    m_text(_text),
-    m_mesh(_mesh)
+    Label(_transform, static_cast<LabelMesh&>(_mesh), _type, 0, 0),
+    m_text(_text)
 {}
 
 void TextLabel::updateBBoxes() {
@@ -21,22 +20,14 @@ void TextLabel::updateBBoxes() {
 
 bool TextLabel::rasterize() {
 
-    m_numGlyphs = m_mesh.rasterize(m_text, m_dim, m_bufferOffset);
+    auto& buffer = dynamic_cast<TextBuffer&>(m_mesh);
+    int nGlyphs = buffer.rasterize(m_text, m_dim, m_bufferOffset);
+    m_nVerts = nGlyphs * 6;
 
-    if (m_numGlyphs == 0) {
+    if (nGlyphs == 0) {
         return false;
     }
     return true;
-}
-
-void TextLabel::pushTransform() {
-    if (m_dirty) {
-        m_dirty = false;
-        size_t attribOffset = offsetof(Label::Vertex, state);
-        int numVerts = m_numGlyphs * 6;
-
-        m_mesh.updateAttribute(m_bufferOffset + attribOffset, numVerts, m_transform.state);
-    }
 }
 
 }

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "label.h"
+#include "labels/label.h"
 #include "text/textBuffer.h"
 
 namespace Tangram {
@@ -9,28 +9,18 @@ class TextLabel : public Label {
 
 public:
     TextLabel(TextBuffer& _mesh, Label::Transform _transform, std::string _text, Type _type);
-    
+
     /* Call the font context to rasterize the label string */
     bool rasterize();
-    
+
     std::string getText() { return m_text; }
-    
-    void pushTransform() override;
-    
+
 private:
-    
+
     std::string m_text;
 
-    int m_numGlyphs;
-
-    // Back-pointer to owning container
-    TextBuffer& m_mesh;
-
-    // byte-offset in m_mesh vertices
-    size_t m_bufferOffset;
-
 protected:
-    
+
     void updateBBoxes() override;
 };
 


### PR DESCRIPTION
Move `updateTransform` as a common interface for labels and consolidate it to perform those updates only on visible label states when necessary, this reduces subBufferData sizes.