### PR TITLE
Style mixing

### DIFF
--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -36,7 +36,7 @@ textures:
 
 styles:
     pillows:
-        base: polygon
+        base: polygons
         lighting: fragment
         material:
             normal:
@@ -50,7 +50,7 @@ styles:
                 color: "color.rgb += vec3(0.5, 0.0, 0.0);"
 
     heightglow:
-        base: polygon
+        base: polygons
         mix: testStyle
         lighting: vertex
         shaders:

--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -44,8 +44,14 @@ styles:
                 mapping: uv
             diffuse: 0.75
 
+    testStyle:
+        shaders:
+            blocks:
+                color: "color.rgb += vec3(0.5, 0.0, 0.0);"
+
     heightglow:
         base: polygon
+        mix: testStyle
         lighting: vertex
         shaders:
             blocks:

--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -32,14 +32,8 @@ textures:
             bookstore: [0, 333, 32, 32]
 
 styles:
-    testStyle:
-        shaders:
-            blocks:
-                color: "color.rgb += vec3(0.5, 0.0, 0.0);"
-
     heightglow:
         base: polygons
-        mix: testStyle
         lighting: vertex
         shaders:
             blocks:

--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -13,9 +13,6 @@ lights:
         ambient: [0.7, 0.7, 0.7, 1.]
 
 textures:
-    water-texture:
-        url: normals.jpg
-        filtering: nearest
     pois:
         url: poi_icons_32.png
         sprites:
@@ -35,15 +32,6 @@ textures:
             bookstore: [0, 333, 32, 32]
 
 styles:
-    pillows:
-        base: polygons
-        lighting: fragment
-        material:
-            normal:
-                texture: water-texture
-                mapping: uv
-            diffuse: 0.75
-
     testStyle:
         shaders:
             blocks:

--- a/core/resources/shaders/point.vs
+++ b/core/resources/shaders/point.vs
@@ -1,9 +1,13 @@
+#pragma tangram: extensions
+
 #ifdef GL_ES
 precision mediump float;
 #define LOWP lowp
 #else
 #define LOWP
 #endif
+
+#pragma tangram: defines
 
 attribute LOWP vec2 a_position;
 attribute LOWP vec2 a_screenPosition;
@@ -14,23 +18,29 @@ attribute LOWP vec4 a_color;
 
 uniform mat4 u_proj;
 
+#pragma tangram: uniforms
+
 varying vec2 v_uv;
 varying float v_alpha;
 varying vec4 v_color;
+
+#pragma tangram: global
 
 void main() {
     if (a_alpha > TANGRAM_EPSILON) {
         float st = sin(a_rotation);
         float ct = cos(a_rotation);
 
+        #pragma tangram: position
+
         // rotates first around +z-axis (0,0,1) and then translates by (tx,ty,0)
-        vec4 p = vec4(
+        vec4 position = vec4(
             a_position.x * ct - a_position.y * st + a_screenPosition.x,
             a_position.x * st + a_position.y * ct + a_screenPosition.y,
             0.0, 1.0
         );
 
-        gl_Position = u_proj * p;
+        gl_Position = u_proj * position;
     } else {
         gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
     }

--- a/core/resources/shaders/polygon.fs
+++ b/core/resources/shaders/polygon.fs
@@ -1,11 +1,17 @@
+#pragma tangram: extensions
+
 #ifdef GL_ES
 precision highp float;
 #endif
+
+#pragma tangram: defines
 
 uniform mat4 u_modelView;
 uniform mat4 u_modelViewProj;
 uniform mat3 u_normalMatrix;
 uniform float u_time;
+
+#pragma tangram: uniforms
 
 varying vec4 v_color;
 varying vec3 v_eyeToPoint;

--- a/core/resources/shaders/polygon.vs
+++ b/core/resources/shaders/polygon.vs
@@ -1,6 +1,10 @@
+#pragma tangram: extensions
+
 #ifdef GL_ES
 precision highp float;
 #endif
+
+#pragma tangram: defines
 
 uniform mat4 u_modelView;
 uniform mat4 u_modelViewProj;
@@ -8,6 +12,8 @@ uniform mat3 u_normalMatrix;
 uniform vec3 u_tile_origin;
 uniform float u_tile_zoom;
 uniform float u_time;
+
+#pragma tangram: uniforms
 
 attribute vec4 a_position;
 attribute vec4 a_color;

--- a/core/resources/shaders/polyline.fs
+++ b/core/resources/shaders/polyline.fs
@@ -1,11 +1,17 @@
+#pragma tangram: extensions
+
 #ifdef GL_ES
 precision highp float;
 #endif
+
+#pragma tangram: defines
 
 uniform mat4 u_modelView;
 uniform mat4 u_modelViewProj;
 uniform mat3 u_normalMatrix;
 uniform float u_time;
+
+#pragma tangram: uniforms
 
 varying vec4 v_color;
 varying vec3 v_eyeToPoint;

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -1,6 +1,10 @@
+#pragma tangram: extensions
+
 #ifdef GL_ES
 precision highp float;
 #endif
+
+#pragma tangram: defines
 
 #define TANGRAM_WORLD_POSITION_WRAP vec3(100000.0)
 
@@ -10,6 +14,8 @@ uniform mat3 u_normalMatrix;
 uniform float u_tile_zoom;
 uniform float u_time;
 uniform float u_zoom;
+
+#pragma tangram: uniforms
 
 attribute vec4 a_position;
 attribute vec4 a_color;

--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -1,3 +1,5 @@
+#pragma tangram: extensions
+
 #ifdef TANGRAM_SDF_MULTISAMPLING
     #ifdef GL_OES_standard_derivatives
         #extension GL_OES_standard_derivatives : enable
@@ -13,15 +15,21 @@
     #define LOWP
 #endif
 
+#pragma tangram: defines
+
 // TODO: use this as attribute
 const float textSize = 15.0;
 const float emSize = textSize / 16.0;
 
 uniform sampler2D u_tex;
 
+#pragma tangram: uniforms
+
 varying vec2 v_uv;
 varying float v_alpha;
 varying vec4 v_color;
+
+#pragma tangram: global
 
 float contour(in float d, in float w) {
     return smoothstep(0.5 - w, 0.5 + w, d);
@@ -56,12 +64,19 @@ void main(void) {
     if (v_alpha < TANGRAM_EPSILON) {
         discard;
     } else {
+        vec4 color;
+
         float distance = texture2D(u_tex, v_uv).a;
 
         float alpha = sampleAlpha(v_uv, distance);
         alpha = pow(alpha, 0.4545);
 
-        gl_FragColor = vec4(v_color.rgb, v_alpha * alpha * v_color.a);
+        color = vec4(v_color.rgb, v_alpha * alpha * v_color.a);
+
+        #pragma tangram: color
+        #pragma tangram: filter
+
+        gl_FragColor = color;
     }
 }
 

--- a/core/resources/shaders/text.fs
+++ b/core/resources/shaders/text.fs
@@ -1,3 +1,5 @@
+#pragma tangram: extensions
+
 #ifdef GL_ES
 precision mediump float;
 #define LOWP lowp
@@ -5,17 +7,30 @@ precision mediump float;
 #define LOWP 
 #endif
 
+#pragma tangram: defines
+
 uniform sampler2D u_tex;
+
+#pragma tangram: uniforms
 
 varying vec2 v_uv;
 varying float v_alpha;
 varying vec4 v_color;
 
+#pragma tangram: global
+
 void main(void) {
     if (v_alpha < TANGRAM_EPSILON) {
         discard;
     } else {
+        vec4 color;
         vec4 texColor = texture2D(u_tex, v_uv);
-        gl_FragColor = vec4(v_color.rgb, texColor.a * v_alpha * v_color.a);
+
+        color = vec4(v_color.rgb, texColor.a * v_alpha * v_color.a);
+
+        #pragma tangram: color
+        #pragma tangram: filter
+
+        gl_FragColor = color;
     }
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -451,10 +451,9 @@ Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
                 break;
             } else if (propNode.IsScalar() || propNode.IsSequence()) {              // Overwrite Properties
                 node = propNode;
-                // this overwrites the previous map value
-                mapMixes.clear();
-                mapTags.clear();
             } else { // Map...
+                // Reset previous scalar/sequence node
+                node = Node::Node();
                 for (const auto& tag : propNode) {
                     auto tagName = tag.first.as<std::string>();
                     if (mapMixes.find(tagName) == mapMixes.end()) {                 // Deep Merge for all Map Props
@@ -464,6 +463,11 @@ Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
                 }
             }
         }
+    }
+
+    if (node.IsScalar() || node.IsSequence()) {
+        mapMixes.clear();
+        mapTags.clear();
     }
 
     // Recursively merge map nodes from this propStr node
@@ -533,7 +537,7 @@ Node SceneLoader::mixStyle(const Mixes& mixes) {
 
     Node styleNode;
 
-    for (auto property : {"animated", "texcoords", "base", "lighting", "texture", "blend", "material", "shaders"}) {
+    for (auto& property : {"animated", "texcoords", "base", "lighting", "texture", "blend", "material", "shaders"}) {
         Node node = propMerge(property, mixes);
         if (!node.IsNull()) { styleNode[property] = node; }
     }
@@ -573,7 +577,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
         Node styleNode = styleIt.second;
 
         bool validName = true;
-        for (auto builtIn : { "polygons", "lines", "points", "text", "debug", "debugtext" }) {
+        for (auto& builtIn : { "polygons", "lines", "points", "text", "debug", "debugtext" }) {
             if (styleName == builtIn) { validName = false; }
         }
         if (!validName) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -436,7 +436,6 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
 Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
 
     Node node;
-    Node nullNode;
 
     if (propStr == "extensions" || propStr == "blocks") { //handled by explicit methods
         return node;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -370,7 +370,7 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
         }
     }
 
-	if (Node blendNode = styleNode["blend"]) {
+    if (Node blendNode = styleNode["blend"]) {
 
         std::string str = blendNode.as<std::string>();
 
@@ -413,20 +413,20 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
         else { logMsg("WARNING: unrecognized lighting type \"%s\"\n", lighting.c_str()); }
     }
 
-	Node textureNode = styleNode["texture"];
+    Node textureNode = styleNode["texture"];
     if (textureNode) {
-    	auto spriteStyle = dynamic_cast<SpriteStyle*>(style);
+        auto spriteStyle = dynamic_cast<SpriteStyle*>(style);
         if (spriteStyle) {
-        	std::string textureName = textureNode.as<std::string>();
+            std::string textureName = textureNode.as<std::string>();
             auto atlases = scene.spriteAtlases();
             auto it = atlases.find(textureName);
             if (it != atlases.end()) {
-            	spriteStyle->setSpriteAtlas(it->second);
+                spriteStyle->setSpriteAtlas(it->second);
             } else {
-            	logMsg("WARNING: undefined texture name %s", textureName.c_str());
+                logMsg("WARNING: undefined texture name %s", textureName.c_str());
             }
         }
-	}
+    }
 
     Node urlNode = styleNode["url"];
     if (urlNode) { logMsg("WARNING: loading style from URL not yet implemented\n"); } // TODO

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -436,6 +436,7 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
 Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
 
     Node node;
+    Node nullNode;
 
     if (propStr == "extensions" || propStr == "blocks") { //handled by explicit methods
         return node;
@@ -453,7 +454,7 @@ Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
                 node = propNode;
             } else { // Map...
                 // Reset previous scalar/sequence node
-                node = Node::Node();
+                node.reset();
                 for (const auto& tag : propNode) {
                     auto tagName = tag.first.as<std::string>();
                     if (mapMixes.find(tagName) == mapMixes.end()) {                 // Deep Merge for all Map Props

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -466,7 +466,7 @@ Node SceneLoader::propMerge(const std::string& propStr, const std::string& subPr
         auto mixStyleNode = styles[mixStyleName];
         if (auto propNode = mixStyleNode[propStr]) {
             if (auto subPropNode = propNode[subPropStr]) {
-                if (subPropNode.IsMap()) { // for something like shaders: defines or unique
+                if (subPropNode.IsMap()) { // for something like shaders: defines or uniforms
                     for (const auto& val : subPropNode) {
                         node[val.first] = val.second;
                     }
@@ -522,7 +522,7 @@ Style* SceneLoader::loadStyle(Node& styles, const MIXES& mixes, Scene& scene) {
         if (!node.IsNull()) { styleNode[property] = node; }
     }
 
-    // Overwriten style properties (last wins)
+    // Overwritten style properties (last wins)
     for (auto property : {"base", "lighting", "texture", "blend"}) {
         Node node = propOverwrite(property, "", styles, mixes);
         if (!node.IsNull()) { styleNode[property] = node; }
@@ -538,10 +538,10 @@ Style* SceneLoader::loadStyle(Node& styles, const MIXES& mixes, Scene& scene) {
     if (!materialNode.IsNull()) { styleNode["material"] = materialNode; }
 
 
-    // shader prooerties merging
+    // shader properties merging
     Node shadersNode;
     // Merge shader uniform and defines (concatinate all)
-    for (auto param : {"defines", "uniform", "extensions"}) {
+    for (auto param : {"defines", "uniforms", "extensions"}) {
         Node node = propMerge("shaders", param, styles, mixes);
         if (!node.IsNull()) { shadersNode[param] = node; }
     }
@@ -557,25 +557,24 @@ Style* SceneLoader::loadStyle(Node& styles, const MIXES& mixes, Scene& scene) {
     const std::string& styleName = mixes.back();
     if (Node baseNode = styleNode["base"]) {
         std::string baseString = baseNode.as<std::string>();
-        if (baseString == "lines") {
+        if (baseString == "polygons") {
+            style = new PolygonStyle(styleName);
+        } else if (baseString == "lines") {
             style = new PolylineStyle(styleName);
-        }
-        else if (baseString == "text") {
+        } else if (baseString == "text") {
             style = new TextStyle(styleName, true, true);
-        }
-        else if (baseString == "points") {
+        } else if (baseString == "points") {
             style = new SpriteStyle(styleName);
         } else {
             logMsg("WARNING: base style \"%s\" not recognized, can not instantiate.\n", baseString.c_str());
-            style = new PolygonStyle(styleName);
+            return nullptr;
         }
-
         loadStyleProps(style, styleNode, scene);
-
     } else {
         // No baseNode, this is an abstract styleNode
         return nullptr;
     }
+
     return style;
 }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -418,8 +418,7 @@ Node SceneLoader::propORing(const std::string& propStr, Node& styles, const MIXE
     Node propNode;
     for (const auto& mixStyleName : mixes) {
         auto mixStyleNode = styles[mixStyleName];
-        propNode = mixStyleNode[propStr];
-        if (propNode) {
+        if ( (propNode = mixStyleNode[propStr]) ) {
             bool val = propNode.as<bool>();
             if (val) { return propNode; }
         }
@@ -432,13 +431,9 @@ Node SceneLoader::propOverwrite(const std::string& propStr, const std::string& s
     Node node;
     for (const auto& mixStyleName : mixes) {
         auto mixStyleNode = styles[mixStyleName];
-        auto propNode = mixStyleNode[propStr];
-        if (propNode) {
+        if (auto propNode = mixStyleNode[propStr]) {
             if (subPropStr.size() == 0) { node = propNode; }
-            else {
-                auto subPropNode = propNode[subPropStr];
-                if (subPropNode) { node = subPropNode; }
-            }
+            else if (auto subPropNode = propNode[subPropStr]) { node = subPropNode; }
         }
     }
     return node;
@@ -449,10 +444,8 @@ Node SceneLoader::propMerge(const std::string& propStr, const std::string& subPr
     Node node;
     for (const auto& mixStyleName : mixes) {
         auto mixStyleNode = styles[mixStyleName];
-        auto propNode = mixStyleNode[propStr];
-        if (propNode) {
-            auto subPropNode = propNode[subPropStr];
-            if (subPropNode) {
+        if (auto propNode = mixStyleNode[propStr]) {
+            if (auto subPropNode = propNode[subPropStr]) {
                 if (subPropNode.IsMap()) {
                     for (const auto& val : subPropNode) {
                         node[val.first] = val.second;
@@ -475,14 +468,11 @@ Node SceneLoader::mergeShaderBlocks(Node& styles, const MIXES& mixes) {
 
     for (const auto& mixStyleName : mixes) {
         auto mixStyleNode = styles[mixStyleName];
-        auto shadersNode = mixStyleNode["shaders"];
-        if (shadersNode) {
-            auto blocksNode = shadersNode["blocks"];
-            for (const auto& block : blocksNode) {
+        if (auto shadersNode = mixStyleNode["shaders"]) {
+            for (const auto& block : shadersNode["blocks"]) {
                 std::string tag = block.first.as<std::string>();
                 std::string value = block.second.as<std::string>();
-                Node blockNode = node[tag];
-                if (blockNode) {
+                if (node[tag]) {
                     node[tag] = node[tag].as<std::string>() + "\n" + value;
                 } else {
                     node[tag] = value;
@@ -539,8 +529,7 @@ Style* SceneLoader::loadStyle(Node& styles, const MIXES& mixes, Scene& scene) {
 
     // Construct style instance using the merged properties
     const std::string& styleName = mixes.back();
-    Node baseNode = styleNode["base"];
-    if (baseNode) {
+    if (Node baseNode = styleNode["base"]) {
         std::string baseString = baseNode.as<std::string>();
         if (baseString == "lines") {
             style = new PolylineStyle(styleName);
@@ -594,9 +583,8 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
             continue;
         }
 
-        Node mixNode = styleNode["mix"];
         MIXES mixes;
-        if (mixNode) {
+        if (Node mixNode = styleNode["mix"]) {
             if (mixNode.IsScalar()) {
                 mixes.reserve(2);
                 mixes.push_back(mixNode.as<std::string>());
@@ -606,7 +594,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
                     mixes.push_back(mixStyleNode.as<std::string>());
                 }
             } else {
-                logMsg("Error parsing mix param for style: %s. Value needs to be scalar or sequence\n", styleName.c_str());
+                logMsg("Error parsing mix param for style: %s. Expected scalar or sequence value\n", styleName.c_str());
             }
         }
         mixes.push_back(styleName);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -136,6 +136,7 @@ void SceneLoader::loadShaderConfig(Node shaders, ShaderProgram& shader) {
         }
     }
 
+    // TODO: global shader injection points
     Node blocksNode = shaders["blocks"];
     if (blocksNode) {
         for (const auto& block : blocksNode) {
@@ -338,7 +339,17 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
     }
 
     Node animatedNode = styleNode["animated"];
-    if (animatedNode) { logMsg("WARNING: animated styles not yet implemented\n"); } // TODO
+    if (animatedNode) {
+        logMsg("WARNING: animated property will be set but not yet implemented in styles\n"); // TODO
+        if (!animatedNode.IsScalar()) { logMsg("WARNING: animated flag should be a scalar\n"); }
+        else {
+            try {
+                style.setAnimated(animatedNode.as<bool>());
+            } catch(const BadConversion& e) {
+                logMsg("WARNING: Expected a boolean value in animated property. Using default (false).\n");
+            }
+        }
+    }
 
 	if (Node blendNode = styleNode["blend"]) {
 
@@ -403,6 +414,150 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
 
 }
 
+Node SceneLoader::propORing(const std::string& propStr, Node& styles, const MIXES& mixes) {
+    Node propNode;
+    for (const auto& mixStyleName : mixes) {
+        auto mixStyleNode = styles[mixStyleName];
+        propNode = mixStyleNode[propStr];
+        if (propNode) {
+            bool val = propNode.as<bool>();
+            if (val) { return propNode; }
+        }
+    }
+    return propNode;
+}
+
+Node SceneLoader::propOverwrite(const std::string& propStr, const std::string& subPropStr, Node& styles,
+        const MIXES& mixes) {
+    Node node;
+    for (const auto& mixStyleName : mixes) {
+        auto mixStyleNode = styles[mixStyleName];
+        auto propNode = mixStyleNode[propStr];
+        if (propNode) {
+            if (subPropStr.size() == 0) { node = propNode; }
+            else {
+                auto subPropNode = propNode[subPropStr];
+                if (subPropNode) { node = subPropNode; }
+            }
+        }
+    }
+    return node;
+}
+
+Node SceneLoader::propMerge(const std::string& propStr, const std::string& subPropStr, Node& styles,
+        const MIXES& mixes) {
+    Node node;
+    for (const auto& mixStyleName : mixes) {
+        auto mixStyleNode = styles[mixStyleName];
+        auto propNode = mixStyleNode[propStr];
+        if (propNode) {
+            auto subPropNode = propNode[subPropStr];
+            if (subPropNode) {
+                if (subPropNode.IsMap()) {
+                    for (const auto& val : subPropNode) {
+                        node[val.first] = val.second;
+                    }
+                }
+            }
+        }
+    }
+    return node;
+}
+
+Node SceneLoader::mergeShaderBlocks(Node& styles, const MIXES& mixes) {
+    Node node;
+
+    for (const auto& mixStyleName : mixes) {
+        auto mixStyleNode = styles[mixStyleName];
+        auto shadersNode = mixStyleNode["shaders"];
+        if (shadersNode) {
+            auto blocksNode = shadersNode["blocks"];
+            for (const auto& block : blocksNode) {
+                std::string tag = block.first.as<std::string>();
+                std::string value = block.second.as<std::string>();
+                Node blockNode = node[tag];
+                if (blockNode) {
+                    node[tag] = node[tag].as<std::string>() + "\n" + value;
+                } else {
+                    node[tag] = value;
+                }
+            }
+        }
+    }
+
+    return node;
+}
+
+Style* SceneLoader::loadStyle(Node& styles, const MIXES& mixes, Scene& scene) {
+
+    Style* style = nullptr;
+
+    Node styleNode;
+
+    // Or`ed style properties
+    for (auto property : {"animated", "texcoords"}) {
+        Node node = propORing(property, styles, mixes);
+        if (!node.IsNull()) { styleNode[property] = node; }
+    }
+
+    // Overwriten style properties (last wins)
+    for (auto property : {"base", "lighting", "texture", "blend"}) {
+        Node node = propOverwrite(property, "", styles, mixes);
+        if (!node.IsNull()) { styleNode[property] = node; }
+    }
+
+
+    // material properties merging
+    Node materialNode;
+    for (auto subProp : {"diffuse", "ambient", "specular", "normal", "shininess"}) {
+        Node node = propOverwrite("material", subProp, styles, mixes);
+        if (!node.IsNull()) { materialNode[subProp] = node; }
+    }
+    if (!materialNode.IsNull()) { styleNode["material"] = materialNode; }
+
+
+    // shader prooerties merging
+    Node shadersNode;
+    // Merge shader uniform and defines (concatinate all)
+    for (auto param : {"defines", "uniform"}) {
+        Node node = propMerge("shaders", param, styles, mixes);
+        if (!node.IsNull()) { shadersNode[param] = node; }
+    }
+
+    // Deep merge shader block (very specific case)
+    Node blocksNode = mergeShaderBlocks(styles, mixes);
+    if (!blocksNode.IsNull()) { shadersNode["blocks"] = blocksNode; }
+
+    if (!shadersNode.IsNull()) { styleNode["shaders"] = shadersNode; }
+
+
+    // Construct style instance using the merged properties
+    const std::string& styleName = mixes.back();
+    Node baseNode = styleNode["base"];
+    if (baseNode) {
+        std::string baseString = baseNode.as<std::string>();
+        if (baseString == "lines") {
+            style = new PolylineStyle(styleName);
+        }
+        else if (baseString == "text") {
+            style = new TextStyle(styleName, true, true);
+        }
+        else if (baseString == "sprites") {
+            logMsg("WARNING: sprite base styles not yet implemented\n"); // TODO
+        } else {
+            logMsg("WARNING: base style \"%s\" not recognized, defaulting to polygons\n", baseString.c_str());
+            style = new PolygonStyle(styleName);
+        }
+
+        loadStyleProps(*style, styleNode, scene);
+
+    } else {
+        // No baseNode, this is an abstract styleNode
+        return nullptr;
+    }
+    return style;
+}
+
 void SceneLoader::loadStyles(Node styles, Scene& scene) {
 
     auto fontCtx = FontContext::GetInstance(); // To add font for debugTextStyle
@@ -421,8 +576,6 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
 
     for (const auto& styleIt : styles) {
 
-        Style* style = nullptr;
-
         std::string styleName = styleIt.first.as<std::string>();
         Node styleNode = styleIt.second;
 
@@ -435,35 +588,28 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
             continue;
         }
 
-        Node baseNode = styleNode["base"];
-        if (baseNode) {
-            std::string baseString = baseNode.as<std::string>();
-            if (baseString == "lines") { style = new PolylineStyle(styleName); }
-            else if (baseString == "text") { style = new TextStyle(styleName, true, true); }
-            else if (baseString == "points") { style = new SpriteStyle(styleName); } // TODO
-            else { logMsg("WARNING: base style \"%s\" not recognized, defaulting to polygons\n", baseString.c_str()); }
-        }
-
-        if (style == nullptr) { style = new PolygonStyle(styleName); }
-
         Node mixNode = styleNode["mix"];
+        MIXES mixes;
         if (mixNode) {
             if (mixNode.IsScalar()) {
-                std::string mixStyleName = mixNode.as<std::string>();
-                loadStyleProps(*style, styles[mixStyleName], scene);
+                mixes.reserve(2);
+                mixes.push_back(mixNode.as<std::string>());
             } else if (mixNode.IsSequence()) {
+                mixes.reserve(mixNode.size() + 1);
                 for (const auto& mixStyleNode : mixNode) {
-                    std::string mixStyleName = mixStyleNode.as<std::string>();
-                    loadStyleProps(*style, styles[mixStyleName], scene);
+                    mixes.push_back(mixStyleNode.as<std::string>());
                 }
             } else {
                 logMsg("Error parsing mix param for style: %s. Value needs to be scalar or sequence\n", styleName.c_str());
             }
         }
+        mixes.push_back(styleName);
 
-        loadStyleProps(*style, styleNode, scene);
+        Style* style = loadStyle(styles, mixes, scene);
 
-        scene.styles().push_back(std::unique_ptr<Style>(style));
+        if (style) {
+            scene.styles().push_back(std::unique_ptr<Style>(style));
+        }
     }
 }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -457,6 +457,12 @@ Node SceneLoader::propMerge(const std::string& propStr, const std::string& subPr
                     for (const auto& val : subPropNode) {
                         node[val.first] = val.second;
                     }
+                } else if (subPropNode.IsScalar()) {
+                    node.push_back(subPropNode);
+                } else if (subPropNode.IsSequence()) {
+                    for (const auto& n : subPropNode) {
+                        node.push_back(n);
+                    }
                 }
             }
         }
@@ -519,7 +525,7 @@ Style* SceneLoader::loadStyle(Node& styles, const MIXES& mixes, Scene& scene) {
     // shader prooerties merging
     Node shadersNode;
     // Merge shader uniform and defines (concatinate all)
-    for (auto param : {"defines", "uniform"}) {
+    for (auto param : {"defines", "uniform", "extensions"}) {
         Node node = propMerge("shaders", param, styles, mixes);
         if (!node.IsNull()) { shadersNode[param] = node; }
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -355,11 +355,11 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
 
         std::string str = blendNode.as<std::string>();
 
-        if      (str == "none")     { style->setBlendMode(Blending::none); }
-        else if (str == "add")      { style->setBlendMode(Blending::add); }
-        else if (str == "multiply") { style->setBlendMode(Blending::multiply); }
-        else if (str == "overlay")  { style->setBlendMode(Blending::overlay); }
-        else if (str == "inlay")    { style->setBlendMode(Blending::inlay); }
+        if      (str == "none")     { style.setBlendMode(Blending::none); }
+        else if (str == "add")      { style.setBlendMode(Blending::add); }
+        else if (str == "multiply") { style.setBlendMode(Blending::multiply); }
+        else if (str == "overlay")  { style.setBlendMode(Blending::overlay); }
+        else if (str == "inlay")    { style.setBlendMode(Blending::inlay); }
         else { logMsg("WARNING: invalid blend mode \"%s\"\n", str.c_str()); }
 
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -433,7 +433,7 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
 
 }
 
-Node SceneLoader::propMerge(const std::string& propStr, const MIXES& mixes) {
+Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
 
     Node node;
 
@@ -442,7 +442,7 @@ Node SceneLoader::propMerge(const std::string& propStr, const MIXES& mixes) {
     }
 
     std::vector<std::string> mapTags;
-    std::unordered_map<std::string, MIXES> mapMixes;
+    std::unordered_map<std::string, Mixes> mapMixes;
 
     for (const auto& mixNode: mixes) {
         if (Node propNode = mixNode[propStr]) {
@@ -475,7 +475,7 @@ Node SceneLoader::propMerge(const std::string& propStr, const MIXES& mixes) {
     return node;
 }
 
-Node SceneLoader::shaderBlockMerge(const MIXES& mixes) {
+Node SceneLoader::shaderBlockMerge(const Mixes& mixes) {
 
     Node node;
     for (const auto& mixNode : mixes) {
@@ -496,7 +496,7 @@ Node SceneLoader::shaderBlockMerge(const MIXES& mixes) {
     return node;
 }
 
-Node SceneLoader::shaderExtMerge(const MIXES& mixes) {
+Node SceneLoader::shaderExtMerge(const Mixes& mixes) {
 
     Node node;
     std::unordered_set<std::string> uniqueList;
@@ -529,7 +529,7 @@ Node SceneLoader::shaderExtMerge(const MIXES& mixes) {
     return node;
 }
 
-Node SceneLoader::mixStyle(const MIXES& mixes) {
+Node SceneLoader::mixStyle(const Mixes& mixes) {
 
     Node styleNode;
 
@@ -581,7 +581,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
             continue;
         }
 
-        MIXES mixes;
+        Mixes mixes;
         if (Node mixNode = styleNode["mix"]) {
             if (mixNode.IsScalar()) {
                 mixes.reserve(2);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -155,7 +155,6 @@ void SceneLoader::loadShaderConfig(Node shaders, ShaderProgram& shader) {
         }
     }
 
-    // TODO: global shader injection points
     Node blocksNode = shaders["blocks"];
     if (blocksNode) {
         for (const auto& block : blocksNode) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -112,6 +112,24 @@ void SceneLoader::loadShaderConfig(Node shaders, ShaderProgram& shader) {
         return;
     }
 
+    if (Node extensionsNode = shaders["extensions"]) {
+        std::vector<std::string> extensions;
+        if (extensionsNode.IsScalar()) {
+            extensions.push_back(extensionsNode.as<std::string>());
+        } else if(extensionsNode.IsSequence()) {
+            extensions.reserve(extensionsNode.size());
+            for (const auto& extNode : extensionsNode) {
+                extensions.push_back(extNode.as<std::string>());
+            }
+        }
+        for (const auto& extName : extensions) {
+            char buffer[1000]; //sufficient space
+            sprintf(buffer, "#ifdef %s\n    #extension %s : enable\n    #define TANGRAM_EXTENSION_%s\n#endif",
+                    extName.c_str(), extName.c_str(), extName.c_str());
+            shader.addSourceBlock("extensions", std::string(buffer));
+        }
+    }
+
     Node definesNode = shaders["defines"];
     if (definesNode) {
         for (const auto& define : definesNode) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -397,7 +397,7 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
 
 	Node textureNode = styleNode["texture"];
     if (textureNode) {
-    	auto spriteStyle = static_cast<SpriteStyle*>(style);
+    	auto spriteStyle = dynamic_cast<SpriteStyle*>(style);
         if (spriteStyle) {
         	std::string textureName = textureNode.as<std::string>();
             auto atlases = scene.spriteAtlases();
@@ -546,10 +546,10 @@ Style* SceneLoader::loadStyle(Node& styles, const MIXES& mixes, Scene& scene) {
         else if (baseString == "text") {
             style = new TextStyle(styleName, true, true);
         }
-        else if (baseString == "sprites") {
-            logMsg("WARNING: sprite base styles not yet implemented\n"); // TODO
+        else if (baseString == "points") {
+            style = new SpriteStyle(styleName);
         } else {
-            logMsg("WARNING: base style \"%s\" not recognized, defaulting to polygons\n", baseString.c_str());
+            logMsg("WARNING: base style \"%s\" not recognized, can not instantiate.\n", baseString.c_str());
             style = new PolygonStyle(styleName);
         }
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -23,7 +23,7 @@ struct DrawRule;
 struct MaterialTexture;
 struct Filter;
 
-using MIXES = std::vector<std::string>;
+using MIXES = std::vector<YAML::Node>;
 
 class SceneLoader {
 
@@ -33,7 +33,6 @@ class SceneLoader {
     void loadCameras(YAML::Node cameras, View& view);
     void loadLayers(YAML::Node layers, Scene& scene, TileManager& tileManager);
     void loadStyles(YAML::Node styles, Scene& scene);
-    Style* loadStyle(YAML::Node& styles, const MIXES& mixes, Scene& scene);
     void loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene);
     void loadTextures(YAML::Node textures, Scene& scene);
     void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
@@ -45,12 +44,16 @@ class SceneLoader {
     Filter generatePredicate(YAML::Node filter, std::string _key);
 
     // Style Mixing helper methods
-    YAML::Node propORing(const std::string& propStr, YAML::Node& styles, const MIXES& mixes);
-    YAML::Node propOverwrite(const std::string& propStr, const std::string& subPropStr, YAML::Node& styles,
-            const MIXES& mixes);
-    YAML::Node propMerge(const std::string& propStr, const std::string& subPropStr, YAML::Node& styles,
-            const MIXES& mixes);
-    YAML::Node mergeShaderBlocks(YAML::Node& styles, const MIXES& mixes);
+    YAML::Node mixStyle(const MIXES& mixes);
+    
+    // Generic methods to merge properties
+    YAML::Node propMerge(const std::string& propStr, const MIXES& mixes);
+    
+    // Methods to merge shader blocks
+    YAML::Node shaderBlockMerge(const MIXES& mixes);
+    
+    // Methods to merge shader extensions
+    YAML::Node shaderExtMerge(const MIXES& mixes);
 
 public:
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -34,7 +34,7 @@ class SceneLoader {
     void loadLayers(YAML::Node layers, Scene& scene, TileManager& tileManager);
     void loadStyles(YAML::Node styles, Scene& scene);
     Style* loadStyle(YAML::Node& styles, const MIXES& mixes, Scene& scene);
-    void loadStyleProps(Style& style, YAML::Node styleNode, Scene& scene);
+    void loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene);
     void loadTextures(YAML::Node textures, Scene& scene);
     void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
     void loadShaderConfig(YAML::Node shaders, ShaderProgram& shader);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -46,15 +46,6 @@ class SceneLoader {
     // Style Mixing helper methods
     YAML::Node mixStyle(const Mixes& mixes);
 
-    // Generic methods to merge properties
-    YAML::Node propMerge(const std::string& propStr, const Mixes& mixes);
-
-    // Methods to merge shader blocks
-    YAML::Node shaderBlockMerge(const Mixes& mixes);
-
-    // Methods to merge shader extensions
-    YAML::Node shaderExtMerge(const Mixes& mixes);
-
 public:
 
     SceneLoader() {};
@@ -65,6 +56,15 @@ public:
 
     // public for testing
     std::vector<StyleParam> parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix = "");
+
+    // Generic methods to merge properties
+    YAML::Node propMerge(const std::string& propStr, const Mixes& mixes);
+
+    // Methods to merge shader blocks
+    YAML::Node shaderBlockMerge(const Mixes& mixes);
+
+    // Methods to merge shader extensions
+    YAML::Node shaderExtMerge(const Mixes& mixes);
     Tangram::Filter generateFilter(YAML::Node filter, Scene& scene);
 };
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -17,6 +17,7 @@ class SceneLayer;
 class View;
 class ShaderProgram;
 class Material;
+class Style;
 struct StyleParam;
 struct DrawRule;
 struct MaterialTexture;
@@ -30,6 +31,7 @@ class SceneLoader {
     void loadCameras(YAML::Node cameras, View& view);
     void loadLayers(YAML::Node layers, Scene& scene, TileManager& tileManager);
     void loadStyles(YAML::Node styles, Scene& scene);
+    void loadStyleProps(Style& style, YAML::Node styleNode, Scene& scene);
     void loadTextures(YAML::Node textures, Scene& scene);
     void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
     void loadShaderConfig(YAML::Node shaders, ShaderProgram& shader);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -23,7 +23,7 @@ struct DrawRule;
 struct MaterialTexture;
 struct Filter;
 
-using MIXES = std::vector<YAML::Node>;
+using Mixes = std::vector<YAML::Node>;
 
 class SceneLoader {
 
@@ -44,16 +44,16 @@ class SceneLoader {
     Filter generatePredicate(YAML::Node filter, std::string _key);
 
     // Style Mixing helper methods
-    YAML::Node mixStyle(const MIXES& mixes);
-    
+    YAML::Node mixStyle(const Mixes& mixes);
+
     // Generic methods to merge properties
-    YAML::Node propMerge(const std::string& propStr, const MIXES& mixes);
-    
+    YAML::Node propMerge(const std::string& propStr, const Mixes& mixes);
+
     // Methods to merge shader blocks
-    YAML::Node shaderBlockMerge(const MIXES& mixes);
-    
+    YAML::Node shaderBlockMerge(const Mixes& mixes);
+
     // Methods to merge shader extensions
-    YAML::Node shaderExtMerge(const MIXES& mixes);
+    YAML::Node shaderExtMerge(const Mixes& mixes);
 
 public:
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -23,6 +23,8 @@ struct DrawRule;
 struct MaterialTexture;
 struct Filter;
 
+using MIXES = std::vector<std::string>;
+
 class SceneLoader {
 
     void loadSources(YAML::Node sources, TileManager& tileManager);
@@ -31,6 +33,7 @@ class SceneLoader {
     void loadCameras(YAML::Node cameras, View& view);
     void loadLayers(YAML::Node layers, Scene& scene, TileManager& tileManager);
     void loadStyles(YAML::Node styles, Scene& scene);
+    Style* loadStyle(YAML::Node& styles, const MIXES& mixes, Scene& scene);
     void loadStyleProps(Style& style, YAML::Node styleNode, Scene& scene);
     void loadTextures(YAML::Node textures, Scene& scene);
     void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
@@ -40,6 +43,14 @@ class SceneLoader {
     Filter generateAnyFilter(YAML::Node filter, Scene& scene);
     Filter generateNoneFilter(YAML::Node filter, Scene& scene);
     Filter generatePredicate(YAML::Node filter, std::string _key);
+
+    // Style Mixing helper methods
+    YAML::Node propORing(const std::string& propStr, YAML::Node& styles, const MIXES& mixes);
+    YAML::Node propOverwrite(const std::string& propStr, const std::string& subPropStr, YAML::Node& styles,
+            const MIXES& mixes);
+    YAML::Node propMerge(const std::string& propStr, const std::string& subPropStr, YAML::Node& styles,
+            const MIXES& mixes);
+    YAML::Node mergeShaderBlocks(YAML::Node& styles, const MIXES& mixes);
 
 public:
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -75,6 +75,9 @@ protected:
     /* Whether the viewport has changed size */
     bool m_dirtyViewport = true;
 
+    /* animated property */
+    bool m_animated = false;
+
     /* Create <VertexLayout> corresponding to this style; subclasses must implement this and call it on construction */
     virtual void constructVertexLayout() = 0;
 
@@ -92,12 +95,12 @@ protected:
 
     /* Create a new mesh object using the vertex layout corresponding to this style */
     virtual VboMesh* newMesh() const = 0;
-    
+
     /* Toggle on read if true, checks whether the context has been lost on last frame */
     bool glContextLost();
 
 private:
-    
+
     /* Whether the context has been lost on last frame */
     bool m_contextLost;
 
@@ -106,7 +109,7 @@ public:
     Style(std::string _name, Blending _blendMode, GLenum _drawMode);
 
     virtual ~Style();
-    
+
     void notifyGLContextLost() { m_contextLost = true; }
 
     void viewportHasChanged() { m_dirtyViewport = true; }
@@ -114,6 +117,9 @@ public:
     Blending blendMode() const { return m_blend; };
 
     void setBlendMode(Blending _blendMode) { m_blend = _blendMode; }
+
+    /* Whether or not the style is animated */
+    bool isAnimated() { return m_animated; }
 
     /* Make this style ready to be used (call after all needed properties are set) */
     virtual void build(const std::vector<std::unique_ptr<Light>>& _lights);
@@ -133,6 +139,8 @@ public:
     virtual void onEndDrawFrame() {}
 
     virtual void setLightingType(LightingType _lType);
+
+    void setAnimated(bool _animated) { m_animated = _animated; }
 
     void setMaterial(const std::shared_ptr<Material>& _material);
 

--- a/tests/unit/styleMixTests.cpp
+++ b/tests/unit/styleMixTests.cpp
@@ -1,0 +1,136 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include "data/filters.h"
+#include "yaml-cpp/yaml.h"
+#include "scene/sceneLoader.h"
+#include "scene/scene.h"
+
+using namespace Tangram;
+using YAML::Node;
+
+// shader property overwrite test
+// shader extensions test
+// shader block test
+
+TEST_CASE( "Style Mixing Test1: propMerge Tests (recursive overWrite properties)", "[mixing][core][yaml]") {
+    SceneLoader sceneLoader;
+    Node node = YAML::Load("Nodes: { \
+                                Node1: { \
+                                    prop1: { \
+                                        subProp1: { \
+                                            tag1: value1 } \
+                                    }, \
+                                    prop2: { \
+                                        subProp3: { \
+                                            tag2: value2 } \
+                                    } \
+                                }, \
+                                Node2: { \
+                                    prop1: { \
+                                        subProp1: { \
+                                            tag3: value3 } \
+                                    }, \
+                                    prop2: { \
+                                        subProp2: value_scalar, \
+                                        subProp3: value_scalar2 \
+                                    } \
+                                }, \
+                                Node3: { \
+                                    prop1: { \
+                                        subProp1: {\
+                                            tag1: value1_3 \
+                                        } \
+                                    }, \
+                                    prop2: { \
+                                        subProp2: [v1, v2], \
+                                        subProp3: { \
+                                            tag4: value4 \
+                                        } \
+                                   } \
+                                }, \
+                            }")["Nodes"];
+
+    // NodeMix:
+    //      prop1:
+    //          subProp1:
+    //              tag1: value1_3
+    //              tag3: value3
+    //      prop2:
+    //          subProp2: [v1, v2]
+    //          subProp3:
+    //              tag4: value4
+    //              tag2: value2
+
+    Node mixedNode;
+
+    for (auto& property : {"prop1", "prop2"}) {
+        mixedNode[property] = sceneLoader.propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
+    }
+
+    REQUIRE(mixedNode["prop1"].IsMap());
+    REQUIRE(mixedNode["prop1"]["subProp1"].IsMap());
+    REQUIRE(mixedNode["prop1"]["subProp1"]["tag1"].as<std::string>() ==  "value1_3");
+    REQUIRE(mixedNode["prop1"]["subProp1"]["tag3"].as<std::string>() ==  "value3");
+    REQUIRE(mixedNode["prop2"].IsMap());
+    REQUIRE(mixedNode["prop2"]["subProp2"].IsSequence());
+    REQUIRE(mixedNode["prop2"]["subProp2"].size() == 2);
+    REQUIRE(mixedNode["prop2"]["subProp3"].IsMap());
+    REQUIRE(mixedNode["prop2"]["subProp3"].size() == 2);
+    REQUIRE(mixedNode["prop2"]["subProp3"]["tag4"].as<std::string>() == "value4");
+    REQUIRE(mixedNode["prop2"]["subProp3"]["tag2"].as<std::string>() == "value2");
+}
+
+TEST_CASE( "Style Mixing Test1: propMerge Tests (overWrite properties)", "[mixing][core][yaml]") {
+    SceneLoader sceneLoader;
+    Node node = YAML::Load("Nodes: { \
+                                Node1: { \
+                                    prop1: value1 }, \
+                                Node2: { \
+                                    prop1: value1_2, \
+                                    prop2: value2 }, \
+                                Node3: { \
+                                    prop1: value1_3 } \
+                                }")["Nodes"];
+
+    // NodeMix:
+    //      prop1: value1_3
+    //      prop2: value2
+
+    Node mixedNode;
+    for (auto& property : {"prop1", "prop2"}) {
+        mixedNode[property] = sceneLoader.propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
+    }
+
+    REQUIRE(mixedNode["prop1"].as<std::string>() == "value1_3");
+    REQUIRE(mixedNode["prop2"].as<std::string>() == "value2");
+}
+
+TEST_CASE( "Style Mixing Test1: propMerge Tests (boolean properties)", "[mixing][core][yaml]") {
+
+    SceneLoader sceneLoader;
+    Node node = YAML::Load("Nodes: { \
+                                Node1: { \
+                                    prop1: false }, \
+                                Node2: { \
+                                    prop1: true }, \
+                                Node3: { \
+                                    prop1: false } \
+                            }")["Nodes"];
+
+    // NodeMix:
+    //      prop1: true
+
+    Node mixedNode;
+    for (auto& property : {"prop1"}) {
+        mixedNode[property] = sceneLoader.propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
+    }
+
+    REQUIRE(mixedNode["prop1"].as<bool>());
+}
+
+

--- a/tests/unit/styleMixTests.cpp
+++ b/tests/unit/styleMixTests.cpp
@@ -13,7 +13,7 @@
 using namespace Tangram;
 using YAML::Node;
 
-TEST_CASE( "Style Mixing Test1: Shader Extensions Merging ()", "[mixing][core][yaml]") {
+TEST_CASE( "Style Mixing Test: Shader Extensions Merging", "[mixing][core][yaml]") {
     SceneLoader sceneLoader;
     Node node = YAML::Load("{ \
                                 Node1: { \
@@ -56,7 +56,7 @@ TEST_CASE( "Style Mixing Test1: Shader Extensions Merging ()", "[mixing][core][y
 
 }
 
-TEST_CASE( "Style Mixing Test1: Shader Blocks Merging ()", "[mixing][core][yaml]") {
+TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
     SceneLoader sceneLoader;
     Node node = YAML::Load("{ \
                                 Node1: { \
@@ -111,7 +111,7 @@ TEST_CASE( "Style Mixing Test1: Shader Blocks Merging ()", "[mixing][core][yaml]
     REQUIRE(shaderBlocksNode["filter"].as<std::string>() == "filterBlockC;");
 }
 
-TEST_CASE( "Style Mixing Test1: propMerge Tests (recursive overWrite properties)", "[mixing][core][yaml]") {
+TEST_CASE( "Style Mixing Test: propMerge Tests (recursive overWrite properties)", "[mixing][core][yaml]") {
     SceneLoader sceneLoader;
     Node node = YAML::Load("{ \
                                 Node1: { \
@@ -179,7 +179,7 @@ TEST_CASE( "Style Mixing Test1: propMerge Tests (recursive overWrite properties)
     REQUIRE(mixedNode["prop2"]["subProp3"]["tag2"].as<std::string>() == "value2");
 }
 
-TEST_CASE( "Style Mixing Test1: propMerge Tests (overWrite properties)", "[mixing][core][yaml]") {
+TEST_CASE( "Style Mixing Test: propMerge Tests (overWrite properties)", "[mixing][core][yaml]") {
     SceneLoader sceneLoader;
     Node node = YAML::Load("{ \
                                 Node1: { \
@@ -204,7 +204,7 @@ TEST_CASE( "Style Mixing Test1: propMerge Tests (overWrite properties)", "[mixin
     REQUIRE(mixedNode["prop2"].as<std::string>() == "value2");
 }
 
-TEST_CASE( "Style Mixing Test1: propMerge Tests (boolean properties)", "[mixing][core][yaml]") {
+TEST_CASE( "Style Mixing Test: propMerge Tests (boolean properties)", "[mixing][core][yaml]") {
 
     SceneLoader sceneLoader;
     Node node = YAML::Load("{ \


### PR DESCRIPTION
- [x] ORing of properties like `animated` or `texcoords`.
- [x] overWriting of properties like `base`, `lighting`, `texture`, `blend`.
- [x] overWriting of `material` subProperties: `diffuse`, `ambient`, `specular`, `shininess`, `normal`.
- [x] merging of shader node `uniforms` and `defines`
- [x] deep merging of `shader blocks`
- [x] mix `extensions` (should be trivial once injection is implemented)
- [x] mix `global` shader blocks (should happen automatically, since the current implementation is generic)
- [x] Remove test styling (to be done before this branch is merged)

Todo:
- Separate PR coming for injection of uniforms.