### PR TITLE
WIP Tile Cache

### DIFF
--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -80,6 +80,12 @@ void DataSource::onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<Tile
         m_cacheUsage += rawDataRef->size();
 
         while (m_cacheUsage > m_cacheMaxUsage) {
+            if (m_cacheList.empty()) {
+                logMsg("Error: invalid cache state!\n");
+                m_cacheUsage = 0;
+                break;
+            }
+
             // logMsg("Limit raw cache tiles:%d, %fMB \n", m_cacheList.size(),
             //        double(m_cacheUsage) / (1024*1024));
 

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -80,8 +80,8 @@ void DataSource::onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<Tile
         m_cacheUsage += rawDataRef->size();
 
         while (m_cacheUsage > m_cacheMaxUsage) {
-            logMsg("Limit raw cache tiles:%d, %fMB \n", m_cacheList.size(),
-                   double(m_cacheUsage) / (1024*1024));
+            // logMsg("Limit raw cache tiles:%d, %fMB \n", m_cacheList.size(),
+            //        double(m_cacheUsage) / (1024*1024));
 
             auto& entry = m_cacheList.back();
             m_cacheUsage -= entry.second->size();

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -10,37 +10,14 @@ namespace Tangram {
 
 DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate) :
     m_name(_name), m_urlTemplate(_urlTemplate) {
-
-}
-
-bool DataSource::hasTileData(const TileID& _tileID) const {
-
-    return m_tileStore.find(_tileID) != m_tileStore.end();
-}
-
-std::shared_ptr<TileData> DataSource::getTileData(const TileID& _tileID) const {
-
-    const auto it = m_tileStore.find(_tileID);
-
-    if (it != m_tileStore.end()) {
-        std::shared_ptr<TileData> tileData = it->second;
-        return tileData;
-    } else {
-        return nullptr;
-    }
+    m_cacheMaxUsage = 10 * 1024 * 1024;
+    m_cacheUsage = 0;
 }
 
 void DataSource::clearData() {
-    for (auto& mapValue : m_tileStore) {
-        mapValue.second->layers.clear();
-    }
-    m_tileStore.clear();
-}
-
-void DataSource::setTileData(const TileID& _tileID, const std::shared_ptr<TileData>& _tileData) {
-
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_tileStore[_tileID] = _tileData;
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_cacheMap.clear();
+    m_cacheList.clear();
 }
 
 void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const {
@@ -60,26 +37,46 @@ void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const
     }
 }
 
+bool DataSource::getTileData(std::shared_ptr<TileTask>& _task) {
+    std::lock_guard<std::mutex> lock(m_mutex);
 
-bool DataSource::getTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb) {
-
-    const auto& tileID = _task->tile->getID();
-
-    if (hasTileData(tileID)) {
-        _task->parsedTileData = m_tileStore[tileID];
-        _cb(std::move(_task));
-        requestRender();
-
-        return true;
+    auto it = m_cacheMap.find(_task->tile->getID());
+    if (it == m_cacheMap.end()) {
+        return false;
     }
+    // Move cached entry to start of list
+    m_cacheList.splice(m_cacheList.begin(), m_cacheList, it->second);
 
-    return false;
+    _task->rawTileData = m_cacheList.front().second;
+    return true;
 }
 
-static void onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<TileTask>& _task, TileTaskCb _cb) {
-    _task->rawTileData = std::move(_rawData);
+void DataSource::onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<TileTask>& _task, TileTaskCb _cb) {
+    TileID tileID = _task->tile->getID();
+
+    auto rawDataRef = std::make_shared<std::vector<char>>();
+    std::swap(*rawDataRef, _rawData);
+    _task->rawTileData = rawDataRef;
+
     _cb(std::move(_task));
-    requestRender();
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    m_cacheList.push_front({tileID, rawDataRef});
+    m_cacheMap[tileID] = m_cacheList.begin();
+
+    m_cacheUsage += rawDataRef->size();
+
+    while (m_cacheUsage > m_cacheMaxUsage) {
+        logMsg("Limit raw cache tiles:%d, %fMB \n", m_cacheList.size(),
+               double(m_cacheUsage) / (1024*1024));
+
+        auto& entry = m_cacheList.back();
+        m_cacheUsage -= entry.second->size();
+
+        m_cacheMap.erase(entry.first);
+        m_cacheList.pop_back();
+    }
 }
 
 
@@ -87,7 +84,9 @@ bool DataSource::loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb)
 
     std::string url(constructURL(_task->tile->getID()));
 
-    return startUrlRequest(url, std::bind(&onTileLoaded,
+    // Using bind instead of lambda to be able to 'move' (until c++14)
+    return startUrlRequest(url, std::bind(&DataSource::onTileLoaded,
+                                          this,
                                           std::placeholders::_1,
                                           std::move(_task), _cb));
 

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <vector>
 #include <mutex>
+#include <list>
 #include "tile/tileTask.h"
 
 namespace Tangram {
@@ -35,29 +36,23 @@ public:
      */
     virtual bool loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb);
 
-    virtual bool getTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb);
+    /* Lookup TileData in cache and */
+    virtual bool getTileData(std::shared_ptr<TileTask>& _task);
 
     /* Stops any running I/O tasks pertaining to @_tile */
     virtual void cancelLoadingTile(const TileID& _tile);
 
-    /* Checks if data exists for a specific <TileID> */
-    virtual bool hasTileData(const TileID& _tileID) const;
-
-    /* Returns the data corresponding to a <TileID>, if it has been fetched already */
-    virtual std::shared_ptr<TileData> getTileData(const TileID& _tileID) const;
-    
     /* Parse an I/O response into a <TileData>, returning an empty TileData on failure */
     virtual std::shared_ptr<TileData> parse(const Tile& _tile, std::vector<char>& _rawData) const = 0;
 
-    /* Stores tileData in m_tileStore */
-    virtual void setTileData(const TileID& _tileID, const std::shared_ptr<TileData>& _tileData);
-    
     /* Clears all data associated with this DataSource */
     void clearData();
 
     const std::string& name() const { return m_name; }
 
 protected:
+
+    void onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<TileTask>& _task, TileTaskCb _cb);
 
     /* Constructs the URL of a tile using <m_urlTemplate> */
     virtual void constructURL(const TileID& _tileCoord, std::string& _url) const;
@@ -68,13 +63,24 @@ protected:
         return url;
     }
 
-    std::map< TileID, std::shared_ptr<TileData> > m_tileStore; // Map of tileIDs to data for that tile
-    
-    std::string m_name; // Name used to identify this source in the style sheet
+    // Name used to identify this source in the style sheet
+    std::string m_name;
 
-    std::mutex m_mutex; // Used to ensure safe access from async loading threads
+    // URL template for requesting tiles from a network or filesystem
+    std::string m_urlTemplate;
 
-    std::string m_urlTemplate; // URL template for requesting tiles from a network or filesystem
+    // Used to ensure safe access from async loading threads
+    std::mutex m_mutex;
+
+    // LRU in-memory cache for raw tile data
+    using CacheEntry = std::pair<TileID, std::shared_ptr<std::vector<char>>>;
+    using CacheList = std::list<CacheEntry>;
+    using CacheMap = std::unordered_map<TileID, typename CacheList::iterator>;
+
+    CacheMap m_cacheMap;
+    CacheList m_cacheList;
+    size_t m_cacheUsage;
+    size_t m_cacheMaxUsage;
 
 };
 

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -84,8 +84,8 @@ protected:
 
     CacheMap m_cacheMap;
     CacheList m_cacheList;
-    size_t m_cacheUsage;
-    size_t m_cacheMaxUsage;
+    int m_cacheUsage;
+    int m_cacheMaxUsage;
 
 };
 

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -50,7 +50,7 @@ public:
 
     const std::string& name() const { return m_name; }
 
-    /* @_cacheSize: Set size of in-memory cache for tile data in bytes. */
+    /* @_cacheSize: Set size of in-memory cache for tile data in bytes */
     void setCacheSize(size_t _cacheSize);
 
 protected:

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -50,7 +50,9 @@ public:
 
     const std::string& name() const { return m_name; }
 
-    /* @_cacheSize: Set size of in-memory cache for tile data in bytes */
+    /* @_cacheSize: Set size of in-memory cache for tile data in bytes.
+     * This cache holds unprocessed tile data for fast recreation of recently used tiles.
+     */
     void setCacheSize(size_t _cacheSize);
 
 protected:

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -22,11 +22,11 @@ public:
     /* Tile data sources must have a name and a URL template that defines where to find 
      * a tile based on its coordinates. A URL template includes exactly one occurrance 
      * each of '{x}', '{y}', and '{z}' which will be replaced by the x index, y index, 
-     * and zoom level of tiles to produce their URL
+     * and zoom level of tiles to produce their URL.
      */
     DataSource(const std::string& _name, const std::string& _urlTemplate);
 
-    virtual ~DataSource() {}
+    virtual ~DataSource();
     
     /* Fetches data for the map tile specified by @_tileID
      *
@@ -49,6 +49,9 @@ public:
     void clearData();
 
     const std::string& name() const { return m_name; }
+
+    /* @_cacheSize: Set size of in-memory cache for tile data in bytes. */
+    void setCacheSize(size_t _cacheSize);
 
 protected:
 

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -38,12 +38,12 @@ void TextureCube::load(const std::string& _file) {
         for (int iFace = 0; iFace < 4; ++iFace) {
             Face* face = nullptr;
 
-            if (iFace == 2 && jFace == 1) face = &m_faces[0]; // POS_X
-            if (iFace == 0 && jFace == 1) face = &m_faces[1]; // NEG_X
-            if (iFace == 1 && jFace == 0) face = &m_faces[2]; // POS_Y
-            if (iFace == 1 && jFace == 2) face = &m_faces[3]; // NEG_Y
-            if (iFace == 1 && jFace == 1) face = &m_faces[4]; // POS_Z
-            if (iFace == 3 && jFace == 1) face = &m_faces[5]; // NEG_Z
+            if (iFace == 2 && jFace == 1) { face = &m_faces[0]; } // POS_X
+            if (iFace == 0 && jFace == 1) { face = &m_faces[1]; } // NEG_X
+            if (iFace == 1 && jFace == 0) { face = &m_faces[2]; } // POS_Y
+            if (iFace == 1 && jFace == 2) { face = &m_faces[3]; } // NEG_Y
+            if (iFace == 1 && jFace == 1) { face = &m_faces[4]; } // POS_Z
+            if (iFace == 3 && jFace == 1) { face = &m_faces[5]; } // NEG_Z
 
             if (!face) { continue; }
 

--- a/core/src/gl/typedMesh.h
+++ b/core/src/gl/typedMesh.h
@@ -4,6 +4,7 @@
 #include "util/types.h"
 
 #include <cstdlib> // std::abs
+#include <cassert>
 
 namespace Tangram {
 
@@ -40,7 +41,8 @@ public:
      */
     template<class A>
     void updateAttribute(Range _vertexRange, const A& _newAttributeValue, size_t _attribOffset = 0) {
-        if (!m_isCompiled) {
+        if (m_glVertexData == nullptr) {
+            assert(false);
             return;
         }
 
@@ -122,7 +124,8 @@ void TypedMesh<T>::setDirty(GLintptr _byteOffset, GLsizei _byteSize) {
 
 template<class T>
 void TypedMesh<T>::updateVertices(Range _vertexRange, const T& _newVertexValue) {
-    if (!m_isCompiled) {
+    if (m_glVertexData == nullptr) {
+        assert(false);
         return;
     }
 

--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -29,8 +29,12 @@ VboMesh::VboMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode, 
 }
 
 VboMesh::~VboMesh() {
-    if (m_glVertexBuffer) glDeleteBuffers(1, &m_glVertexBuffer);
-    if (m_glIndexBuffer) glDeleteBuffers(1, &m_glIndexBuffer);
+    if (m_glVertexBuffer) {
+        glDeleteBuffers(1, &m_glVertexBuffer);
+    }
+    if (m_glIndexBuffer) {
+        glDeleteBuffers(1, &m_glIndexBuffer);
+    }
 
     delete[] m_glVertexData;
     delete[] m_glIndexData;
@@ -141,9 +145,8 @@ void VboMesh::draw(ShaderProgram& _shader) {
 
     checkValidity();
 
-    if (!m_isCompiled) return;
-
-    if (m_nVertices == 0) return;
+    if (!m_isCompiled) { return; }
+    if (m_nVertices == 0) { return; }
 
     // Ensure that geometry is buffered into GPU
     if (!m_isUploaded) {

--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -120,9 +120,6 @@ bool VboMesh::upload() {
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_nIndices * sizeof(GLushort), m_glIndexData, m_hint);
     }
 
-    // m_glVertexData.resize(0);
-    // m_glIndexData.resize(0);
-
     // TODO: For now, we retain copies of the vertex and index data in CPU memory to allow VBOs
     // to easily rebuild themselves after GL context loss. For optimizing memory usage (and for
     // other reasons) we'll want to change this in the future. This probably means going back to
@@ -195,6 +192,11 @@ void VboMesh::checkValidity() {
         m_generation = s_validGeneration;
     }
 }
+
+size_t VboMesh::bufferSize() {
+    return m_nVertices * m_vertexLayout->getStride() + m_nIndices * sizeof(GLushort);
+}
+
 
 void VboMesh::invalidateAllVBOs() {
 

--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -64,6 +64,7 @@ bool VboMesh::subDataUpload() {
 
     if (m_hint == GL_STATIC_DRAW) {
         logMsg("WARNING: wrong usage hint provided to the Vbo\n");
+        assert(false);
     }
 
     RenderState::vertexBuffer(m_glVertexBuffer);
@@ -101,12 +102,17 @@ bool VboMesh::upload() {
         glGenBuffers(1, &m_glVertexBuffer);
     }
 
-    // TODO check if compiled?
     // Buffer vertex data
     int vertexBytes = m_nVertices * m_vertexLayout->getStride();
 
     RenderState::vertexBuffer(m_glVertexBuffer);
     glBufferData(GL_ARRAY_BUFFER, vertexBytes, m_glVertexData, m_hint);
+
+    // Clear vertex data that is not supposed to be updated.
+    if (m_hint == GL_STATIC_DRAW) {
+        delete[] m_glVertexData;
+        m_glVertexData = nullptr;
+    }
 
     if (m_glIndexData) {
 
@@ -118,12 +124,10 @@ bool VboMesh::upload() {
         RenderState::indexBuffer(m_glIndexBuffer);
 
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_nIndices * sizeof(GLushort), m_glIndexData, m_hint);
-    }
 
-    // TODO: For now, we retain copies of the vertex and index data in CPU memory to allow VBOs
-    // to easily rebuild themselves after GL context loss. For optimizing memory usage (and for
-    // other reasons) we'll want to change this in the future. This probably means going back to
-    // data sources and styles to rebuild the vertex data.
+        delete[] m_glIndexData;
+        m_glIndexData = nullptr;
+    }
 
     m_generation = s_validGeneration;
 

--- a/core/src/gl/vboMesh.h
+++ b/core/src/gl/vboMesh.h
@@ -68,6 +68,8 @@ public:
      */
     virtual void draw(ShaderProgram& _shader);
 
+    size_t bufferSize();
+
     static void addManagedVBO(VboMesh* _vbo);
 
     static void removeManagedVBO(VboMesh* _vbo);
@@ -88,12 +90,12 @@ protected:
 
     std::shared_ptr<VertexLayout> m_vertexLayout;
 
-    int m_nVertices;
+    size_t m_nVertices;
     GLuint m_glVertexBuffer;
     // Compiled vertices for upload
     GLbyte* m_glVertexData = nullptr;
 
-    int m_nIndices;
+    size_t m_nIndices;
     GLuint m_glIndexBuffer;
     // Compiled  indices for upload
     GLushort* m_glIndexData = nullptr;

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -228,18 +228,21 @@ bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
             }
             setAlpha(m_fade.update(_dt));
             animate = true;
-            if (m_fade.isFinished())
+            if (m_fade.isFinished()) {
                 enterState(State::visible, 1.0);
+            }
             break;
         case State::fading_out:
             setAlpha(m_fade.update(_dt));
             animate = true;
-            if (m_fade.isFinished())
+            if (m_fade.isFinished()) {
                 enterState(State::sleep, 0.0);
+            }
             break;
         case State::out_of_screen:
-            if (!offViewport(_screenSize))
+            if (!offViewport(_screenSize)) {
                 enterState(State::wait_occ, 0.0);
+            }
             break;
         case State::wait_occ:
             if (m_occlusionSolved) {

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -77,9 +77,8 @@ void LabelMesh::draw(ShaderProgram& _shader) {
 
     checkValidity();
 
-    if (!m_isCompiled) return;
-
-    if (m_nVertices == 0) return;
+    if (!m_isCompiled) { return; }
+    if (m_nVertices == 0) { return; }
 
     bool bound = false;
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -105,8 +105,9 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
     }
 
     // Request for render if labels are in fading in/out states
-    if (m_needUpdate)
+    if (m_needUpdate) {
         requestRender();
+    }
 }
 
 void Labels::drawDebug(const View& _view) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -27,6 +27,10 @@ using YAML::BadConversion;
 
 namespace Tangram {
 
+// FIXME
+constexpr size_t CACHE_SIZE = 10 * (1024 * 1024);
+
+
 void SceneLoader::loadScene(const std::string& _file, Scene& _scene, TileManager& _tileManager, View& _view) {
 
     std::string configString = stringFromResource(_file.c_str());
@@ -399,10 +403,12 @@ void SceneLoader::loadSources(Node sources, TileManager& tileManager) {
 
         if (type == "GeoJSONTiles") {
             sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url));
+            sourcePtr->setCacheSize(CACHE_SIZE);
         } else if (type == "TopoJSONTiles") {
             logMsg("WARNING: TopoJSON data sources not yet implemented\n"); // TODO
         } else if (type == "MVT") {
             sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url));
+            sourcePtr->setCacheSize(CACHE_SIZE);
         } else {
             logMsg("WARNING: unrecognized data source type \"%s\", skipping\n", type.c_str());
         }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -27,9 +27,8 @@ using YAML::BadConversion;
 
 namespace Tangram {
 
-// FIXME
-constexpr size_t CACHE_SIZE = 10 * (1024 * 1024);
-
+// TODO: make this configurable: 16MB default in-memory DataSource cache:
+constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
 void SceneLoader::loadScene(const std::string& _file, Scene& _scene, TileManager& _tileManager, View& _view) {
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -288,8 +288,9 @@ void onContextDestroyed() {
 
     logMsg("context destroyed\n");
 
-    if (m_tileManager)
+    if (m_tileManager) {
         m_tileManager->clearTileSet();
+    }
 
     // The OpenGL context has been destroyed since the last time resources were created,
     // so we invalidate all data that depends on OpenGL object handles.

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -288,6 +288,9 @@ void onContextDestroyed() {
 
     logMsg("context destroyed\n");
 
+    if (m_tileManager)
+        m_tileManager->clearTileSet();
+
     // The OpenGL context has been destroyed since the last time resources were created,
     // so we invalidate all data that depends on OpenGL object handles.
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -113,13 +113,15 @@ std::unique_ptr<VboMesh>& Tile::getMesh(const Style& _style) {
 }
 
 size_t Tile::getMemoryUsage() const {
-    size_t sum = 0;
-
-    for (auto& entry : m_geometry) {
-        if (entry.second)
-            sum += entry.second->bufferSize();
+    if (m_memoryUsage == 0) {
+        for (auto& entry : m_geometry) {
+            if (entry.second) {
+                m_memoryUsage += entry.second->bufferSize();
+            }
+        }
     }
-    return sum;
+
+    return m_memoryUsage;
 }
 
 }

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -112,4 +112,14 @@ std::unique_ptr<VboMesh>& Tile::getMesh(const Style& _style) {
     return m_geometry[_style.getName()];
 }
 
+size_t Tile::getMemoryUsage() const {
+    size_t sum = 0;
+
+    for (auto& entry : m_geometry) {
+        if (entry.second)
+            sum += entry.second->bufferSize();
+    }
+    return sum;
+}
+
 }

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -175,6 +175,7 @@ private:
 
     std::unordered_map<std::string, std::unique_ptr<VboMesh>> m_geometry; // Map of <Style>s and their associated <VboMesh>es
 
+    mutable size_t m_memoryUsage = 0;
 };
 
 }

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -138,7 +138,7 @@ public:
         m_state = _state;
     }
 
-    /* Get the sum in bytes of all <VboMesh>es + TODO labels?  */
+    /* Get the sum in bytes of all <VboMesh>es */
     size_t getMemoryUsage() const;
 
 private:

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -138,6 +138,9 @@ public:
         m_state = _state;
     }
 
+    /* Get the sum in bytes of all <VboMesh>es + TODO labels?  */
+    size_t getMemoryUsage() const;
+
 private:
 
     const TileID m_id;

--- a/core/src/tile/tileCache.h
+++ b/core/src/tile/tileCache.h
@@ -22,12 +22,7 @@ public:
         m_cacheMap[_tile->getID()] = m_cacheList.begin();
         m_cacheUsage += _tile->getMemoryUsage();
 
-        while (m_cacheUsage > m_cacheMaxUsage) {
-            auto& tile = m_cacheList.back();
-            m_cacheUsage -= tile->getMemoryUsage();
-            m_cacheMap.erase(tile->getID());
-            m_cacheList.pop_back();
-        }
+        limitCacheSize(m_cacheMaxUsage);
     }
 
     std::shared_ptr<Tile> get(TileID _tileID) {
@@ -43,7 +38,16 @@ public:
         return tile;
     }
 
-    size_t size() const { return m_cacheList.size(); }
+    void limitCacheSize(size_t _cacheSizeBytes) {
+        m_cacheMaxUsage = _cacheSizeBytes;
+
+        while (m_cacheUsage > m_cacheMaxUsage) {
+            auto& tile = m_cacheList.back();
+            m_cacheUsage -= tile->getMemoryUsage();
+            m_cacheMap.erase(tile->getID());
+            m_cacheList.pop_back();
+        }
+    }
 
     size_t getMemoryUsage() const {
         size_t sum = 0;

--- a/core/src/tile/tileCache.h
+++ b/core/src/tile/tileCache.h
@@ -13,12 +13,9 @@ class TileCache {
     using CacheList = std::list<std::shared_ptr<Tile>>;
     using CacheMap = std::unordered_map<TileID, typename CacheList::iterator>;
 
-    // 32 MB
-    const static size_t DEFAULT_CACHE_SIZE = 32*1024*1024;
-
 public:
 
-    TileCache(size_t _cacheSizeMB = DEFAULT_CACHE_SIZE) : m_cacheMaxUsage(_cacheSizeMB) {}
+    TileCache(size_t _cacheSizeMB) : m_cacheMaxUsage(_cacheSizeMB) {}
 
     void put(std::shared_ptr<Tile> _tile) {
         m_cacheList.push_front(_tile);
@@ -50,7 +47,6 @@ public:
 
     size_t getMemoryUsage() const {
         size_t sum = 0;
-
         for (auto& tile : m_cacheList) {
             sum += tile->getMemoryUsage();
         }

--- a/core/src/tile/tileCache.h
+++ b/core/src/tile/tileCache.h
@@ -15,7 +15,9 @@ class TileCache {
 
 public:
 
-    TileCache(size_t _cacheSizeMB) : m_cacheMaxUsage(_cacheSizeMB) {}
+    TileCache(size_t _cacheSizeMB) :
+        m_cacheUsage(0),
+        m_cacheMaxUsage(_cacheSizeMB) {}
 
     void put(std::shared_ptr<Tile> _tile) {
         m_cacheList.push_front(_tile);
@@ -42,6 +44,11 @@ public:
         m_cacheMaxUsage = _cacheSizeBytes;
 
         while (m_cacheUsage > m_cacheMaxUsage) {
+            if (m_cacheList.empty()) {
+                logMsg("Error: invalid cache state!\n");
+                m_cacheUsage = 0;
+                break;
+            }
             auto& tile = m_cacheList.back();
             m_cacheUsage -= tile->getMemoryUsage();
             m_cacheMap.erase(tile->getID());
@@ -66,8 +73,8 @@ private:
     CacheMap m_cacheMap;
     CacheList m_cacheList;
 
-    size_t m_cacheUsage;
-    size_t m_cacheMaxUsage;
+    int m_cacheUsage;
+    int m_cacheMaxUsage;
 };
 
 }

--- a/core/src/tile/tileCache.h
+++ b/core/src/tile/tileCache.h
@@ -10,10 +10,8 @@
 namespace Tangram {
 
 class TileCache {
-    // using Entry = std::pair<TileID, std::shared_ptr<Tile>>;
     using CacheList = std::list<std::shared_ptr<Tile>>;
     using CacheMap = std::unordered_map<TileID, typename CacheList::iterator>;
-    //using CacheMap = std::unordered_map<TileID, std::shared_ptr<Tile>>;
 
 public:
     void put(std::shared_ptr<Tile> _tile) {
@@ -49,6 +47,11 @@ public:
             sum += tile->getMemoryUsage();
         }
         return sum;
+    }
+
+    void clear() {
+        m_cacheMap.clear();
+        m_cacheList.clear();
     }
 
 private:

--- a/core/src/tile/tileCache.h
+++ b/core/src/tile/tileCache.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "tileID.h"
+#include "tile.h"
+
+#include <unordered_map>
+#include <list>
+#include <memory>
+
+namespace Tangram {
+
+class TileCache {
+    // using Entry = std::pair<TileID, std::shared_ptr<Tile>>;
+    using CacheList = std::list<std::shared_ptr<Tile>>;
+    using CacheMap = std::unordered_map<TileID, typename CacheList::iterator>;
+    //using CacheMap = std::unordered_map<TileID, std::shared_ptr<Tile>>;
+
+public:
+    void put(std::shared_ptr<Tile> _tile) {
+        m_cacheList.push_front(_tile);
+        m_cacheMap[_tile->getID()] = m_cacheList.begin();
+
+        if ( m_cacheList.size() > m_maxEntries ) {
+            m_cacheMap.erase(m_cacheList.back()->getID());
+            m_cacheList.pop_back();
+        }
+    }
+
+    std::shared_ptr<Tile> get(TileID _tileID) {
+        std::shared_ptr<Tile> tile;
+        auto it = m_cacheMap.find(_tileID);
+        if (it != m_cacheMap.end()) {
+
+            std::swap(tile, *(it->second));
+
+            m_cacheList.erase(it->second);
+
+            m_cacheMap.erase(it);
+        }
+        return tile;
+    }
+
+    size_t size() const { return m_cacheList.size(); }
+
+    size_t getMemoryUsage() const {
+        size_t sum = 0;
+
+        for (auto& tile : m_cacheList) {
+            sum += tile->getMemoryUsage();
+        }
+        return sum;
+    }
+
+private:
+    CacheMap m_cacheMap;
+    CacheList m_cacheList;
+
+    size_t m_maxEntries = 40;
+};
+
+}

--- a/core/src/tile/tileID.h
+++ b/core/src/tile/tileID.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional> // for hash function
+
 /* An immutable identifier for a map tile 
  * 
  * Contains the x, y, and z indices of a tile in a quad tree; TileIDs are ordered by:
@@ -62,4 +64,25 @@ struct TileID {
 
 static TileID NOT_A_TILE(-1, -1, -1);
 
+}
+
+// The generic hash_combine used in Boost
+// http://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+template <class T>
+inline void hash_combine(std::size_t & seed, const T & v) {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+namespace std {
+    template <>
+    struct hash<Tangram::TileID> {
+        size_t operator()(const Tangram::TileID& k) const {
+            std::size_t seed = 0;
+            hash_combine(seed, k.x);
+            hash_combine(seed, k.y);
+            hash_combine(seed, k.z);
+            return seed;
+        }
+    };
 }

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -124,6 +124,17 @@ void TileManager::enqueueLoadTask(const TileID& tileID, const glm::dvec2& viewCe
     }
 }
 
+void TileManager::clearTileSet() {
+    for (auto& entry : m_tileSet) {
+        setTileState(*entry.second, TileState::canceled);
+    }
+
+    m_tileSet.clear();
+    m_tileCache.clear();
+
+    m_loadPending = 0;
+}
+
 void TileManager::updateTileSet() {
 
     m_tileSetChanged = false;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -13,7 +13,6 @@
 
 #define DBG(...)
 //logMsg(__VA_ARGS__)
-#define DBGC(...) logMsg(__VA_ARGS__)
 
 namespace Tangram {
 
@@ -247,7 +246,7 @@ void TileManager::updateTileSet() {
                 DBG("[%d, %d, %d] Load\n", id.z, id.x, id.y);
 
                 if (source->getTileData(task)) {
-                    DBGC("USE RAW CACHE\n");
+                    DBG("USE RAW CACHE\n");
 
                     m_dataCallback(std::move(task));
 
@@ -276,7 +275,7 @@ bool TileManager::addTile(const TileID& _tileID) {
     bool fromCache = false;
 
     if (tile) {
-        DBGC("USING CACHED TILE\n");
+        DBG("USING CACHED TILE\n");
         fromCache = true;
     }
 
@@ -341,7 +340,7 @@ void TileManager::updateProxyTiles(Tile& _tile) {
     {
         auto parent = m_tileCache.get(parentID);
         if (parent) {
-            DBGC("USE CACHED PARENT PROXY\n");
+            DBG("USE CACHED PARENT PROXY\n");
 
             _tile.setProxy(Tile::parent);
             parent->incProxyCounter();
@@ -365,7 +364,7 @@ void TileManager::updateProxyTiles(Tile& _tile) {
             } else {
                 auto child = m_tileCache.get(childID);
                 if (child) {
-                    DBGC("USE CACHED CHILD PROXY\n");
+                    DBG("USE CACHED CHILD PROXY\n");
 
                     _tile.setProxy(static_cast<Tile::ProxyID>(1 << i));
                     child->incProxyCounter();

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -226,11 +226,10 @@ void TileManager::updateTileSet() {
                 auto task = std::make_shared<TileTask>(tile, source.get());
                 DBG("[%d, %d, %d] Load\n", id.z, id.x, id.y);
 
-                if (source->getTileData(std::move(task), m_dataCallback)) {
-                    continue;
-                }
+                if (source->getTileData(task)) {
+                    m_dataCallback(std::move(task));
 
-                if (m_loadPending < MAX_DOWNLOADS) {
+                } else if (m_loadPending < MAX_DOWNLOADS) {
                     setTileState(*tile, TileState::loading);
 
                     if (!source->loadTileData(std::move(task), m_dataCallback)) {

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -417,4 +417,8 @@ void TileManager::clearProxyTiles(Tile& _tile, std::vector<TileID>& _removes) {
     }
 }
 
+void TileManager::setCacheSize(size_t _cacheSize) {
+    m_tileCache->limitCacheSize(_cacheSize);
+}
+
 }

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -188,8 +188,9 @@ void TileManager::updateTileSet() {
 
             } else if (curTileId == NOT_A_TILE || visTileId < curTileId) {
                 // tileSet is missing an element present in visibleTiles
-                if (!addTile(visTileId))
+                if (!addTile(visTileId)) {
                     enqueueLoadTask(visTileId, viewCenter);
+                }
 
                 ++visTilesIter;
             } else {

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -12,7 +12,8 @@
 #include <algorithm>
 
 #define DBG(...)
-// logMsg(__VA_ARGS__)
+//logMsg(__VA_ARGS__)
+#define DBGC(...) logMsg(__VA_ARGS__)
 
 namespace Tangram {
 
@@ -33,6 +34,8 @@ TileManager::~TileManager() {
     if (m_workers->isRunning()) {
         m_workers->stop();
     }
+    m_dataSources.clear();
+    m_tileSet.clear();
 }
 
 void TileManager::tileProcessed(std::shared_ptr<TileTask>&& task) {
@@ -54,7 +57,6 @@ bool TileManager::setTileState(Tile& tile, TileState state) {
             tile.setState(state);
             return true;
         }
-
         break;
 
     case TileState::loading:
@@ -90,7 +92,7 @@ bool TileManager::setTileState(Tile& tile, TileState state) {
         return true;
     }
 
-    DBG("Wrong state change %d -> %d<<<", tile.state(), state);
+    logMsg("Wrong state change %d -> %d<<<", tile.getState(), state);
     assert(false);
     return false; // ...
 }
@@ -126,6 +128,8 @@ void TileManager::updateTileSet() {
 
     m_tileSetChanged = false;
 
+    std::vector<TileID> removeTiles;
+
     if (!m_readyTiles.empty()) {
         std::lock_guard<std::mutex> lock(m_readyTileMutex);
         auto it = m_readyTiles.begin();
@@ -135,7 +139,7 @@ void TileManager::updateTileSet() {
             auto& tile = *(task->tile);
 
             if (setTileState(tile, TileState::ready)) {
-                clearProxyTiles(tile);
+                clearProxyTiles(tile, removeTiles);
                 m_tileSetChanged = true;
             }
             it = m_readyTiles.erase(it);
@@ -143,8 +147,6 @@ void TileManager::updateTileSet() {
     }
 
     const std::set<TileID>& visibleTiles = m_view->getVisibleTiles();
-
-    std::vector<TileID> removeTiles;
 
     glm::dvec2 viewCenter(m_view->getPosition().x, -m_view->getPosition().y);
 
@@ -158,7 +160,7 @@ void TileManager::updateTileSet() {
 
             auto& visTileId = *visTilesIter;
             auto& curTileId = setTilesIter == m_tileSet.end() ? NOT_A_TILE : setTilesIter->first;
-            DBG("visible: [%d, %d, %d]\n", visTileId.z, visTileId.x, visTileId.y);
+            //DBG("visible: [%d, %d, %d]\n", visTileId.z, visTileId.x, visTileId.y);
 
             if (visTileId == curTileId) {
                 if (setTilesIter->second->hasState(TileState::none)) {
@@ -173,8 +175,8 @@ void TileManager::updateTileSet() {
 
             } else if (curTileId == NOT_A_TILE || visTileId < curTileId) {
                 // tileSet is missing an element present in visibleTiles
-                addTile(visTileId);
-                enqueueLoadTask(visTileId, viewCenter);
+                if (!addTile(visTileId))
+                    enqueueLoadTask(visTileId, viewCenter);
 
                 ++visTilesIter;
             } else {
@@ -199,11 +201,13 @@ void TileManager::updateTileSet() {
     }
 
     {
-        for (const auto& id : removeTiles) {
-            auto tileIter = m_tileSet.find(id);
+        while (!removeTiles.empty()) {
+            auto tileIter = m_tileSet.find(removeTiles.back());
+            removeTiles.pop_back();
+
             if (tileIter != m_tileSet.end()) {
                 if (tileIter->second->getProxyCounter() <= 0) {
-                    removeTile(tileIter);
+                    removeTile(tileIter, removeTiles);
                 }
             }
         }
@@ -220,45 +224,67 @@ void TileManager::updateTileSet() {
     {
         for (auto& item : m_loadTasks) {
             auto& id = *item.second;
-            auto& tile = m_tileSet[id];
+            auto it = m_tileSet.find(id);
+            if (it == m_tileSet.end()) {
+                continue;
+            }
+
+            auto& tile = it->second;
 
             for (auto& source : m_dataSources) {
                 auto task = std::make_shared<TileTask>(tile, source.get());
                 DBG("[%d, %d, %d] Load\n", id.z, id.x, id.y);
 
                 if (source->getTileData(task)) {
+                    DBGC("USE RAW CACHE\n");
+
                     m_dataCallback(std::move(task));
 
                 } else if (m_loadPending < MAX_DOWNLOADS) {
                     setTileState(*tile, TileState::loading);
 
                     if (!source->loadTileData(std::move(task), m_dataCallback)) {
-                        DBG("ERROR: Loading failed for tile [%d, %d, %d]\n", id.z, id.x, id.y);
+                        logMsg("ERROR: Loading failed for tile [%d, %d, %d]\n", id.z, id.x, id.y);
                     }
                 }
             }
         }
     }
-    m_loadTasks.clear();
 
-    // DBG("all:%d loading:%d processing:%d pending:%d\n",
-    //        m_tileSet.size(), m_loadTasks.size(),
-    //        m_queuedTiles.size(), m_loadPending);
+    DBG("all:%d loading:%d pending:%d cached:%d cache: %fMB\n",
+        m_tileSet.size(), m_loadTasks.size(),
+        m_loadPending, m_tileCache.size(),
+        (double(m_tileCache.getMemoryUsage()) / (1024 * 1024)));
+
+    m_loadTasks.clear();
 }
 
-void TileManager::addTile(const TileID& _tileID) {
+bool TileManager::addTile(const TileID& _tileID) {
     DBG("[%d, %d, %d] Add\n", _tileID.z, _tileID.x, _tileID.y);
+    auto tile = m_tileCache.get(_tileID);
+    bool fromCache = false;
 
-    std::shared_ptr<Tile> tile(new Tile(_tileID, m_view->getMapProjection()));
+    if (tile) {
+        DBGC("USING CACHED TILE\n");
+        fromCache = true;
+    }
+
+    if (!tile) {
+        tile = std::shared_ptr<Tile>(new Tile(_tileID, m_view->getMapProjection()));
+
+        //Add Proxy if corresponding proxy MapTile ready
+        updateProxyTiles(*tile);
+    }
+
     tile->setVisible(true);
 
-    //Add Proxy if corresponding proxy Tile ready
-    updateProxyTiles(*tile);
+    m_tileSet.emplace(_tileID, std::move(tile));
 
-    m_tileSet.emplace(_tileID, tile);
+    return fromCache;
 }
 
-void TileManager::removeTile(std::map< TileID, std::shared_ptr<Tile> >::iterator& _tileIter) {
+void TileManager::removeTile(std::map<TileID, std::shared_ptr<Tile>>::iterator& _tileIter,
+                             std::vector<TileID>& _removes) {
 
     const TileID& id = _tileIter->first;
     auto& tile = _tileIter->second;
@@ -274,7 +300,12 @@ void TileManager::removeTile(std::map< TileID, std::shared_ptr<Tile> >::iterator
         }
     }
 
-    clearProxyTiles(*tile);
+    clearProxyTiles(*tile, _removes);
+
+    if (tile->hasState(TileState::ready)) {
+        // Add to cache
+        m_tileCache.put(tile);
+    }
 
     // Remove tile from set
     _tileIter = m_tileSet.erase(_tileIter);
@@ -284,7 +315,9 @@ void TileManager::removeTile(std::map< TileID, std::shared_ptr<Tile> >::iterator
 void TileManager::updateProxyTiles(Tile& _tile) {
     const TileID& _tileID = _tile.getID();
 
-    const auto& parentTileIter = m_tileSet.find(_tileID.getParent());
+    auto parentID = _tileID.getParent();
+
+    const auto& parentTileIter = m_tileSet.find(parentID);
     if (parentTileIter != m_tileSet.end()) {
         auto& parent = parentTileIter->second;
         if (_tile.setProxy(Tile::parent)) {
@@ -293,24 +326,47 @@ void TileManager::updateProxyTiles(Tile& _tile) {
         return;
     }
 
+    // Get proxy from cache
+    {
+        auto parent = m_tileCache.get(parentID);
+        if (parent) {
+            DBGC("USE CACHED PARENT PROXY\n");
+
+            _tile.setProxy(Tile::parent);
+            parent->incProxyCounter();
+            m_tileSet.emplace(parentID, std::move(parent));
+
+            return;
+        }
+    }
+
     if (m_view->s_maxZoom > _tileID.z) {
         for (int i = 0; i < 4; i++) {
-            const auto& childTileIter = m_tileSet.find(_tileID.getChild(i));
+            auto childID = _tileID.getChild(i);
+
+            const auto& childTileIter = m_tileSet.find(childID);
             if (childTileIter != m_tileSet.end()) {
                 auto& child = childTileIter->second;
 
                 if (_tile.setProxy(static_cast<Tile::ProxyID>(1 << i))) {
                     child->incProxyCounter();
                 }
+            } else {
+                auto child = m_tileCache.get(childID);
+                if (child) {
+                    DBGC("USE CACHED CHILD PROXY\n");
+
+                    _tile.setProxy(static_cast<Tile::ProxyID>(1 << i));
+                    child->incProxyCounter();
+                    m_tileSet.emplace(childID, std::move(child));
+                }
             }
         }
     }
 }
 
-void TileManager::clearProxyTiles(Tile& _tile) {
+void TileManager::clearProxyTiles(Tile& _tile, std::vector<TileID>& _removes) {
     const TileID& _tileID = _tile.getID();
-
-    std::vector<TileID> removeTiles;
 
     // Check if parent proxy is present
     if (_tile.unsetProxy(Tile::parent)) {
@@ -321,7 +377,7 @@ void TileManager::clearProxyTiles(Tile& _tile) {
             parent->decProxyCounter();
 
             if (parent->getProxyCounter() == 0 && !parent->isVisible()) {
-                 removeTiles.push_back(parentID);
+                _removes.push_back(parentID);
             }
         } else {
             DBG("ERROR: parent proxy unset but not found!\n");
@@ -339,18 +395,11 @@ void TileManager::clearProxyTiles(Tile& _tile) {
                 child->decProxyCounter();
 
                 if (child->getProxyCounter() == 0 && !child->isVisible()) {
-                    removeTiles.push_back(childID);
+                    _removes.push_back(childID);
                 }
             } else {
                 DBG("ERROR: child proxy unset but not found! %d\n", i);
             }
-        }
-    }
-
-    for (const auto& id : removeTiles) {
-        auto tileIter = m_tileSet.find(id);
-        if (tileIter != m_tileSet.end()) {
-            removeTile(tileIter);
         }
     }
 }

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -70,6 +70,9 @@ public:
 
     bool hasTileSetChanged() { return m_tileSetChanged; }
 
+    /* @_cacheSize: Set size of in-memory tile cache in bytes */
+    void setCacheSize(size_t _cacheSize);
+
 private:
 
     TileManager();

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -4,6 +4,7 @@
 #include "tile/tileWorker.h"
 #include "tile/tileID.h"
 #include "tileTask.h"
+#include "tileCache.h"
 
 #include <map>
 #include <list>
@@ -70,7 +71,6 @@ private:
     std::shared_ptr<View> m_view;
     std::shared_ptr<Scene> m_scene;
 
-
     std::mutex m_readyTileMutex;
     std::vector<std::shared_ptr<TileTask>> m_readyTiles;
 
@@ -82,6 +82,8 @@ private:
     std::map<TileID, std::shared_ptr<Tile>> m_tileSet;
 
     std::vector<std::shared_ptr<DataSource>> m_dataSources;
+
+    TileCache m_tileCache;
 
     const static size_t MAX_WORKERS = 2;
     std::unique_ptr<TileWorker> m_workers;
@@ -101,12 +103,13 @@ private:
      *      this is also responsible for loading proxy tiles for the newly visible tiles
      * @_tileID: TileID for which new Tile needs to be constructed
      */
-    void addTile(const TileID& _tileID);
+    bool addTile(const TileID& _tileID);
 
     /*
      * Removes a tile from m_tileSet
      */
-    void removeTile(std::map<TileID, std::shared_ptr<Tile>>::iterator& _tileIter);
+    void removeTile(std::map<TileID, std::shared_ptr<Tile>>::iterator& _tileIter,
+                    std::vector<TileID>& _removes);
 
     /*
      * Checks and updates m_tileSet with proxy tiles for every new visible tile
@@ -117,7 +120,7 @@ private:
     /*
      *  Once a visible tile finishes loading and is added to m_tileSet, all its proxy(ies) Tiles are removed
      */
-    void clearProxyTiles(Tile& _tile);
+    void clearProxyTiles(Tile& _tile, std::vector<TileID>& _removes);
 
     bool setTileState(Tile& tile, TileState state);
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -70,7 +70,9 @@ public:
 
     bool hasTileSetChanged() { return m_tileSetChanged; }
 
-    /* @_cacheSize: Set size of in-memory tile cache in bytes */
+    /* @_cacheSize: Set size of in-memory tile cache in bytes.
+     * This cache holds recently used <Tile>s that are ready for rendering.
+     */
     void setCacheSize(size_t _cacheSize);
 
 private:

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -4,7 +4,6 @@
 #include "tile/tileWorker.h"
 #include "tile/tileID.h"
 #include "tileTask.h"
-#include "tileCache.h"
 
 #include <map>
 #include <list>
@@ -20,12 +19,17 @@ class DataSource;
 class Tile;
 class Scene;
 class View;
+class TileCache;
 
 /* Singleton container of <Tile>s
  *
  * TileManager is a singleton that maintains a set of Tiles based on the current view into the map
  */
 class TileManager {
+
+    const static size_t MAX_WORKERS = 2;
+    const static size_t MAX_DOWNLOADS = 4;
+    const static size_t DEFAULT_CACHE_SIZE = 32*1024*1024; // 32 MB
 
 public:
 
@@ -85,9 +89,8 @@ private:
 
     std::vector<std::shared_ptr<DataSource>> m_dataSources;
 
-    TileCache m_tileCache;
+    std::unique_ptr<TileCache> m_tileCache;
 
-    const static size_t MAX_WORKERS = 2;
     std::unique_ptr<TileWorker> m_workers;
 
     bool m_tileSetChanged = false;
@@ -97,7 +100,6 @@ private:
      */
     TileTaskCb m_dataCallback;
 
-    const static int MAX_DOWNLOADS = 4;
     std::vector<std::pair<double, const TileID*>> m_loadTasks;
 
     /*
@@ -127,6 +129,7 @@ private:
     bool setTileState(Tile& tile, TileState state);
 
     void enqueueLoadTask(const TileID& tileID, const glm::dvec2& viewCenter);
+
 };
 
 }

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -52,6 +52,8 @@ public:
      */
     void updateTileSet();
 
+    void clearTileSet();
+
     /* For TileWorker: Pass TileTask with processed data back
      * to TileManager.
      */

--- a/core/src/tile/tileTask.h
+++ b/core/src/tile/tileTask.h
@@ -16,12 +16,8 @@ public:
     std::shared_ptr<Tile> tile;
     /*const*/ DataSource* source;
 
-    // Only one of either parsedTileData or rawTileData will be non-empty for a given task.
-    // If parsedTileData is non-empty, then the data for this tile was previously fetched
-    // and parsed. Otherwise rawTileData will be non-empty, indicating that the data needs
-    // to be parsed using the given DataSource.
-    std::shared_ptr<TileData> parsedTileData;
-    std::vector<char> rawTileData;
+    // Raw tile data that will be processed by DataSource.
+    std::shared_ptr<std::vector<char>> rawTileData;
 
     TileTask(std::shared_ptr<Tile> _tile, DataSource* _source) :
         tile(_tile),

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -75,24 +75,10 @@ void TileWorker::run() {
             continue;
         }
 
-        DataSource* dataSource = task->source;
-        auto& tile = task->tile;
-
-        std::shared_ptr<TileData> tileData;
-
-        if (task->parsedTileData) {
-            // Data has already been parsed!
-            tileData = task->parsedTileData;
-        } else {
-            // Data needs to be parsed
-            tileData = dataSource->parse(*tile, task->rawTileData);
-
-            // Cache parsed data with the original data source
-            dataSource->setTileData(tile->getID(), tileData);
-        }
+        auto tileData = task->source->parse(*task->tile, *task->rawTileData);
 
         if (tileData) {
-            tile->build(*m_tileManager.getScene(), *tileData, *dataSource);
+            task->tile->build(*m_tileManager.getScene(), *tileData, *task->source);
         }
 
         m_tileManager.tileProcessed(std::move(task));

--- a/core/src/util/geom.cpp
+++ b/core/src/util/geom.cpp
@@ -12,15 +12,17 @@ float mapValue(const float& _value, const float& _inputMin, const float& _inputM
 
         if (_clamp) {
             if (_outputMax < _outputMin) {
-                if (outVal < _outputMax)
+                if (outVal < _outputMax) {
                     outVal = _outputMax;
-                else if (outVal > _outputMin)
+                } else if (outVal > _outputMin) {
                     outVal = _outputMin;
+                }
             } else {
-                if (outVal > _outputMax)
+                if (outVal > _outputMax) {
                     outVal = _outputMax;
-                else if (outVal < _outputMin)
+                } else if (outVal < _outputMin) {
                     outVal = _outputMin;
+                }
             }
         }
         return outVal;


### PR DESCRIPTION
This branch replaces the unlimited cache for parsed tile data with an LRU memory cache for raw tile data. The raw data of the most recent tiles is also kept in memory for fast recreation of tiles on context loss.

The new LRU TileCache stores tiles that are ready for rendering. It is limited by maximum tiles and buffer usage. 
The cached tiles are also used for missing proxies. 

To reduce the memory usage of cached tiles the byte buffers for static VboMesh are discarded now.

TODO: 
- cache size config. Where should this go? I would add Tangram::setCacheLimits(raw MB, gl MB) so that it can be set by the backends
