### PR TITLE
use fontstash directly

### DIFF
--- a/core/src/gl/typedMesh.h
+++ b/core/src/gl/typedMesh.h
@@ -15,15 +15,15 @@ public:
 
     void addVertices(std::vector<T>&& _vertices,
                      std::vector<int>&& _indices) {
-        vertices.push_back(_vertices);
-        indices.push_back(_indices);
+        m_vertices.push_back(_vertices);
+        m_indices.push_back(_indices);
 
         m_nVertices += _vertices.size();
         m_nIndices += _indices.size();
     }
 
     virtual void compileVertexBuffer() override {
-        compile(vertices, indices);
+        compile(m_vertices, m_indices);
     }
 
     /*
@@ -66,8 +66,8 @@ protected:
 
     void setDirty(GLintptr _byteOffset, GLsizei _byteSize);
 
-    std::vector<std::vector<T>> vertices;
-    std::vector<std::vector<int>> indices;
+    std::vector<std::vector<T>> m_vertices;
+    std::vector<std::vector<int>> m_indices;
 
 };
 

--- a/core/src/gl/vboMesh.h
+++ b/core/src/gl/vboMesh.h
@@ -137,7 +137,7 @@ protected:
         }
 
         for (size_t i = 0; i < vertices.size(); i++) {
-            auto curVertices = vertices[i];
+            auto& curVertices = vertices[i];
             size_t nVertices = curVertices.size();
             int nBytes = nVertices * stride;
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -37,6 +37,9 @@ public:
             float alpha;
             float rotation;
         } state;
+        Vertex() {}
+        Vertex(glm::vec2 pos, glm::vec2 uv) : pos(pos), uv(uv){}
+        Vertex(glm::vec2 pos, glm::vec2 uv, State state) : pos(pos), uv(uv), state(state){}
     };
 
     struct Transform {

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -30,6 +30,9 @@ public:
     };
 
     struct Vertex {
+        Vertex(glm::vec2 pos, glm::vec2 uv)
+            : pos(pos), uv(uv){}
+
         glm::vec2 pos;
         glm::vec2 uv;
         struct State {
@@ -37,12 +40,19 @@ public:
             float alpha;
             float rotation;
         } state;
-        Vertex() {}
-        Vertex(glm::vec2 pos, glm::vec2 uv) : pos(pos), uv(uv){}
-        Vertex(glm::vec2 pos, glm::vec2 uv, State state) : pos(pos), uv(uv), state(state){}
     };
 
     struct Transform {
+        Transform(glm::vec2 _pos)
+            : modelPosition1(_pos),
+              modelPosition2(_pos),
+              offset(glm::vec2(0)){}
+
+        Transform(glm::vec2 _pos1, glm::vec2 _pos2, glm::vec2 _offset)
+            : modelPosition1(_pos1),
+              modelPosition2(_pos2),
+              offset(_offset){}
+
         glm::vec2 modelPosition1;
         glm::vec2 modelPosition2;
         glm::vec2 offset;

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -1,7 +1,13 @@
 #include "labels/labelMesh.h"
 #include "labels/label.h"
+#include "shaderProgram.h"
 
 namespace Tangram {
+
+GLuint s_quadIndexBuffer = 0;
+int s_quadGeneration = -1;
+
+const size_t maxVertices = 1 << 14;
 
 LabelMesh::LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
     : TypedMesh<Label::Vertex>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW) {
@@ -11,6 +17,104 @@ LabelMesh::~LabelMesh() {}
 
 void LabelMesh::addLabel(std::unique_ptr<Label> _label) {
     m_labels.push_back(std::move(_label));
+}
+
+void LabelMesh::loadQuadIndices() {
+    if (s_quadGeneration == s_validGeneration) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s_quadIndexBuffer);
+
+    } else {
+        s_quadGeneration = s_validGeneration;
+
+        std::vector<GLushort> indices;
+        indices.reserve(maxVertices / 4 * 6);
+
+        for (size_t i = 0; i < maxVertices; i += 4) {
+            indices.push_back(i + 2);
+            indices.push_back(i + 0);
+            indices.push_back(i + 1);
+            indices.push_back(i + 1);
+            indices.push_back(i + 3);
+            indices.push_back(i + 2);
+        }
+
+        glGenBuffers(1, &s_quadIndexBuffer);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s_quadIndexBuffer);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(GLushort),
+                     reinterpret_cast<GLbyte*>(indices.data()), GL_STATIC_DRAW);
+    }
+}
+
+void LabelMesh::compileVertexBuffer() {
+
+    size_t sumVertices = 0;
+    int stride = m_vertexLayout->getStride();
+    m_glVertexData = new GLbyte[stride * m_nVertices];
+
+    for (auto& vertices : m_vertices) {
+        size_t nVertices = vertices.size();
+
+        std::memcpy(m_glVertexData + (sumVertices * stride),
+                    reinterpret_cast<GLbyte*>(vertices.data()), nVertices * stride);
+        sumVertices += nVertices;
+    }
+
+    for (size_t offset = 0; offset < sumVertices; offset += maxVertices) {
+        size_t nVertices = maxVertices;
+        if (offset + maxVertices > sumVertices) {
+            nVertices = sumVertices - offset;
+        }
+        m_vertexOffsets.emplace_back(nVertices / 4 * 6, nVertices);
+    }
+
+    // clear vertices...
+    std::vector<std::vector<Label::Vertex>>().swap(m_vertices);
+
+    m_isCompiled = true;
+}
+
+void LabelMesh::draw(ShaderProgram& _shader) {
+
+    checkValidity();
+
+    if (!m_isCompiled) return;
+
+    if (m_nVertices == 0) return;
+
+    bool bound = false;
+
+    // Ensure that geometry is buffered into GPU
+    if (!m_isUploaded) {
+        bound = upload();
+    } else if (m_dirty) {
+        bound = subDataUpload();
+    }
+
+    if (!bound) {
+        // Bind buffers for drawing
+        glBindBuffer(GL_ARRAY_BUFFER, m_glVertexBuffer);
+    }
+
+    loadQuadIndices();
+
+    // Enable shader program
+    _shader.use();
+
+    size_t vertexOffset = 0;
+
+    for (auto& o : m_vertexOffsets) {
+        uint32_t nIndices = o.first;
+        uint32_t nVertices = o.second;
+
+        size_t byteOffset = vertexOffset * m_vertexLayout->getStride();
+
+        // Enable vertex attribs via vertex layout object
+        m_vertexLayout->enable(_shader, byteOffset);
+
+        glDrawElements(m_drawMode, nIndices, GL_UNSIGNED_SHORT, 0);
+
+        vertexOffset += nVertices;
+    }
 }
 
 }

--- a/core/src/labels/labelMesh.h
+++ b/core/src/labels/labelMesh.h
@@ -19,8 +19,13 @@ public:
     const std::vector<std::unique_ptr<Label>>& getLabels() const {
         return m_labels;
     }
+    virtual void compileVertexBuffer() override;
+
+    virtual void draw(ShaderProgram& _shader) override;
 
 protected:
+    void loadQuadIndices();
+
     std::vector<std::unique_ptr<Label>> m_labels;
 };
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -2,11 +2,15 @@
 
 namespace Tangram {
 
-TextLabel::TextLabel(TextBuffer& _mesh, Label::Transform _transform, std::string _text, Type _type) :
-    Label(_transform, _type),
-    m_text(_text),
-    m_mesh(_mesh)
-{}
+TextLabel::TextLabel(std::string _text, Label::Transform _transform, Type _type, int _numGlyphs,
+                     glm::vec2 _dim, TextBuffer& _mesh, size_t _bufferOffset)
+    : Label(_transform, _type),
+      m_text(_text),
+      m_numGlyphs(_numGlyphs),
+      m_mesh(_mesh),
+      m_bufferOffset(_bufferOffset) {
+    m_dim = _dim;
+}
 
 void TextLabel::updateBBoxes() {
     glm::vec2 t = glm::vec2(cos(m_transform.state.rotation), sin(m_transform.state.rotation));
@@ -17,16 +21,6 @@ void TextLabel::updateBBoxes() {
 
     m_obb = isect2d::OBB(obbCenter.x, obbCenter.y, m_transform.state.rotation, m_dim.x, m_dim.y);
     m_aabb = m_obb.getExtent();
-}
-
-bool TextLabel::rasterize() {
-
-    m_numGlyphs = m_mesh.rasterize(m_text, m_dim, m_bufferOffset);
-
-    if (m_numGlyphs == 0) {
-        return false;
-    }
-    return true;
 }
 
 void TextLabel::pushTransform() {

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -8,10 +8,8 @@ namespace Tangram {
 class TextLabel : public Label {
 
 public:
-    TextLabel(TextBuffer& _mesh, Label::Transform _transform, std::string _text, Type _type);
-    
-    /* Call the font context to rasterize the label string */
-    bool rasterize();
+    TextLabel(std::string _text, Label::Transform _transform, Type _type, int _numGlyphs,
+              glm::vec2 _dim, TextBuffer& _mesh, size_t _bufferOffset);
     
     std::string getText() { return m_text; }
     
@@ -28,6 +26,7 @@ private:
 
     // byte-offset in m_mesh vertices
     size_t m_bufferOffset;
+
 
 protected:
     

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -19,7 +19,7 @@ void DebugTextStyle::addData(TileData& _data, Tile& _tile) {
         onBeginBuildTile(*mesh);
 
         std::string tileID = std::to_string(_tile.getID().x) + "/" + std::to_string(_tile.getID().y) + "/" + std::to_string(_tile.getID().z);
-        buffer.addLabel(tileID, { glm::vec2(0), glm::vec2(0) }, Label::Type::debug);
+        buffer.addLabel(tileID, { glm::vec2(0) }, Label::Type::debug);
 
         onEndBuildTile(*mesh);
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -19,7 +19,7 @@ void DebugTextStyle::addData(TileData& _data, Tile& _tile) {
         onBeginBuildTile(*mesh);
 
         std::string tileID = std::to_string(_tile.getID().x) + "/" + std::to_string(_tile.getID().y) + "/" + std::to_string(_tile.getID().z);
-        addTextLabel(buffer, { glm::vec2(0), glm::vec2(0) }, tileID, Label::Type::debug);
+        buffer.addLabel(tileID, { glm::vec2(0), glm::vec2(0) }, Label::Type::debug);
 
         onEndBuildTile(*mesh);
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -62,7 +62,7 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
 
     SpriteBuilder builder = {
         [&](const glm::vec2& coord, const glm::vec2& screenPos, const glm::vec2& uv) {
-            vertices.push_back({ coord, uv, { screenPos, 0.5f, M_PI_2 } });
+            vertices.push_back({ coord, uv });
         }
     };
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -60,12 +60,6 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
     // TODO : make this configurable
     std::vector<Label::Vertex> vertices;
 
-    SpriteBuilder builder = {
-        [&](const glm::vec2& coord, const glm::vec2& screenPos, const glm::vec2& uv) {
-            vertices.push_back({ coord, uv });
-        }
-    };
-
     // TODO : configure this
     float spriteScale = .5f;
     glm::vec2 offset = {0.f, 10.f};
@@ -89,11 +83,19 @@ void SpriteStyle::buildPoint(Point& _point, const StyleParamMap&, Properties& _p
 
     std::unique_ptr<SpriteLabel> label(new SpriteLabel(mesh, t, spriteNode.m_size * spriteScale, bufferOffset));
 
-    Builders::buildQuadAtPoint(label->getTransform().state.screenPos + offset,
-                               spriteNode.m_size * spriteScale,
-                               spriteNode.m_uvBL, spriteNode.m_uvTR, builder);
+    auto size = spriteNode.m_size * spriteScale;
+    float halfWidth = size.x * .5f;
+    float halfHeight = size.y * .5f;
+    const glm::vec2& uvBL = spriteNode.m_uvBL;
+    const glm::vec2& uvTR = spriteNode.m_uvTR;
 
-    mesh.addVertices(std::move(vertices), std::move(builder.indices));
+    vertices.reserve(4);
+    vertices.push_back({{-halfWidth, -halfHeight}, {uvBL.x, uvBL.y}});
+    vertices.push_back({{-halfWidth, halfHeight}, {uvBL.x, uvTR.y}});
+    vertices.push_back({{halfWidth, -halfHeight}, {uvTR.x, uvBL.y}});
+    vertices.push_back({{halfWidth, halfHeight}, {uvTR.x, uvTR.y}});
+
+    mesh.addVertices(std::move(vertices), {});
     mesh.addLabel(std::move(label));
 }
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -52,8 +52,7 @@ void TextStyle::buildPoint(Point& _point, const StyleParamMap& _styleParamMap, P
         return;
     }
 
-    Label::Transform t { glm::vec2(_point), glm::vec2(_point), glm::vec2(0) };
-    addTextLabel(buffer, t, text, Label::Type::point);
+    buffer.addLabel(text, { glm::vec2(_point), glm::vec2(_point), glm::vec2(0) }, Label::Type::point);
 }
 
 void TextStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Properties& _props, VboMesh& _mesh, Tile& _tile) const {
@@ -80,7 +79,7 @@ void TextStyle::buildLine(Line& _line, const StyleParamMap& _styleParamMap, Prop
             continue;
         }
 
-        addTextLabel(buffer, { p1, p2, glm::vec2(0) }, text, Label::Type::line);
+        buffer.addLabel(text, { p1, p2, glm::vec2(0) }, Label::Type::line);
     }
 }
 
@@ -105,19 +104,9 @@ void TextStyle::buildPolygon(Polygon& _polygon, const StyleParamMap& _styleParam
 
     centroid /= n;
 
-    Label::Transform t { centroid, centroid, glm::vec2(0) };
-
-    addTextLabel(buffer, t, text, Label::Type::point);
+    buffer.addLabel(text, { centroid, centroid, glm::vec2(0) }, Label::Type::point);
 }
 
-void TextStyle::addTextLabel(TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const {
-
-    std::unique_ptr<TextLabel> label(new TextLabel(_buffer, _transform, _text, _type));
-
-    if (label->rasterize()) {
-        _buffer.addLabel(std::move(label));
-    }
-}
 
 void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
@@ -128,10 +117,6 @@ void TextStyle::onBeginBuildTile(VboMesh& _mesh) const {
 }
 
 void TextStyle::onEndBuildTile(VboMesh& _mesh) const {
-
-    auto& buffer = static_cast<TextBuffer&>(_mesh);
-
-    buffer.addBufferVerticesToMesh();
 }
 
 void TextStyle::setColor(unsigned int _color) {

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include "gl.h"
-#include "glfontstash.h"
+#include "fontstash.h"
 #include "gl/texture.h"
 #include "platform.h"
-#include "textBuffer.h"
 #include <memory>
 #include <mutex>
 #include <string>
@@ -13,7 +12,7 @@
 
 namespace Tangram {
 
-class TextBuffer;
+typedef unsigned int FontID;
 
 class FontContext {
 
@@ -34,13 +33,13 @@ public:
     /* sets the current font for a size in pixels */
     void setFont(const std::string& _name, int size);
 
-    fsuint getFontID(const std::string& _name);
+    FontID getFontID(const std::string& _name);
 
     /* sets the blur spread when using signed distance field rendering */
     void setSignedDistanceField(float _blurSpread);
 
     void clearState();
-    
+
     /* lock thread access to this font context */
     void lock();
 
@@ -49,12 +48,18 @@ public:
 
     void bindAtlas(GLuint _textureUnit);
 
-    FONScontext* getFontContext() const { return m_fsContext; }
+    /*
+     * Create quads and glyphs for @_text with given options.
+     *
+     * NB: the returned quads are only valid while <FontContext> is locked!
+     */
+    std::vector<FONSquad>& rasterize(const std::string& _text, FontID _fontID, float _fontSize, float _sdf);
+
 
 private:
-
-    static void updateAtlas(void* _userPtr, unsigned int _xoff, unsigned int _yoff,
-                            unsigned int _width, unsigned int _height, const unsigned int* _pixels);
+    static void renderUpdate(void* _userPtr, int* _rect, const unsigned char* _data);
+    static int renderCreate(void* _userPtr, int _width, int _height);
+    static void pushQuad(void* _userPtr, const FONSquad* _quad);
 
     void initFontContext(int _atlasSize);
 
@@ -64,6 +69,7 @@ private:
     std::mutex m_atlasMutex;
 
     FONScontext* m_fsContext;
+    std::vector<FONSquad> m_quadBuffer;
 
 };
 

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -36,7 +36,7 @@ bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform,
         return false;
     }
 
-    auto& verts = vertices[0];
+    auto& verts = m_vertices[0];
 
     // byte offset of added vertices
     size_t bufferPosition = m_vertexLayout->getStride() * verts.size();

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -1,5 +1,5 @@
 #include "textBuffer.h"
-#include "fontContext.h"
+#include "labels/textLabel.h"
 
 #include "gl/texture.h"
 #include "gl/vboMesh.h"
@@ -10,104 +10,69 @@ TextBuffer::TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout)
     : LabelMesh(_vertexLayout, GL_TRIANGLES) {
 
     m_dirtyTransform = false;
-    m_bufferPosition = 0;
-    m_fsBuffer = 0;
+    addVertices({}, {});
 }
 
-void TextBuffer::init(fsuint _fontID, float _size, float _blurSpread) {
+void TextBuffer::init(uint32_t _fontID, float _size, float _blurSpread) {
     m_fontID = _fontID;
     m_fontSize = _size;
     m_fontBlurSpread = _blurSpread;
 }
 
 TextBuffer::~TextBuffer() {
-    if (m_fsBuffer != 0) {
-        auto fontContext = FontContext::GetInstance();
-
-        fontContext->lock();
-        glfonsBufferDelete(fontContext->getFontContext(), m_fsBuffer);
-        fontContext->unlock();
-    }
 }
 
-int TextBuffer::rasterize(const std::string& _text, glm::vec2& _size, size_t& _bufferOffset) {
-    int numGlyphs = 0;
+bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform, Label::Type _type) {
 
     auto fontContext = FontContext::GetInstance();
 
     fontContext->lock();
 
-    auto ctx = fontContext->getFontContext();
-    if (m_fsBuffer == 0)
-        glfonsBufferCreate(ctx, &m_fsBuffer);
+    auto& quads = fontContext->rasterize(_text, m_fontID, m_fontSize, m_fontBlurSpread);
+    size_t numGlyphs = quads.size();
 
-    glfonsBindBuffer(ctx, m_fsBuffer);
-
-    fonsSetSize(ctx, m_fontSize);
-    fonsSetFont(ctx, m_fontID);
-
-    if (m_fontBlurSpread > 0){
-        fonsSetBlur(ctx, m_fontBlurSpread);
-        fonsSetBlurType(ctx, FONS_EFFECT_DISTANCE_FIELD);
-    } else {
-        fonsSetBlurType(ctx, FONS_EFFECT_NONE);
-    }
-
-    fsuint textID;
-    glfonsGenText(ctx, 1, &textID);
-
-    int status = glfonsRasterize(ctx, textID, _text.c_str());
-    if (status == GLFONS_VALID) {
-        _bufferOffset = m_bufferPosition;
-
-        numGlyphs = glfonsGetGlyphCount(ctx, textID);
-        m_bufferPosition += m_vertexLayout->getStride() * numGlyphs * 6;
-
-        glm::vec4 bbox;
-        glfonsGetBBox(ctx, textID, &bbox.x, &bbox.y, &bbox.z, &bbox.w);
-        _size.x = std::abs(bbox.z - bbox.x);
-        _size.y = std::abs(bbox.w - bbox.y);
-    }
-
-    glfonsBindBuffer(ctx, 0);
-    fontContext->unlock();
-
-    return numGlyphs;
-}
-
-void TextBuffer::addBufferVerticesToMesh() {
-    if (m_fsBuffer == 0)
-        return;
-
-    auto fontContext = FontContext::GetInstance();
-
-    fontContext->lock();
-    auto ctx = fontContext->getFontContext();
-    glfonsBindBuffer(ctx, m_fsBuffer);
-
-    int bufferSize = glfonsVerticesSize(ctx);
-    if (bufferSize == 0) {
-        glfonsBindBuffer(ctx, 0);
-        glfonsBufferDelete(ctx, m_fsBuffer);
-        m_fsBuffer = 0;
-
+    if (numGlyphs == 0) {
         fontContext->unlock();
-        return;
+        return false;
     }
 
-    std::vector<Label::Vertex> vertices(bufferSize);
+    auto& verts = vertices[0];
 
-    bool res = glfonsVertices(ctx, reinterpret_cast<float*>(vertices.data()));
+    // byte offset of added vertices
+    size_t bufferPosition = m_vertexLayout->getStride() * verts.size();
 
-    if (res) {
-        addVertices(std::move(vertices), {});
+    verts.reserve(verts.size() + numGlyphs * 6);
+
+    float inf = std::numeric_limits<float>::infinity();
+    float x0 = inf, x1 = -inf, y0 = inf, y1 = -inf;
+
+    for (auto& q : quads) {
+        x0 = std::min(x0, std::min(q.x0, q.x1));
+        x1 = std::max(x1, std::max(q.x0, q.x1));
+        y0 = std::min(y0, std::min(q.y0, q.y1));
+        y1 = std::max(y1, std::max(q.y0, q.y1));
+
+        verts.push_back({{q.x0, q.y0}, {q.s0, q.t0}});
+        verts.push_back({{q.x1, q.y1}, {q.s1, q.t1}});
+        verts.push_back({{q.x1, q.y0}, {q.s1, q.t0}});
+
+        verts.push_back({{q.x0, q.y0}, {q.s0, q.t0}});
+        verts.push_back({{q.x0, q.y1}, {q.s0, q.t1}});
+        verts.push_back({{q.x1, q.y1}, {q.s1, q.t1}});
     }
-
-    glfonsBindBuffer(ctx, 0);
-    glfonsBufferDelete(ctx, m_fsBuffer);
-    m_fsBuffer = 0;
 
     fontContext->unlock();
+
+    glm::vec2 size((x1 - x0), (y1 - y0));
+
+    m_labels.emplace_back(new TextLabel(_text, _transform, _type,
+                                        numGlyphs, size,
+                                        *this, bufferPosition));
+
+    // TODO: change this in TypeMesh::adVertices()
+    m_nVertices = verts.size();
+
+    return true;
 }
 
 }

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -36,12 +36,12 @@ bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform,
         return false;
     }
 
-    auto& verts = m_vertices[0];
+    auto& vertices = m_vertices[0];
 
     // byte offset of added vertices
-    size_t bufferPosition = m_vertexLayout->getStride() * verts.size();
+    size_t bufferPosition = m_vertexLayout->getStride() * vertices.size();
 
-    verts.reserve(verts.size() + numGlyphs * 6);
+    vertices.reserve(vertices.size() + numGlyphs * 4);
 
     float inf = std::numeric_limits<float>::infinity();
     float x0 = inf, x1 = -inf, y0 = inf, y1 = -inf;
@@ -52,13 +52,10 @@ bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform,
         y0 = std::min(y0, std::min(q.y0, q.y1));
         y1 = std::max(y1, std::max(q.y0, q.y1));
 
-        verts.push_back({{q.x0, q.y0}, {q.s0, q.t0}});
-        verts.push_back({{q.x1, q.y1}, {q.s1, q.t1}});
-        verts.push_back({{q.x1, q.y0}, {q.s1, q.t0}});
-
-        verts.push_back({{q.x0, q.y0}, {q.s0, q.t0}});
-        verts.push_back({{q.x0, q.y1}, {q.s0, q.t1}});
-        verts.push_back({{q.x1, q.y1}, {q.s1, q.t1}});
+        vertices.push_back({{q.x0, q.y0}, {q.s0, q.t0}});
+        vertices.push_back({{q.x0, q.y1}, {q.s0, q.t1}});
+        vertices.push_back({{q.x1, q.y0}, {q.s1, q.t0}});
+        vertices.push_back({{q.x1, q.y1}, {q.s1, q.t1}});
     }
 
     fontContext->unlock();
@@ -70,7 +67,7 @@ bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform,
                                         *this, bufferPosition));
 
     // TODO: change this in TypeMesh::adVertices()
-    m_nVertices = verts.size();
+    m_nVertices = vertices.size();
 
     return true;
 }

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -2,10 +2,9 @@
 
 #include "gl.h"
 #include "labels/labelMesh.h"
+#include "text/fontContext.h" // for FontID
 #include "glm/vec4.hpp"
 #include "glm/vec2.hpp"
-
-#include "glfontstash.h" // for fsuint
 
 #include <memory>
 
@@ -14,7 +13,7 @@ namespace Tangram {
 class FontContext;
 
 /*
- * This class represents a text buffer, each text buffer has several text ids
+ * This class holds TextLabels together with their VboMesh
  */
 class TextBuffer : public LabelMesh {
 
@@ -23,27 +22,19 @@ public:
     TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout);
     ~TextBuffer();
 
-    /* creates a text buffer and bind it */
-    void init(fsuint _fontID, float _size, float _blurSpread);
+    /* Set <TextBuffer> options for subsequent added labels */
+    void init(FontID _fontID, float _size, float _blurSpread);
 
-    /* ask the font rasterizer to rasterize a specific text.
-     * Returns number of glyphs > 0 on success.
-     * @_size is set to the text extents
-     * @_bufferOffset is set to the byteOffset of the first glyph-vertex */
-    int rasterize(const std::string& _text, glm::vec2& _size, size_t& bufferOffset);
-
-    /* get the vertices from the font context and add them as vbo mesh data */
-    void addBufferVerticesToMesh();
+    /* Create and add TextLabel */
+    bool addLabel(const std::string& _text, Label::Transform _transform, Label::Type _type);
 
 private:
 
-    fsuint m_fontID;
+    FontID m_fontID;
     float m_fontSize;
     float m_fontBlurSpread;
 
     bool m_dirtyTransform;
-    fsuint m_fsBuffer;
-    int m_bufferPosition;
 };
 
 }

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -13,8 +13,13 @@ using namespace Tangram;
 glm::vec2 screenSize(500.f, 500.f);
 TextBuffer dummy(nullptr);
 
+TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
+    return TextLabel("label", _transform, _type, 0, {0, 0}, dummy, 0);
+
+}
+
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
-    TextLabel l(dummy, {screenSize/2.f}, "label", Label::Type::point);
+    TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
     REQUIRE(l.getState() == Label::State::wait_occ);
     l.setOcclusion(true);
@@ -33,7 +38,7 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
 }
 
 TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens", "[Core][Label]" ) {
-    TextLabel l(dummy, {screenSize/2.f}, "label", Label::Type::point);
+    TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
     REQUIRE(l.getState() == Label::State::wait_occ);
 
@@ -56,7 +61,7 @@ TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens
 }
 
 TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]" ) {
-    TextLabel l(dummy, {screenSize/2.f}, "label", Label::Type::point);
+    TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
     l.setOcclusion(false);
     l.occlusionSolved();
@@ -74,7 +79,7 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
 }
 
 TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
-    TextLabel l(dummy, {screenSize*2.f}, "label", Label::Type::point);
+    TextLabel l(makeLabel({screenSize*2.f}, Label::Type::point));
 
     REQUIRE(l.getState() == Label::State::wait_occ);
 
@@ -102,7 +107,7 @@ TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
 }
 
 TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][Label]" ) {
-    TextLabel l(dummy, {screenSize/2.f}, "label", Label::Type::debug);
+    TextLabel l(makeLabel({screenSize/2.f}, Label::Type::debug));
 
     REQUIRE(l.getState() == Label::State::visible);
     REQUIRE(!l.canOcclude());


### PR DESCRIPTION
Most of what is provided by glfontstash is now replicated in tangram. This patch removes the dependency on glfontstash by getting the glyph quads directly from fontstash.

- hide FONScontext in FontContext
- pass everything into TextLabel constructor