### PR TITLE
use uint16 for indices

### DIFF
--- a/core/src/gl/typedMesh.h
+++ b/core/src/gl/typedMesh.h
@@ -17,7 +17,7 @@ public:
         : VboMesh(_vertexLayout, _drawMode, _hint, _keepMemoryData) {};
 
     void addVertices(std::vector<T>&& _vertices,
-                     std::vector<int>&& _indices) {
+                     std::vector<uint16_t>&& _indices) {
         m_vertices.push_back(_vertices);
         m_indices.push_back(_indices);
 
@@ -79,7 +79,7 @@ protected:
     void setDirty(GLintptr _byteOffset, GLsizei _byteSize);
 
     std::vector<std::vector<T>> m_vertices;
-    std::vector<std::vector<int>> m_indices;
+    std::vector<std::vector<uint16_t>> m_indices;
 
 };
 

--- a/core/src/gl/vboMesh.h
+++ b/core/src/gl/vboMesh.h
@@ -115,10 +115,10 @@ protected:
 
     template <typename T>
     void compile(std::vector<std::vector<T>>& _vertices,
-                 std::vector<std::vector<int>>& _indices) {
+                 std::vector<std::vector<uint16_t>>& _indices) {
 
         std::vector<std::vector<T>> vertices;
-        std::vector<std::vector<int>> indices;
+        std::vector<std::vector<uint16_t>> indices;
 
         // take over contents
         std::swap(_vertices, vertices);

--- a/core/src/scene/skybox.cpp
+++ b/core/src/scene/skybox.cpp
@@ -24,7 +24,7 @@ void Skybox::init() {
 
     m_mesh = std::unique_ptr<Mesh>(new Mesh(layout, GL_TRIANGLES, GL_STATIC_DRAW, true));
 
-    std::vector<int> indices = {
+    std::vector<uint16_t> indices = {
         5, 1, 3, 3, 7, 5, // +x
         6, 2, 0, 0, 4, 6, // -x
         2, 6, 7, 7, 3, 2, // +y

--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -163,7 +163,7 @@ inline void addPolyLineVertex(const glm::vec3& _coord, const glm::vec2& _normal,
 }
 
 // Helper function for polyline tesselation; adds indices for pairs of vertices arranged like a line strip
-void indexPairs( int _nPairs, int _nVertices, std::vector<int>& _indicesOut) {
+void indexPairs( int _nPairs, int _nVertices, std::vector<uint16_t>& _indicesOut) {
     for (int i = 0; i < _nPairs; i++) {
         _indicesOut.push_back(_nVertices - 2*i - 4);
         _indicesOut.push_back(_nVertices - 2*i - 2);

--- a/core/src/util/builders.h
+++ b/core/src/util/builders.h
@@ -37,7 +37,7 @@ typedef std::function<void(size_t reserve)> SizeHintFn;
  * see Builders::buildPolygon() and Builders::buildPolygonExtrusion()
  */
 struct PolygonBuilder {
-    std::vector<int> indices; // indices for drawing the polyon as triangles are added to this vector
+    std::vector<uint16_t> indices; // indices for drawing the polyon as triangles are added to this vector
     PolygonVertexFn addVertex;
     SizeHintFn sizeHint;
     size_t numVertices = 0;
@@ -60,7 +60,7 @@ typedef std::function<void(const glm::vec3& coord, const glm::vec2& enormal, con
  * see Builders::buildPolyLine()
  */
 struct PolyLineBuilder {
-    std::vector<int> indices; // indices for drawing the polyline as triangles are added to this vector
+    std::vector<uint16_t> indices; // indices for drawing the polyline as triangles are added to this vector
     PolyLineVertexFn addVertex;
     SizeHintFn sizeHint;
     size_t numVertices = 0;
@@ -81,7 +81,7 @@ typedef std::function<void(const glm::vec2& coord, const glm::vec2& screenPos, c
 /* SpriteBuidler context
  */
 struct SpriteBuilder {
-    std::vector<int> indices;
+    std::vector<uint16_t> indices;
     SpriteBuilderFn addVertex;
     size_t numVerts = 0;
 


### PR DESCRIPTION
A single mesh may not have more than max GLushort vertices so this
can already be restricted in mesh building.
(otherwise the vertex index will overflow VboMesh::compile)