### PR TITLE
Use variant types

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,6 @@
 [submodule "core/dependencies/benchmark"]
 	path = core/dependencies/benchmark
 	url = https://github.com/google/benchmark
+[submodule "core/include/variant"]
+	path = core/include/variant
+	url = https://github.com/mapbox/variant

--- a/core/src/data/filters.h
+++ b/core/src/data/filters.h
@@ -94,9 +94,7 @@ namespace Tangram {
                 }
                 case FilterType::existence: {
 
-                    bool found = ctx.find(key) != ctx.end() ||
-                                 feat.props.stringProps.find(key) != feat.props.stringProps.end() ||
-                                 feat.props.numericProps.find(key) != feat.props.numericProps.end();
+                    bool found = ctx.find(key) != ctx.end() || feat.props.contains(key);
 
                     return exists == found;
                 }
@@ -109,18 +107,20 @@ namespace Tangram {
                         }
                         return false;
                     }
-                    auto strIt = feat.props.stringProps.find(key);
-                    if (strIt != feat.props.stringProps.end()) {
+
+                    auto& value = feat.props.get(key);
+                    if (value.is<std::string>()) {
+                        const auto& str = value.get<std::string>();
                         for (const auto& v : values) {
-                            if (v.equals(strIt->second)) { return true; }
+                            if (v.equals(str)) { return true; }
+                        }
+                    } else if (value.is<float>()) {
+                        float num =  value.get<float>();
+                        for (const auto& v : values) {
+                            if (v.equals(num)) { return true; }
                         }
                     }
-                    auto numIt = feat.props.numericProps.find(key);
-                    if (numIt != feat.props.numericProps.end()) {
-                        for (const auto& v : values) {
-                            if (v.equals(numIt->second)) { return true; }
-                        }
-                    }
+
                     return false;
                 }
                 case FilterType::range: {
@@ -133,11 +133,12 @@ namespace Tangram {
                         if (!val.numeric) { return false; } // only check range for numbers
                         return val.num >= min && val.num < max;
                     }
-                    auto numIt = feat.props.numericProps.find(key);
-                    if (numIt != feat.props.numericProps.end()) {
-                        const auto& num = numIt->second;
+                    auto& value = feat.props.get(key);
+                    if (value.is<float>()) {
+                        float num =  value.get<float>();
                         return num >= min && num < max;
                     }
+
                     return false;
                 }
                 default:

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -18,6 +18,7 @@ std::shared_ptr<TileData> MVTSource::parse(const Tile& _tile, std::vector<char>&
     std::shared_ptr<TileData> tileData = std::make_shared<TileData>();
 
     protobuf::message item(_rawData.data(), _rawData.size());
+    PbfParser::ParserContext ctx;
 
     while(item.next()) {
         if(item.tag == 3) {
@@ -27,7 +28,7 @@ std::shared_ptr<TileData> MVTSource::parse(const Tile& _tile, std::vector<char>&
                 if (layerItr.tag == 1) {
                     auto layerName = layerItr.string();
                     tileData->layers.emplace_back(layerName);
-                    PbfParser::extractLayer(layerMsg, tileData->layers.back());
+                    PbfParser::extractLayer(ctx, layerMsg, tileData->layers.back());
                 } else {
                     layerItr.skip();
                 }

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<TileData> MVTSource::parse(const Tile& _tile, std::vector<char>&
                 if (layerItr.tag == 1) {
                     auto layerName = layerItr.string();
                     tileData->layers.emplace_back(layerName);
-                    PbfParser::extractLayer(layerMsg, tileData->layers.back(), _tile);
+                    PbfParser::extractLayer(layerMsg, tileData->layers.back());
                 } else {
                     layerItr.skip();
                 }

--- a/core/src/data/tileData.cpp
+++ b/core/src/data/tileData.cpp
@@ -1,0 +1,15 @@
+#include "tileData.h"
+
+namespace Tangram {
+static Properties::Value NOT_FOUND = Properties::none_type{};
+
+const Properties::Value& Properties::get(const std::string& key) const {
+
+    auto it = props.find(key);
+    if (it == props.end()) {
+        return NOT_FOUND;
+    }
+    return it->second;
+}
+
+}

--- a/core/src/data/tileData.cpp
+++ b/core/src/data/tileData.cpp
@@ -1,7 +1,7 @@
 #include "tileData.h"
 
 namespace Tangram {
-static Properties::Value NOT_FOUND = Properties::none_type{};
+static Properties::Value NOT_FOUND = none_type{};
 
 const Properties::Value& Properties::get(const std::string& key) const {
 

--- a/core/src/data/tileData.cpp
+++ b/core/src/data/tileData.cpp
@@ -19,8 +19,8 @@ Properties& Properties::operator=(Properties&& _other) {
      return *this;
 }
 
-const Properties::Value& Properties::get(const std::string& key) const {
-    const static Properties::Value NOT_FOUND(none_type{});
+const Value& Properties::get(const std::string& key) const {
+    const static Value NOT_FOUND(none_type{});
 
     const auto it = std::lower_bound(props.begin(), props.end(), key,
                                      [](const auto& item, const auto& key) {

--- a/core/src/data/tileData.cpp
+++ b/core/src/data/tileData.cpp
@@ -1,15 +1,39 @@
 #include "tileData.h"
+#include <algorithm>
 
 namespace Tangram {
 static Properties::Value NOT_FOUND = none_type{};
 
-const Properties::Value& Properties::get(const std::string& key) const {
+Properties::Properties(std::vector<Item>&& _items) {
+    typedef std::vector<Item>::iterator iter_t;
 
-    auto it = props.find(key);
-    if (it == props.end()) {
+    props.reserve(_items.size());
+    props.insert(props.begin(),
+                 std::move_iterator<iter_t>(_items.begin()),
+                 std::move_iterator<iter_t>(_items.end()));
+    _items.clear();
+    sort();
+}
+
+Properties& Properties::operator=(Properties&& _other) {
+     props = std::move(_other.props);
+     return *this;
+}
+
+const Properties::Value& Properties::get(const std::string& key) const {
+    const auto it = std::lower_bound(props.begin(), props.end(), key,
+                                     [](const auto& item, const auto& key) {
+                                         return item.key < key;
+                                     });
+
+    if (it == props.end() || it->key != key) {
         return NOT_FOUND;
     }
-    return it->second;
+    return it->value;
+}
+
+void Properties::sort() {
+    std::sort(props.begin(), props.end());
 }
 
 }

--- a/core/src/data/tileData.cpp
+++ b/core/src/data/tileData.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 
 namespace Tangram {
-static Properties::Value NOT_FOUND = none_type{};
 
 Properties::Properties(std::vector<Item>&& _items) {
     typedef std::vector<Item>::iterator iter_t;
@@ -21,6 +20,8 @@ Properties& Properties::operator=(Properties&& _other) {
 }
 
 const Properties::Value& Properties::get(const std::string& key) const {
+    const static Properties::Value NOT_FOUND(none_type{});
+
     const auto it = std::lower_bound(props.begin(), props.end(), key,
                                      [](const auto& item, const auto& key) {
                                          return item.key < key;

--- a/core/src/data/tileData.cpp
+++ b/core/src/data/tileData.cpp
@@ -33,6 +33,16 @@ const Properties::Value& Properties::get(const std::string& key) const {
     return it->value;
 }
 
+const std::string& Properties::getString(const std::string& key) const {
+    const static std::string EMPTY_STRING = "";
+
+    auto& it = get(key);
+    if (it.is<std::string>()) {
+        return it.get<std::string>();
+    }
+    return EMPTY_STRING;
+}
+
 void Properties::sort() {
     std::sort(props.begin(), props.end());
 }

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "glm/vec3.hpp"
-#include "variant/variant.hpp"
-#include "variant/optional.hpp"
+#include "util/variant.h"
 
 #include <vector>
 #include <string>
@@ -68,9 +67,8 @@ typedef std::vector<Point> Line;
 typedef std::vector<Line> Polygon;
 
 struct Properties {
-    struct none_type {};
 
-    using Value = mapbox::util::variant<none_type, std::string, float>;
+    using Value = variant<none_type, std::string, float>;
 
     const Value& get(const std::string& key) const;
 

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -68,7 +68,6 @@ typedef std::vector<Line> Polygon;
 
 struct Properties {
 
-    using Value = variant<none_type, std::string, float>;
     struct Item {
         Item(std::string _key, Value _value) :
             key(std::move(_key)), value(std::move(_value)) {}

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -118,13 +118,7 @@ struct Properties {
         return false;
     }
 
-    std::string getString(const std::string& key) const {
-        auto& it = get(key);
-        if (it.is<std::string>()) {
-            return it.get<std::string>();
-        }
-        return "";
-    }
+    const std::string& getString(const std::string& key) const;
 
     template <typename... Args> void add(std::string key, Args&&... args) {
         props.emplace_back(std::move(key), Value{std::forward<Args>(args)...});

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -11,6 +11,7 @@ namespace Tangram {
 const StyleParam NONE;
 
 const std::map<std::string, StyleParamKey> s_StyleParamMap = {
+    {"none", StyleParamKey::none},
     {"order", StyleParamKey::order},
     {"color", StyleParamKey::color},
     {"width", StyleParamKey::width},
@@ -25,6 +26,7 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
 StyleParam::StyleParam(const std::string& _key, const std::string& _value) {
     auto it = s_StyleParamMap.find(_key);
     if (it == s_StyleParamMap.end()) {
+        logMsg("Unknown StyleParam %s:%s\n", _key.c_str(), _value.c_str());
         value = "";
         return;
     }
@@ -73,6 +75,8 @@ std::string StyleParam::toString() const {
     case StyleParamKey::join:
     case StyleParamKey::outline_join:
         return std::to_string(static_cast<int>(value.get<CapTypes>()));
+    case StyleParamKey::none:
+        break;
     }
     return "undefined";
 }

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -14,11 +14,11 @@ using Color = CSSColorParser::Color;
 namespace Tangram {
 
 enum class StyleParamKey : uint8_t {
-    order, color, width, cap, join, outline_color, outline_width, outline_cap, outline_join,
+    none, order, color, width, cap, join, outline_color, outline_width, outline_cap, outline_join,
 };
 
 struct StyleParam {
-    using Value = variant<none_type, std::string, Color, CapTypes, JoinTypes, float, int32_t>;
+    using Value = variant<none_type, std::string, Color, CapTypes, JoinTypes, int32_t, float>;
 
     StyleParam() {}
     StyleParam(const std::string& _key, const std::string& _value);

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -1,9 +1,15 @@
 #pragma once
+
+#include "util/variant.h"
+
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "builders.h" // for Cap/Join types
+#include "csscolorparser.hpp"
+
+using Color = CSSColorParser::Color;
 
 namespace Tangram {
 
@@ -12,20 +18,24 @@ enum class StyleParamKey : uint8_t {
 };
 
 struct StyleParam {
+    using Value = variant<none_type, std::string, Color, CapTypes, JoinTypes, float, int32_t>;
+
     StyleParam() {}
     StyleParam(const std::string& _key, const std::string& _value);
     StyleParam(StyleParamKey _key, std::string _value) : key(_key), value(std::move(_value)){}
 
     StyleParamKey key;
-    std::string value;
+    Value value;
     bool operator<(const StyleParam& _rhs) const { return key < _rhs.key; }
-    bool valid() const { return !value.empty(); }
+    bool valid() const { return !value.is<none_type>(); }
     operator bool() const { return valid(); }
+
+    std::string toString() const;
 };
 
 struct DrawRule {
 
-    static uint32_t parseColor(const std::string& _color);
+    static Color parseColor(const std::string& _color);
 
     std::string style;
     std::vector<StyleParam> parameters;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -659,6 +659,11 @@ Filter SceneLoader::generateFilter(YAML::Node _filter) {
 Filter SceneLoader::generatePredicate(YAML::Node _node, std::string _key) {
 
     if (_node.IsScalar()) {
+        if (_node.Tag() == "tag:yaml.org,2002:str") {
+            // Node was explicitly tagged with '!!str' or the canonical tag 'tag:yaml.org,2002:str'
+            // yaml-cpp normalizes the tag value to the canonical form
+            return Filter(_key, { Value(_node.as<std::string>()) });
+        }
         try {
             return Filter(_key, { Value(_node.as<float>()) });
         } catch (const BadConversion& e) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -660,7 +660,7 @@ Filter SceneLoader::generatePredicate(YAML::Node _node, std::string _key) {
 
     if (_node.IsScalar()) {
         try {
-            return Filter(_key, { Value(_node.as<float>(), _node.as<std::string>()) });
+            return Filter(_key, { Value(_node.as<float>()) });
         } catch (const BadConversion& e) {
             std::string value = _node.as<std::string>();
             if (value == "true") {
@@ -675,7 +675,7 @@ Filter SceneLoader::generatePredicate(YAML::Node _node, std::string _key) {
         std::vector<Value> values;
         for (const auto& valItr : _node) {
             try {
-                values.emplace_back(valItr.as<float>(), valItr.as<std::string>());
+                values.emplace_back(valItr.as<float>());
             } catch(const BadConversion& e) {
                 std::string value = valItr.as<std::string>();
                 values.emplace_back(value);

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -76,8 +76,8 @@ void PolygonStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, 
         abgr = abgr << (_tile.getID().z % 6);
     }
 
-    float height = _props.getNumeric("height");
-    float minHeight = _props.getNumeric("min_height");
+    float height = _props.getNumeric("height") * _tile.getInverseScale();
+    float minHeight = _props.getNumeric("min_height") * _tile.getInverseScale();
 
     PolygonBuilder builder = {
         [&](const glm::vec3& coord, const glm::vec3& normal, const glm::vec2& uv){

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -76,8 +76,11 @@ void PolygonStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, 
         abgr = abgr << (_tile.getID().z % 6);
     }
 
-    float height = _props.getNumeric("height") * _tile.getInverseScale();
-    float minHeight = _props.getNumeric("min_height") * _tile.getInverseScale();
+    const static std::string key_height("height");
+    const static std::string key_min_height("min_height");
+
+    float height = _props.getNumeric(key_height) * _tile.getInverseScale();
+    float minHeight = _props.getNumeric(key_min_height) * _tile.getInverseScale();
 
     PolygonBuilder builder = {
         [&](const glm::vec3& coord, const glm::vec3& normal, const glm::vec2& uv){

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -60,7 +60,7 @@ void PolylineStyle::buildLine(const Line& _line, const DrawRule& _rule, const Pr
         abgr = abgr << (_tile.getID().z % 6);
     }
 
-    GLfloat layer = _props.getNumeric("sort_key", 0) + params.order;
+    GLfloat layer = _props.getNumeric("sort_key") + params.order;
     float halfWidth = params.width * .5f;
 
     PolyLineBuilder builder {

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -64,12 +64,9 @@ void SpriteStyle::buildPoint(const Point& _point, const DrawRule& _rule, const P
     float spriteScale = .5f;
     glm::vec2 offset = {0.f, 10.f};
 
-    auto& value = _props.get("kind");
-    if (!value.is<std::string>()) {
-        return;
-    }
+    const auto& kind = _props.getString("kind");
+    if(kind.length() == 0) { return; }
 
-    const auto& kind = value.get<std::string>();
     if (!m_spriteAtlas->hasSpriteNode(kind)) {
         return;
     }

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -64,12 +64,12 @@ void SpriteStyle::buildPoint(const Point& _point, const DrawRule& _rule, const P
     float spriteScale = .5f;
     glm::vec2 offset = {0.f, 10.f};
 
-    auto it = _props.stringProps.find("kind");
-    if (it == _props.stringProps.end()) {
+    auto& value = _props.get("kind");
+    if (!value.is<std::string>()) {
         return;
     }
 
-    const std::string& kind = (*it).second;
+    const auto& kind = value.get<std::string>();
     if (!m_spriteAtlas->hasSpriteNode(kind)) {
         return;
     }

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -64,7 +64,9 @@ void SpriteStyle::buildPoint(const Point& _point, const DrawRule& _rule, const P
     float spriteScale = .5f;
     glm::vec2 offset = {0.f, 10.f};
 
-    const auto& kind = _props.getString("kind");
+    const static std::string key("kind");
+
+    const std::string& kind = _props.getString(key);
     if(kind.length() == 0) { return; }
 
     if (!m_spriteAtlas->hasSpriteNode(kind)) {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -20,7 +20,6 @@ class VboMesh;
 class VertexLayout;
 class View;
 class Scene;
-struct Value;
 using Context = std::unordered_map<std::string, Value>;
 
 enum class LightingType : char {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -10,6 +10,8 @@
 
 namespace Tangram {
 
+const static std::string key_name("name");
+
 TextStyle::TextStyle(const std::string& _fontName, std::string _name, float _fontSize, unsigned int _color, bool _sdf, bool _sdfMultisampling, GLenum _drawMode)
 : Style(_name, _drawMode), m_fontName(_fontName), m_fontSize(_fontSize), m_color(_color), m_sdf(_sdf), m_sdfMultisampling(_sdfMultisampling)  {
 }
@@ -47,10 +49,8 @@ void TextStyle::constructShaderProgram() {
 void TextStyle::buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
 
-    std::string text;
-    if (!_props.getString("name", text)) {
-        return;
-    }
+    const auto& text = _props.getString(key_name);
+    if (text.length() == 0) { return; }
 
     buffer.addLabel(text, { glm::vec2(_point), glm::vec2(_point), glm::vec2(0) }, Label::Type::point);
 }
@@ -58,10 +58,8 @@ void TextStyle::buildPoint(const Point& _point, const DrawRule& _rule, const Pro
 void TextStyle::buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
 
-    std::string text;
-    if (!_props.getString("name", text)) {
-        return;
-    }
+    const auto& text = _props.getString(key_name);
+    if (text.length() == 0) { return; }
 
     int lineLength = _line.size();
     int skipOffset = floor(lineLength / 2);
@@ -86,10 +84,8 @@ void TextStyle::buildLine(const Line& _line, const DrawRule& _rule, const Proper
 void TextStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
 
-    std::string text;
-    if (!_props.getString("name", text)) {
-        return;
-    }
+    const auto& text = _props.getString(key_name);
+    if (text.length() == 0) { return; }
 
     glm::vec2 centroid;
     int n = 0;

--- a/core/src/util/geoJson.cpp
+++ b/core/src/util/geoJson.cpp
@@ -46,20 +46,20 @@ void GeoJson::extractFeature(const rapidjson::Value& _in, Feature& _out, const T
 
         // height and minheight need to be handled separately so that their dimensions are normalized
         if (strcmp(member, "height") == 0) {
-            _out.props.numericProps[member] = prop.GetDouble() * _tile.getInverseScale();
+            _out.props.add(member, prop.GetDouble() * _tile.getInverseScale());
             continue;
         }
 
         if (strcmp(member, "min_height") == 0) {
-            _out.props.numericProps[member] = prop.GetDouble() * _tile.getInverseScale();
+            _out.props.add(member, prop.GetDouble() * _tile.getInverseScale());
             continue;
         }
 
 
         if (prop.IsNumber()) {
-            _out.props.numericProps[member] = prop.GetDouble();
+            _out.props.add(member, prop.GetDouble());
         } else if (prop.IsString()) {
-            _out.props.stringProps[member] = prop.GetString();
+            _out.props.add(member, prop.GetString());
         }
 
     }

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -236,6 +236,7 @@ void PbfParser::extractLayer(ParserContext& _ctx, protobuf::message& _layerIn, L
         }
     }
 
+    _out.features.reserve(_ctx.featureMsgs.size());
     for(auto& featureMsg : _ctx.featureMsgs) {
         _out.features.emplace_back();
         extractFeature(_ctx, featureMsg, _out.features.back());

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -7,12 +7,12 @@
 
 namespace Tangram {
 
-void PbfParser::extractGeometry(protobuf::message& _geomIn, int _tileExtent, std::vector<Line>& _out) {
+void PbfParser::extractGeometry(ParserContext& ctx, protobuf::message& _geomIn, std::vector<Line>& _out) {
 
     pbfGeomCmd cmd = pbfGeomCmd::moveTo;
     uint32_t cmdRepeat = 0;
 
-    double invTileExtent = (1.0/(double)_tileExtent);
+    double invTileExtent = (1.0/(double)ctx.tileExtent);
 
     Line line;
 
@@ -41,8 +41,8 @@ void PbfParser::extractGeometry(protobuf::message& _geomIn, int _tileExtent, std
 
             // bring the points in -1 to 1 space
             Point p;
-            p.x = invTileExtent * (double)(2 * x - _tileExtent);
-            p.y = invTileExtent * (double)(_tileExtent - 2 * y);
+            p.x = invTileExtent * (double)(2 * x - ctx.tileExtent);
+            p.y = invTileExtent * (double)(ctx.tileExtent - 2 * y);
 
             line.push_back(p);
 
@@ -62,7 +62,7 @@ void PbfParser::extractGeometry(protobuf::message& _geomIn, int _tileExtent, std
 
 }
 
-void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, std::vector<std::string>& _keys, std::vector<float>& _numericValues, std::vector<std::string>& _stringValues, int _tileExtent) {
+void PbfParser::extractFeature(ParserContext& ctx, protobuf::message& _featureIn, Feature& _out) {
 
     //Iterate through this feature
     std::vector<Line> geometryLines;
@@ -84,7 +84,7 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, std
                 while(tagsMsg) {
                     std::size_t tagKey = tagsMsg.varint();
 
-                    if(_keys.size() <= tagKey) {
+                    if(ctx.keys.size() <= tagKey) {
                         logMsg("ERROR: accessing out of bound key\n");
                         return;
                     }
@@ -96,14 +96,14 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, std
 
                     std::size_t valueKey = tagsMsg.varint();
 
-                    if( _numericValues.size() <= valueKey ) {
+                    if( ctx.numericValues.size() <= valueKey ) {
                         logMsg("ERROR: accessing out of bound values\n");
                         return;
                     }
 
-                    const std::string& key = _keys[tagKey];
-                    const std::string& strVal = _stringValues[valueKey];
-                    float numVal = _numericValues[valueKey];
+                    const std::string& key = ctx.keys[tagKey];
+                    const std::string& strVal = ctx.stringValues[valueKey];
+                    float numVal = ctx.numericValues[valueKey];
 
                     if(!isnan(numVal)) {
                         _out.props.numericProps[key] = numVal;
@@ -120,7 +120,7 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, std
             // Actual geometry data
             case 4:
                 geometry = _featureIn.getMessage();
-                extractGeometry(geometry, _tileExtent, geometryLines);
+                extractGeometry(ctx, geometry, geometryLines);
                 break;
             // None.. skip
             default:
@@ -153,26 +153,25 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, std
 
 }
 
-void PbfParser::extractLayer(protobuf::message& _layerIn, Layer& _out) {
+void PbfParser::extractLayer(ParserContext& ctx, protobuf::message& _layerIn, Layer& _out) {
 
-    std::vector<std::string> keys;
-    std::vector<float> numericValues;
-    std::vector<std::string> stringValues;
-    std::vector<protobuf::message> featureMsgs;
-    int tileExtent = 0;
+    ctx.keys.clear();
+    ctx.numericValues.clear();
+    ctx.stringValues.clear();
+    ctx.featureMsgs.clear();
 
     //iterate layer to populate featureMsgs, keys and values
     while(_layerIn.next()) {
         switch(_layerIn.tag) {
             case 2: // features
             {
-                featureMsgs.push_back(_layerIn.getMessage());
+                ctx.featureMsgs.push_back(_layerIn.getMessage());
                 break;
             }
 
             case 3: // key string
             {
-                keys.push_back(_layerIn.string());
+                ctx.keys.push_back(_layerIn.string());
                 break;
             }
 
@@ -183,36 +182,36 @@ void PbfParser::extractLayer(protobuf::message& _layerIn, Layer& _out) {
                 while (valueItr.next()) {
                     switch (valueItr.tag) {
                         case 1: // string value
-                            stringValues.push_back(valueItr.string());
-                            numericValues.push_back(NAN);
+                            ctx.stringValues.push_back(valueItr.string());
+                            ctx.numericValues.push_back(NAN);
                             break;
                         case 2: // float value
-                            numericValues.push_back(valueItr.float32());
-                            stringValues.push_back("");
+                            ctx.numericValues.push_back(valueItr.float32());
+                            ctx.stringValues.push_back("");
                             break;
                         case 3: // double value
-                            numericValues.push_back(valueItr.float64());
-                            stringValues.push_back("");
+                            ctx.numericValues.push_back(valueItr.float64());
+                            ctx.stringValues.push_back("");
                             break;
                         case 4: // int value
-                            numericValues.push_back(valueItr.int64());
-                            stringValues.push_back("");
+                            ctx.numericValues.push_back(valueItr.int64());
+                            ctx.stringValues.push_back("");
                             break;
                         case 5: // uint value
-                            numericValues.push_back(valueItr.varint());
-                            stringValues.push_back("");
+                            ctx.numericValues.push_back(valueItr.varint());
+                            ctx.stringValues.push_back("");
                             break;
                         case 6: // sint value
-                            numericValues.push_back(valueItr.int64());
-                            stringValues.push_back("");
+                            ctx.numericValues.push_back(valueItr.int64());
+                            ctx.stringValues.push_back("");
                             break;
                         case 7: // bool value
-                            numericValues.push_back(valueItr.boolean());
-                            stringValues.push_back("");
+                            ctx.numericValues.push_back(valueItr.boolean());
+                            ctx.stringValues.push_back("");
                             break;
                         default:
-                            numericValues.push_back(NAN);
-                            stringValues.push_back("");
+                            ctx.numericValues.push_back(NAN);
+                            ctx.stringValues.push_back("");
                             valueItr.skip();
                             break;
                     }
@@ -221,7 +220,7 @@ void PbfParser::extractLayer(protobuf::message& _layerIn, Layer& _out) {
             }
 
             case 5: //extent
-                tileExtent = static_cast<int>(_layerIn.int64());
+                ctx.tileExtent = static_cast<int>(_layerIn.int64());
                 break;
 
             default: // skip
@@ -231,9 +230,9 @@ void PbfParser::extractLayer(protobuf::message& _layerIn, Layer& _out) {
         }
     }
 
-    for(auto& featureMsg : featureMsgs) {
+    for(auto& featureMsg : ctx.featureMsgs) {
         _out.features.emplace_back();
-        extractFeature(featureMsg, _out.features.back(), keys, numericValues, stringValues, tileExtent);
+        extractFeature(ctx, featureMsg, _out.features.back());
     }
 }
 

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -106,9 +106,9 @@ void PbfParser::extractFeature(ParserContext& ctx, protobuf::message& _featureIn
                     float numVal = ctx.numericValues[valueKey];
 
                     if(!isnan(numVal)) {
-                        _out.props.numericProps[key] = numVal;
+                        _out.props.add(key, numVal);
                     } else {
-                        _out.props.stringProps[key] = strVal;
+                        _out.props.add(key, strVal);
                     }
                 }
                 break;

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -7,7 +7,7 @@
 
 namespace Tangram {
 
-void PbfParser::extractGeometry(protobuf::message& _geomIn, int _tileExtent, std::vector<Line>& _out, const Tile& _tile) {
+void PbfParser::extractGeometry(protobuf::message& _geomIn, int _tileExtent, std::vector<Line>& _out) {
 
     pbfGeomCmd cmd = pbfGeomCmd::moveTo;
     uint32_t cmdRepeat = 0;
@@ -62,7 +62,7 @@ void PbfParser::extractGeometry(protobuf::message& _geomIn, int _tileExtent, std
 
 }
 
-void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, const Tile& _tile, std::vector<std::string>& _keys, std::vector<float>& _numericValues, std::vector<std::string>& _stringValues, int _tileExtent) {
+void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, std::vector<std::string>& _keys, std::vector<float>& _numericValues, std::vector<std::string>& _stringValues, int _tileExtent) {
 
     //Iterate through this feature
     std::vector<Line> geometryLines;
@@ -106,17 +106,9 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, con
                     float numVal = _numericValues[valueKey];
 
                     if(!isnan(numVal)) {
-
-                        // height and minheight need to be handled separately so that their dimensions are normalized
-                        if(key.compare("height") == 0 || key.compare("min_height") == 0) {
-                            numVal *= _tile.getInverseScale();
-                        }
                         _out.props.numericProps[key] = numVal;
-
                     } else {
-
                         _out.props.stringProps[key] = strVal;
-
                     }
                 }
                 break;
@@ -128,7 +120,7 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, con
             // Actual geometry data
             case 4:
                 geometry = _featureIn.getMessage();
-                extractGeometry(geometry, _tileExtent, geometryLines, _tile);
+                extractGeometry(geometry, _tileExtent, geometryLines);
                 break;
             // None.. skip
             default:
@@ -161,7 +153,7 @@ void PbfParser::extractFeature(protobuf::message& _featureIn, Feature& _out, con
 
 }
 
-void PbfParser::extractLayer(protobuf::message& _layerIn, Layer& _out, const Tile& _tile) {
+void PbfParser::extractLayer(protobuf::message& _layerIn, Layer& _out) {
 
     std::vector<std::string> keys;
     std::vector<float> numericValues;
@@ -241,7 +233,7 @@ void PbfParser::extractLayer(protobuf::message& _layerIn, Layer& _out, const Til
 
     for(auto& featureMsg : featureMsgs) {
         _out.features.emplace_back();
-        extractFeature(featureMsg, _out.features.back(), _tile, keys, numericValues, stringValues, tileExtent);
+        extractFeature(featureMsg, _out.features.back(), keys, numericValues, stringValues, tileExtent);
     }
 }
 

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -192,7 +192,7 @@ void PbfParser::extractLayer(ParserContext& ctx, protobuf::message& _layerIn, La
                             ctx.values.push_back(valueItr.boolean());
                             break;
                         default:
-                            ctx.values.push_back(Properties::none_type{});
+                            ctx.values.push_back(none_type{});
                             valueItr.skip();
                             break;
                     }

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -3,8 +3,6 @@
 #include "tile/tile.h"
 #include "platform.h"
 
-#include <cmath> // for isnan
-
 namespace Tangram {
 
 void PbfParser::extractGeometry(ParserContext& ctx, protobuf::message& _geomIn, std::vector<Line>& _out) {
@@ -96,20 +94,12 @@ void PbfParser::extractFeature(ParserContext& ctx, protobuf::message& _featureIn
 
                     std::size_t valueKey = tagsMsg.varint();
 
-                    if( ctx.numericValues.size() <= valueKey ) {
+                    if( ctx.values.size() <= valueKey ) {
                         logMsg("ERROR: accessing out of bound values\n");
                         return;
                     }
 
-                    const std::string& key = ctx.keys[tagKey];
-                    const std::string& strVal = ctx.stringValues[valueKey];
-                    float numVal = ctx.numericValues[valueKey];
-
-                    if(!isnan(numVal)) {
-                        _out.props.add(key, numVal);
-                    } else {
-                        _out.props.add(key, strVal);
-                    }
+                    _out.props.add(ctx.keys[tagKey], ctx.values[valueKey]);
                 }
                 break;
             }
@@ -156,8 +146,7 @@ void PbfParser::extractFeature(ParserContext& ctx, protobuf::message& _featureIn
 void PbfParser::extractLayer(ParserContext& ctx, protobuf::message& _layerIn, Layer& _out) {
 
     ctx.keys.clear();
-    ctx.numericValues.clear();
-    ctx.stringValues.clear();
+    ctx.values.clear();
     ctx.featureMsgs.clear();
 
     //iterate layer to populate featureMsgs, keys and values
@@ -182,36 +171,28 @@ void PbfParser::extractLayer(ParserContext& ctx, protobuf::message& _layerIn, La
                 while (valueItr.next()) {
                     switch (valueItr.tag) {
                         case 1: // string value
-                            ctx.stringValues.push_back(valueItr.string());
-                            ctx.numericValues.push_back(NAN);
+                            ctx.values.push_back(valueItr.string());
                             break;
                         case 2: // float value
-                            ctx.numericValues.push_back(valueItr.float32());
-                            ctx.stringValues.push_back("");
+                            ctx.values.push_back(valueItr.float32());
                             break;
                         case 3: // double value
-                            ctx.numericValues.push_back(valueItr.float64());
-                            ctx.stringValues.push_back("");
+                            ctx.values.push_back(valueItr.float64());
                             break;
                         case 4: // int value
-                            ctx.numericValues.push_back(valueItr.int64());
-                            ctx.stringValues.push_back("");
+                            ctx.values.push_back(valueItr.int64());
                             break;
                         case 5: // uint value
-                            ctx.numericValues.push_back(valueItr.varint());
-                            ctx.stringValues.push_back("");
+                            ctx.values.push_back(valueItr.varint());
                             break;
                         case 6: // sint value
-                            ctx.numericValues.push_back(valueItr.int64());
-                            ctx.stringValues.push_back("");
+                            ctx.values.push_back(valueItr.int64());
                             break;
                         case 7: // bool value
-                            ctx.numericValues.push_back(valueItr.boolean());
-                            ctx.stringValues.push_back("");
+                            ctx.values.push_back(valueItr.boolean());
                             break;
                         default:
-                            ctx.numericValues.push_back(NAN);
-                            ctx.stringValues.push_back("");
+                            ctx.values.push_back(Properties::none_type{});
                             valueItr.skip();
                             break;
                     }

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -66,6 +66,8 @@ void PbfParser::extractFeature(ParserContext& ctx, protobuf::message& _featureIn
     std::vector<Line> geometryLines;
     protobuf::message geometry; // By default data_ and end_ are nullptr
 
+    ctx.properties.clear();
+
     while(_featureIn.next()) {
         switch(_featureIn.tag) {
             // Feature ID
@@ -99,7 +101,7 @@ void PbfParser::extractFeature(ParserContext& ctx, protobuf::message& _featureIn
                         return;
                     }
 
-                    _out.props.add(ctx.keys[tagKey], ctx.values[valueKey]);
+                    ctx.properties.emplace_back(ctx.keys[tagKey], ctx.values[valueKey]);
                 }
                 break;
             }
@@ -118,6 +120,7 @@ void PbfParser::extractFeature(ParserContext& ctx, protobuf::message& _featureIn
                 break;
         }
     }
+    _out.props = std::move(ctx.properties);
 
     switch(_out.geometryType) {
         case GeometryType::points:

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -23,11 +23,11 @@ namespace PbfParser {
         int tileExtent = 0;
     };
     
-    void extractGeometry(ParserContext& ctx, protobuf::message& _geomIn);
+    void extractGeometry(ParserContext& _ctx, protobuf::message& _geomIn);
     
-    void extractFeature(ParserContext& ctx, protobuf::message& _featureIn, Feature& _out);
+    void extractFeature(ParserContext& _ctx, protobuf::message& _featureIn, Feature& _out);
     
-    void extractLayer(ParserContext& ctx, protobuf::message& _in, Layer& _out);
+    void extractLayer(ParserContext& _ctx, protobuf::message& _in, Layer& _out);
     
     enum pbfGeomCmd {
         moveTo = 1,

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -11,12 +11,20 @@ namespace Tangram {
 class Tile;
 
 namespace PbfParser {
+
+    struct ParserContext {
+        std::vector<std::string> keys;
+        std::vector<float> numericValues;
+        std::vector<std::string> stringValues;
+        std::vector<protobuf::message> featureMsgs;
+        int tileExtent = 0;
+    };
     
-    void extractGeometry(protobuf::message& _geomIn, int _tileExtent, std::vector<Line>& _out);
+    void extractGeometry(ParserContext& ctx, protobuf::message& _geomIn, std::vector<Line>& _out);
     
-    void extractFeature(protobuf::message& _featureIn, Feature& _out, std::vector<std::string>& _keys, std::vector<float>& _numericValues, std::vector<std::string>& _stringValues, int _tileExtent);
+    void extractFeature(ParserContext& ctx, protobuf::message& _featureIn, Feature& _out);
     
-    void extractLayer(protobuf::message& _in, Layer& _out);
+    void extractLayer(ParserContext& ctx, protobuf::message& _in, Layer& _out);
     
     enum pbfGeomCmd {
         moveTo = 1,

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -17,10 +17,13 @@ namespace PbfParser {
         std::vector<Properties::Value> values;
         std::vector<Properties::Item> properties;
         std::vector<protobuf::message> featureMsgs;
+        std::vector<Point> coordinates;
+        std::vector<int> numCoordinates;
+
         int tileExtent = 0;
     };
     
-    void extractGeometry(ParserContext& ctx, protobuf::message& _geomIn, std::vector<Line>& _out);
+    void extractGeometry(ParserContext& ctx, protobuf::message& _geomIn);
     
     void extractFeature(ParserContext& ctx, protobuf::message& _featureIn, Feature& _out);
     

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -14,8 +14,7 @@ namespace PbfParser {
 
     struct ParserContext {
         std::vector<std::string> keys;
-        std::vector<float> numericValues;
-        std::vector<std::string> stringValues;
+        std::vector<Properties::Value> values;
         std::vector<protobuf::message> featureMsgs;
         int tileExtent = 0;
     };

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -12,11 +12,11 @@ class Tile;
 
 namespace PbfParser {
     
-    void extractGeometry(protobuf::message& _geomIn, int _tileExtent, std::vector<Line>& _out, const Tile& _tile);
+    void extractGeometry(protobuf::message& _geomIn, int _tileExtent, std::vector<Line>& _out);
     
-    void extractFeature(protobuf::message& _featureIn, Feature& _out, const Tile& _tile, std::vector<std::string>& _keys, std::vector<float>& _numericValues, std::vector<std::string>& _stringValues, int _tileExtent);
+    void extractFeature(protobuf::message& _featureIn, Feature& _out, std::vector<std::string>& _keys, std::vector<float>& _numericValues, std::vector<std::string>& _stringValues, int _tileExtent);
     
-    void extractLayer(protobuf::message& _in, Layer& _out, const Tile& _tile);
+    void extractLayer(protobuf::message& _in, Layer& _out);
     
     enum pbfGeomCmd {
         moveTo = 1,

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -14,7 +14,7 @@ namespace PbfParser {
 
     struct ParserContext {
         std::vector<std::string> keys;
-        std::vector<Properties::Value> values;
+        std::vector<Value> values;
         std::vector<Properties::Item> properties;
         std::vector<protobuf::message> featureMsgs;
         std::vector<Point> coordinates;

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -15,6 +15,7 @@ namespace PbfParser {
     struct ParserContext {
         std::vector<std::string> keys;
         std::vector<Properties::Value> values;
+        std::vector<Properties::Item> properties;
         std::vector<protobuf::message> featureMsgs;
         int tileExtent = 0;
     };

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -3,8 +3,20 @@
 #include "variant/variant.hpp"
 
 namespace Tangram {
-    struct none_type {};
+struct none_type {
+    bool operator==(none_type const& rhs) const {
+        return true;
+    }
+    bool operator<(none_type const& rhs) const {
+        return false;
+    }
+};
 
-    template<typename... Types>
-    using variant = mapbox::util::variant<Types...>;
+template<typename... Types>
+using variant = mapbox::util::variant<Types...>;
+
+
+/* Common Value type for Feature Properties and Filter Values */
+using Value = variant<none_type, std::string, float>;
+
 }

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "variant/variant.hpp"
+
+namespace Tangram {
+    struct none_type {};
+
+    template<typename... Types>
+    using variant = mapbox::util::variant<Types...>;
+}

--- a/tests/unit/drawRuleTests.cpp
+++ b/tests/unit/drawRuleTests.cpp
@@ -66,11 +66,16 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
         // printf("rule_c:\n %s", rule_c.toString().c_str());
         // printf("merged_ac:\n %s", merged_ac.toString().c_str());
 
-        REQUIRE(merged_ab.parameters[0].key == StyleParamKey::order); REQUIRE(merged_ab.parameters[0].value == "value_0b");
-        REQUIRE(merged_ab.parameters[1].key == StyleParamKey::color); REQUIRE(merged_ab.parameters[1].value == "value_1b");
-        REQUIRE(merged_ab.parameters[2].key == StyleParamKey::width); REQUIRE(merged_ab.parameters[2].value == "value_2b");
-        REQUIRE(merged_ab.parameters[3].key == StyleParamKey::cap); REQUIRE(merged_ab.parameters[3].value == "value_3b");
-        REQUIRE(merged_ab.parameters[4].key == StyleParamKey::join); REQUIRE(merged_ab.parameters[4].value == "value_4a");
+        REQUIRE(merged_ab.parameters[0].key == StyleParamKey::order);
+        REQUIRE(merged_ab.parameters[0].value.get<std::string>() == "value_0b");
+        REQUIRE(merged_ab.parameters[1].key == StyleParamKey::color);
+        REQUIRE(merged_ab.parameters[1].value.get<std::string>() == "value_1b");
+        REQUIRE(merged_ab.parameters[2].key == StyleParamKey::width);
+        REQUIRE(merged_ab.parameters[2].value.get<std::string>() == "value_2b");
+        REQUIRE(merged_ab.parameters[3].key == StyleParamKey::cap);
+        REQUIRE(merged_ab.parameters[3].value.get<std::string>() == "value_3b");
+        REQUIRE(merged_ab.parameters[4].key == StyleParamKey::join);
+        REQUIRE(merged_ab.parameters[4].value.get<std::string>() == "value_4a");
     }
 
     {
@@ -79,11 +84,16 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
 
         auto merged_ba = rule_b.merge(rule_a);
 
-        REQUIRE(merged_ba.parameters[0].key == StyleParamKey::order); REQUIRE(merged_ba.parameters[0].value == "value_0a");
-        REQUIRE(merged_ba.parameters[1].key == StyleParamKey::color); REQUIRE(merged_ba.parameters[1].value == "value_1a");
-        REQUIRE(merged_ba.parameters[2].key == StyleParamKey::width); REQUIRE(merged_ba.parameters[2].value == "value_2b");
-        REQUIRE(merged_ba.parameters[3].key == StyleParamKey::cap); REQUIRE(merged_ba.parameters[3].value == "value_3b");
-        REQUIRE(merged_ba.parameters[4].key == StyleParamKey::join); REQUIRE(merged_ba.parameters[4].value == "value_4a");
+        REQUIRE(merged_ba.parameters[0].key == StyleParamKey::order);
+        REQUIRE(merged_ba.parameters[0].value.get<std::string>() == "value_0a");
+        REQUIRE(merged_ba.parameters[1].key == StyleParamKey::color);
+        REQUIRE(merged_ba.parameters[1].value.get<std::string>() == "value_1a");
+        REQUIRE(merged_ba.parameters[2].key == StyleParamKey::width);
+        REQUIRE(merged_ba.parameters[2].value.get<std::string>() == "value_2b");
+        REQUIRE(merged_ba.parameters[3].key == StyleParamKey::cap);
+        REQUIRE(merged_ba.parameters[3].value.get<std::string>() == "value_3b");
+        REQUIRE(merged_ba.parameters[4].key == StyleParamKey::join);
+        REQUIRE(merged_ba.parameters[4].value.get<std::string>() == "value_4a");
     }
 
     {
@@ -94,7 +104,8 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
 
         for (size_t i = 0; i < merged_bc.parameters.size(); i++) {
             REQUIRE(merged_bc.parameters[i].key == rule_b.parameters[i].key);
-            REQUIRE(merged_bc.parameters[i].value == rule_b.parameters[i].value);
+            REQUIRE(merged_bc.parameters[i].value.get<std::string>() ==
+                    rule_b.parameters[i].value.get<std::string>());
         }
     }
 

--- a/tests/unit/layerTests.cpp
+++ b/tests/unit/layerTests.cpp
@@ -107,11 +107,11 @@ TEST_CASE("SceneLayer correctly merges rules matched from sublayer", "[SceneLaye
     // deeper match from layer_a should override parameters in same style from layer_d
     REQUIRE(matches[0].style == "style_0");
     REQUIRE(matches[0].parameters[0].key == StyleParamKey::order);
-    REQUIRE(matches[0].parameters[0].value == "value_a");
+    REQUIRE(matches[0].parameters[0].value.get<std::string>() == "value_a");
 
     // deeper match from layer_c should override parameters in same style from layer_e
     REQUIRE(matches[1].style == "style_2");
     REQUIRE(matches[1].parameters[0].key == StyleParamKey::order);
-    REQUIRE(matches[1].parameters[0].value == "value_c");
+    REQUIRE(matches[1].parameters[0].value.get<std::string>() == "value_c");
 
 }

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -18,32 +18,29 @@ Feature civic, bmw1, bike;
 
 void init() {
 
-    civic.props.stringProps.clear();
-    civic.props.numericProps.clear();
-    civic.props.stringProps["name"] = "civic";
-    civic.props.stringProps["brand"] = "honda";
-    civic.props.numericProps["wheel"] = 4;
-    civic.props.stringProps["drive"] = "fwd";
-    civic.props.stringProps["type"] = "car";
+    civic.props.clear();
+    civic.props.add("name", "civic");
+    civic.props.add("brand", "honda");
+    civic.props.add("wheel",  4);
+    civic.props.add("drive", "fwd");
+    civic.props.add("type", "car");
 
-    bmw1.props.stringProps.clear();
-    bmw1.props.numericProps.clear();
-    bmw1.props.stringProps["name"] = "bmw320i";
-    bmw1.props.stringProps["brand"] = "bmw";
-    bmw1.props.stringProps["check"] = "false";
-    bmw1.props.stringProps["series"] = "3";
-    bmw1.props.numericProps["wheel"] = 4;
-    bmw1.props.stringProps["drive"] = "all";
-    bmw1.props.stringProps["type"] = "car";
+    bmw1.props.clear();
+    bmw1.props.add("name", "bmw320i");
+    bmw1.props.add("brand", "bmw");
+    bmw1.props.add("check", "false");
+    bmw1.props.add("series", "3");
+    bmw1.props.add("wheel", 4);
+    bmw1.props.add("drive", "all");
+    bmw1.props.add("type", "car");
 
-    bike.props.stringProps.clear();
-    bike.props.numericProps.clear();
-    bike.props.stringProps["name"] = "cb1100";
-    bike.props.stringProps["brand"] = "honda";
-    bike.props.numericProps["wheel"] = 2;
-    bike.props.stringProps["type"] = "bike";
-    bike.props.stringProps["series"] = "CB";
-    bike.props.stringProps["check"] = "available";
+    bike.props.clear();
+    bike.props.add("name", "cb1100");
+    bike.props.add("brand", "honda");
+    bike.props.add("wheel", 2);
+    bike.props.add("type", "bike");
+    bike.props.add("series", "CB");
+    bike.props.add("check", "available");
 
     ctx["$vroom"] = Value(1);
     ctx["$zooooom"] = Value("false");

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -50,11 +50,11 @@ void init() {
 //1. basic predicate
 TEST_CASE( "yaml-filter-tests: basic predicate test", "[filters][core][yaml]") {
     init();
-    YAML::Node node = YAML::Load("filter: { series: 3}");
+    YAML::Node node = YAML::Load("filter: { series: !!str 3}");
     Filter filter = sceneLoader.generateFilter(node["filter"]);
 
     REQUIRE(!filter.eval(civic, ctx));
-    // FIXME:  REQUIRE(filter.eval(bmw1, ctx));
+    REQUIRE(filter.eval(bmw1, ctx));
     REQUIRE(!filter.eval(bike, ctx));
 
 }

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -54,7 +54,7 @@ TEST_CASE( "yaml-filter-tests: basic predicate test", "[filters][core][yaml]") {
     Filter filter = sceneLoader.generateFilter(node["filter"]);
 
     REQUIRE(!filter.eval(civic, ctx));
-    REQUIRE(filter.eval(bmw1, ctx));
+    // FIXME:  REQUIRE(filter.eval(bmw1, ctx));
     REQUIRE(!filter.eval(bike, ctx));
 
 }


### PR DESCRIPTION
Introducing variant for Property::Value and StyleParam::Value

- StyleParams, especially Color values are now only parsed once 
- less allocations: The pbf parser uses a single vector for values (instead of parallel ones for float and string)
- likewise Properties uses a single map now
