### PR TITLE
Alpha discard

### DIFF
--- a/core/resources/shaders/point.vs
+++ b/core/resources/shaders/point.vs
@@ -17,23 +17,22 @@ varying vec2 v_uv;
 varying float v_alpha;
 
 void main() {
-    if (a_alpha != 0.0) {
+    if (a_alpha > TANGRAM_EPSILON) {
         float st = sin(a_rotation);
         float ct = cos(a_rotation);
-        
+
         // rotates first around +z-axis (0,0,1) and then translates by (tx,ty,0)
         vec4 p = vec4(
             a_position.x * ct - a_position.y * st + a_screenPosition.x,
             a_position.x * st + a_position.y * ct + a_screenPosition.y,
             0.0, 1.0
         );
-        
-        v_uv = a_uv;
-        v_alpha = a_alpha;
-        
+
         gl_Position = u_proj * p;
     } else {
-        // clip it
-        gl_Position = vec4(0.0);
+        gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
     }
+
+    v_alpha = a_alpha;
+    v_uv = a_uv;
 }

--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -51,10 +51,14 @@ float sampleAlpha(in vec2 uv, float distance, in float off) {
 }
 
 void main(void) {
-    float distance = texture2D(u_tex, v_uv).a;
-    float alpha = sampleAlpha(v_uv, distance, sdf) * tint;
-    alpha = pow(alpha, 1.0 / gamma);
+    if (v_alpha < TANGRAM_EPSILON) {
+        discard;
+    } else {
+        float distance = texture2D(u_tex, v_uv).a;
+        float alpha = sampleAlpha(v_uv, distance, sdf) * tint;
+        alpha = pow(alpha, 1.0 / gamma);
 
-    gl_FragColor = vec4(u_color, v_alpha * alpha);
+        gl_FragColor = vec4(u_color, v_alpha * alpha);
+    }
 }
 

--- a/core/resources/shaders/sprite.fs
+++ b/core/resources/shaders/sprite.fs
@@ -11,6 +11,10 @@ varying vec2 v_uv;
 varying float v_alpha;
 
 void main(void) {
-    vec4 color = texture2D(u_tex, v_uv);
-    gl_FragColor = vec4(color.rgb, v_alpha * color.a);
+    if (v_alpha < TANGRAM_EPSILON) {
+        discard;
+    } else {
+        vec4 color = texture2D(u_tex, v_uv);
+        gl_FragColor = vec4(color.rgb, v_alpha * color.a);
+    }
 }

--- a/core/resources/shaders/text.fs
+++ b/core/resources/shaders/text.fs
@@ -12,6 +12,10 @@ varying vec2 v_uv;
 varying float v_alpha;
 
 void main(void) {
-    vec4 texColor = texture2D(u_tex, v_uv);
-    gl_FragColor = vec4(u_color.rgb, texColor.a * v_alpha);
+    if (v_alpha < TANGRAM_EPSILON) {
+        discard;
+    } else {
+        vec4 texColor = texture2D(u_tex, v_uv);
+        gl_FragColor = vec4(u_color.rgb, texColor.a * v_alpha);
+    }
 }

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -222,7 +222,11 @@ void ShaderProgram::applySourceBlocks(std::string& _vertSrcOut, std::string& _fr
     _fragSrcOut.insert(0, "#pragma tangram: defines\n");
 
     float depthDelta = 1.f / (1 << 16);
-    _vertSrcOut.insert(0, "#define TANGRAM_DEPTH_DELTA "+std::to_string(depthDelta)+"\n");
+
+    // inject tangram defines
+    _vertSrcOut.insert(0, "#define TANGRAM_DEPTH_DELTA " + std::to_string(depthDelta) + "\n");
+    _vertSrcOut.insert(0, "#define TANGRAM_EPSILON 0.00001\n");
+    _fragSrcOut.insert(0, "#define TANGRAM_EPSILON 0.00001\n");
 
     Light::assembleLights(m_sourceBlocks);
 


### PR DESCRIPTION
"Clip" the vertex by setting all values to 0.0 (with `w=0`) would make the vertex become a vector (direction) in homogeneous space instead of a point and lots of issues can happen from that, including that the triangle can become inconsistent (since its vertices are now directions), and overdrawn can happen on some devices. It's better to directly discard the fragment and let the vertex output with `w=1`.

Another solution could be to flip the unused vertex quads around the `z=0` plane, with culling to true for back faces, we can consolidate on that when we find a good way to clip those vertices.