### PR TITLE
Map position is the focus of the view

### DIFF
--- a/core/src/scene/skybox.cpp
+++ b/core/src/scene/skybox.cpp
@@ -56,6 +56,9 @@ void Skybox::draw(const View& _view) {
 
     glm::mat4 vp = _view.getViewProjectionMatrix();
 
+    // Remove translation so that skybox is centered on view
+    vp[3] = { 0, 0, 0, 0 };
+
     m_shader->setUniformMatrix4f("u_modelViewProj", glm::value_ptr(vp));
     m_shader->setUniformi("u_tex", 0);
     

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -88,7 +88,6 @@ void Tile::update(float _dt, const View& _view) {
     const auto& viewOrigin = _view.getPosition();
     m_modelMatrix[3][0] = m_tileOrigin.x - viewOrigin.x;
     m_modelMatrix[3][1] = m_tileOrigin.y - viewOrigin.y;
-    m_modelMatrix[3][2] = -viewOrigin.z;
 
 }
 

--- a/core/src/util/inputHandler.cpp
+++ b/core/src/util/inputHandler.cpp
@@ -90,11 +90,6 @@ void InputHandler::handlePinchGesture(float _posX, float _posY, float _scale, fl
 void InputHandler::handleRotateGesture(float _posX, float _posY, float _radians) {
 
     onGesture();
-    m_view->screenToGroundPlane(_posX, _posY);
-    glm::vec2 radial = { _posX, _posY };
-    glm::vec2 displacement = radial - glm::rotate(radial, _radians);
-
-    m_view->translate(displacement.x, displacement.y);
     m_view->roll(_radians);
 
 }

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -217,7 +217,7 @@ void View::updateMatrices() {
     // the "top" face of the view frustum with the ground plane
 
     // NOTE: far here can go to infinity and hence a std::min below!
-    float far = m_pos.z / std::min(0., cos(m_pitch + 0.5 * fovy));
+    float far = m_pos.z / std::max(0., cos(m_pitch + 0.5 * fovy));
 
     // limit the far clipping distance to be no greater than the maximum
     // distance of visible tiles

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -132,6 +132,7 @@ protected:
     std::set<TileID> m_visibleTiles;
 
     glm::dvec3 m_pos;
+    glm::vec3 m_eye;
 
     glm::mat4 m_view;
     glm::mat4 m_orthoViewport;
@@ -144,7 +145,6 @@ protected:
     float m_pitch = 0.f;
 
     float m_zoom;
-    float m_zoomAltitude;
     float m_initZoom = 16.0;
 
     float m_width;


### PR DESCRIPTION
This has always been true in top-down views, but there has been some confusion about what corresponds to the "map position" when the view is tilted: the position of the camera in space, or the position at which the camera is looking. 

With these changes, the "map position" is always the point at which the camera is looking. This resolves an issue in eraser-map where the user's current location is not visible in a (tilted) routing view. 

While making these changes, I found a subtle but important issue related to input handling: 

`InputHandler` sets a fling delta every time that a pan above some threshold occurs. On any frame in which `handlePanGesture` isn't called, that delta is repeatedly applied and decremented to give a smooth fling. The problem is that while a finger/mouse is down and moving, *input events may not occur on every frame*. This results in a panning motion from both the fling delta and (later) the input callback, causing a translational drift. Fixing this with our existing input callbacks seems difficult - the information we really need is touch-up and touch-down events.

Since this issue may require API revision and isn't terribly problematic for most use cases, I've elected to leave it unresolved for now. 