### PR TITLE
Text source option

### DIFF
--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -180,6 +180,22 @@ layers:
             draw:
                 heightglow:
                     extrude: true
+        label_building:
+            filter: { name: true, height: true }
+            draw:
+                text:
+                    text_source: |
+                        function() {
+                            if (feature.height > 100) { return 'high'; }
+                            else { return 'low'; }
+                        }
+                    priority: 0
+                    font:
+                        family: sans-serif
+                        weight: 400
+                        style: normal
+                        size: 1.5em
+                        fill: yellow
         high-line:
             filter: {roof_material: grass}
             draw:
@@ -245,7 +261,7 @@ layers:
         filter:
             name: true
             not: { kind: [county, state, island] }
-            any: 
+            any:
                 - { $zoom: { min: 1 }, kind: ocean }
                 - { $zoom: { min: 2, max: 5 }, kind: continent }
                 #important contries

--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -180,8 +180,6 @@ layers:
             draw:
                 heightglow:
                     extrude: true
-        label_building:
-            filter: { name: true, height: true }
         high-line:
             filter: {roof_material: grass}
             draw:

--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -103,6 +103,16 @@ layers:
             polygons:
                 order: 3
                 color: '#9dc3de'
+        label_water:
+            draw:
+                text:
+                    text_source: kind
+                    font:
+                        family: sans-serif
+                        weight: 400
+                        style: normal
+                        size: 1.2em
+                        fill: magenta
 
     roads:
         data: { source: osm }
@@ -184,10 +194,11 @@ layers:
             filter: { name: true, height: true }
             draw:
                 text:
+                    #text_source: kind
                     text_source: |
                         function() {
                             if (feature.height > 100) { return 'high'; }
-                            else { return 'low'; }
+                           else { return 'low'; }
                         }
                     priority: 0
                     font:

--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -103,16 +103,6 @@ layers:
             polygons:
                 order: 3
                 color: '#9dc3de'
-        label_water:
-            draw:
-                text:
-                    text_source: kind
-                    font:
-                        family: sans-serif
-                        weight: 400
-                        style: normal
-                        size: 1.2em
-                        fill: magenta
 
     roads:
         data: { source: osm }
@@ -192,21 +182,6 @@ layers:
                     extrude: true
         label_building:
             filter: { name: true, height: true }
-            draw:
-                text:
-                    #text_source: kind
-                    text_source: |
-                        function() {
-                            if (feature.height > 100) { return 'high'; }
-                           else { return 'low'; }
-                        }
-                    priority: 0
-                    font:
-                        family: sans-serif
-                        weight: 400
-                        style: normal
-                        size: 1.5em
-                        fill: yellow
         high-line:
             filter: {roof_material: grass}
             draw:
@@ -282,7 +257,7 @@ layers:
                 # this function matches the "cities" sublayer
                 #- function() {return (feature.scalerank * .75) <= ($zoom - 4); }
         draw:
-            text: 
+            text:
                 priority: 5
                 font:
                     family: sans-serif
@@ -302,7 +277,7 @@ layers:
         minor-places:
             filter: { kind: [hamlet, village, town, neighbourhood, suburb, quarter], $zoom: { max: 13 } }
             draw: {}
-            #visible: false 
+            #visible: false
         #cities:
             # this filter shows lower scaleranks at higher zooms, starting at z4
             #filter: function() { return (feature.scalerank * .75) <= ($zoom - 4); }

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -65,6 +65,14 @@ const StyleParam& DrawRule::findParameter(StyleParamKey _key) const {
     return NONE;
 }
 
+bool DrawRule::isJSFunction(StyleParamKey _key) const {
+    auto& param = findParameter(_key);
+    if (!param) {
+        return false;
+    }
+    return param.function >= 0;
+}
+
 bool DrawRule::operator<(const DrawRule& _rhs) const {
     return style < _rhs.style;
 }

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -8,8 +8,6 @@
 
 namespace Tangram {
 
-using Function = std::string;
-
 class StyleContext;
 
 struct DrawRule {

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -24,6 +24,8 @@ struct DrawRule {
 
     const StyleParam& findParameter(StyleParamKey _key) const;
 
+    bool isJSFunction(StyleParamKey _key) const;
+
     template<typename T>
     bool get(StyleParamKey _key, T& _value) const {
         auto& param = findParameter(_key);

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -30,6 +30,7 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"outline:width", StyleParamKey::outline_width},
     {"priority", StyleParamKey::priority},
     {"sprite", StyleParamKey::sprite},
+    {"text_source", StyleParamKey::text_source},
     {"transform", StyleParamKey::transform},
     {"visible", StyleParamKey::visible},
     {"width", StyleParamKey::width},
@@ -79,6 +80,7 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::font_family:
     case StyleParamKey::font_weight:
     case StyleParamKey::font_style:
+    case StyleParamKey::text_source:
     case StyleParamKey::transform:
     case StyleParamKey::sprite:
         return _value;
@@ -161,6 +163,7 @@ std::string StyleParam::toString() const {
     case StyleParamKey::font_family:
     case StyleParamKey::font_weight:
     case StyleParamKey::font_style:
+    case StyleParamKey::text_source:
     case StyleParamKey::transform:
     case StyleParamKey::sprite:
         if (!value.is<std::string>()) break;

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -9,6 +9,7 @@
 namespace Tangram {
 
 using Color = CSSColorParser::Color;
+using Function = std::string;
 
 enum class StyleParamKey : uint8_t {
     cap,
@@ -32,6 +33,7 @@ enum class StyleParamKey : uint8_t {
     outline_width,
     priority,
     sprite,
+    text_source,
     transform,
     visible,
     width,

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -97,13 +97,15 @@ Label::Options TextStyle::optionsFromTextParams(const Parameters& _params) const
 
 const std::string& TextStyle::applyTextSource(const Parameters& _parameters, const Properties& _props) const {
 
-    if (_parameters.textSource.text.empty()) {
-        // Default: use 'name' property
-        return _props.getString("name");
-    }
+    const static std::string key_name("name");
 
     if (_parameters.textSource.isFunction) {
         return _parameters.textSource.text;
+    }
+
+    if (_parameters.textSource.text.empty()) {
+        // Default: use 'name' property
+        return _props.getString(key_name);
     } else {
         return _props.getString(_parameters.textSource.text);
     }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -70,7 +70,8 @@ Parameters TextStyle::parseRule(const DrawRule& _rule) const {
     _rule.get(StyleParamKey::transform, transform);
     _rule.get(StyleParamKey::visible, p.visible);
     _rule.get(StyleParamKey::priority, p.priority);
-    _rule.get(StyleParamKey::text_source, p.textSource);
+    _rule.get(StyleParamKey::text_source, p.textSource.second);
+    p.textSource.first = _rule.isJSFunction(StyleParamKey::text_source);
 
     if (transform == capitalize) {
         p.transform = TextTransform::capitalize;
@@ -99,9 +100,12 @@ Label::Options TextStyle::optionsFromTextParams(const Parameters& _params) const
 }
 
 const std::string& TextStyle::applyTextSource(const Parameters& _parameters, const Properties& _props) const {
-    if (!_parameters.textSource.empty()) {
-        // TODO: check whether the text source was a js function
-        return _parameters.textSource;
+    if (!_parameters.textSource.second.empty()) {
+        if (_parameters.textSource.first) {
+            return _parameters.textSource.second;
+        } else {
+            return _props.getString(_parameters.textSource.second);
+        }
     }
     return _props.getString(key_name);
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -70,8 +70,9 @@ Parameters TextStyle::parseRule(const DrawRule& _rule) const {
     _rule.get(StyleParamKey::transform, transform);
     _rule.get(StyleParamKey::visible, p.visible);
     _rule.get(StyleParamKey::priority, p.priority);
-    _rule.get(StyleParamKey::text_source, p.textSource.second);
-    p.textSource.first = _rule.isJSFunction(StyleParamKey::text_source);
+    if (_rule.get(StyleParamKey::text_source, p.textSource.text)) {
+        p.textSource.isFunction = _rule.isJSFunction(StyleParamKey::text_source);
+    }
 
     if (transform == capitalize) {
         p.transform = TextTransform::capitalize;
@@ -100,14 +101,17 @@ Label::Options TextStyle::optionsFromTextParams(const Parameters& _params) const
 }
 
 const std::string& TextStyle::applyTextSource(const Parameters& _parameters, const Properties& _props) const {
-    if (!_parameters.textSource.second.empty()) {
-        if (_parameters.textSource.first) {
-            return _parameters.textSource.second;
-        } else {
-            return _props.getString(_parameters.textSource.second);
-        }
+
+    if (_parameters.textSource.text.empty()) {
+        // Default: use 'name' property
+        return _props.getString(key_name);
     }
-    return _props.getString(key_name);
+
+    if (_parameters.textSource.isFunction) {
+        return _parameters.textSource.text;
+    } else {
+        return _props.getString(_parameters.textSource.text);
+    }
 }
 
 void TextStyle::buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -119,7 +119,7 @@ void TextStyle::buildPoint(const Point& _point, const DrawRule& _rule, const Pro
         return;
     }
 
-    const std::string text = applyTextSource(params, _props);
+    const std::string& text = applyTextSource(params, _props);
 
     if (text.length() == 0) { return; }
 
@@ -135,7 +135,7 @@ void TextStyle::buildLine(const Line& _line, const DrawRule& _rule, const Proper
         return;
     }
 
-    const std::string text = applyTextSource(params, _props);
+    const std::string& text = applyTextSource(params, _props);
 
     if (text.length() == 0) { return; }
 
@@ -169,7 +169,7 @@ void TextStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, con
         return;
     }
 
-    const std::string text = applyTextSource(params, _props);
+    const std::string& text = applyTextSource(params, _props);
 
     if (text.length() == 0) { return; }
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -126,14 +126,13 @@ void TextStyle::buildPoint(const Point& _point, const DrawRule& _rule, const Pro
     const std::string& text = applyTextSource(params, _props);
 
     if (text.length() == 0) { return; }
-
     buffer.addLabel(text, { glm::vec2(_point), glm::vec2(_point) }, Label::Type::point, params, optionsFromTextParams(params));
 }
 
 void TextStyle::buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
 
-	Parameters params = parseRule(_rule);
+    Parameters params = parseRule(_rule);
 
     if (!params.visible) {
         return;
@@ -167,7 +166,7 @@ void TextStyle::buildLine(const Line& _line, const DrawRule& _rule, const Proper
 void TextStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     auto& buffer = static_cast<TextBuffer&>(_mesh);
 
-	Parameters params = parseRule(_rule);
+    Parameters params = parseRule(_rule);
 
     if (!params.visible) {
         return;
@@ -208,7 +207,7 @@ void TextStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
         m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getOrthoViewportMatrix()));
         m_dirtyViewport = false;
     }
-    
+
     Style::onBeginDrawFrame(_view, _scene);
 
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -11,11 +11,6 @@
 
 namespace Tangram {
 
-const static std::string key_name("name");
-const static std::string uppercase("uppercase");
-const static std::string lowercase("lowercase");
-const static std::string capitalize("capitalize");
-
 TextStyle::TextStyle(std::string _name, bool _sdf, bool _sdfMultisampling, Blending _blendMode, GLenum _drawMode) :
     Style(_name, _blendMode, _drawMode), m_sdf(_sdf), m_sdfMultisampling(_sdfMultisampling) {
 }
@@ -74,11 +69,11 @@ Parameters TextStyle::parseRule(const DrawRule& _rule) const {
         p.textSource.isFunction = _rule.isJSFunction(StyleParamKey::text_source);
     }
 
-    if (transform == capitalize) {
+    if (transform == "capitalize") {
         p.transform = TextTransform::capitalize;
-    } else if (transform == lowercase) {
+    } else if (transform == "lowercase") {
         p.transform = TextTransform::lowercase;
-    } else if (transform == uppercase) {
+    } else if (transform == "uppercase") {
         p.transform = TextTransform::uppercase;
     }
 
@@ -104,7 +99,7 @@ const std::string& TextStyle::applyTextSource(const Parameters& _parameters, con
 
     if (_parameters.textSource.text.empty()) {
         // Default: use 'name' property
-        return _props.getString(key_name);
+        return _props.getString("name");
     }
 
     if (_parameters.textSource.isFunction) {

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -42,6 +42,8 @@ private:
 
     inline Label::Options optionsFromTextParams(const Parameters& _params) const;
 
+    const std::string& applyTextSource(const Parameters& _parameters, const Properties& _props) const;
+
 };
 
 }

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -33,7 +33,7 @@ struct Parameters {
     uint32_t priority = std::numeric_limits<uint32_t>::max();
     glm::vec2 offset;
     struct {
-        bool isFunction;
+        bool isFunction = false;
         std::string text;
     } textSource;
 };

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -32,6 +32,7 @@ struct Parameters {
     bool visible = true;
     uint32_t priority = std::numeric_limits<uint32_t>::max();
     glm::vec2 offset;
+    std::string textSource;
 };
 
 /*

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -32,7 +32,7 @@ struct Parameters {
     bool visible = true;
     uint32_t priority = std::numeric_limits<uint32_t>::max();
     glm::vec2 offset;
-    std::string textSource;
+    std::pair<bool, std::string> textSource;
 };
 
 /*

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -32,7 +32,10 @@ struct Parameters {
     bool visible = true;
     uint32_t priority = std::numeric_limits<uint32_t>::max();
     glm::vec2 offset;
-    std::pair<bool, std::string> textSource;
+    struct {
+        bool isFunction;
+        std::string text;
+    } textSource;
 };
 
 /*


### PR DESCRIPTION
As descibed in [tangram docs](https://github.com/tangrams/tangram-docs/blob/c834ed2013fc6d5734acb9eb0c7028066533a01b/pages/draw.md#text_source).

- [x] text source as a js function
- [x] text source as a non-js function