### PR TITLE
Specify colors and distances with Stops

### DIFF
--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -128,17 +128,15 @@ layers:
     roads:
         data: { source: osm }
         filter:
-            not: {kind: [rail]}
+            not: { kind: [rail] }
         draw:
             lines:
-                order: 4
+                color: white
                 width: .02
-                cap: round
-                color: [ [13, '#000'], [16, '#999'] ]
+                order: 4
                 outline:
-                    width: .01
-                    cap: round
-                    color: '#999'
+                    color: [[16, '#999'], [18, '#aaa']]
+                    width: [[15, 0], [16, .01]]
         rounded:
             filter: { $zoom: { min: 18 } }
             draw:
@@ -149,42 +147,56 @@ layers:
             draw:
                 lines:
                     color: '#D16768'
-                    width: [ [10, 0], [12, .02], [16, .04], [18, .2] ]
+                    width: [[14, .01], [15, .05]]
+                    outline:
+                        width: [[14, 0], [15, .01]]
             link:
                 filter: { is_link: yes }
                 draw:
                     lines:
                         color: '#aaa'
-                        width: .001
-        path:
-            filter:
-                kind: path
+                        width: [[13, 0], [14, .025]]
+        major_road:
+            filter: { kind: major_road, $zoom: { min: 10 } }
+            draw:
+                lines:
+                    width: [[10, 0], [13, .01], [14, .01], [16, .05]]
+                    outline:
+                        width: [[16, 0], [17, .03]]
+        minor_road:
+            filter: { kind: minor_road }
+            draw:
+                lines:
+                    width: [[13, 0], [14, .005], [15, .02]]
+                    outline:
+                        width: [[17, 0], [18, .005]]
+        paths:
+            filter: { kind: path }
             draw:
                 lines:
                     color: '#bbb'
-                    width: .001
+                    width: [[15, 0], [18, .01]]
         airports:
             filter: { aeroway: true }
             draw:
                 lines:
                     color: '#ddd'
-                    outline:
-                        width: 0
             taxiways:
                 filter: { aeroway: taxiway }
                 draw:
                     lines:
-                        width: .005
+                        width: [[13, 0], [14, .01], [17, .05]]
             runways:
                 filter: { aeroway: runway }
                 draw:
                     lines:
-                        color: '#FFE4B5'
-                        width: .02
+                        color: [[13, '#FFE4B5'], [16, white]]
+                        width: [[11, .015], [12, .025], [13, .05], [15, .07]]
+                        order: 39
                         cap: square
                         outline:
                             color: orange
-                            width: 0.01
+                            width: [[11, 0], [12, .005], [13, .01], [15, .02]]
 
     poi_icons:
         data: { source: osm, layer: pois }

--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -134,7 +134,7 @@ layers:
                 order: 4
                 width: .02
                 cap: round
-                color: [ [13, '#000'], [14, '#555'], [15, '#777'], [16, '#999'] ]
+                color: [ [13, '#000'], [16, '#999'] ]
                 outline:
                     width: .01
                     cap: round

--- a/core/resources/scene/scene.yaml
+++ b/core/resources/scene/scene.yaml
@@ -134,7 +134,7 @@ layers:
                 order: 4
                 width: .02
                 cap: round
-                color: white
+                color: [ [13, '#000'], [14, '#555'], [15, '#777'], [16, '#999'] ]
                 outline:
                     width: .01
                     cap: round
@@ -149,7 +149,7 @@ layers:
             draw:
                 lines:
                     color: '#D16768'
-                    width: .04
+                    width: [ [10, 0], [12, .02], [16, .04], [18, .2] ]
             link:
                 filter: { is_link: yes }
                 draw:

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -38,11 +38,11 @@ void main() {
     {
         float width = a_extrude.z;
         float dwdz = a_extrude.w;
-        float dz = abs(u_tile_zoom) - u_zoom;
-        // scale to screen-space
-        width *= exp2(dz);
+        float dz =  u_zoom - abs(u_tile_zoom);
         // interpolate between zoom levels
         width += dwdz * dz;
+        // scale to screen-space
+        width *= exp2(-dz);
 
         position.xy += a_extrude.xy * width;
     }

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -13,8 +13,7 @@ uniform float u_zoom;
 
 attribute vec4 a_position;
 attribute vec4 a_color;
-attribute vec3 a_extrudeNormal;
-attribute float a_extrudeWidth;
+attribute vec4 a_extrude;
 attribute vec2 a_texcoord;
 attribute float a_layer;
 
@@ -35,7 +34,18 @@ varying vec2 v_texcoord;
 void main() {
 
     vec4 position = a_position;
-    position.xyz += a_extrudeNormal * (a_extrudeWidth * 2.) * pow(2., abs(u_tile_zoom) - u_zoom);
+
+    {
+        float width = a_extrude.z;
+        float dwdz = a_extrude.w;
+        float dz = abs(u_tile_zoom) - u_zoom;
+        // scale to screen-space
+        width *= exp2(dz);
+        // interpolate between zoom levels
+        width += dwdz * dz;
+
+        position.xy += a_extrude.xy * width;
+    }
 
     // Modify position before camera projection
     #pragma tangram: position

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -1,5 +1,6 @@
 #include "drawRule.h"
 #include "platform.h"
+#include "scene/stops.h"
 #include "scene/styleContext.h"
 
 #include <algorithm>
@@ -81,6 +82,14 @@ void DrawRule::eval(const StyleContext& _ctx) {
      for (auto& param : parameters) {
          if (param.function >= 0) {
              _ctx.evalStyle(param.function, param.key, param.value);
+         }
+         if (param.stops) {
+             float z = _ctx.getGlobal("$zoom").get<float>();
+             if (param.value.is<float>()) {
+                 param.value = param.stops->evalFloat(z);
+             } else if (param.value.is<uint32_t>()) {
+                 param.value = param.stops->evalColor(z);
+             }
          }
      }
 }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -3,6 +3,8 @@
 #include "scene/light.h"
 #include "scene/dataLayer.h"
 #include "scene/spriteAtlas.h"
+#include "scene/stops.h"
+#include <list>
 #include <memory>
 #include <string>
 #include <vector>
@@ -29,6 +31,7 @@ public:
     auto& textures() { return m_textures; };
     auto& functions() { return m_jsFunctions; };
     auto& spriteAtlases() { return m_spriteAtlases; };
+    auto& stops() { return m_stops; }
 
     const auto& layers() const { return m_layers; };
     const auto& styles() const { return m_styles; };
@@ -49,6 +52,7 @@ private:
     std::unordered_map<std::string, std::shared_ptr<SpriteAtlas>> m_spriteAtlases;
 
     std::vector<std::string> m_jsFunctions;
+    std::list<Stops> m_stops;
 };
 
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -847,10 +847,18 @@ std::vector<StyleParam> SceneLoader::parseStyleParams(Node params, Scene& scene,
                      out.push_back({ key, val });
                  }
                  break;
-             }
-
-            case NodeType::Sequence: out.push_back({ key, parseSequence(value) });
+            }
+            case NodeType::Sequence: {
+                if (value[0].IsSequence()) {
+                    StyleParam p = { key, value[0][1].Scalar() }; // TODO ensure valid placeholder value
+                    scene.stops().push_back(Stops(value, StyleParam::isColor(key)));
+                    p.stops = &scene.stops().back();
+                    out.push_back(p);
+                } else {
+                    out.push_back({ key, parseSequence(value) });
+                }
                 break;
+            }
             case NodeType::Map: {
                 auto subparams = parseStyleParams(value, scene, key);
                 out.insert(out.end(), subparams.begin(), subparams.end());

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -1,8 +1,13 @@
 #include "stops.h"
-#include "util/geom.h"
+#include "csscolorparser.hpp"
 #include "yaml-cpp/yaml.h"
 #include <cassert>
 #include <algorithm>
+
+#define RED(col) (col % 256)
+#define GRE(col) ((col >> 8) % 256)
+#define BLU(col) ((col >> 16) % 256)
+#define ALP(col) ((col >> 24) % 256)
 
 namespace Tangram {
 
@@ -15,18 +20,16 @@ Stops::Stops(const YAML::Node& _node, bool _isColor) {
         float key = frameNode[0].as<float>();
         if (_isColor) {
             // parse color from sequence or string
-            Color color;
+            uint32_t color = 0;
             YAML::Node colorNode = frameNode[1];
             if (colorNode.IsScalar()) {
-                color = CSSColorParser::parse(colorNode.as<std::string>());
+                color = CSSColorParser::parse(colorNode.as<std::string>()).getInt();
             } else if (colorNode.IsSequence() && colorNode.size() >= 3) {
                 float alpha = colorNode.size() > 3 ? colorNode[3].as<float>() : 1.f;
-                color = Color(
-                    colorNode[0].as<float>() * 255,
-                    colorNode[1].as<float>() * 255,
-                    colorNode[2].as<float>() * 255,
-                    alpha
-                );
+                color = alpha * 255.;
+                color = (color << 8) + colorNode[2].as<float>() * 255.;
+                color = (color << 8) + colorNode[1].as<float>() * 255.;
+                color = (color << 8) + colorNode[0].as<float>() * 255.;
             }
             frames.emplace_back(key, color);
         } else {
@@ -55,19 +58,19 @@ auto Stops::evalColor(float _key) const -> uint32_t {
 
     auto upper = nearestHigherFrame(_key);
     auto lower = upper - 1;
-    if (upper == frames.end()) { return lower->color.getInt(); }
-    if (lower < frames.begin()) { return upper->color.getInt(); }
+    if (upper == frames.end())  { return lower->color; }
+    if (lower < frames.begin()) { return upper->color; }
 
     float lerp = (_key - lower->key) / (upper->key - lower->key);
     auto lowerColor = lower->color;
     auto upperColor = upper->color;
 
-    return Color(
-        (1. - lerp) * lowerColor.r + lerp * upperColor.r,
-        (1. - lerp) * lowerColor.g + lerp * upperColor.g,
-        (1. - lerp) * lowerColor.b + lerp * upperColor.b,
-        (1. - lerp) * lowerColor.a + lerp * upperColor.a
-    ).getInt();
+    uint32_t color = 0;
+    color = (color << 8) + ALP(lowerColor) * (1. - lerp) + ALP(upperColor) * lerp;
+    color = (color << 8) + BLU(lowerColor) * (1. - lerp) + BLU(upperColor) * lerp;
+    color = (color << 8) + GRE(lowerColor) * (1. - lerp) + GRE(upperColor) * lerp;
+    color = (color << 8) + RED(lowerColor) * (1. - lerp) + RED(upperColor) * lerp;
+    return color;
 
 }
 

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -1,8 +1,41 @@
 #include "stops.h"
+#include "csscolorparser.hpp"
+#include "util/geom.h"
+#include "yaml-cpp/yaml.h"
 #include <cassert>
 #include <algorithm>
 
 namespace Tangram {
+
+Stops::Stops(const YAML::Node& _node, bool _isColor) {
+
+    if (!_node.IsSequence()) { return; }
+
+    for (const auto& frameNode : _node) {
+        if (!frameNode.IsSequence() || frameNode.size() != 2) { continue; }
+        float key = frameNode[0].as<float>();
+        if (_isColor) {
+            // parse color from sequence or string
+            uint32_t color = 0;
+            YAML::Node colorNode = frameNode[1];
+            if (colorNode.IsScalar()) {
+                color = CSSColorParser::parse(colorNode.as<std::string>()).getInt();
+            } else if (colorNode.IsSequence()) {
+                uint32_t r, g, b, a;
+                r = CLAMP(colorNode[0].as<float>() * 255., 0., 255.);
+                g = CLAMP(colorNode[1].as<float>() * 255., 0., 255.);
+                b = CLAMP(colorNode[2].as<float>() * 255., 0., 255.);
+                a = CLAMP(colorNode[3].as<float>() * 255., 0., 255.);
+                color = (a << 24) + (b << 16) + (g << 8) + (r);
+            }
+            frames.emplace_back(key, color);
+        } else {
+            // parse distance from string
+            float value = frameNode[1].as<float>();
+            frames.emplace_back(key, value);
+        }
+    }
+}
 
 auto Stops::evalFloat(float _key) const -> float {
 

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -1,0 +1,38 @@
+#include "stops.h"
+#include <cassert>
+#include <algorithm>
+
+namespace Tangram {
+
+auto Stops::evalFloat(float _key) const -> float {
+
+    auto upper = nearestHigherFrame(_key);
+    auto lower = upper - 1;
+
+    if (upper == frames.end()) { return lower->value; }
+    if (lower < frames.begin()) { return upper->value; }
+
+    float lerp = (_key - lower->key) / (upper->key - lower->key);
+
+    return (lower->value * (1 - lerp) + upper->value * lerp);
+
+}
+
+auto Stops::evalColor(float _key) const -> uint32_t {
+
+    auto upper = nearestHigherFrame(_key);
+    return (upper == frames.end()) ? (upper - 1)->color : upper->color;
+
+    // Colors aren't interpolated. Linear interpolation in RGBA is usually not what you want,
+    // but I need to check on how tangram-js handles this. 
+
+}
+
+auto Stops::nearestHigherFrame(float _key) const -> std::vector<Frame>::const_iterator {
+
+    return std::lower_bound(frames.begin(), frames.end(), _key,
+                            [](const Frame& f, float z) { return f.key < z; });
+    
+}
+
+}

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "csscolorparser.hpp"
+#include <cstdint>
 #include <vector>
 
 namespace YAML {
@@ -9,16 +9,14 @@ namespace YAML {
 
 namespace Tangram {
 
-using Color = CSSColorParser::Color;
-
 struct Frame {
     float key = 0;
     union {
         float value;
-        Color color;
+        uint32_t color = 0;
     };
     Frame(float _k, float _v) : key(_k), value(_v) {}
-    Frame(float _k, Color _c) : key(_k), color(_c) {}
+    Frame(float _k, uint32_t _c) : key(_k), color(_c) {}
 };
 
 struct Stops {

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <vector>
+
+namespace Tangram {
+
+struct Frame {
+    float key = 0;
+    union {
+        float value;
+        uint32_t color = 0;
+    };
+    Frame(float _k, float _v) : key(_k), value(_v) {}
+    Frame(float _k, uint32_t _c) : key(_k), color(_c) {}
+};
+
+struct Stops {
+
+    std::vector<Frame> frames;
+
+    auto evalFloat(float _key) const -> float;
+    auto evalColor(float _key) const -> uint32_t;
+    auto nearestHigherFrame(float _key) const -> std::vector<Frame>::const_iterator;
+};
+
+}

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "csscolorparser.hpp"
 #include <vector>
 
 namespace YAML {
@@ -8,14 +9,16 @@ namespace YAML {
 
 namespace Tangram {
 
+using Color = CSSColorParser::Color;
+
 struct Frame {
     float key = 0;
     union {
         float value;
-        uint32_t color = 0;
+        Color color;
     };
     Frame(float _k, float _v) : key(_k), value(_v) {}
-    Frame(float _k, uint32_t _c) : key(_k), color(_c) {}
+    Frame(float _k, Color _c) : key(_k), color(_c) {}
 };
 
 struct Stops {

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -2,6 +2,10 @@
 
 #include <vector>
 
+namespace YAML {
+    class Node;
+}
+
 namespace Tangram {
 
 struct Frame {
@@ -17,6 +21,9 @@ struct Frame {
 struct Stops {
 
     std::vector<Frame> frames;
+
+    Stops(const YAML::Node& _node, bool _isColor = false);
+    Stops(const std::vector<Frame>& _frames) : frames(_frames) {}
 
     auto evalFloat(float _key) const -> float;
     auto evalColor(float _key) const -> uint32_t;

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -1,5 +1,6 @@
 #include "styleParam.h"
 
+#include "csscolorparser.hpp"
 #include "platform.h"
 #include "util/builders.h" // for cap, join
 #include "util/geom.h" // for CLAMP
@@ -7,6 +8,8 @@
 #include <map>
 
 namespace Tangram {
+
+using Color = CSSColorParser::Color;
 
 const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"cap", StyleParamKey::cap},
@@ -45,6 +48,8 @@ static const char* keyName(StyleParamKey key) {
     }
     return empty.c_str();
 }
+
+
 
 StyleParam::StyleParam(const std::string& _key, const std::string& _value) {
 
@@ -301,6 +306,21 @@ bool StyleParam::parseFontSize(const std::string& _str, float& _pxSize) {
     }
 
     return true;
+}
+
+bool StyleParam::isColor(const std::string &_keyName) {
+    auto it = s_StyleParamMap.find(_keyName);
+    if (it == s_StyleParamMap.end()) { return false; }
+    switch (it->second) {
+        case StyleParamKey::color:
+        case StyleParamKey::outline_color:
+        case StyleParamKey::font_fill:
+        case StyleParamKey::font_stroke:
+        case StyleParamKey::font_stroke_color:
+            return true;
+        default:
+            return false;
+    }
 }
 
 }

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -2,14 +2,12 @@
 
 #include "util/variant.h"
 #include "glm/vec2.hpp"
-#include "csscolorparser.hpp"
 #include <string>
 #include <vector>
 
 namespace Tangram {
 
-using Color = CSSColorParser::Color;
-using Function = std::string;
+struct Stops;
 
 enum class StyleParamKey : uint8_t {
     cap,
@@ -53,6 +51,7 @@ struct StyleParam {
 
     StyleParamKey key;
     Value value;
+    Stops* stops = nullptr;
     int32_t function = -1;
 
     bool operator<(const StyleParam& _rhs) const { return key < _rhs.key; }
@@ -69,6 +68,8 @@ struct StyleParam {
     static bool parseVec2(const std::string& _value, const std::vector<std::string>& _allowedUnits, glm::vec2& _vec2);
 
     static Value parseString(StyleParamKey key, const std::string& _value);
+
+    static bool isColor(const std::string& _keyName);
 };
 
 }

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -30,8 +30,7 @@ protected:
     struct PolylineVertex {
         glm::vec3 pos;
         glm::vec2 texcoord;
-        glm::vec2 enorm;
-        GLfloat ewidth;
+        glm::vec4 extrude;
         GLuint abgr;
         GLfloat layer;
     };

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -1,0 +1,52 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "scene/stops.h"
+
+using namespace Tangram;
+
+Stops instance_float() {
+    Stops stops;
+    stops.frames = { Frame(0, 0.f), Frame(1, 10.f), Frame(5, 50.f), Frame(7, 0.f) };
+    return stops;
+}
+
+Stops instance_color() {
+    Stops stops;
+    stops.frames = { Frame(0, 0xffffffff), Frame(1, 0xeeeeeeee), Frame(5, 0xaaaaaaaa) };
+    return stops;
+}
+
+TEST_CASE( "Stops evaluate float values correctly at key frames", "[Stops]" ) {
+
+    auto stops = instance_float();
+
+    REQUIRE(stops.evalFloat(0) == 0.f);
+    REQUIRE(stops.evalFloat(1) == 10.f);
+    REQUIRE(stops.evalFloat(5) == 50.f);
+    REQUIRE(stops.evalFloat(7) == 0.f);
+
+}
+
+TEST_CASE( "Stops evaluate float values correctly between key frames", "[Stops]" ) {
+
+    auto stops = instance_float();
+
+    REQUIRE(stops.evalFloat(-3) == 0.f);
+    REQUIRE(stops.evalFloat(0.3) == 3.f);
+    REQUIRE(stops.evalFloat(3) == 30.f);
+    REQUIRE(stops.evalFloat(6) == 25.f);
+    REQUIRE(stops.evalFloat(8) == 0.f);
+
+}
+
+TEST_CASE( "Stops evaluates color values correctly at key frames", "[Stops]" ) {
+
+    auto stops = instance_color();
+
+    REQUIRE(stops.evalColor(-1) == 0xffffffff);
+    REQUIRE(stops.evalColor(1) == 0xeeeeeeee);
+    REQUIRE(stops.evalColor(2) == 0xaaaaaaaa);
+    REQUIRE(stops.evalColor(7) == 0xaaaaaaaa);
+
+}

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -17,9 +17,9 @@ Stops instance_float() {
 
 Stops instance_color() {
     return Stops({
-        Frame(0, Color(0xff, 0xff, 0xff, 1.)),
-        Frame(1, Color(0xee, 0xee, 0xee, 1.)),
-        Frame(5, Color(0xaa, 0xaa, 0xaa, 1.))
+        Frame(0, 0xffffffff),
+        Frame(1, 0xffeeeeee),
+        Frame(5, 0xffaaaaaa)
     });
 }
 
@@ -76,8 +76,8 @@ TEST_CASE("Stops parses correctly from YAML color values", "[Stops][YAML]") {
     REQUIRE(stops.frames[0].key == 10.f);
     REQUIRE(stops.frames[1].key == 16.f);
     REQUIRE(stops.frames[2].key == 18.f);
-    REQUIRE(stops.frames[0].color.getInt() == 0xffaaaaaa);
-    REQUIRE(stops.frames[1].color.getInt() == 0xffff7f00);
-    REQUIRE(stops.frames[2].color.getInt() == 0x7fff3f00);
+    REQUIRE(stops.frames[0].color == 0xffaaaaaa);
+    REQUIRE(stops.frames[1].color == 0xffff7f00);
+    REQUIRE(stops.frames[2].color == 0x7fff3f00);
 
 }

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 
 #include "scene/stops.h"
+#include "yaml-cpp/yaml.h"
 
 using namespace Tangram;
 
@@ -22,7 +23,7 @@ Stops instance_color() {
     });
 }
 
-TEST_CASE( "Stops evaluate float values correctly at and between key frames", "[Stops]" ) {
+TEST_CASE("Stops evaluate float values correctly at and between key frames", "[Stops]") {
 
     auto stops = instance_float();
 
@@ -38,7 +39,7 @@ TEST_CASE( "Stops evaluate float values correctly at and between key frames", "[
 
 }
 
-TEST_CASE( "Stops evaluate color values correctly at and between key frames", "[Stops]" ) {
+TEST_CASE("Stops evaluate color values correctly at and between key frames", "[Stops]") {
 
     auto stops = instance_color();
 
@@ -46,5 +47,37 @@ TEST_CASE( "Stops evaluate color values correctly at and between key frames", "[
     REQUIRE(stops.evalColor(1) == 0xffeeeeee);
     REQUIRE(stops.evalColor(2) == 0xffdddddd);
     REQUIRE(stops.evalColor(7) == 0xffaaaaaa);
+
+}
+
+TEST_CASE("Stops parses correctly from YAML distance values", "[Stops][YAML]") {
+
+    YAML::Node node = YAML::Load("[ [10, 0], [16, .04], [18, .2] ]");
+
+    Stops stops(node);
+
+    REQUIRE(stops.frames.size() == 3);
+    REQUIRE(stops.frames[0].key == 10.f);
+    REQUIRE(stops.frames[1].key == 16.f);
+    REQUIRE(stops.frames[2].key == 18.f);
+    REQUIRE(stops.frames[0].value == 0.f);
+    REQUIRE(stops.frames[1].value == .04f);
+    REQUIRE(stops.frames[2].value == .2f);
+
+}
+
+TEST_CASE("Stops parses correctly from YAML color values", "[Stops][YAML]") {
+
+    YAML::Node node = YAML::Load("[ [10, '#aaa'], [16, [0, .5, 1] ], [18, [0, .25, 1, .5] ] ]");
+
+    Stops stops(node, true);
+
+    REQUIRE(stops.frames.size() == 3);
+    REQUIRE(stops.frames[0].key == 10.f);
+    REQUIRE(stops.frames[1].key == 16.f);
+    REQUIRE(stops.frames[2].key == 18.f);
+    REQUIRE(stops.frames[0].color.getInt() == 0xffaaaaaa);
+    REQUIRE(stops.frames[1].color.getInt() == 0xffff7f00);
+    REQUIRE(stops.frames[2].color.getInt() == 0x7fff3f00);
 
 }

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -6,47 +6,45 @@
 using namespace Tangram;
 
 Stops instance_float() {
-    Stops stops;
-    stops.frames = { Frame(0, 0.f), Frame(1, 10.f), Frame(5, 50.f), Frame(7, 0.f) };
-    return stops;
+    return Stops({
+        Frame(0, 0.f),
+        Frame(1, 10.f),
+        Frame(5, 50.f),
+        Frame(7, 0.f)
+    });
 }
 
 Stops instance_color() {
-    Stops stops;
-    stops.frames = { Frame(0, 0xffffffff), Frame(1, 0xeeeeeeee), Frame(5, 0xaaaaaaaa) };
-    return stops;
+    return Stops({
+        Frame(0, Color(0xff, 0xff, 0xff, 1.)),
+        Frame(1, Color(0xee, 0xee, 0xee, 1.)),
+        Frame(5, Color(0xaa, 0xaa, 0xaa, 1.))
+    });
 }
 
-TEST_CASE( "Stops evaluate float values correctly at key frames", "[Stops]" ) {
-
-    auto stops = instance_float();
-
-    REQUIRE(stops.evalFloat(0) == 0.f);
-    REQUIRE(stops.evalFloat(1) == 10.f);
-    REQUIRE(stops.evalFloat(5) == 50.f);
-    REQUIRE(stops.evalFloat(7) == 0.f);
-
-}
-
-TEST_CASE( "Stops evaluate float values correctly between key frames", "[Stops]" ) {
+TEST_CASE( "Stops evaluate float values correctly at and between key frames", "[Stops]" ) {
 
     auto stops = instance_float();
 
     REQUIRE(stops.evalFloat(-3) == 0.f);
+    REQUIRE(stops.evalFloat(0) == 0.f);
     REQUIRE(stops.evalFloat(0.3) == 3.f);
+    REQUIRE(stops.evalFloat(1) == 10.f);
     REQUIRE(stops.evalFloat(3) == 30.f);
+    REQUIRE(stops.evalFloat(5) == 50.f);
     REQUIRE(stops.evalFloat(6) == 25.f);
+    REQUIRE(stops.evalFloat(7) == 0.f);
     REQUIRE(stops.evalFloat(8) == 0.f);
 
 }
 
-TEST_CASE( "Stops evaluates color values correctly at key frames", "[Stops]" ) {
+TEST_CASE( "Stops evaluate color values correctly at and between key frames", "[Stops]" ) {
 
     auto stops = instance_color();
 
     REQUIRE(stops.evalColor(-1) == 0xffffffff);
-    REQUIRE(stops.evalColor(1) == 0xeeeeeeee);
-    REQUIRE(stops.evalColor(2) == 0xaaaaaaaa);
-    REQUIRE(stops.evalColor(7) == 0xaaaaaaaa);
+    REQUIRE(stops.evalColor(1) == 0xffeeeeee);
+    REQUIRE(stops.evalColor(2) == 0xffdddddd);
+    REQUIRE(stops.evalColor(7) == 0xffaaaaaa);
 
 }


### PR DESCRIPTION
To demonstrate and test the implementation, Stops for the "roads" layer have been ported from the tangram-js default scene file. Roads behave much more sanely now!

For parity with tangram-js, we still need:
 - [ ] resolving distance units to a common scale (right now distances specify a fraction of the tile size)
 - [ ] management of camera properties with Stops
 - [ ] sprite sizes as Stops (not in tangram-docs, but used in examples)
 - [ ] "z" parameter as Stops (we don't handle this parameter at all, but it's quite seldom used)

Some items above make sense to approach in a separate change set, so this isn't a completion list for this PR. 