### PR TITLE
Initialize Tangram before GL context creation

### DIFF
--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -63,8 +63,8 @@ extern "C" {
         Tangram::render();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_onContextDestroyed(JNIEnv* jniEnv, jobject obj) {
-        Tangram::onContextDestroyed();
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setupGL(JNIEnv* jniEnv, jobject obj) {
+        Tangram::setupGL();
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setPixelScale(JNIEnv* jniEnv, jobject obj, jfloat scale) {

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -334,6 +334,8 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
 
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
         init(this, assetManager, scenePath);
+        // init() is safe to call twice, this invocation ensures that the jni
+        // environment is attached to the rendering thread
         setupGL();
     }
 

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -88,6 +88,8 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
         view.setRenderer(this);
         view.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
 
+        init(this, assetManager, scenePath);
+
     }
 
     /**
@@ -110,9 +112,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @param lat Degrees latitude of the position to set
      */
     public void setMapPosition(double lon, double lat) {
-        mapLonLat[0] = lon;
-        mapLonLat[1] = lat;
-        if (initialized) { setPosition(lon, lat); }
+        setPosition(lon, lat);
     }
 
     /**
@@ -129,9 +129,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @return Degrees longitude and latitude of the current map position, in a two-element array
      */
     public double[] getMapPosition(double[] coordinatesOut) {
-        if (initialized) { getPosition(mapLonLat); }
-        coordinatesOut[0] = mapLonLat[0];
-        coordinatesOut[1] = mapLonLat[1];
+        getPosition(coordinatesOut);
         return coordinatesOut;
     }
 
@@ -140,8 +138,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @param zoom Fractional zoom level
      */
     public void setMapZoom(float zoom) {
-        mapZoom = zoom;
-        if (initialized) { setZoom(zoom); }
+        setZoom(zoom);
     }
 
     /**
@@ -149,8 +146,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @return Fractional zoom level
      */
     public float getMapZoom() {
-        if (initialized) { mapZoom = getZoom(); }
-        return mapZoom;
+        return getZoom();
     }
 
     /**
@@ -158,8 +154,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @param radians Rotation in radians
      */
     public void setMapRotation(float radians) {
-        mapRotation = radians;
-        if (initialized) { setRotation(radians); }
+        setRotation(radians);
     }
 
     /**
@@ -167,8 +162,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @return Rotation in radians
      */
     public float getMapRotation() {
-        if (initialized) { mapRotation = getRotation(); }
-        return mapRotation;
+        return getRotation();
     }
 
     /**
@@ -176,8 +170,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @param radians Tilt angle in radians
      */
     public void setMapTilt(float radians) {
-        mapTilt = radians;
-        if (initialized) { setTilt(radians); }
+        setTilt(radians);
     }
 
     /**
@@ -185,8 +178,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @return Tilt angle in radians
      */
     public float getMapTilt() {
-        if (initialized) { mapTilt = getTilt(); }
-        return mapTilt;
+        return getTilt();
     }
 
     /**
@@ -206,7 +198,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
      * @return Degrees longitude and latitude corresponding to the given point, in a two-element array
      */
     public double[] coordinatesAtScreenPosition(double[] coordinatesInOut) {
-        if (initialized) { screenToWorldCoordinates(coordinatesInOut); }
+        screenToWorldCoordinates(coordinatesInOut);
         return coordinatesInOut;
     }
 
@@ -278,11 +270,6 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
 
     private String scenePath;
     private long time = System.nanoTime();
-    private boolean initialized = false;
-    private double[] mapLonLat = {0, 0};
-    private float mapZoom = 0;
-    private float mapRotation = 0;
-    private float mapTilt = 0;
     private MapView mapView;
     private AssetManager assetManager;
     private GestureDetector gestureDetector;
@@ -348,11 +335,6 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
         onContextDestroyed();
         init(this, assetManager, scenePath);
-        setPosition(mapLonLat[0], mapLonLat[1]);
-        setZoom(mapZoom);
-        setRotation(mapRotation);
-        setTilt(mapTilt);
-        initialized = true;
     }
 
     // GestureDetector.OnDoubleTapListener methods

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -242,6 +242,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
     // ==============
 
     private synchronized native void init(MapController instance, AssetManager assetManager, String stylePath);
+    private synchronized native void setupGL();
     private synchronized native void resize(int width, int height);
     private synchronized native void update(float dt);
     private synchronized native void render();
@@ -254,7 +255,6 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
     private synchronized native void setTilt(float radians);
     private synchronized native float getTilt();
     private synchronized native void screenToWorldCoordinates(double[] screenCoords);
-    private synchronized native void onContextDestroyed();
     private synchronized native void setPixelScale(float scale);
     private synchronized native void handleTapGesture(float posX, float posY);
     private synchronized native void handleDoubleTapGesture(float posX, float posY);
@@ -333,8 +333,8 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
     }
 
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
-        onContextDestroyed();
         init(this, assetManager, scenePath);
+        setupGL();
     }
 
     // GestureDetector.OnDoubleTapListener methods

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -37,7 +37,6 @@ Texture::Texture(const std::string& _file, TextureOptions _options, bool _genera
 
     resize(width, height);
     setData(reinterpret_cast<GLuint*>(pixels), width * height);
-    update(0);
 
     free(data);
     stbi_image_free(pixels);

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -56,7 +56,6 @@ void TextureCube::load(const std::string& _file) {
     free(data);
     stbi_image_free(pixels);
 
-    update(0);
 }
 
 void TextureCube::update(GLuint _textureUnit) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -308,6 +308,8 @@ void setupGL() {
     RenderState::configure();
 
     Primitives::setColor(0xffffff);
+
+    while (Error::hadGlError("Tangram::setupGL()")) {}
 }
 
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -69,11 +69,7 @@ void initialize(const char* _scenePath) {
 
         loader.loadScene(sceneString, *m_scene, *m_tileManager, *m_view);
 
-        Primitives::setColor(0xffffff);
-        RenderState::configure();
     }
-
-    while (Error::hadGlError("Tangram::initialize()")) {}
 
     logMsg("finish initialize\n");
 
@@ -310,6 +306,8 @@ void onContextDestroyed() {
 
     // Reconfigure the render states
     RenderState::configure();
+
+    Primitives::setColor(0xffffff);
 }
 
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -280,9 +280,9 @@ void toggleDebugFlag(DebugFlags _flag) {
 
 }
 
-void onContextDestroyed() {
+void setupGL() {
 
-    logMsg("context destroyed\n");
+    logMsg("setup GL\n");
 
     if (m_tileManager) {
         m_tileManager->clearTileSets();

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -12,6 +12,9 @@ namespace Tangram {
 // Create resources and initialize the map view using the scene file at the given resource path
 void initialize(const char* _scenePath);
 
+// Initialize graphics resources; OpenGL context must be created prior to calling this
+void setupGL();
+
 // Resize the map view to a new width and height (in pixels)
 void resize(int _newWidth, int _newHeight);
 
@@ -47,9 +50,6 @@ float getTilt();
 
 // Transform coordinates in screen space (x right, y down) into their longitude and latitude in the map view
 void screenToWorldCoordinates(double& _x, double& _y);
-
-// Invalidate and re-create all OpenGL resources
-void onContextDestroyed();
 
 // Set the ratio of hardware pixels to logical pixels (defaults to 1.0)
 void setPixelScale(float _pixelsPerPoint);

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -194,6 +194,7 @@
     [EAGLContext setCurrentContext:self.context];
     
     Tangram::initialize("scene.yaml");
+    Tangram::setupGL();
     
     int width = self.view.bounds.size.width;
     int height = self.view.bounds.size.height;
@@ -205,8 +206,6 @@
 
 - (void)tearDownGL
 {
-    [EAGLContext setCurrentContext:self.context];
-    Tangram::onContextDestroyed();
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -130,12 +130,12 @@ void window_size_callback(GLFWwindow* window, int width, int height) {
 
 void init_main_window() {
 
-    bool contextDestroyed = false;
+    // Setup tangram
+    Tangram::initialize("scene.yaml");
 
     // Destroy old window
     if (main_window != nullptr) {
         glfwDestroyWindow(main_window);
-        contextDestroyed = true;
     }
 
     // Create a windowed mode window and its OpenGL context
@@ -148,10 +148,6 @@ void init_main_window() {
     // Make the main_window's context current
     glfwMakeContextCurrent(main_window);
 
-    if (contextDestroyed) {
-        Tangram::onContextDestroyed();
-    }
-
     // Set input callbacks
     glfwSetWindowSizeCallback(main_window, window_size_callback);
     glfwSetMouseButtonCallback(main_window, mouse_button_callback);
@@ -159,8 +155,8 @@ void init_main_window() {
     glfwSetScrollCallback(main_window, scroll_callback);
     glfwSetKeyCallback(main_window, key_callback);
 
-    // Setup tangram
-    Tangram::initialize("scene.yaml");
+    // Setup graphics
+    Tangram::setupGL();
     Tangram::resize(width, height);
 
 }

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -130,11 +130,12 @@ void window_size_callback(GLFWwindow* window, int width, int height) {
 
 void init_main_window() {
 
+    // Setup tangram
+    Tangram::initialize("scene.yaml");
+
     // Destroy old window
-    bool contextDestroyed = false;
     if (main_window != nullptr) {
         glfwDestroyWindow(main_window);
-        contextDestroyed = true;
     }
 
     // Create a windowed mode window and its OpenGL context
@@ -147,10 +148,6 @@ void init_main_window() {
     // Make the main_window's context current
     glfwMakeContextCurrent(main_window);
     
-    if (contextDestroyed) {
-        Tangram::onContextDestroyed();
-    }
-    
     // Set input callbacks
     glfwSetWindowSizeCallback(main_window, window_size_callback);
     glfwSetMouseButtonCallback(main_window, mouse_button_callback);
@@ -158,8 +155,8 @@ void init_main_window() {
     glfwSetScrollCallback(main_window, scroll_callback);
     glfwSetKeyCallback(main_window, key_callback);
     
-    // Setup tangram
-    Tangram::initialize("scene.yaml");
+    // Setup graphics
+    Tangram::setupGL();
     Tangram::resize(width, height);
 
     // Work-around for a bug in GLFW on retina displays

--- a/rpi/src/main.cpp
+++ b/rpi/src/main.cpp
@@ -44,6 +44,7 @@ int main(int argc, char **argv){
 
     // Set background color and clear buffers
     Tangram::initialize("scene.yaml");
+    Tangram::setupGL();
     Tangram::resize(getWindowWidth(), getWindowHeight());
 
     setup();


### PR DESCRIPTION
This is important primarily for Android, where the time at which the GL context is created is not necessarily the same as the time of application creation. Previously I had to store some state variables in `MapController` and wait until `MapView` called `onSurfaceCreated` before I could make any native calls. The Android library still has issues around the idea of a tangram "instance" (i.e. there's no such thing) but this helps a bit. 