### PR TITLE
cmake: use public headers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/tangrams/isect2d.git
 [submodule "core/dependencies/yaml-cpp"]
 	path = core/dependencies/yaml-cpp
-	url = https://github.com/blair1618/yaml-cpp.git
+	url = https://github.com/tangrams/yaml-cpp.git
 	branch = no-boost
 	ignore = untracked
 [submodule "glfw"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ matrix:
           env: PLATFORM=android
           addons:
             apt:
-              packages: [ 'lib32z1-dev', 'lib32stdc++6', 's3cmd' ]
+              sources: [ 'kalakris-cmake' ]
+              packages: [ 'cmake', 'lib32z1-dev', 'lib32stdc++6', 's3cmd' ]
           android:
             components: [ 'build-tools-21.1.2', 'android-22' ]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 project(tangram)
 
 include(${PROJECT_SOURCE_DIR}/toolchains/utils.cmake)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -20,9 +20,6 @@ foreach(_headerFile ${FOUND_HEADERS})
     list(APPEND INCLUDE_DIRS ${_dir})
 endforeach()
 set(CORE_INCLUDE_DIRS ${INCLUDE_DIRS} CACHE INTERNAL "core include directories" FORCE)
-list(APPEND INCLUDE_DIRS "${DEPENDENCIES_DIR}/libtess2/Include")
-list(APPEND INCLUDE_DIRS "${DEPENDENCIES_DIR}/css-color-parser-cpp")
-list(APPEND INCLUDE_DIRS "${DEPENDENCIES_DIR}/yaml-cpp/include")
 list(APPEND INCLUDE_DIRS "${INCLUDE_DIR}/stb")
 list(APPEND INCLUDE_DIRS "${INCLUDE_DIR}/glm")
 list(APPEND INCLUDE_DIRS "${INCLUDE_DIR}/isect2d/include")
@@ -32,9 +29,6 @@ list(REMOVE_DUPLICATES INCLUDE_DIRS)
 include_directories(${INCLUDE_DIR} ${INCLUDE_DIRS})
 
 set(CORE_LIBRARIES_INCLUDE_DIRS
-    ${PROJECT_SOURCE_DIR}/${DEPENDENCIES_DIR}/libtess2/Include/
-    ${PROJECT_SOURCE_DIR}/${DEPENDENCIES_DIR}/css-color-parser-cpp/
-    ${PROJECT_SOURCE_DIR}/${DEPENDENCIES_DIR}/yaml-cpp/include/
     ${PROJECT_SOURCE_DIR}/${INCLUDE_DIR}/
     ${PROJECT_SOURCE_DIR}/${INCLUDE_DIR}/glm/
     ${PROJECT_SOURCE_DIR}/${INCLUDE_DIR}/stb/

--- a/core/dependencies/CMakeLists.txt
+++ b/core/dependencies/CMakeLists.txt
@@ -1,8 +1,11 @@
 # css-color-parser-cpp #
 ########################
 
-include_directories("css-color-parser-cpp")
 add_library(css-color-parser-cpp "css-color-parser-cpp/csscolorparser.cpp")
+target_include_directories(css-color-parser-cpp
+  PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/css-color-parser-cpp
+)
 
 # benchmark #
 #############
@@ -19,8 +22,11 @@ endif()
 
 add_definitions(-DNDEBUG)
 file(GLOB_RECURSE LIBTESS2_SOURCES "libtess2/Source/*.c")
-include_directories("libtess2/Include")
 add_library(tess2 ${LIBTESS2_SOURCES})
+target_include_directories(tess2
+  PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Include
+)
 
 # yaml-cpp #
 ############


### PR DESCRIPTION
When using target_include_directories the public includes will be inherited by other targets when referenced with target_link_libraries