### PR TITLE
Use render states for textures

### DIFF
--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -3,7 +3,7 @@
 namespace Tangram {
 
 namespace RenderState {
-    
+
     Blending blending;
     DepthTest depthTest;
     StencilTest stencilTest;
@@ -20,8 +20,21 @@ namespace RenderState {
     VertexBuffer vertexBuffer;
     IndexBuffer indexBuffer;
 
+    TextureUnit textureUnit;
+    Texture texture;
+
+    GLuint getTextureUnit(GLuint _unit) {
+        if (_unit >= TANGRAM_MAX_TEXTURE_UNIT) {
+            logMsg("Warning: trying to access unavailable texture unit");
+        }
+
+        return GL_TEXTURE0 + _unit;
+    }
+
     void bindVertexBuffer(GLuint _id) { glBindBuffer(GL_ARRAY_BUFFER, _id); }
     void bindIndexBuffer(GLuint _id) { glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _id); }
+    void activeTextureUnit(GLuint _unit) { glActiveTexture(getTextureUnit(_unit)); }
+    void bindTexture(GLenum _target, GLuint _textureId) { glBindTexture(_target, _textureId); }
 
     void configure() {
         blending.init(GL_FALSE);
@@ -40,6 +53,9 @@ namespace RenderState {
 
         vertexBuffer.init(std::numeric_limits<unsigned int>::max(), false);
         indexBuffer.init(std::numeric_limits<unsigned int>::max(), false);
+        texture.init(GL_TEXTURE_2D, std::numeric_limits<unsigned int>::max(), false);
+        texture.init(GL_TEXTURE_CUBE_MAP, std::numeric_limits<unsigned int>::max(), false);
+        textureUnit.init(std::numeric_limits<unsigned int>::max(), false);
     }
 
 }

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -84,6 +84,11 @@ namespace RenderState {
             }
         }
 
+        inline bool compare(Args... _args) {
+            auto _params = std::make_tuple(_args...);
+            return _params == params;
+        }
+
         template<int ...S>
         inline void call(seq<S...>) {
             fn(std::get<S>(params) ...);

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -6,9 +6,25 @@
 #include <tuple>
 #include <limits>
 
+// Max texture units used at the same time by a shader
+#define TANGRAM_MAX_TEXTURE_UNIT 6
+
 namespace Tangram {
 
 namespace RenderState {
+
+    /* Configure the render states */
+    void configure();
+    /* Get the texture slot from a texture unit from 0 to TANGRAM_MAX_TEXTURE_UNIT */
+    GLuint getTextureUnit(GLuint _unit);
+    /* Bind a vertex buffer */
+    void bindVertexBuffer(GLuint _id);
+    /* Bind an index buffer */
+    void bindIndexBuffer(GLuint _id);
+    /* Sets the currently active texture unit */
+    void activeTextureUnit(GLuint _unit);
+    /* Bind a texture for the specified target */
+    void bindTexture(GLenum _target, GLuint _textureId);
 
     template <typename T>
     class State {
@@ -114,11 +130,11 @@ namespace RenderState {
     using CullFace = StateWrap<FUN(glCullFace),
                                GLenum>;
 
-    void bindVertexBuffer(GLuint _id);
-    void bindIndexBuffer(GLuint _id);
-
     using VertexBuffer = StateWrap<FUN(bindVertexBuffer), GLuint>;
     using IndexBuffer = StateWrap<FUN(bindIndexBuffer), GLuint>;
+
+    using TextureUnit = StateWrap<FUN(activeTextureUnit), GLuint>;
+    using Texture = StateWrap<FUN(bindTexture), GLenum, GLuint>;
 
 #undef FUN
 
@@ -138,7 +154,8 @@ namespace RenderState {
     extern VertexBuffer vertexBuffer;
     extern IndexBuffer indexBuffer;
 
-    void configure();
+    extern TextureUnit textureUnit;
+    extern Texture texture;
 }
 
 }

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -15,7 +15,7 @@ namespace RenderState {
 
     /* Configure the render states */
     void configure();
-    /* Get the texture slot from a texture unit from 0 to TANGRAM_MAX_TEXTURE_UNIT */
+    /* Get the texture slot from a texture unit from 0 to TANGRAM_MAX_TEXTURE_UNIT-1 */
     GLuint getTextureUnit(GLuint _unit);
     /* Bind a vertex buffer */
     void bindVertexBuffer(GLuint _id);

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -46,6 +46,12 @@ Texture::Texture(const std::string& _file, TextureOptions _options, bool _genera
 Texture::~Texture() {
     if (m_glHandle) {
         glDeleteTextures(1, &m_glHandle);
+
+        // if the texture is bound, and deleted, the binding defaults to 0 according to the OpenGL
+        // spec, in this case we need to force the currently bound texture to 0 in the render states
+        if (RenderState::texture.compare(m_target, m_glHandle)) {
+            RenderState::texture.init(m_target, 0, false);
+        }
     }
 }
 
@@ -78,7 +84,7 @@ void Texture::setSubData(const GLuint* _subData, unsigned int _xoff, unsigned in
 
     m_dirty = true;
 }
-    
+
 void Texture::bind(GLuint _unit) {
     RenderState::textureUnit(_unit);
     RenderState::texture(m_target, m_glHandle);

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -42,9 +42,6 @@ public:
 
     virtual ~Texture();
 
-    /* Binds the texture to the specified slot */
-    void bind(GLuint _textureSlot);
-
     /* Perform texture updates, should be called at least once and after adding data or resizing */
     virtual void update(GLuint _textureSlot);
 
@@ -54,6 +51,8 @@ public:
     /* Width and Height texture getters */
     unsigned int getWidth() const { return m_width; }
     unsigned int getHeight() const { return m_height; }
+    
+    void bind(GLuint _unit);
 
     GLuint getGlHandle() { return m_glHandle; }
 
@@ -89,8 +88,6 @@ protected:
     int m_generation;
     static int s_validGeneration;
 
-    static GLuint getTextureUnit(GLuint _slot);
-
 private:
     struct TextureSubData {
         std::unique_ptr<std::vector<GLuint>> m_data;
@@ -106,14 +103,6 @@ private:
 
     // used to queue the subdata updates, each call of setSubData would be treated in the order that they arrived
     std::queue<std::unique_ptr<TextureSubData>> m_subData;
-
-    // We refer to both 'texture slots' and 'texture units', which are almost (but not quite) the same.
-    // Texture slots range from 0 to GL_MAX_COMBINED_TEXTURE_UNITS-1 and the texture unit corresponding to
-    // a given texture slot is (slot + GL_TEXTURE0).
-    static GLuint s_activeSlot;
-
-    // if (s_boundTextures[s] == h) then the texture with handle 'h' is currently bound at slot 's'
-    static GLuint s_boundTextures[TANGRAM_MAX_TEXTURE_UNIT];
 };
 
 }


### PR DESCRIPTION
Use of the render states tracking we've added for texture unit/id binding.