### PR TITLE
Blend modes

### DIFF
--- a/core/resources/shaders/debug.vs
+++ b/core/resources/shaders/debug.vs
@@ -14,5 +14,4 @@ void main() {
     v_color = a_color;
 
     gl_Position = u_modelViewProj * a_position;
-    gl_Position.z = 0.0; // Debug geometry draws above everything else
 }

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -10,7 +10,7 @@
 
 namespace Tangram {
 
-DebugStyle::DebugStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
+DebugStyle::DebugStyle(std::string _name, Blending _blendMode, GLenum _drawMode) : Style(_name, _blendMode, _drawMode) {
 }
 
 void DebugStyle::constructVertexLayout() {

--- a/core/src/style/debugStyle.h
+++ b/core/src/style/debugStyle.h
@@ -29,7 +29,7 @@ protected:
 public:
 
     DebugStyle(GLenum _drawMode = GL_LINE_LOOP);
-    DebugStyle(std::string _name, GLenum _drawMode = GL_LINE_LOOP);
+    DebugStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_LINE_LOOP);
 
     virtual ~DebugStyle() {
     }

--- a/core/src/style/debugStyle.h
+++ b/core/src/style/debugStyle.h
@@ -28,13 +28,10 @@ protected:
 
 public:
 
-    DebugStyle(GLenum _drawMode = GL_LINE_LOOP);
     DebugStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_LINE_LOOP);
 
     virtual ~DebugStyle() {
     }
-
-    virtual bool isOpaque() const override { return false; };
 
 };
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -6,8 +6,8 @@
 
 namespace Tangram {
 
-DebugTextStyle::DebugTextStyle(const std::string& _fontName, std::string _name, float _fontSize, bool _sdf, bool _sdfMultisampling, GLenum _drawMode)
-: TextStyle(_name, _sdf, _sdfMultisampling, _drawMode), m_fontName(_fontName), m_fontSize(_fontSize) {
+DebugTextStyle::DebugTextStyle(const std::string& _fontName, std::string _name, float _fontSize, bool _sdf, bool _sdfMultisampling, Blending _blendMode, GLenum _drawMode)
+: TextStyle(_name, _sdf, _sdfMultisampling, _blendMode, _drawMode), m_fontName(_fontName), m_fontSize(_fontSize) {
 }
 
 void DebugTextStyle::onBeginBuildTile(Tangram::Tile &_tile) const {

--- a/core/src/style/debugTextStyle.h
+++ b/core/src/style/debugTextStyle.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    DebugTextStyle(const std::string& _fontName, std::string _name, float _fontSize, bool _sdf = false, bool _sdfMultisampling = false, GLenum _drawMode = GL_TRIANGLES);
+    DebugTextStyle(const std::string& _fontName, std::string _name, float _fontSize, bool _sdf = false, bool _sdfMultisampling = false, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
 
     std::string m_fontName;
     float m_fontSize;

--- a/core/src/style/debugTextStyle.h
+++ b/core/src/style/debugTextStyle.h
@@ -17,8 +17,6 @@ public:
 
     std::string m_fontName;
     float m_fontSize;
-
-    virtual bool isOpaque() const override { return false; };
 };
 
 }

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -9,7 +9,7 @@
 
 namespace Tangram {
 
-PolygonStyle::PolygonStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
+PolygonStyle::PolygonStyle(std::string _name, Blending _blendMode, GLenum _drawMode) : Style(_name, _blendMode, _drawMode) {
 }
 
 void PolygonStyle::constructVertexLayout() {

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -44,7 +44,7 @@ protected:
 public:
 
     PolygonStyle(GLenum _drawMode = GL_TRIANGLES);
-    PolygonStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);
+    PolygonStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
 
     virtual ~PolygonStyle() {
     }

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -43,7 +43,6 @@ protected:
 
 public:
 
-    PolygonStyle(GLenum _drawMode = GL_TRIANGLES);
     PolygonStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
 
     virtual ~PolygonStyle() {

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -6,7 +6,7 @@
 
 namespace Tangram {
 
-PolylineStyle::PolylineStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
+PolylineStyle::PolylineStyle(std::string _name, Blending _blendMode, GLenum _drawMode) : Style(_name, _blendMode, _drawMode) {
 }
 
 void PolylineStyle::constructVertexLayout() {

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -50,7 +50,6 @@ protected:
 
 public:
 
-    PolylineStyle(GLenum _drawMode = GL_TRIANGLES);
     PolylineStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
 
     virtual ~PolylineStyle() {

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -51,7 +51,7 @@ protected:
 public:
 
     PolylineStyle(GLenum _drawMode = GL_TRIANGLES);
-    PolylineStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);
+    PolylineStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
 
     virtual ~PolylineStyle() {
     }

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -13,7 +13,7 @@
 
 namespace Tangram {
 
-SpriteStyle::SpriteStyle(std::string _name, GLenum _drawMode) : Style(_name, _drawMode) {
+SpriteStyle::SpriteStyle(std::string _name, Blending _blendMode, GLenum _drawMode) : Style(_name, _blendMode, _drawMode) {
 }
 
 SpriteStyle::~SpriteStyle() {}
@@ -117,9 +117,7 @@ void SpriteStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
         m_dirtyViewport = false;
     }
 
-    RenderState::blending(GL_TRUE);
-    RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    RenderState::depthTest(GL_FALSE);
+    Style::onBeginDrawFrame(_view, _scene);
 }
 
 }

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -32,7 +32,7 @@ public:
 
     virtual void onBeginDrawFrame(const View& _view, const Scene& _scene) override;
 
-    SpriteStyle(std::string _name, GLenum _drawMode = GL_TRIANGLES);
+    SpriteStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
 
     virtual ~SpriteStyle();
 

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -28,8 +28,6 @@ protected:
 
 public:
 
-    bool isOpaque() const override { return false; }
-
     virtual void onBeginDrawFrame(const View& _view, const Scene& _scene) override;
 
     SpriteStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -9,8 +9,9 @@
 
 namespace Tangram {
 
-Style::Style(std::string _name, GLenum _drawMode) :
+    Style::Style(std::string _name, Blending _blendMode, GLenum _drawMode) :
     m_name(_name),
+    m_blend(_blendMode),
     m_drawMode(_drawMode),
     m_contextLost(true) {
 }
@@ -94,9 +95,41 @@ void Style::onBeginDrawFrame(const View& _view, const Scene& _scene) {
 
     m_shaderProgram->setUniformf("u_zoom", _view.getZoom());
     
-    // default capabilities
-    RenderState::blending(GL_FALSE);
-    RenderState::depthTest(GL_TRUE);
+    // Configure render state
+    switch (m_blend) {
+        case Blending::none:
+            RenderState::blending(GL_FALSE);
+            RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            RenderState::depthTest(GL_TRUE);
+            RenderState::depthWrite(GL_TRUE);
+            break;
+        case Blending::add:
+            RenderState::blending(GL_TRUE);
+            RenderState::blendingFunc(GL_ONE, GL_ONE);
+            RenderState::depthTest(GL_FALSE);
+            RenderState::depthWrite(GL_TRUE);
+            break;
+        case Blending::multiply:
+            RenderState::blending(GL_TRUE);
+            RenderState::blendingFunc(GL_ZERO, GL_SRC_COLOR);
+            RenderState::depthTest(GL_FALSE);
+            RenderState::depthWrite(GL_TRUE);
+            break;
+        case Blending::overlay:
+            RenderState::blending(GL_TRUE);
+            RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            RenderState::depthTest(GL_FALSE);
+            RenderState::depthWrite(GL_FALSE);
+            break;
+        case Blending::inlay:
+            RenderState::blending(GL_TRUE);
+            RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            RenderState::depthTest(GL_TRUE);
+            RenderState::depthWrite(GL_FALSE);
+            break;
+        default:
+            break;
+    }
 }
 
 void Style::onBeginBuildTile(Tile& _tile) const {

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -122,6 +122,7 @@ void Style::onBeginDrawFrame(const View& _view, const Scene& _scene) {
             RenderState::depthWrite(GL_FALSE);
             break;
         case Blending::inlay:
+            // TODO: inlay does not behave correctly for labels because they don't have a z position
             RenderState::blending(GL_TRUE);
             RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             RenderState::depthTest(GL_TRUE);

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -113,7 +113,7 @@ public:
     void viewportHasChanged() { m_dirtyViewport = true; }
 
     /* Whether or not the style uses blending operation for drawing */
-    virtual bool isOpaque() const { return true; };
+    bool isOpaque() const { return m_blend == Blending::none; };
 
     /* Make this style ready to be used (call after all needed properties are set) */
     virtual void build(const std::vector<std::unique_ptr<Light>>& _lights);

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -28,6 +28,14 @@ enum class LightingType : char {
     fragment
 };
 
+enum class Blending : char {
+    none,
+    add,
+    multiply,
+    overlay,
+    inlay,
+};
+
 /* Means of constructing and rendering map geometry
  *
  * A Style defines a way to
@@ -59,6 +67,8 @@ protected:
 
     /* <LightingType> to determine how lighting will be calculated for this style */
     LightingType m_lightingType = LightingType::fragment;
+    
+    Blending m_blend = Blending::none;
 
     /* Draw mode to pass into <VboMesh>es created with this style */
     GLenum m_drawMode;
@@ -94,7 +104,7 @@ private:
 
 public:
 
-    Style(std::string _name, GLenum _drawMode);
+    Style(std::string _name, Blending _blendMode, GLenum _drawMode);
 
     virtual ~Style();
     

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -112,8 +112,9 @@ public:
 
     void viewportHasChanged() { m_dirtyViewport = true; }
 
-    /* Whether or not the style uses blending operation for drawing */
-    bool isOpaque() const { return m_blend == Blending::none; };
+    Blending blendMode() const { return m_blend; };
+
+    void setBlendMode(Blending _blendMode) { m_blend = _blendMode; }
 
     /* Make this style ready to be used (call after all needed properties are set) */
     virtual void build(const std::vector<std::unique_ptr<Light>>& _lights);

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -12,10 +12,9 @@ namespace Tangram {
 
 const static std::string key_name("name");
 
-TextStyle::TextStyle(std::string _name, bool _sdf, bool _sdfMultisampling, GLenum _drawMode) :
-    Style(_name, _drawMode), m_sdf(_sdf), m_sdfMultisampling(_sdfMultisampling) {
-        logMsg("multisam: %d\n", _sdfMultisampling);
-    }
+TextStyle::TextStyle(std::string _name, bool _sdf, bool _sdfMultisampling, Blending _blendMode, GLenum _drawMode) :
+    Style(_name, _blendMode, _drawMode), m_sdf(_sdf), m_sdfMultisampling(_sdfMultisampling) {
+}
 
 TextStyle::~TextStyle() {
 }
@@ -175,10 +174,9 @@ void TextStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
         m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getOrthoViewportMatrix()));
         m_dirtyViewport = false;
     }
+    
+    Style::onBeginDrawFrame(_view, _scene);
 
-    RenderState::blending(GL_TRUE);
-    RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    RenderState::depthTest(GL_FALSE);
 }
 
 }

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -32,8 +32,6 @@ protected:
 
 public:
 
-    bool isOpaque() const override { return false; }
-
     TextStyle(std::string _name, bool _sdf = false, bool _sdfMultisampling = false, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
 
     virtual void onBeginDrawFrame(const View& _view, const Scene& _scene) override;

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -34,7 +34,7 @@ public:
 
     bool isOpaque() const override { return false; }
 
-    TextStyle(std::string _name,  bool _sdf = false, bool _sdfMultisampling = false, GLenum _drawMode = GL_TRIANGLES);
+    TextStyle(std::string _name, bool _sdf = false, bool _sdfMultisampling = false, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
 
     virtual void onBeginDrawFrame(const View& _view, const Scene& _scene) override;
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -120,6 +120,7 @@ void update(float _dt) {
 void render() {
 
     // Set up openGL for new frame
+    RenderState::depthWrite(GL_TRUE);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     // Loop over all styles


### PR DESCRIPTION
This enables blend modes configured per-style. 

Note that the `inlay` blend mode won't behave correctly for text and sprites because they don't render in the same 3D coordinate space as other geometry; this can be addressed separately. 