### PR TITLE
Scene reloading - was: Decouple SceneLoader from TileManager and View

### DIFF
--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -6,12 +6,18 @@
 #include "tile/tile.h"
 #include "tile/tileManager.h"
 
+#include <atomic>
+
 namespace Tangram {
+
+static std::atomic<int32_t> s_serial;
 
 DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate) :
     m_name(_name), m_urlTemplate(_urlTemplate),
     m_cacheUsage(0),
     m_cacheMaxUsage(0) {
+
+    m_id = s_serial++;
 }
 
 DataSource::~DataSource() {

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -55,6 +55,8 @@ public:
      */
     void setCacheSize(size_t _cacheSize);
 
+    int32_t id() { return m_id; }
+
 protected:
 
     void onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<TileTask>& _task, TileTaskCb _cb);
@@ -71,6 +73,8 @@ protected:
     // Name used to identify this source in the style sheet
     std::string m_name;
 
+    // Unique id for DataSource
+    int32_t m_id;
     // URL template for requesting tiles from a network or filesystem
     std::string m_urlTemplate;
 

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -50,12 +50,18 @@ public:
 
     const std::string& name() const { return m_name; }
 
+    virtual bool equals(const DataSource& _other) const {
+        return m_name == _other.m_name &&
+               m_urlTemplate == _other.m_urlTemplate;
+    }
+
     /* @_cacheSize: Set size of in-memory cache for tile data in bytes.
      * This cache holds unprocessed tile data for fast recreation of recently used tiles.
      */
     void setCacheSize(size_t _cacheSize);
 
     int32_t id() { return m_id; }
+
 
 protected:
 

--- a/core/src/data/filters.h
+++ b/core/src/data/filters.h
@@ -47,34 +47,38 @@ namespace Tangram {
         };
 
         FilterType type;
-        variant<none_type, Operator, Equality, Range, Existence, Function> data;
+        using Data = variant<none_type, Operator, Equality, Range, Existence, Function>;
+        Data data;
 
         Filter() : type(FilterType::undefined), data(none_type{}) {}
+        Filter(FilterType _type, Data _data) : type(_type), data(std::move(_data)) {}
 
         // Create an 'any', 'all', or 'none' filter
-        Filter(Operators op, const std::vector<Filter>& filters) :
-            type(static_cast<FilterType>(op)),
-            data(Operator{ filters }) {}
-
+        inline static Filter MatchAny(const std::vector<Filter>& filters) {
+            return { FilterType::any,  Operator{ filters }};
+        }
+        inline static Filter MatchAll(const std::vector<Filter>& filters) {
+            return { FilterType::all,  Operator{ filters }};
+        }
+        inline static Filter MatchNone(const std::vector<Filter>& filters) {
+            return { FilterType::none, Operator{ filters }};
+        }
         // Create an 'equality' filter
-        Filter(const std::string& k, const std::vector<Value>& vals) :
-            type(FilterType::equality),
-            data(Equality{ k, vals }) {}
-
+        inline static Filter MatchEquality(const std::string& k, const std::vector<Value>& vals) {
+            return { FilterType::equality, Equality{ k, vals }};
+        }
         // Create a 'range' filter
-        Filter(const std::string& k, float min, float max) :
-            type(FilterType::range),
-            data(Range{ k, min, max }) {}
-
+        inline static Filter MatchRange(const std::string& k, float min, float max) {
+            return { FilterType::range, Range{ k, min, max }};
+        }
         // Create an 'existence' filter
-        Filter(const std::string& k, bool ex) :
-            type(FilterType::existence),
-            data(Existence{ k, ex }) {}
-
+        inline static Filter MatchExistence(const std::string& k, bool ex) {
+            return { FilterType::existence, Existence{ k, ex }};
+        }
         // Create an 'function' filter with reference to Scene function id
-        Filter(uint32_t id) :
-            type(FilterType::function),
-            data(Function{ id }) {}
+        inline static Filter MatchFunction(uint32_t id) {
+            return { FilterType::function, Function{ id }};
+        }
 
         bool eval(const Feature& feat, const StyleContext& ctx) const {
 

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -93,6 +93,7 @@ public:
      */
     static void invalidateAllPrograms();
 
+    auto getSourceBlocks() const { return  m_sourceBlocks; }
 private:
 
     struct ShaderLocation {

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -3,9 +3,13 @@
 #include "platform.h"
 #include "style/style.h"
 
+#include <atomic>
+
 namespace Tangram {
 
-Scene::Scene() : id(0) {}
+static std::atomic<int32_t> s_serial;
+
+Scene::Scene() : id(s_serial++) {}
 Scene::~Scene() {}
 
 const Style* Scene::findStyle(const std::string &_name) const {

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -10,10 +10,13 @@
 #include <vector>
 #include <unordered_map>
 
+#include "glm/glm.hpp"
+
 namespace Tangram {
 
 class Style;
 class Texture;
+class DataSource;
 
 /* Singleton container of <Style> information
  *
@@ -25,6 +28,7 @@ public:
     Scene();
     ~Scene();
 
+    auto& dataSources() { return m_dataSources; };
     auto& layers() { return m_layers; };
     auto& styles() { return m_styles; };
     auto& lights() { return m_lights; };
@@ -33,6 +37,7 @@ public:
     auto& spriteAtlases() { return m_spriteAtlases; };
     auto& stops() { return m_stops; }
 
+    const auto& dataSources() const { return m_dataSources; };
     const auto& layers() const { return m_layers; };
     const auto& styles() const { return m_styles; };
     const auto& lights() const { return m_lights; };
@@ -43,9 +48,13 @@ public:
 
     const int32_t id;
 
+    glm::dvec2 startPosition = { 0, 0 };
+    float startZoom = 0;
+
 private:
 
     std::vector<DataLayer> m_layers;
+    std::vector<std::shared_ptr<DataSource>> m_dataSources;
     std::vector<std::unique_ptr<Style>> m_styles;
     std::vector<std::unique_ptr<Light>> m_lights;
     std::unordered_map<std::string, std::shared_ptr<Texture>> m_textures;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -672,20 +672,20 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
 
         if (type == "ambient") {
 
-            lightPtr = std::unique_ptr<Light>(new AmbientLight(name));
+            lightPtr = std::make_unique<AmbientLight>(name);
 
         } else if (type == "directional") {
 
-            DirectionalLight* dLightPtr = new DirectionalLight(name);
+            auto dLightPtr(std::make_unique<DirectionalLight>(name));
             Node direction = light["direction"];
             if (direction) {
                 dLightPtr->setDirection(parseVec<glm::vec3>(direction));
             }
-            lightPtr = std::unique_ptr<Light>(dLightPtr);
+            lightPtr = std::move(dLightPtr);
 
         } else if (type == "point") {
 
-            PointLight* pLightPtr = new PointLight(name);
+            auto pLightPtr(std::make_unique<PointLight>(name));
             Node position = light["position"];
             if (position) {
                 pLightPtr->setPosition(parseVec<glm::vec3>(position));
@@ -702,11 +702,11 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
             if (att) {
                 pLightPtr->setAttenuation(att.as<float>());
             }
-            lightPtr = std::unique_ptr<Light>(pLightPtr);
+            lightPtr = std::move(pLightPtr);
 
         } else if (type == "spotlight") {
 
-            SpotLight* sLightPtr = new SpotLight(name);
+            auto sLightPtr(std::make_unique<SpotLight>(name));
             Node position = light["position"];
             if (position) {
                 sLightPtr->setPosition(parseVec<glm::vec3>(position));
@@ -732,8 +732,7 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
                 sLightPtr->setCutoffExponent(exponent.as<float>());
             }
 
-            lightPtr = std::unique_ptr<Light>(sLightPtr);
-
+            lightPtr = std::move(sLightPtr);
         }
 
         Node origin = light["origin"];

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -29,9 +29,9 @@ using YAML::Node;
 using YAML::NodeType;
 using YAML::BadConversion;
 
-#define LOGE(fmt, ...) do { logMsg("SceneLoader/Error:" fmt , ## __VA_ARGS__); } while(0)
-#define LOGW(fmt, ...) do { logMsg("SceneLoader/Warn:" fmt , ## __VA_ARGS__); } while(0)
-#define LOGN(fmt, node) do { logMsg("SceneLoader/Warn:" fmt ":\n'%s'\n", Dump(node).c_str())); } while(0)
+#define LOGE(fmt, ...) do { logMsg("SceneLoader/Error: " fmt "\n", ## __VA_ARGS__); } while(0)
+#define LOGW(fmt, ...) do { logMsg("SceneLoader/Warn: " fmt "\n", ## __VA_ARGS__); } while(0)
+#define LOGN(fmt, node) do { logMsg("SceneLoader/Warn: " fmt ":\n'%s'\n", Dump(node).c_str()); } while(0)
 
 namespace Tangram {
 
@@ -44,7 +44,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
 
     try { config = YAML::Load(_sceneString); }
     catch (YAML::ParserException e) {
-        LOGE("Parsing scene config '%s'\n", e.what());
+        LOGE("Parsing scene config '%s'", e.what());
         return false;
     }
 
@@ -63,19 +63,19 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         for (const auto& source : sources) {
             try { loadSource(source, _scene); }
             catch (YAML::RepresentationException e) {
-                LOGE("Parsing source: '%s' in:\n%s\n",
+                LOGE("Parsing source: '%s' in:\n%s",
                      e.what(), Dump(source).c_str());
             }
         }
     } else {
-        LOGW("No source defined in the yaml scene configuration.\n");
+        LOGW("No source defined in the yaml scene configuration.");
     }
 
     if (Node textures = config["textures"]) {
         for (const auto& texture : textures) {
             try { loadTexture(texture, _scene); }
             catch (YAML::RepresentationException e) {
-                LOGE("Parsing texture: '%s' in:\n%s\n",
+                LOGE("Parsing texture: '%s' in:\n%s",
                      e.what(), Dump(texture).c_str());
             }
         }
@@ -85,7 +85,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         for (const auto& style : styles) {
             try { loadStyle(style, styles, _scene); }
             catch (YAML::RepresentationException e) {
-                LOGE("Parsing style: '%s' in:\n%s\n",
+                LOGE("Parsing style: '%s' in:\n%s",
                      e.what(), Dump(style).c_str());
             }
         }
@@ -95,7 +95,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         for (const auto& layer : layers) {
             try { loadLayer(layer, _scene); }
             catch (YAML::RepresentationException e) {
-                LOGE("Parsing layer: '%s' in:\n%s\n",
+                LOGE("Parsing layer: '%s' in:\n%s",
                      e.what(), Dump(layer).c_str());
             }
         }
@@ -105,7 +105,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         for (const auto& light : lights) {
             try { loadLight(light, _scene); }
             catch (YAML::RepresentationException e) {
-                LOGE("Parsing light: '%s' in:\n%s\n",
+                LOGE("Parsing light: '%s' in:\n%s",
                      e.what(), Dump(light).c_str());
             }
         }
@@ -119,7 +119,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
     if (Node cameras = config["cameras"]) {
         try { loadCameras(cameras, _scene); }
         catch (YAML::RepresentationException e) {
-            LOGE("Parsing cameras: '%s' in:\n%s\n",
+            LOGE("Parsing cameras: '%s' in:\n%s",
                    e.what(), Dump(cameras).c_str());
         }
     }
@@ -158,7 +158,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
             }
             break;
         default:
-            LOGW("Invalid 'extensions':\n'%s'\n", Dump(extensionsNode).c_str());
+            LOGN("Invalid 'extensions'", extensionsNode);
         }
 
         for (const auto& extName : extensions) {
@@ -227,7 +227,7 @@ glm::vec4 parseMaterialVec(const Node& prop) {
             float value = prop.as<float>();
             return glm::vec4(value, value, value, 1.0);
         } catch (const BadConversion& e) {
-            LOGW("Invalid 'material':\n'%s'\n", Dump(prop).c_str());
+            LOGN("Invalid 'material'", prop);
             // TODO: css color parser and hex_values
         }
         break;
@@ -235,7 +235,7 @@ glm::vec4 parseMaterialVec(const Node& prop) {
         // Handled as texture
         break;
     default:
-        LOGW("Invalid 'material':\n'%s'\n", Dump(prop).c_str());
+        LOGN("Invalid 'material'", prop);
         break;
     }
     return glm::vec4(0.0);
@@ -275,8 +275,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
     if (Node shininess = matNode["shininess"]) {
         try { material.setShininess(shininess.as<float>()); }
         catch(const BadConversion& e) {
-            LOGW("Expected float value for 'shininess':\n'%s'\n",
-                Dump(matNode).c_str());
+            LOGN("Expected float value for 'shininess'", matNode);
         }
     }
 
@@ -289,8 +288,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
 
     Node textureNode = matCompNode["texture"];
     if (!textureNode) {
-        LOGW("Expected a 'texture' parameter: '%s'\n",
-               Dump(matCompNode).c_str());
+        LOGN("Expected a 'texture' parameter", matCompNode);
 
         return MaterialTexture{};
     }
@@ -310,12 +308,12 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
             matTex.mapping = MappingType::spheremap;
         } else if (mapping == "planar") {
             // TODO
-            LOGW("Planar texture mapping not yet implemented\n");
+            LOGW("Planar texture mapping not yet implemented");
         } else if (mapping == "triplanar") {
             // TODO
-            LOGW("Triplanar texture mapping not yet implemented\n");
+            LOGW("Triplanar texture mapping not yet implemented");
         } else {
-            LOGW("Unrecognized texture mapping '%s'\n", mapping.c_str());
+            LOGW("Unrecognized texture mapping '%s'", mapping.c_str());
         }
     }
 
@@ -325,7 +323,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
         } else if (scaleNode.IsScalar()) {
             matTex.scale = glm::vec3(scaleNode.as<float>());
         } else {
-            LOGW("Unrecognized scale parameter in material\n");
+            LOGW("Unrecognized scale parameter in material");
         }
     }
 
@@ -337,7 +335,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
         } else if (amountNode.IsScalar()) {
             matTex.amount = glm::vec3(amountNode.as<float>());
         } else {
-            LOGW("Unrecognized amount parameter in material\n");
+            LOGW("Unrecognized amount parameter in material");
         }
     }
 
@@ -361,7 +359,7 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
     if (Node url = textureConfig["url"]) {
         file = url.as<std::string>();
     } else {
-        LOGW("No url specified for texture '%s', skipping.\n", name.c_str());
+        LOGW("No url specified for texture '%s', skipping.", name.c_str());
         return;
     }
 
@@ -402,18 +400,18 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
 void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scene) {
 
     if (!styleNode) {
-        LOGW("Can not parse style parameters, bad style YAML Node\n");
+        LOGW("Can not parse style parameters, bad style YAML Node");
         return;
     }
 
     if (Node animatedNode = styleNode["animated"]) {
-        LOGW("'animated' property will be set but not yet implemented in styles\n"); // TODO
-        if (!animatedNode.IsScalar()) { LOGW("animated flag should be a scalar\n"); }
+        LOGW("'animated' property will be set but not yet implemented in styles"); // TODO
+        if (!animatedNode.IsScalar()) { LOGW("animated flag should be a scalar"); }
         else {
             try {
                 style.setAnimated(animatedNode.as<bool>());
             } catch(const BadConversion& e) {
-                LOGW("Expected a boolean value in 'animated' property. Using default (false).\n");
+                LOGW("Expected a boolean value in 'animated' property. Using default (false).");
             }
         }
     }
@@ -425,11 +423,11 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
         else if (str == "multiply") { style.setBlendMode(Blending::multiply); }
         else if (str == "overlay")  { style.setBlendMode(Blending::overlay); }
         else if (str == "inlay")    { style.setBlendMode(Blending::inlay); }
-        else { LOGW("Invalid blend mode '%s'\n", str.c_str()); }
+        else { LOGW("Invalid blend mode '%s'", str.c_str()); }
     }
 
     if (Node texcoordsNode = styleNode["texcoords"]) {
-        LOGW("'texcoords' style parameter is currently ignored\n");
+        LOGW("'texcoords' style parameter is currently ignored");
         if (texcoordsNode.as<bool>()) { } // TODO
         else { } // TODO
     }
@@ -448,7 +446,7 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
         else if (lighting == "vertex") { style.setLightingType(LightingType::vertex); }
         else if (lighting == "false") { style.setLightingType(LightingType::none); }
         else if (lighting == "true") { } // use default lighting
-        else { LOGW("Unrecognized lighting type '%s'\n", lighting.c_str()); }
+        else { LOGW("Unrecognized lighting type '%s'", lighting.c_str()); }
     }
 
     if (Node textureNode = styleNode["texture"]) {
@@ -468,7 +466,7 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
 
     if (Node urlNode = styleNode["url"]) {
         // TODO
-        LOGW("Loading style from URL not yet implemented\n");
+        LOGW("Loading style from URL not yet implemented");
     }
 }
 
@@ -519,7 +517,7 @@ Node SceneLoader::propMerge(const std::string& propName, const Mixes& mixes) {
             }
             break;
         default:
-            LOGW("Cannot merge property:\n'%s'\n", Dump(propValue).c_str());
+            LOGN("Cannot merge property", propValue);
             break;
         }
     }
@@ -546,15 +544,13 @@ Node SceneLoader::shaderBlockMerge(const Mixes& mixes) {
         Node shaderNode = mixNode["shaders"];
         if (!shaderNode) { continue; }
         if (!shaderNode.IsMap()) {
-            LOGW("Expected map for 'shader':\n'%s'\n",
-                Dump(shaderNode).c_str());
+            LOGN("Expected map for 'shader'", shaderNode);
             continue;
         }
         Node blocks = shaderNode["blocks"];
         if (!blocks) { continue; }
         if (!blocks.IsMap()) {
-            LOGW("Expected map for 'blocks':\n'%s'\n",
-                Dump(shaderNode).c_str());
+            LOGN("Expected map for 'blocks'", shaderNode);
             continue;
         }
 
@@ -580,8 +576,7 @@ Node SceneLoader::shaderExtMerge(const Mixes& mixes) {
         Node shaderNode = mixNode["shaders"];
         if (!shaderNode) { continue; }
         if (!shaderNode.IsMap()) {
-            LOGW("Expected map for 'shader':\n%s\n",
-                Dump(shaderNode).c_str());
+            LOGN("Expected map for 'shader'", shaderNode);
             continue;
         }
         Node extNode = shaderNode["extensions"];
@@ -607,8 +602,7 @@ Node SceneLoader::shaderExtMerge(const Mixes& mixes) {
             break;
         }
         default:
-            LOGW("Expected scalar or sequence value for 'extensions' node:\n%s\n",
-                 Dump(node).c_str());
+            LOGN("Expected scalar or sequence value for 'extensions' node", node);
         }
     }
 
@@ -650,7 +644,7 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
         if (styleName == builtIn) { validName = false; }
     }
     if (!validName) {
-        LOGW("Cannot use built-in style name '%s' for new style\n", styleName.c_str());
+        LOGW("Cannot use built-in style name '%s' for new style", styleName.c_str());
         return;
     }
 
@@ -665,7 +659,7 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
                 mixes.push_back(styles[mixStyleNode.as<std::string>()]);
             }
         } else {
-            LOGW("Parsing mix param for style: '%s'. Expected scalar or sequence value\n",
+            LOGW("Parsing mix param for style: '%s'. Expected scalar or sequence value",
                  styleName.c_str());
         }
     }
@@ -687,7 +681,7 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
         } else if (baseString == "points") {
             style = std::make_unique<SpriteStyle>(styleName);
         } else {
-            LOGW("Base style '%s' not recognized, cannot instantiate.\n", baseString.c_str());
+            LOGW("Base style '%s' not recognized, cannot instantiate.", baseString.c_str());
             return;
         }
 
@@ -723,11 +717,11 @@ void SceneLoader::loadSource(const std::pair<Node, Node>& src, Scene& _scene) {
             sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url));
         }
     } else if (type == "TopoJSONTiles") {
-        LOGW("TopoJSON data sources not yet implemented\n"); // TODO
+        LOGW("TopoJSON data sources not yet implemented"); // TODO
     } else if (type == "MVT") {
         sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url));
     } else {
-        LOGW("Unrecognized data source type '%s', skipping\n", type.c_str());
+        LOGW("Unrecognized data source type '%s', skipping", type.c_str());
     }
 
     if (sourcePtr) {
@@ -981,27 +975,25 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
                 try {
                     minVal = valItr.second.as<float>();
                 } catch (const BadConversion& e) {
-                    LOGW("Invalid  'filter', expect a float value type:\n'%s'\n",
-                         Dump(_node).c_str());
+                    LOGN("Invalid  'filter', expect a float value type\n", _node);
                     return Filter();
                 }
             } else if (valItr.first.as<std::string>() == "max") {
                 try {
                     maxVal = valItr.second.as<float>();
                 } catch (const BadConversion& e) {
-                    LOGW("Invalid  'filter', expect a float value type:\n'%s'\n",
-                         Dump(_node).c_str());
+                    LOGN("Invalid  'filter', expect a float value type", _node);
                     return Filter();
                 }
             } else {
-                LOGW("Invalid  'filter'\n");
+                LOGN("Invalid  'filter'", _node);
                 return Filter();
             }
         }
         return Filter::MatchRange(_key, minVal, maxVal);
     }
     default:
-        LOGW("Invalid Filter '%s'\n", Dump(_node).c_str());
+        LOGN("Invalid 'filter'", _node);
         return Filter();
     }
 }
@@ -1010,7 +1002,7 @@ Filter SceneLoader::generateAnyFilter(Node _filter, Scene& scene) {
     std::vector<Filter> filters;
 
     if (!_filter.IsSequence()) {
-        LOGW("Invalid filter. 'Any' expects a list.\n");
+        LOGW("Invalid filter. 'Any' expects a list.");
         return Filter();
     }
     for (const auto& filt : _filter) {
@@ -1033,7 +1025,7 @@ Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
             filters.emplace_back(generatePredicate(_filter[keyFilter], keyFilter));
         }
     } else {
-        LOGW("Invalid filter. 'None' expects a list or an object.\n");
+        LOGW("Invalid filter. 'None' expects a list or an object.");
         return Filter();
     }
 
@@ -1077,7 +1069,7 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
 
                     out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                 } else {
-                    LOGW("Unknown style parameter %s\n", key.c_str());
+                    LOGW("Unknown style parameter %s", key.c_str());
                 }
 
             } else {
@@ -1091,7 +1083,7 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
             break;
         }
         default:
-            LOGW("Style parameter %s must be a scalar, sequence, or map.\n", key.c_str());
+            LOGW("Style parameter %s must be a scalar, sequence, or map.", key.c_str());
         }
     }
 }
@@ -1152,7 +1144,7 @@ StyleUniforms SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
             }
         }
     } else {
-        LOGW("Expected a scalar or sequence value for uniforms\n");
+        LOGW("Expected a scalar or sequence value for uniforms");
     }
     return std::make_pair(type, std::move(uniformValues));
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -44,8 +44,9 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         return false;
     }
 
-    auto fontCtx = FontContext::GetInstance(); // To add font for debugTextStyle
-    fontCtx->addFont("FiraSans", "Medium", "");
+    // To add font for debugTextStyle
+    FontContext::GetInstance()->addFont("FiraSans", "Medium", "");
+
     // Instantiate built-in styles
     _scene.styles().emplace_back(new PolygonStyle("polygons"));
     _scene.styles().emplace_back(new PolylineStyle("lines"));
@@ -54,8 +55,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
     _scene.styles().emplace_back(new DebugStyle("debug"));
     _scene.styles().emplace_back(new SpriteStyle("sprites"));
 
-    Node sources = config["sources"];
-    if (sources) {
+    if (Node sources = config["sources"]) {
         for (const auto& source : sources) {
             try { loadSource(source, _scene); }
             catch (YAML::RepresentationException e) {
@@ -67,8 +67,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         logMsg("Scene: No source defined in the yaml scene configuration.\n");
     }
 
-    Node textures = config["textures"];
-    if (textures) {
+    if (Node textures = config["textures"]) {
         for (const auto& texture : textures) {
             try { loadTexture(texture, _scene); }
             catch (YAML::RepresentationException e) {
@@ -78,8 +77,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         }
     }
 
-    Node styles = config["styles"];
-    if (styles) {
+    if (Node styles = config["styles"]) {
         for (const auto& style : styles) {
             try { loadStyle(style, styles, _scene); }
             catch (YAML::RepresentationException e) {
@@ -89,8 +87,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         }
     }
 
-    Node layers = config["layers"];
-    if (layers) {
+    if (Node layers = config["layers"]) {
         for (const auto& layer : layers) {
             try { loadLayer(layer, _scene); }
             catch (YAML::RepresentationException e) {
@@ -100,8 +97,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         }
     }
 
-    Node lights = config["lights"];
-    if (lights) {
+    if (Node lights = config["lights"]) {
         for (const auto& light : lights) {
             try { loadLight(light, _scene); }
             catch (YAML::RepresentationException e) {
@@ -116,10 +112,12 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         _scene.lights().push_back(std::move(amb));
     }
 
-    try { loadCameras(config["cameras"], _scene); }
-    catch (YAML::RepresentationException e) {
-        logMsg("Error: Parsing cameras: '%s' in:\n%s\n",
-               e.what(), Dump(config["cameras"]).c_str());
+    if (Node cameras = config["cameras"]) {
+        try { loadCameras(cameras, _scene); }
+        catch (YAML::RepresentationException e) {
+            logMsg("Error: Parsing cameras: '%s' in:\n%s\n",
+                   e.what(), Dump(cameras).c_str());
+        }
     }
 
     for (auto& style : _scene.styles()) {
@@ -143,6 +141,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
     auto& shader = *(style.getShaderProgram());
 
     if (Node extensionsNode = shaders["extensions"]) {
+
         std::vector<std::string> extensions;
         switch (extensionsNode.Type()) {
         case NodeType::Scalar:
@@ -203,11 +202,12 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
         }
     }
 
-    Node blocksNode = shaders["blocks"];
-    if (blocksNode) {
+    if (Node blocksNode = shaders["blocks"]) {
         for (const auto& block : blocksNode) {
             std::string name = block.first.as<std::string>();
             std::string value = block.second.as<std::string>();
+            //logMsg("add block '%s - %s'\n",name.c_str(), value.c_str());
+
             shader.addSourceBlock(name, value); // TODO: Warn on unrecognized injection points
         }
     }
@@ -261,12 +261,9 @@ void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
                          std::bind(&Material::setSpecularTex, &material, _1),
                          std::bind(&Material::setSpecular, &material, _1));
 
-    Node shininess = matNode["shininess"];
-
-    if (shininess) {
-        try {
-            material.setShininess(shininess.as<float>());
-        } catch(const BadConversion& e) {
+    if (Node shininess = matNode["shininess"]) {
+        try { material.setShininess(shininess.as<float>()); }
+        catch(const BadConversion& e) {
             logMsg("Scene: Float value expected for shininess material parameter");
         }
     }
@@ -278,41 +275,39 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
 
     if (!matCompNode) { return MaterialTexture{}; }
 
-    MaterialTexture matTex;
     Node textureNode = matCompNode["texture"];
-    Node mappingNode = matCompNode["mapping"];
-    Node scaleNode = matCompNode["scale"];
-    Node amountNode = matCompNode["amount"];
-
     if (!textureNode) {
         logMsg("Scene: Expected a 'texture' parameter: '%s'\n",
                Dump(matCompNode).c_str());
 
-        return matTex;
+        return MaterialTexture{};
     }
 
     std::string name = textureNode.as<std::string>();
 
-    auto& tex = scene.textures()[name];
+    MaterialTexture matTex;
+    matTex.tex = scene.textures()[name];
 
-    if (!tex) {
-        tex = std::make_shared<Texture>(name);
-    }
+    if (!matTex.tex) { matTex.tex = std::make_shared<Texture>(name); }
 
-    matTex.tex = tex;
-
-    if (!matTex.tex) { matTex.tex.reset(new Texture(name)); }
-
-    if (mappingNode) {
+    if (Node mappingNode = matCompNode["mapping"]) {
         std::string mapping = mappingNode.as<std::string>();
-        if (mapping == "uv") { matTex.mapping = MappingType::uv; }
-        else if (mapping == "spheremap") { matTex.mapping = MappingType::spheremap; }
-        else if (mapping == "planar") { logMsg("Scene: Planar texture mapping not yet implemented\n"); } // TODO
-        else if (mapping == "triplanar") { logMsg("Scene: Triplanar texture mapping not yet implemented\n"); } // TODO
-        else { logMsg("Scene: Unrecognized texture mapping '%s'\n", mapping.c_str()); }
+        if (mapping == "uv") {
+            matTex.mapping = MappingType::uv;
+        } else if (mapping == "spheremap") {
+            matTex.mapping = MappingType::spheremap;
+        } else if (mapping == "planar") {
+            // TODO
+            logMsg("Scene: Planar texture mapping not yet implemented\n");
+        } else if (mapping == "triplanar") {
+            // TODO
+            logMsg("Scene: Triplanar texture mapping not yet implemented\n");
+        } else {
+            logMsg("Scene: Unrecognized texture mapping '%s'\n", mapping.c_str());
+        }
     }
 
-    if (scaleNode) {
+    if (Node scaleNode = matCompNode["scale"]) {
         if (scaleNode.IsSequence() && scaleNode.size() == 2) {
             matTex.scale = { scaleNode[0].as<float>(), scaleNode[1].as<float>(), 1.f };
         } else if (scaleNode.IsScalar()) {
@@ -322,9 +317,11 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
         }
     }
 
-    if (amountNode) {
+    if (Node amountNode = matCompNode["amount"]) {
         if (amountNode.IsSequence() && amountNode.size() == 3) {
-            matTex.amount = { amountNode[0].as<float>(), amountNode[1].as<float>(), amountNode[2].as<float>() };
+            matTex.amount = { amountNode[0].as<float>(),
+                              amountNode[1].as<float>(),
+                              amountNode[2].as<float>() };
         } else if (amountNode.IsScalar()) {
             matTex.amount = glm::vec3(amountNode.as<float>());
         } else {
@@ -349,17 +346,16 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
     std::string file;
     TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
 
-    Node url = textureConfig["url"];
-    if (url) {
+    if (Node url = textureConfig["url"]) {
         file = url.as<std::string>();
     } else {
         logMsg("Scene: No url specified for texture '%s', skipping.\n", name.c_str());
         return;
     }
 
-    Node filtering = textureConfig["filtering"];
     bool generateMipmaps = false;
-    if (filtering) {
+
+    if (Node filtering = textureConfig["filtering"]) {
         std::string f = filtering.as<std::string>();
         if (f == "linear") { options.m_filtering = { GL_LINEAR, GL_LINEAR }; }
         else if (f == "mipmap") {
@@ -370,8 +366,7 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
 
     std::shared_ptr<Texture> texture(new Texture(file, options, generateMipmaps));
 
-    Node sprites = textureConfig["sprites"];
-    if (sprites) {
+    if (Node sprites = textureConfig["sprites"]) {
         std::shared_ptr<SpriteAtlas> atlas(new SpriteAtlas(texture, file));
 
         for (auto it = sprites.begin(); it != sprites.end(); ++it) {
@@ -387,10 +382,8 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
                 atlas->addSpriteNode(spriteName, pos, size);
             }
         }
-
         scene.spriteAtlases()[name] = atlas;
     }
-
     scene.textures().emplace(name, texture);
 }
 
@@ -554,31 +547,32 @@ Node SceneLoader::shaderExtMerge(const Mixes& mixes) {
     std::unordered_set<std::string> uniqueList;
 
     for (const auto& mixNode : mixes) {
-        if (Node shaderNode = mixNode["shaders"]) {
-            if (Node extNode = shaderNode["extensions"]) {
-                switch(extNode.Type()) {
-                case NodeType::Scalar: {
-                    auto val = extNode.as<std::string>();
+        Node shaderNode = mixNode["shaders"];
+        Node extNode = shaderNode["extensions"];
+
+        if (shaderNode && extNode) {
+            switch(extNode.Type()) {
+            case NodeType::Scalar: {
+                auto val = extNode.as<std::string>();
+                if (uniqueList.find(val) == uniqueList.end()) {
+                    node.push_back(extNode);
+                    uniqueList.insert(val);
+                }
+                break;
+            }
+            case NodeType::Sequence: {
+                for (const auto& n : extNode) {
+                    auto val = n.as<std::string>();
                     if (uniqueList.find(val) == uniqueList.end()) {
-                        node.push_back(extNode);
+                        node.push_back(n);
                         uniqueList.insert(val);
                     }
-                    break;
                 }
-                case NodeType::Sequence: {
-                    for (const auto& n : extNode) {
-                        auto val = n.as<std::string>();
-                        if (uniqueList.find(val) == uniqueList.end()) {
-                            node.push_back(n);
-                            uniqueList.insert(val);
-                        }
-                    }
-                    break;
-                }
-                default:
-                    logMsg("Scene: Expected scalar or sequence value for extensions node '%s'.\n",
-                        Dump(node).c_str());
-                }
+                break;
+            }
+            default:
+                logMsg("Scene: Expected scalar or sequence value for extensions node '%s'.\n",
+                       Dump(node).c_str());
             }
         }
     }
@@ -608,8 +602,6 @@ Node SceneLoader::mixStyle(const Mixes& mixes) {
 }
 
 void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, Scene& scene) {
-
-    Style* style = nullptr;
 
     std::string styleName = styleIt.first.as<std::string>();
     Node styleNode = styleIt.second;
@@ -644,21 +636,23 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
 
     // Construct style instance using the merged properties
     if (Node baseNode = mixedStyleNode["base"]) {
+        std::unique_ptr<Style> style;
+
         std::string baseString = baseNode.as<std::string>();
         if (baseString == "polygons") {
-            style = new PolygonStyle(styleName);
+            style = std::make_unique<PolygonStyle>(styleName);
         } else if (baseString == "lines") {
-            style = new PolylineStyle(styleName);
+            style = std::make_unique<PolylineStyle>(styleName);
         } else if (baseString == "text") {
-            style = new TextStyle(styleName, true, true);
+            style = std::make_unique<TextStyle>(styleName, true, true);
         } else if (baseString == "points") {
-            style = new SpriteStyle(styleName);
+            style = std::make_unique<SpriteStyle>(styleName);
         } else {
             logMsg("Scene: Base style '%s' not recognized, cannot instantiate.\n", baseString.c_str());
             return;
         }
-        loadStyleProps(style, mixedStyleNode, scene);
-        scene.styles().push_back(std::unique_ptr<Style>(style));
+        loadStyleProps(style.get(), mixedStyleNode, scene);
+        scene.styles().push_back(std::move(style));
     } else {
         // No baseNode, this is an abstract styleNode
         return;
@@ -705,101 +699,82 @@ void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
     const std::string name = node.first.Scalar();
     const std::string type = light["type"].as<std::string>();
 
-    std::unique_ptr<Light> lightPtr;
+    std::unique_ptr<Light> sceneLight;
 
     if (type == "ambient") {
-
-        lightPtr = std::make_unique<AmbientLight>(name);
+        sceneLight = std::make_unique<AmbientLight>(name);
 
     } else if (type == "directional") {
+        auto dLight(std::make_unique<DirectionalLight>(name));
 
-        auto dLightPtr(std::make_unique<DirectionalLight>(name));
-        Node direction = light["direction"];
-        if (direction) {
-            dLightPtr->setDirection(parseVec<glm::vec3>(direction));
+        if (Node direction = light["direction"]) {
+            dLight->setDirection(parseVec<glm::vec3>(direction));
         }
-        lightPtr = std::move(dLightPtr);
+        sceneLight = std::move(dLight);
 
     } else if (type == "point") {
+        auto pLight(std::make_unique<PointLight>(name));
 
-        auto pLightPtr(std::make_unique<PointLight>(name));
-        Node position = light["position"];
-        if (position) {
-            pLightPtr->setPosition(parseVec<glm::vec3>(position));
+        if (Node position = light["position"]) {
+            pLight->setPosition(parseVec<glm::vec3>(position));
         }
-        Node radius = light["radius"];
-        if (radius) {
+        if (Node radius = light["radius"]) {
             if (radius.size() > 1) {
-                pLightPtr->setRadius(radius[0].as<float>(), radius[1].as<float>());
+                pLight->setRadius(radius[0].as<float>(), radius[1].as<float>());
             } else {
-                pLightPtr->setRadius(radius.as<float>());
+                pLight->setRadius(radius.as<float>());
             }
         }
-        Node att = light["attenuation"];
-        if (att) {
-            pLightPtr->setAttenuation(att.as<float>());
+        if (Node att = light["attenuation"]) {
+            pLight->setAttenuation(att.as<float>());
         }
-        lightPtr = std::move(pLightPtr);
+        sceneLight = std::move(pLight);
 
     } else if (type == "spotlight") {
+        auto sLight(std::make_unique<SpotLight>(name));
 
-        auto sLightPtr(std::make_unique<SpotLight>(name));
-        Node position = light["position"];
-        if (position) {
-            sLightPtr->setPosition(parseVec<glm::vec3>(position));
+        if (Node position = light["position"]) {
+            sLight->setPosition(parseVec<glm::vec3>(position));
         }
-        Node direction = light["direction"];
-        if (direction) {
-            sLightPtr->setDirection(parseVec<glm::vec3>(direction));
+        if (Node direction = light["direction"]) {
+            sLight->setDirection(parseVec<glm::vec3>(direction));
         }
-        Node radius = light["radius"];
-        if (radius) {
+        if (Node radius = light["radius"]) {
             if (radius.size() > 1) {
-                sLightPtr->setRadius(radius[0].as<float>(), radius[1].as<float>());
+                sLight->setRadius(radius[0].as<float>(), radius[1].as<float>());
             } else {
-                sLightPtr->setRadius(radius.as<float>());
+                sLight->setRadius(radius.as<float>());
             }
         }
-        Node angle = light["angle"];
-        if (angle) {
-            sLightPtr->setCutoffAngle(angle.as<float>());
+        if (Node angle = light["angle"]) {
+            sLight->setCutoffAngle(angle.as<float>());
         }
-        Node exponent = light["exponent"];
-        if (exponent) {
-            sLightPtr->setCutoffExponent(exponent.as<float>());
+        if (Node exponent = light["exponent"]) {
+            sLight->setCutoffExponent(exponent.as<float>());
         }
-
-        lightPtr = std::move(sLightPtr);
+        sceneLight = std::move(sLight);
     }
-
-    Node origin = light["origin"];
-    if (origin) {
+    if (Node origin = light["origin"]) {
         const std::string originStr = origin.as<std::string>();
         if (originStr == "world") {
-            lightPtr->setOrigin(LightOrigin::world);
+            sceneLight->setOrigin(LightOrigin::world);
         } else if (originStr == "camera") {
-            lightPtr->setOrigin(LightOrigin::camera);
+            sceneLight->setOrigin(LightOrigin::camera);
         } else if (originStr == "ground") {
-            lightPtr->setOrigin(LightOrigin::ground);
+            sceneLight->setOrigin(LightOrigin::ground);
         }
     }
-
-    Node ambient = light["ambient"];
-    if (ambient) {
-        lightPtr->setAmbientColor(parseVec<glm::vec4>(ambient));
+    if (Node ambient = light["ambient"]) {
+        sceneLight->setAmbientColor(parseVec<glm::vec4>(ambient));
+    }
+    if (Node diffuse = light["diffuse"]) {
+        sceneLight->setDiffuseColor(parseVec<glm::vec4>(diffuse));
+    }
+    if (Node specular = light["specular"]) {
+        sceneLight->setSpecularColor(parseVec<glm::vec4>(specular));
     }
 
-    Node diffuse = light["diffuse"];
-    if (diffuse) {
-        lightPtr->setDiffuseColor(parseVec<glm::vec4>(diffuse));
-    }
-
-    Node specular = light["specular"];
-    if (specular) {
-        lightPtr->setSpecularColor(parseVec<glm::vec4>(specular));
-    }
-
-    scene.lights().push_back(std::move(lightPtr));
+    scene.lights().push_back(std::move(sceneLight));
 }
 
 void SceneLoader::loadCameras(Node _cameras, Scene& _scene) {
@@ -1035,43 +1010,43 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
         Node value = prop.second;
 
         switch (value.Type()) {
-             case NodeType::Scalar: {
-                 auto& val = value.as<std::string>();
+        case NodeType::Scalar: {
+            auto& val = value.as<std::string>();
 
-                 if (val.compare(0, 8, "function") == 0) {
-                     StyleParam param(key, "");
-                     param.function = scene.functions().size();
-                     scene.functions().push_back(val);
-                     out.push_back(std::move(param));
-                 } else {
-                     out.push_back(StyleParam{ key, val });
-                 }
-                 break;
+            if (val.compare(0, 8, "function") == 0) {
+                StyleParam param(key, "");
+                param.function = scene.functions().size();
+                scene.functions().push_back(val);
+                out.push_back(std::move(param));
+            } else {
+                out.push_back(StyleParam{ key, val });
             }
-            case NodeType::Sequence: {
-                if (value[0].IsSequence()) {
-                    auto styleKey = StyleParam::getKey(key);
-                    if (styleKey != StyleParamKey::none) {
+            break;
+        }
+        case NodeType::Sequence: {
+            if (value[0].IsSequence()) {
+                auto styleKey = StyleParam::getKey(key);
+                if (styleKey != StyleParamKey::none) {
 
-                        scene.stops().push_back(Stops(value, StyleParam::isColor(styleKey)));
+                    scene.stops().push_back(Stops(value, StyleParam::isColor(styleKey)));
 
-                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
-                    } else {
-                        logMsg("Unknown style parameter %s\n", key.c_str());
-                    }
-
+                    out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                 } else {
-                    out.push_back(StyleParam{ key, parseSequence(value) });
+                    logMsg("Unknown style parameter %s\n", key.c_str());
                 }
-                break;
+
+            } else {
+                out.push_back(StyleParam{ key, parseSequence(value) });
             }
-            case NodeType::Map: {
-                // NB: Flatten parameter map
-                parseStyleParams(value, scene, key, out);
-                break;
-            }
-            default:
-                logMsg("Scene: Style parameter %s must be a scalar, sequence, or map.\n", key.c_str());
+            break;
+        }
+        case NodeType::Map: {
+            // NB: Flatten parameter map
+            parseStyleParams(value, scene, key, out);
+            break;
+        }
+        default:
+            logMsg("Scene: Style parameter %s must be a scalar, sequence, or map.\n", key.c_str());
         }
     }
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -29,6 +29,10 @@ using YAML::Node;
 using YAML::NodeType;
 using YAML::BadConversion;
 
+#define LOGE(fmt, ...) do { logMsg("SceneLoader/Error:" fmt , ## __VA_ARGS__); } while(0)
+#define LOGW(fmt, ...) do { logMsg("SceneLoader/Warn:" fmt , ## __VA_ARGS__); } while(0)
+#define LOGN(fmt, node) do { logMsg("SceneLoader/Warn:" fmt ":\n'%s'\n", Dump(node).c_str())); } while(0)
+
 namespace Tangram {
 
 // TODO: make this configurable: 16MB default in-memory DataSource cache:
@@ -40,7 +44,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
 
     try { config = YAML::Load(_sceneString); }
     catch (YAML::ParserException e) {
-        logMsg("Error: Parsing scene config '%s'\n", e.what());
+        LOGE("Parsing scene config '%s'\n", e.what());
         return false;
     }
 
@@ -59,20 +63,20 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         for (const auto& source : sources) {
             try { loadSource(source, _scene); }
             catch (YAML::RepresentationException e) {
-                logMsg("Error: Parsing source: '%s' in:\n%s\n",
-                       e.what(), Dump(source).c_str());
+                LOGE("Parsing source: '%s' in:\n%s\n",
+                     e.what(), Dump(source).c_str());
             }
         }
     } else {
-        logMsg("Scene: No source defined in the yaml scene configuration.\n");
+        LOGW("No source defined in the yaml scene configuration.\n");
     }
 
     if (Node textures = config["textures"]) {
         for (const auto& texture : textures) {
             try { loadTexture(texture, _scene); }
             catch (YAML::RepresentationException e) {
-                logMsg("Error: Parsing texture: '%s' in:\n%s\n",
-                       e.what(), Dump(texture).c_str());
+                LOGE("Parsing texture: '%s' in:\n%s\n",
+                     e.what(), Dump(texture).c_str());
             }
         }
     }
@@ -81,8 +85,8 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         for (const auto& style : styles) {
             try { loadStyle(style, styles, _scene); }
             catch (YAML::RepresentationException e) {
-                logMsg("Error: Parsing style: '%s' in:\n%s\n",
-                       e.what(), Dump(style).c_str());
+                LOGE("Parsing style: '%s' in:\n%s\n",
+                     e.what(), Dump(style).c_str());
             }
         }
     }
@@ -91,8 +95,8 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         for (const auto& layer : layers) {
             try { loadLayer(layer, _scene); }
             catch (YAML::RepresentationException e) {
-                logMsg("Error: Parsing layer: '%s' in:\n%s\n",
-                       e.what(), Dump(layer).c_str());
+                LOGE("Parsing layer: '%s' in:\n%s\n",
+                     e.what(), Dump(layer).c_str());
             }
         }
     }
@@ -101,8 +105,8 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         for (const auto& light : lights) {
             try { loadLight(light, _scene); }
             catch (YAML::RepresentationException e) {
-                logMsg("Error: Parsing light: '%s' in:\n%s\n",
-                       e.what(), Dump(light).c_str());
+                LOGE("Parsing light: '%s' in:\n%s\n",
+                     e.what(), Dump(light).c_str());
             }
         }
     } else {
@@ -115,7 +119,7 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
     if (Node cameras = config["cameras"]) {
         try { loadCameras(cameras, _scene); }
         catch (YAML::RepresentationException e) {
-            logMsg("Error: Parsing cameras: '%s' in:\n%s\n",
+            LOGE("Parsing cameras: '%s' in:\n%s\n",
                    e.what(), Dump(cameras).c_str());
         }
     }
@@ -154,7 +158,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
             }
             break;
         default:
-            logMsg("Scene: Unexpected Node: '%s'\n", Dump(extensionsNode).c_str());
+            LOGW("Invalid 'extensions':\n'%s'\n", Dump(extensionsNode).c_str());
         }
 
         for (const auto& extName : extensions) {
@@ -223,8 +227,7 @@ glm::vec4 parseMaterialVec(const Node& prop) {
             float value = prop.as<float>();
             return glm::vec4(value, value, value, 1.0);
         } catch (const BadConversion& e) {
-            logMsg("Scene: Invalid material value:\n'%s'\n",
-                   Dump(prop).c_str());
+            LOGW("Invalid 'material':\n'%s'\n", Dump(prop).c_str());
             // TODO: css color parser and hex_values
         }
         break;
@@ -232,8 +235,7 @@ glm::vec4 parseMaterialVec(const Node& prop) {
         // Handled as texture
         break;
     default:
-        logMsg("Scene: Invalid material value:\n'%s'\n",
-               Dump(prop).c_str());
+        LOGW("Invalid 'material':\n'%s'\n", Dump(prop).c_str());
         break;
     }
     return glm::vec4(0.0);
@@ -273,7 +275,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
     if (Node shininess = matNode["shininess"]) {
         try { material.setShininess(shininess.as<float>()); }
         catch(const BadConversion& e) {
-            logMsg("Scene: Expected float value for 'shininess':\n'%s'\n",
+            LOGW("Expected float value for 'shininess':\n'%s'\n",
                 Dump(matNode).c_str());
         }
     }
@@ -287,7 +289,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
 
     Node textureNode = matCompNode["texture"];
     if (!textureNode) {
-        logMsg("Scene: Expected a 'texture' parameter: '%s'\n",
+        LOGW("Expected a 'texture' parameter: '%s'\n",
                Dump(matCompNode).c_str());
 
         return MaterialTexture{};
@@ -308,12 +310,12 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
             matTex.mapping = MappingType::spheremap;
         } else if (mapping == "planar") {
             // TODO
-            logMsg("Scene: Planar texture mapping not yet implemented\n");
+            LOGW("Planar texture mapping not yet implemented\n");
         } else if (mapping == "triplanar") {
             // TODO
-            logMsg("Scene: Triplanar texture mapping not yet implemented\n");
+            LOGW("Triplanar texture mapping not yet implemented\n");
         } else {
-            logMsg("Scene: Unrecognized texture mapping '%s'\n", mapping.c_str());
+            LOGW("Unrecognized texture mapping '%s'\n", mapping.c_str());
         }
     }
 
@@ -323,7 +325,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
         } else if (scaleNode.IsScalar()) {
             matTex.scale = glm::vec3(scaleNode.as<float>());
         } else {
-            logMsg("Scene: Unrecognized scale parameter in material\n");
+            LOGW("Unrecognized scale parameter in material\n");
         }
     }
 
@@ -335,7 +337,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
         } else if (amountNode.IsScalar()) {
             matTex.amount = glm::vec3(amountNode.as<float>());
         } else {
-            logMsg("Scene: Unrecognized amount parameter in material\n");
+            LOGW("Unrecognized amount parameter in material\n");
         }
     }
 
@@ -359,7 +361,7 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
     if (Node url = textureConfig["url"]) {
         file = url.as<std::string>();
     } else {
-        logMsg("Scene: No url specified for texture '%s', skipping.\n", name.c_str());
+        LOGW("No url specified for texture '%s', skipping.\n", name.c_str());
         return;
     }
 
@@ -400,18 +402,18 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
 void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scene) {
 
     if (!styleNode) {
-        logMsg("Scene: Can not parse style parameters, bad style YAML Node\n");
+        LOGW("Can not parse style parameters, bad style YAML Node\n");
         return;
     }
 
     if (Node animatedNode = styleNode["animated"]) {
-        logMsg("Scene: 'animated' property will be set but not yet implemented in styles\n"); // TODO
-        if (!animatedNode.IsScalar()) { logMsg("Scene: animated flag should be a scalar\n"); }
+        LOGW("'animated' property will be set but not yet implemented in styles\n"); // TODO
+        if (!animatedNode.IsScalar()) { LOGW("animated flag should be a scalar\n"); }
         else {
             try {
                 style.setAnimated(animatedNode.as<bool>());
             } catch(const BadConversion& e) {
-                logMsg("Scene: Expected a boolean value in 'animated' property. Using default (false).\n");
+                LOGW("Expected a boolean value in 'animated' property. Using default (false).\n");
             }
         }
     }
@@ -423,11 +425,11 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
         else if (str == "multiply") { style.setBlendMode(Blending::multiply); }
         else if (str == "overlay")  { style.setBlendMode(Blending::overlay); }
         else if (str == "inlay")    { style.setBlendMode(Blending::inlay); }
-        else { logMsg("Scene: Invalid blend mode '%s'\n", str.c_str()); }
+        else { LOGW("Invalid blend mode '%s'\n", str.c_str()); }
     }
 
     if (Node texcoordsNode = styleNode["texcoords"]) {
-        logMsg("Scene: 'texcoords' style parameter is currently ignored\n");
+        LOGW("'texcoords' style parameter is currently ignored\n");
         if (texcoordsNode.as<bool>()) { } // TODO
         else { } // TODO
     }
@@ -446,7 +448,7 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
         else if (lighting == "vertex") { style.setLightingType(LightingType::vertex); }
         else if (lighting == "false") { style.setLightingType(LightingType::none); }
         else if (lighting == "true") { } // use default lighting
-        else { logMsg("Scene: Unrecognized lighting type '%s'\n", lighting.c_str()); }
+        else { LOGW("Unrecognized lighting type '%s'\n", lighting.c_str()); }
     }
 
     if (Node textureNode = styleNode["texture"]) {
@@ -459,14 +461,14 @@ void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scen
             if (it != atlases.end()) {
                 spriteStyle->setSpriteAtlas(it->second);
             } else {
-                logMsg("Scene: Undefined texture name %s", textureName.c_str());
+                LOGW("Undefined texture name %s", textureName.c_str());
             }
         }
     }
 
     if (Node urlNode = styleNode["url"]) {
         // TODO
-        logMsg("Scene: Loading style from URL not yet implemented\n");
+        LOGW("Loading style from URL not yet implemented\n");
     }
 }
 
@@ -517,7 +519,7 @@ Node SceneLoader::propMerge(const std::string& propName, const Mixes& mixes) {
             }
             break;
         default:
-            logMsg("Scene: Cannot merge property:\n'%s'\n", Dump(propValue).c_str());
+            LOGW("Cannot merge property:\n'%s'\n", Dump(propValue).c_str());
             break;
         }
     }
@@ -544,14 +546,14 @@ Node SceneLoader::shaderBlockMerge(const Mixes& mixes) {
         Node shaderNode = mixNode["shaders"];
         if (!shaderNode) { continue; }
         if (!shaderNode.IsMap()) {
-            logMsg("Scene: Expected map for 'shader':\n'%s'\n",
+            LOGW("Expected map for 'shader':\n'%s'\n",
                 Dump(shaderNode).c_str());
             continue;
         }
         Node blocks = shaderNode["blocks"];
         if (!blocks) { continue; }
         if (!blocks.IsMap()) {
-            logMsg("Scene: Expected map for 'blocks':\n'%s'\n",
+            LOGW("Expected map for 'blocks':\n'%s'\n",
                 Dump(shaderNode).c_str());
             continue;
         }
@@ -578,7 +580,7 @@ Node SceneLoader::shaderExtMerge(const Mixes& mixes) {
         Node shaderNode = mixNode["shaders"];
         if (!shaderNode) { continue; }
         if (!shaderNode.IsMap()) {
-            logMsg("Scene: Expected map for 'shader':\n%s\n",
+            LOGW("Expected map for 'shader':\n%s\n",
                 Dump(shaderNode).c_str());
             continue;
         }
@@ -605,8 +607,8 @@ Node SceneLoader::shaderExtMerge(const Mixes& mixes) {
             break;
         }
         default:
-            logMsg("Scene: Expected scalar or sequence value for 'extensions' node:\n%s\n",
-                   Dump(node).c_str());
+            LOGW("Expected scalar or sequence value for 'extensions' node:\n%s\n",
+                 Dump(node).c_str());
         }
     }
 
@@ -648,7 +650,7 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
         if (styleName == builtIn) { validName = false; }
     }
     if (!validName) {
-        logMsg("Scene: Cannot use built-in style name '%s' for new style\n", styleName.c_str());
+        LOGW("Cannot use built-in style name '%s' for new style\n", styleName.c_str());
         return;
     }
 
@@ -663,8 +665,8 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
                 mixes.push_back(styles[mixStyleNode.as<std::string>()]);
             }
         } else {
-            logMsg("Scene parsing mix param for style: '%s'. Expected scalar or sequence value\n",
-                   styleName.c_str());
+            LOGW("Parsing mix param for style: '%s'. Expected scalar or sequence value\n",
+                 styleName.c_str());
         }
     }
     mixes.push_back(styles[styleName]);
@@ -685,7 +687,7 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
         } else if (baseString == "points") {
             style = std::make_unique<SpriteStyle>(styleName);
         } else {
-            logMsg("Scene: Base style '%s' not recognized, cannot instantiate.\n", baseString.c_str());
+            LOGW("Base style '%s' not recognized, cannot instantiate.\n", baseString.c_str());
             return;
         }
 
@@ -721,11 +723,11 @@ void SceneLoader::loadSource(const std::pair<Node, Node>& src, Scene& _scene) {
             sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url));
         }
     } else if (type == "TopoJSONTiles") {
-        logMsg("Scene: TopoJSON data sources not yet implemented\n"); // TODO
+        LOGW("TopoJSON data sources not yet implemented\n"); // TODO
     } else if (type == "MVT") {
         sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url));
     } else {
-        logMsg("Scene: Unrecognized data source type '%s', skipping\n", type.c_str());
+        LOGW("Unrecognized data source type '%s', skipping\n", type.c_str());
     }
 
     if (sourcePtr) {
@@ -979,25 +981,27 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
                 try {
                     minVal = valItr.second.as<float>();
                 } catch (const BadConversion& e) {
-                    logMsg("Scene: Badly formed filter.\tExpect a float value type.\n");
+                    LOGW("Invalid  'filter', expect a float value type:\n'%s'\n",
+                         Dump(_node).c_str());
                     return Filter();
                 }
             } else if (valItr.first.as<std::string>() == "max") {
                 try {
                     maxVal = valItr.second.as<float>();
                 } catch (const BadConversion& e) {
-                    logMsg("Scene: Badly formed filter.\tExpect a float value type.\n");
+                    LOGW("Invalid  'filter', expect a float value type:\n'%s'\n",
+                         Dump(_node).c_str());
                     return Filter();
                 }
             } else {
-                logMsg("Scene: Badly formed Filter\n");
+                LOGW("Invalid  'filter'\n");
                 return Filter();
             }
         }
         return Filter::MatchRange(_key, minVal, maxVal);
     }
     default:
-        logMsg("Scene: Badly formed Filter '%s'\n", Dump(_node).c_str());
+        LOGW("Invalid Filter '%s'\n", Dump(_node).c_str());
         return Filter();
     }
 }
@@ -1006,7 +1010,7 @@ Filter SceneLoader::generateAnyFilter(Node _filter, Scene& scene) {
     std::vector<Filter> filters;
 
     if (!_filter.IsSequence()) {
-        logMsg("Scene: Badly formed filter. 'Any' expects a list.\n");
+        LOGW("Invalid filter. 'Any' expects a list.\n");
         return Filter();
     }
     for (const auto& filt : _filter) {
@@ -1029,7 +1033,7 @@ Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
             filters.emplace_back(generatePredicate(_filter[keyFilter], keyFilter));
         }
     } else {
-        logMsg("Scene: Badly formed filter. 'None' expects a list or an object.\n");
+        LOGW("Invalid filter. 'None' expects a list or an object.\n");
         return Filter();
     }
 
@@ -1073,7 +1077,7 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
 
                     out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                 } else {
-                    logMsg("Unknown style parameter %s\n", key.c_str());
+                    LOGW("Unknown style parameter %s\n", key.c_str());
                 }
 
             } else {
@@ -1087,7 +1091,7 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
             break;
         }
         default:
-            logMsg("Scene: Style parameter %s must be a scalar, sequence, or map.\n", key.c_str());
+            LOGW("Style parameter %s must be a scalar, sequence, or map.\n", key.c_str());
         }
     }
 }
@@ -1148,7 +1152,7 @@ StyleUniforms SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
             }
         }
     } else {
-        logMsg("Warning: Expected a scalar or sequence value for uniforms\n");
+        LOGW("Expected a scalar or sequence value for uniforms\n");
     }
     return std::make_pair(type, std::move(uniformValues));
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -68,9 +68,9 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
 
 void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
 
-    auto& shader = *(style.getShaderProgram());
-
     if (!shaders) { return; }
+
+    auto& shader = *(style.getShaderProgram());
 
     if (Node extensionsNode = shaders["extensions"]) {
         std::vector<std::string> extensions;
@@ -984,9 +984,8 @@ Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
     return Filter(Operators::none, std::move(filters));
 }
 
-std::vector<StyleParam> SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string& prefix) {
-
-    std::vector<StyleParam> out;
+void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string& prefix,
+                                   std::vector<StyleParam>& out) {
 
     for (const auto& prop : params) {
 
@@ -1031,15 +1030,13 @@ std::vector<StyleParam> SceneLoader::parseStyleParams(Node params, Scene& scene,
                 break;
             }
             case NodeType::Map: {
-                auto subparams = parseStyleParams(value, scene, key);
-                out.insert(out.end(), subparams.begin(), subparams.end());
+                // NB: Flatten parameter map
+                parseStyleParams(value, scene, key, out);
                 break;
             }
             default: logMsg("ERROR: Style parameter %s must be a scalar, sequence, or map.\n", key.c_str());
         }
     }
-
-    return out;
 }
 
 StyleUniforms SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
@@ -1144,8 +1141,9 @@ SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& name, Scene&
                     ? explicitStyle.as<std::string>()
                     : ruleNode.first.as<std::string>();
 
-                auto params = parseStyleParams(ruleNode.second, scene);
-                rules.push_back({ style, params });
+                std::vector<StyleParam> params;
+                parseStyleParams(ruleNode.second, scene, "", params);
+                rules.push_back({ style, std::move(params) });
             }
         } else if (key == "filter") {
             filter = generateFilter(member.second, scene);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -50,7 +50,8 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
             style->build(_scene.lights());
         }
 
-        // Styles that are opaque must be ordered first in the scene so that they are rendered 'under' styles that require blending
+        // Styles that are opaque must be ordered first in the scene so that
+        // they are rendered 'under' styles that require blending
         std::sort(_scene.styles().begin(), _scene.styles().end(),
                   [](std::unique_ptr<Style>& a, std::unique_ptr<Style>& b) {
                       return a->blendMode() == Blending::none;
@@ -85,12 +86,12 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
             }
             break;
         default:
-            logMsg("Warning: Unexpected Node: '%s'\n", Dump(extensionsNode).c_str());
+            logMsg("Scene: Unexpected Node: '%s'\n", Dump(extensionsNode).c_str());
         }
 
         for (const auto& extName : extensions) {
             char buffer[1000]; //sufficient space
-            sprintf(buffer, "#ifdef %s\n    #extension %s : enable\n    #define TANGRAM_EXTENSION_%s\n#endif",
+            sprintf(buffer, "#ifdef %s\n  #extension %s : enable\n  #define TANGRAM_EXTENSION_%s\n#endif",
                     extName.c_str(), extName.c_str(), extName.c_str());
             shader.addSourceBlock("extensions", std::string(buffer));
         }
@@ -101,10 +102,12 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
             std::string name = define.first.as<std::string>();
             std::string value = define.second.as<std::string>();
             if (value == "true") {
-                // specifying a define to be 'true' means that it is simply defined and has no value
+                // specifying a define to be 'true' means that it is simply
+                // defined and has no value
                 value = "";
             } else if (value == "false") {
-                // specifying a define to be 'false' means that the define will not be defined at all
+                // specifying a define to be 'false' means that the define will
+                // not be defined at all
                 continue;
             }
             shader.addSourceBlock("defines", "#define " + name + " " + value);
@@ -164,7 +167,7 @@ void loadMaterialProperty(const Node& prop, Scene& scene,
         }
         break;
     default:
-        logMsg("Warning: Unexpected value for material '%s'",
+        logMsg("Scene: Unexpected value for material '%s'",
                Dump(prop).c_str());
         break;
     }
@@ -195,7 +198,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
         try {
             material.setShininess(shininess.as<float>());
         } catch(const BadConversion& e) {
-            logMsg("Warning: float value expected for shininess material parameter");
+            logMsg("Scene: Float value expected for shininess material parameter");
         }
     }
 
@@ -213,7 +216,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
     Node amountNode = matCompNode["amount"];
 
     if (!textureNode) {
-        logMsg("Warning: Expected a \"texture\" parameter: '%s'\n",
+        logMsg("Scene: Expected a 'texture' parameter: '%s'\n",
                Dump(matCompNode).c_str());
 
         return matTex;
@@ -234,10 +237,10 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
     if (mappingNode) {
         std::string mapping = mappingNode.as<std::string>();
         if (mapping == "uv") { matTex.mapping = MappingType::uv; }
-        else if (mapping == "planar") { logMsg("Warning: planar texture mapping not yet implemented\n"); } // TODO
-        else if (mapping == "triplanar") { logMsg("Warning: triplanar texture mapping not yet implemented\n"); } // TODO
         else if (mapping == "spheremap") { matTex.mapping = MappingType::spheremap; }
-        else { logMsg("Warning: unrecognized texture mapping \"%s\"\n", mapping.c_str()); }
+        else if (mapping == "planar") { logMsg("Scene: Planar texture mapping not yet implemented\n"); } // TODO
+        else if (mapping == "triplanar") { logMsg("Scene: Triplanar texture mapping not yet implemented\n"); } // TODO
+        else { logMsg("Scene: Unrecognized texture mapping '%s'\n", mapping.c_str()); }
     }
 
     if (scaleNode) {
@@ -246,7 +249,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
         } else if (scaleNode.IsScalar()) {
             matTex.scale = glm::vec3(scaleNode.as<float>());
         } else {
-            logMsg("Warning: unrecognized scale parameter in material\n");
+            logMsg("Scene: Unrecognized scale parameter in material\n");
         }
     }
 
@@ -256,7 +259,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
         } else if (amountNode.IsScalar()) {
             matTex.amount = glm::vec3(amountNode.as<float>());
         } else {
-            logMsg("Warning: unrecognized amount parameter in material\n");
+            logMsg("Scene: Unrecognized amount parameter in material\n");
         }
     }
 
@@ -271,9 +274,7 @@ void SceneLoader::loadTexture(const std::string& url, Scene& scene) {
 
 void SceneLoader::loadTextures(Node textures, Scene& scene) {
 
-    if (!textures) {
-        return;
-    }
+    if (!textures) { return; }
 
     for (const auto& textureNode : textures) {
 
@@ -287,7 +288,7 @@ void SceneLoader::loadTextures(Node textures, Scene& scene) {
         if (url) {
             file = url.as<std::string>();
         } else {
-            logMsg("Warning: No url specified for texture \"%s\", skipping.\n", name.c_str());
+            logMsg("Scene: No url specified for texture '%s', skipping.\n", name.c_str());
             continue;
         }
 
@@ -332,19 +333,19 @@ void SceneLoader::loadTextures(Node textures, Scene& scene) {
 void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene) {
 
     if (!styleNode) {
-        logMsg("Error: Can not parse style parameters, bad style YAML Node\n");
+        logMsg("Scene: Can not parse style parameters, bad style YAML Node\n");
         return;
     }
 
     Node animatedNode = styleNode["animated"];
     if (animatedNode) {
-        logMsg("Warning: animated property will be set but not yet implemented in styles\n"); // TODO
-        if (!animatedNode.IsScalar()) { logMsg("Warning: animated flag should be a scalar\n"); }
+        logMsg("Scene: 'animated' property will be set but not yet implemented in styles\n"); // TODO
+        if (!animatedNode.IsScalar()) { logMsg("Scene: animated flag should be a scalar\n"); }
         else {
             try {
                 style->setAnimated(animatedNode.as<bool>());
             } catch(const BadConversion& e) {
-                logMsg("Warning: Expected a boolean value in animated property. Using default (false).\n");
+                logMsg("Scene: Expected a boolean value in 'animated' property. Using default (false).\n");
             }
         }
     }
@@ -358,14 +359,14 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
         else if (str == "multiply") { style->setBlendMode(Blending::multiply); }
         else if (str == "overlay")  { style->setBlendMode(Blending::overlay); }
         else if (str == "inlay")    { style->setBlendMode(Blending::inlay); }
-        else { logMsg("Warning: invalid blend mode \"%s\"\n", str.c_str()); }
+        else { logMsg("Scene: Invalid blend mode '%s'\n", str.c_str()); }
 
     }
 
     Node texcoordsNode = styleNode["texcoords"];
     if (texcoordsNode) {
 
-        logMsg("Warning: texcoords style parameter is currently ignored\n");
+        logMsg("Scene: 'texcoords' style parameter is currently ignored\n");
 
         if (texcoordsNode.as<bool>()) { } // TODO
         else { } // TODO
@@ -389,7 +390,7 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
         else if (lighting == "vertex") { style->setLightingType(LightingType::vertex); }
         else if (lighting == "false") { style->setLightingType(LightingType::none); }
         else if (lighting == "true") { } // use default lighting
-        else { logMsg("Warning: unrecognized lighting type \"%s\"\n", lighting.c_str()); }
+        else { logMsg("Scene: Unrecognized lighting type '%s'\n", lighting.c_str()); }
     }
 
     Node textureNode = styleNode["texture"];
@@ -402,13 +403,13 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
             if (it != atlases.end()) {
                 spriteStyle->setSpriteAtlas(it->second);
             } else {
-                logMsg("Warning: undefined texture name %s", textureName.c_str());
+                logMsg("Scene: Undefined texture name %s", textureName.c_str());
             }
         }
     }
 
     Node urlNode = styleNode["url"];
-    if (urlNode) { logMsg("Warning: loading style from URL not yet implemented\n"); } // TODO
+    if (urlNode) { logMsg("Scene: Loading style from URL not yet implemented\n"); } // TODO
 
 }
 
@@ -416,7 +417,8 @@ Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
 
     Node node;
 
-    if (propStr == "extensions" || propStr == "blocks") { //handled by explicit methods
+    if (propStr == "extensions" || propStr == "blocks") {
+         // handled by explicit methods
         return node;
     }
 
@@ -425,17 +427,20 @@ Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
 
     for (const auto& mixNode: mixes) {
         if (Node propNode = mixNode[propStr]) {
-            if (propNode.IsScalar() && propNode.as<std::string>() == "true") {      // OR Properties
+            if (propNode.IsScalar() && propNode.as<std::string>() == "true") {
+                // OR Properties
                 node = propNode;
                 break;
-            } else if (propNode.IsScalar() || propNode.IsSequence()) {              // Overwrite Properties
+            } else if (propNode.IsScalar() || propNode.IsSequence()) {
+                // Overwrite Properties
                 node = propNode;
             } else { // Map...
                 // Reset previous scalar/sequence node
                 node.reset();
                 for (const auto& tag : propNode) {
                     auto tagName = tag.first.as<std::string>();
-                    if (mapMixes.find(tagName) == mapMixes.end()) {                 // Deep Merge for all Map Props
+                    // Deep Merge for all Map Props
+                    if (mapMixes.find(tagName) == mapMixes.end()) {
                         mapTags.push_back(tagName);
                     }
                     mapMixes[tagName].push_back(propNode);
@@ -507,7 +512,8 @@ Node SceneLoader::shaderExtMerge(const Mixes& mixes) {
                     break;
                 }
                 default:
-                    logMsg("Warning: Expected scalar or sequence value for extensions node.\n");
+                    logMsg("Scene: Expected scalar or sequence value for extensions node '%s'.\n",
+                        Dump(node).c_str());
                 }
             }
         }
@@ -520,7 +526,8 @@ Node SceneLoader::mixStyle(const Mixes& mixes) {
 
     Node styleNode;
 
-    for (auto& property : {"animated", "texcoords", "base", "lighting", "texture", "blend", "material", "shaders"}) {
+    for (auto& property : { "animated", "texcoords", "base", "lighting",
+                            "texture", "blend", "material", "shaders" }) {
         Node node = propMerge(property, mixes);
         if (!node.IsNull()) { styleNode[property] = node; }
     }
@@ -564,7 +571,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
             if (styleName == builtIn) { validName = false; }
         }
         if (!validName) {
-            logMsg("Warning: cannot use built-in style name \"%s\" for new style\n", styleName.c_str());
+            logMsg("Scene: Cannot use built-in style name '%s' for new style\n", styleName.c_str());
             continue;
         }
 
@@ -579,7 +586,8 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
                     mixes.push_back(styles[mixStyleNode.as<std::string>()]);
                 }
             } else {
-                logMsg("Error parsing mix param for style: %s. Expected scalar or sequence value\n", styleName.c_str());
+                logMsg("Scene parsing mix param for style: '%s'. Expected scalar or sequence value\n",
+                       styleName.c_str());
             }
         }
         mixes.push_back(styles[styleName]);
@@ -598,7 +606,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
             } else if (baseString == "points") {
                 style = new SpriteStyle(styleName);
             } else {
-                logMsg("Warning: base style \"%s\" not recognized, can not instantiate.\n", baseString.c_str());
+                logMsg("Scene: Base style '%s' not recognized, cannot instantiate.\n", baseString.c_str());
                 continue;
             }
             loadStyleProps(style, mixedStyleNode, scene);
@@ -613,7 +621,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
 void SceneLoader::loadSources(Node sources, Scene& _scene) {
 
     if (!sources) {
-        logMsg("Warning: No source defined in the yaml scene configuration.\n");
+        logMsg("Scene: No source defined in the yaml scene configuration.\n");
         return;
     }
 
@@ -638,11 +646,11 @@ void SceneLoader::loadSources(Node sources, Scene& _scene) {
                 sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url));
             }
         } else if (type == "TopoJSONTiles") {
-            logMsg("Warning: TopoJSON data sources not yet implemented\n"); // TODO
+            logMsg("Scene: TopoJSON data sources not yet implemented\n"); // TODO
         } else if (type == "MVT") {
             sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url));
         } else {
-            logMsg("Warning: unrecognized data source type \"%s\", skipping\n", type.c_str());
+            logMsg("Scene: Unrecognized data source type '%s', skipping\n", type.c_str());
         }
 
         if (sourcePtr) {
@@ -892,8 +900,9 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
 
     if (_node.IsScalar()) {
         if (_node.Tag() == "tag:yaml.org,2002:str") {
-            // Node was explicitly tagged with '!!str' or the canonical tag 'tag:yaml.org,2002:str'
-            // yaml-cpp normalizes the tag value to the canonical form
+            // Node was explicitly tagged with '!!str' or the canonical tag
+            // 'tag:yaml.org,2002:str' yaml-cpp normalizes the tag value to the
+            // canonical form
             return Filter(_key, { Value(_node.as<std::string>()) });
         }
         try {
@@ -928,25 +937,25 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
                 try {
                     minVal = valItr.second.as<float>();
                 } catch (const BadConversion& e) {
-                    logMsg("Error: Badly formed filter.\tExpect a float value type, string found.\n");
+                    logMsg("Scene: Badly formed filter.\tExpect a float value type.\n");
                     return Filter();
                 }
             } else if (valItr.first.as<std::string>() == "max") {
                 try {
                     maxVal = valItr.second.as<float>();
                 } catch (const BadConversion& e) {
-                    logMsg("Error: Badly formed filter.\tExpect a float value type, string found.\n");
+                    logMsg("Scene: Badly formed filter.\tExpect a float value type.\n");
                     return Filter();
                 }
             } else {
-                logMsg("Error: Badly formed Filter\n");
+                logMsg("Scene: Badly formed Filter\n");
                 return Filter();
             }
         }
         return Filter(_key, minVal, maxVal);
 
     } else {
-        logMsg("Error: Badly formed Filter\n");
+        logMsg("Scene: Badly formed Filter\n");
         return Filter();
     }
 }
@@ -955,7 +964,7 @@ Filter SceneLoader::generateAnyFilter(Node _filter, Scene& scene) {
     std::vector<Filter> filters;
 
     if (!_filter.IsSequence()) {
-        logMsg("Error: Badly formed filter. \"Any\" expects a list.\n");
+        logMsg("Scene: Badly formed filter. 'Any' expects a list.\n");
         return Filter();
     }
     for (const auto& filt : _filter) {
@@ -978,7 +987,7 @@ Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
             filters.emplace_back(generatePredicate(_filter[keyFilter], keyFilter));
         }
     } else {
-        logMsg("Error: Badly formed filter. \"None\" expects a list or an object.\n");
+        logMsg("Scene: Badly formed filter. 'None' expects a list or an object.\n");
         return Filter();
     }
 
@@ -1035,7 +1044,8 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
                 parseStyleParams(value, scene, key, out);
                 break;
             }
-            default: logMsg("ERROR: Style parameter %s must be a scalar, sequence, or map.\n", key.c_str());
+            default:
+                logMsg("Scene: Style parameter %s must be a scalar, sequence, or map.\n", key.c_str());
         }
     }
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -387,20 +387,19 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
     scene.textures().emplace(name, texture);
 }
 
-void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene) {
+void SceneLoader::loadStyleProps(Style& style, YAML::Node styleNode, Scene& scene) {
 
     if (!styleNode) {
         logMsg("Scene: Can not parse style parameters, bad style YAML Node\n");
         return;
     }
 
-    Node animatedNode = styleNode["animated"];
-    if (animatedNode) {
+    if (Node animatedNode = styleNode["animated"]) {
         logMsg("Scene: 'animated' property will be set but not yet implemented in styles\n"); // TODO
         if (!animatedNode.IsScalar()) { logMsg("Scene: animated flag should be a scalar\n"); }
         else {
             try {
-                style->setAnimated(animatedNode.as<bool>());
+                style.setAnimated(animatedNode.as<bool>());
             } catch(const BadConversion& e) {
                 logMsg("Scene: Expected a boolean value in 'animated' property. Using default (false).\n");
             }
@@ -408,53 +407,43 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
     }
 
     if (Node blendNode = styleNode["blend"]) {
-
-        std::string str = blendNode.as<std::string>();
-
-        if      (str == "none")     { style->setBlendMode(Blending::none); }
-        else if (str == "add")      { style->setBlendMode(Blending::add); }
-        else if (str == "multiply") { style->setBlendMode(Blending::multiply); }
-        else if (str == "overlay")  { style->setBlendMode(Blending::overlay); }
-        else if (str == "inlay")    { style->setBlendMode(Blending::inlay); }
+        auto str = blendNode.as<std::string>();
+        if      (str == "none")     { style.setBlendMode(Blending::none); }
+        else if (str == "add")      { style.setBlendMode(Blending::add); }
+        else if (str == "multiply") { style.setBlendMode(Blending::multiply); }
+        else if (str == "overlay")  { style.setBlendMode(Blending::overlay); }
+        else if (str == "inlay")    { style.setBlendMode(Blending::inlay); }
         else { logMsg("Scene: Invalid blend mode '%s'\n", str.c_str()); }
-
     }
 
-    Node texcoordsNode = styleNode["texcoords"];
-    if (texcoordsNode) {
-
+    if (Node texcoordsNode = styleNode["texcoords"]) {
         logMsg("Scene: 'texcoords' style parameter is currently ignored\n");
-
         if (texcoordsNode.as<bool>()) { } // TODO
         else { } // TODO
-
     }
 
-    Node shadersNode = styleNode["shaders"];
-    if (shadersNode) {
-        loadShaderConfig(shadersNode, *style, scene);
+    if (Node shadersNode = styleNode["shaders"]) {
+        loadShaderConfig(shadersNode, style, scene);
     }
 
-    Node materialNode = styleNode["material"];
-    if (materialNode) {
-        loadMaterial(materialNode, *(style->getMaterial()), scene);
+    if (Node materialNode = styleNode["material"]) {
+        loadMaterial(materialNode, *(style.getMaterial()), scene);
     }
 
-    Node lightingNode = styleNode["lighting"];
-    if (lightingNode) {
-        std::string lighting = lightingNode.as<std::string>();
-        if (lighting == "fragment") { style->setLightingType(LightingType::fragment); }
-        else if (lighting == "vertex") { style->setLightingType(LightingType::vertex); }
-        else if (lighting == "false") { style->setLightingType(LightingType::none); }
+    if (Node lightingNode = styleNode["lighting"]) {
+        auto lighting = lightingNode.as<std::string>();
+        if (lighting == "fragment") { style.setLightingType(LightingType::fragment); }
+        else if (lighting == "vertex") { style.setLightingType(LightingType::vertex); }
+        else if (lighting == "false") { style.setLightingType(LightingType::none); }
         else if (lighting == "true") { } // use default lighting
         else { logMsg("Scene: Unrecognized lighting type '%s'\n", lighting.c_str()); }
     }
 
-    Node textureNode = styleNode["texture"];
-    if (textureNode) {
-        auto spriteStyle = dynamic_cast<SpriteStyle*>(style);
-        if (spriteStyle) {
-            std::string textureName = textureNode.as<std::string>();
+    if (Node textureNode = styleNode["texture"]) {
+
+        if (auto spriteStyle = dynamic_cast<SpriteStyle*>(&style)) {
+
+            auto textureName = textureNode.as<std::string>();
             auto atlases = scene.spriteAtlases();
             auto it = atlases.find(textureName);
             if (it != atlases.end()) {
@@ -465,9 +454,10 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
         }
     }
 
-    Node urlNode = styleNode["url"];
-    if (urlNode) { logMsg("Scene: Loading style from URL not yet implemented\n"); } // TODO
-
+    if (Node urlNode = styleNode["url"]) {
+        // TODO
+        logMsg("Scene: Loading style from URL not yet implemented\n");
+    }
 }
 
 Node SceneLoader::propMerge(const std::string& propStr, const Mixes& mixes) {
@@ -651,7 +641,8 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
             logMsg("Scene: Base style '%s' not recognized, cannot instantiate.\n", baseString.c_str());
             return;
         }
-        loadStyleProps(style.get(), mixedStyleNode, scene);
+
+        loadStyleProps(*style.get(), mixedStyleNode, scene);
         scene.styles().push_back(std::move(style));
     } else {
         // No baseNode, this is an abstract styleNode

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -693,6 +693,9 @@ void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, S
         scene.styles().push_back(std::move(style));
     } else {
         // No baseNode, this is an abstract styleNode
+        //
+        // TODO check why do all the merging above then?
+        // when the mixedStyleNode is lost now
         return;
     }
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -16,7 +16,6 @@
 #include "filters.h"
 #include "sceneLayer.h"
 #include "scene/dataLayer.h"
-#include "text/fontContext.h"
 #include "util/yamlHelper.h"
 
 #include "yaml-cpp/yaml.h"
@@ -48,14 +47,11 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         return false;
     }
 
-    // To add font for debugTextStyle
-    FontContext::GetInstance()->addFont("FiraSans", "Medium", "");
-
     // Instantiate built-in styles
     _scene.styles().emplace_back(new PolygonStyle("polygons"));
     _scene.styles().emplace_back(new PolylineStyle("lines"));
     _scene.styles().emplace_back(new TextStyle("text", true, true));
-    _scene.styles().emplace_back(new DebugTextStyle("FiraSans_Medium_", "debugtext", 30.0f, true, false));
+    _scene.styles().emplace_back(new DebugTextStyle(0, "debugtext", 30.0f, true, false));
     _scene.styles().emplace_back(new DebugStyle("debug"));
     _scene.styles().emplace_back(new SpriteStyle("sprites"));
 
@@ -1037,18 +1033,18 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
 
     for (const auto& prop : params) {
 
-        // Load Fonts if prop is font
-        if (prop.first.as<std::string>() == "font") {
-            loadFont(prop.second);
+        std::string key;
+        if (!prefix.empty()) {
+            key = prefix + ":" + prop.first.Scalar();
+        } else {
+            key = prop.first.Scalar();
         }
-
-        std::string key = (prefix.empty() ? "" : (prefix + ":")) + prop.first.as<std::string>();
 
         Node value = prop.second;
 
         switch (value.Type()) {
         case NodeType::Scalar: {
-            auto& val = value.as<std::string>();
+            auto& val = value.Scalar();
 
             if (val.compare(0, 8, "function") == 0) {
                 StyleParam param(key, "");
@@ -1147,26 +1143,6 @@ StyleUniforms SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
         LOGW("Expected a scalar or sequence value for uniforms");
     }
     return std::make_pair(type, std::move(uniformValues));
-}
-
-void SceneLoader::loadFont(Node fontProps) {
-
-    std::string family = "";
-    std::string weight = "";
-    std::string style = "";
-    auto fontCtx = FontContext::GetInstance();
-
-    auto familyNode = fontProps["family"];
-    if (familyNode) { family = familyNode.as<std::string>(); }
-
-    auto weightNode = fontProps["weight"];
-    if (weightNode) { weight = weightNode.as<std::string>(); }
-
-    auto styleNode = fontProps["style"];
-    if (styleNode) { style = styleNode.as<std::string>(); }
-
-    fontCtx->addFont(std::move(family), std::move(weight), std::move(style));
-
 }
 
 SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& name, Scene& scene) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -36,35 +36,104 @@ constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
 bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
 
-    try {
-        Node config = YAML::Load(_sceneString);
+    Node config;
 
-        loadSources(config["sources"], _scene);
-        loadTextures(config["textures"], _scene);
-        loadStyles(config["styles"], _scene);
-        loadLayers(config["layers"], _scene);
-        loadCameras(config["cameras"], _scene);
-        loadLights(config["lights"], _scene);
-
-        for (auto& style : _scene.styles()) {
-            style->build(_scene.lights());
-        }
-
-        // Styles that are opaque must be ordered first in the scene so that
-        // they are rendered 'under' styles that require blending
-        std::sort(_scene.styles().begin(), _scene.styles().end(),
-                  [](std::unique_ptr<Style>& a, std::unique_ptr<Style>& b) {
-                      return a->blendMode() == Blending::none;
-                  });
-
-        return true;
-
-    } catch (YAML::ParserException e) {
+    try { config = YAML::Load(_sceneString); }
+    catch (YAML::ParserException e) {
         logMsg("Error: Parsing scene config '%s'\n", e.what());
-    } catch (YAML::RepresentationException e) {
-        logMsg("Error: Parsing scene config '%s'\n", e.what());
+        return false;
     }
-    return false;
+
+    auto fontCtx = FontContext::GetInstance(); // To add font for debugTextStyle
+    fontCtx->addFont("FiraSans", "Medium", "");
+    // Instantiate built-in styles
+    _scene.styles().emplace_back(new PolygonStyle("polygons"));
+    _scene.styles().emplace_back(new PolylineStyle("lines"));
+    _scene.styles().emplace_back(new TextStyle("text", true, true));
+    _scene.styles().emplace_back(new DebugTextStyle("FiraSans_Medium_", "debugtext", 30.0f, true, false));
+    _scene.styles().emplace_back(new DebugStyle("debug"));
+    _scene.styles().emplace_back(new SpriteStyle("sprites"));
+
+    Node sources = config["sources"];
+    if (sources) {
+        for (const auto& source : sources) {
+            try { loadSource(source, _scene); }
+            catch (YAML::RepresentationException e) {
+                logMsg("Error: Parsing source: '%s' in:\n%s\n",
+                       e.what(), Dump(source).c_str());
+            }
+        }
+    } else {
+        logMsg("Scene: No source defined in the yaml scene configuration.\n");
+    }
+
+    Node textures = config["textures"];
+    if (textures) {
+        for (const auto& texture : textures) {
+            try { loadTexture(texture, _scene); }
+            catch (YAML::RepresentationException e) {
+                logMsg("Error: Parsing texture: '%s' in:\n%s\n",
+                       e.what(), Dump(texture).c_str());
+            }
+        }
+    }
+
+    Node styles = config["styles"];
+    if (styles) {
+        for (const auto& style : styles) {
+            try { loadStyle(style, styles, _scene); }
+            catch (YAML::RepresentationException e) {
+                logMsg("Error: Parsing style: '%s' in:\n%s\n",
+                       e.what(), Dump(style).c_str());
+            }
+        }
+    }
+
+    Node layers = config["layers"];
+    if (layers) {
+        for (const auto& layer : layers) {
+            try { loadLayer(layer, _scene); }
+            catch (YAML::RepresentationException e) {
+                logMsg("Error: Parsing layer: '%s' in:\n%s\n",
+                       e.what(), Dump(layer).c_str());
+            }
+        }
+    }
+
+    Node lights = config["lights"];
+    if (lights) {
+        for (const auto& light : lights) {
+            try { loadLight(light, _scene); }
+            catch (YAML::RepresentationException e) {
+                logMsg("Error: Parsing light: '%s' in:\n%s\n",
+                       e.what(), Dump(light).c_str());
+            }
+        }
+    } else {
+        // Add an ambient light if nothing else is specified
+        std::unique_ptr<AmbientLight> amb(new AmbientLight("defaultLight"));
+        amb->setAmbientColor({ .5f, .5f, .5f, 1.f });
+        _scene.lights().push_back(std::move(amb));
+    }
+
+    try { loadCameras(config["cameras"], _scene); }
+    catch (YAML::RepresentationException e) {
+        logMsg("Error: Parsing cameras: '%s' in:\n%s\n",
+               e.what(), Dump(config["cameras"]).c_str());
+    }
+
+    for (auto& style : _scene.styles()) {
+        style->build(_scene.lights());
+    }
+
+    // Styles that are opaque must be ordered first in the scene so that
+    // they are rendered 'under' styles that require blending
+    std::sort(_scene.styles().begin(), _scene.styles().end(),
+              [](std::unique_ptr<Style>& a, std::unique_ptr<Style>& b) {
+                  return a->blendMode() == Blending::none;
+              });
+
+    return true;
 }
 
 void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
@@ -272,62 +341,57 @@ void SceneLoader::loadTexture(const std::string& url, Scene& scene) {
     scene.textures().emplace(url, texture);
 }
 
-void SceneLoader::loadTextures(Node textures, Scene& scene) {
+void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
 
-    if (!textures) { return; }
+    std::string name = node.first.as<std::string>();
+    Node textureConfig = node.second;
 
-    for (const auto& textureNode : textures) {
+    std::string file;
+    TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
 
-        std::string name = textureNode.first.as<std::string>();
-        Node textureConfig = textureNode.second;
-
-        std::string file;
-        TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
-
-        Node url = textureConfig["url"];
-        if (url) {
-            file = url.as<std::string>();
-        } else {
-            logMsg("Scene: No url specified for texture '%s', skipping.\n", name.c_str());
-            continue;
-        }
-
-        Node filtering = textureConfig["filtering"];
-        bool generateMipmaps = false;
-        if (filtering) {
-            std::string f = filtering.as<std::string>();
-            if (f == "linear") { options.m_filtering = { GL_LINEAR, GL_LINEAR }; }
-            else if (f == "mipmap") {
-                options.m_filtering = { GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR_MIPMAP_LINEAR };
-                generateMipmaps = true;
-            } else if (f == "nearest") { options.m_filtering = { GL_NEAREST, GL_NEAREST }; }
-        }
-
-        std::shared_ptr<Texture> texture(new Texture(file, options, generateMipmaps));
-
-        Node sprites = textureConfig["sprites"];
-        if (sprites) {
-            std::shared_ptr<SpriteAtlas> atlas(new SpriteAtlas(texture, file));
-
-            for (auto it = sprites.begin(); it != sprites.end(); ++it) {
-
-                const Node sprite = it->second;
-                std::string spriteName = it->first.as<std::string>();
-
-                if (sprite) {
-                    glm::vec4 desc = parseVec<glm::vec4>(sprite);
-                    glm::vec2 pos = glm::vec2(desc.x, desc.y);
-                    glm::vec2 size = glm::vec2(desc.z, desc.w);
-
-                    atlas->addSpriteNode(spriteName, pos, size);
-                }
-            }
-
-            scene.spriteAtlases()[name] = atlas;
-        }
-
-        scene.textures().emplace(name, texture);
+    Node url = textureConfig["url"];
+    if (url) {
+        file = url.as<std::string>();
+    } else {
+        logMsg("Scene: No url specified for texture '%s', skipping.\n", name.c_str());
+        return;
     }
+
+    Node filtering = textureConfig["filtering"];
+    bool generateMipmaps = false;
+    if (filtering) {
+        std::string f = filtering.as<std::string>();
+        if (f == "linear") { options.m_filtering = { GL_LINEAR, GL_LINEAR }; }
+        else if (f == "mipmap") {
+            options.m_filtering = { GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR_MIPMAP_LINEAR };
+            generateMipmaps = true;
+        } else if (f == "nearest") { options.m_filtering = { GL_NEAREST, GL_NEAREST }; }
+    }
+
+    std::shared_ptr<Texture> texture(new Texture(file, options, generateMipmaps));
+
+    Node sprites = textureConfig["sprites"];
+    if (sprites) {
+        std::shared_ptr<SpriteAtlas> atlas(new SpriteAtlas(texture, file));
+
+        for (auto it = sprites.begin(); it != sprites.end(); ++it) {
+
+            const Node sprite = it->second;
+            std::string spriteName = it->first.as<std::string>();
+
+            if (sprite) {
+                glm::vec4 desc = parseVec<glm::vec4>(sprite);
+                glm::vec2 pos = glm::vec2(desc.x, desc.y);
+                glm::vec2 size = glm::vec2(desc.z, desc.w);
+
+                atlas->addSpriteNode(spriteName, pos, size);
+            }
+        }
+
+        scene.spriteAtlases()[name] = atlas;
+    }
+
+    scene.textures().emplace(name, texture);
 }
 
 void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene) {
@@ -543,237 +607,199 @@ Node SceneLoader::mixStyle(const Mixes& mixes) {
     return styleNode;
 }
 
-void SceneLoader::loadStyles(Node styles, Scene& scene) {
+void SceneLoader::loadStyle(const std::pair<Node, Node>& styleIt, Node styles, Scene& scene) {
 
     Style* style = nullptr;
 
-    auto fontCtx = FontContext::GetInstance(); // To add font for debugTextStyle
-    fontCtx->addFont("FiraSans", "Medium", "");
-    // Instantiate built-in styles
-    scene.styles().emplace_back(new PolygonStyle("polygons"));
-    scene.styles().emplace_back(new PolylineStyle("lines"));
-    scene.styles().emplace_back(new TextStyle("text", true, true));
-    scene.styles().emplace_back(new DebugTextStyle("FiraSans_Medium_", "debugtext", 30.0f, true, false));
-    scene.styles().emplace_back(new DebugStyle("debug"));
-    scene.styles().emplace_back(new SpriteStyle("sprites"));
+    std::string styleName = styleIt.first.as<std::string>();
+    Node styleNode = styleIt.second;
 
-    if (!styles) {
+    bool validName = true;
+    for (auto& builtIn : { "polygons", "lines", "points", "text", "debug", "debugtext" }) {
+        if (styleName == builtIn) { validName = false; }
+    }
+    if (!validName) {
+        logMsg("Scene: Cannot use built-in style name '%s' for new style\n", styleName.c_str());
         return;
     }
 
-    for (const auto& styleIt : styles) {
-
-        std::string styleName = styleIt.first.as<std::string>();
-        Node styleNode = styleIt.second;
-
-        bool validName = true;
-        for (auto& builtIn : { "polygons", "lines", "points", "text", "debug", "debugtext" }) {
-            if (styleName == builtIn) { validName = false; }
-        }
-        if (!validName) {
-            logMsg("Scene: Cannot use built-in style name '%s' for new style\n", styleName.c_str());
-            continue;
-        }
-
-        Mixes mixes;
-        if (Node mixNode = styleNode["mix"]) {
-            if (mixNode.IsScalar()) {
-                mixes.reserve(2);
-                mixes.push_back(styles[mixNode.as<std::string>()]);
-            } else if (mixNode.IsSequence()) {
-                mixes.reserve(mixNode.size() + 1);
-                for (const auto& mixStyleNode : mixNode) {
-                    mixes.push_back(styles[mixStyleNode.as<std::string>()]);
-                }
-            } else {
-                logMsg("Scene parsing mix param for style: '%s'. Expected scalar or sequence value\n",
-                       styleName.c_str());
+    Mixes mixes;
+    if (Node mixNode = styleNode["mix"]) {
+        if (mixNode.IsScalar()) {
+            mixes.reserve(2);
+            mixes.push_back(styles[mixNode.as<std::string>()]);
+        } else if (mixNode.IsSequence()) {
+            mixes.reserve(mixNode.size() + 1);
+            for (const auto& mixStyleNode : mixNode) {
+                mixes.push_back(styles[mixStyleNode.as<std::string>()]);
             }
-        }
-        mixes.push_back(styles[styleName]);
-
-        Node mixedStyleNode = mixStyle(mixes);
-
-        // Construct style instance using the merged properties
-        if (Node baseNode = mixedStyleNode["base"]) {
-            std::string baseString = baseNode.as<std::string>();
-            if (baseString == "polygons") {
-                style = new PolygonStyle(styleName);
-            } else if (baseString == "lines") {
-                style = new PolylineStyle(styleName);
-            } else if (baseString == "text") {
-                style = new TextStyle(styleName, true, true);
-            } else if (baseString == "points") {
-                style = new SpriteStyle(styleName);
-            } else {
-                logMsg("Scene: Base style '%s' not recognized, cannot instantiate.\n", baseString.c_str());
-                continue;
-            }
-            loadStyleProps(style, mixedStyleNode, scene);
-            scene.styles().push_back(std::unique_ptr<Style>(style));
         } else {
-            // No baseNode, this is an abstract styleNode
-            continue;
+            logMsg("Scene parsing mix param for style: '%s'. Expected scalar or sequence value\n",
+                   styleName.c_str());
         }
+    }
+    mixes.push_back(styles[styleName]);
+
+    Node mixedStyleNode = mixStyle(mixes);
+
+    // Construct style instance using the merged properties
+    if (Node baseNode = mixedStyleNode["base"]) {
+        std::string baseString = baseNode.as<std::string>();
+        if (baseString == "polygons") {
+            style = new PolygonStyle(styleName);
+        } else if (baseString == "lines") {
+            style = new PolylineStyle(styleName);
+        } else if (baseString == "text") {
+            style = new TextStyle(styleName, true, true);
+        } else if (baseString == "points") {
+            style = new SpriteStyle(styleName);
+        } else {
+            logMsg("Scene: Base style '%s' not recognized, cannot instantiate.\n", baseString.c_str());
+            return;
+        }
+        loadStyleProps(style, mixedStyleNode, scene);
+        scene.styles().push_back(std::unique_ptr<Style>(style));
+    } else {
+        // No baseNode, this is an abstract styleNode
+        return;
     }
 }
 
-void SceneLoader::loadSources(Node sources, Scene& _scene) {
+void SceneLoader::loadSource(const std::pair<Node, Node>& src, Scene& _scene) {
 
-    if (!sources) {
-        logMsg("Scene: No source defined in the yaml scene configuration.\n");
-        return;
+    const Node source = src.second;
+    std::string name = src.first.as<std::string>();
+    std::string type = source["type"].as<std::string>();
+    std::string url = source["url"].as<std::string>();
+
+    // distinguish tiled and non-tiled sources by url
+    bool tiled = url.find("{x}") != std::string::npos &&
+        url.find("{y}") != std::string::npos &&
+        url.find("{z}") != std::string::npos;
+
+    std::shared_ptr<DataSource> sourcePtr;
+
+    if (type == "GeoJSONTiles") {
+        if (tiled) {
+            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url));
+        } else {
+            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url));
+        }
+    } else if (type == "TopoJSONTiles") {
+        logMsg("Scene: TopoJSON data sources not yet implemented\n"); // TODO
+    } else if (type == "MVT") {
+        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url));
+    } else {
+        logMsg("Scene: Unrecognized data source type '%s', skipping\n", type.c_str());
     }
 
-    for (const auto& src : sources) {
-
-        const Node source = src.second;
-        std::string name = src.first.as<std::string>();
-        std::string type = source["type"].as<std::string>();
-        std::string url = source["url"].as<std::string>();
-
-        // distinguish tiled and non-tiled sources by url
-        bool tiled = url.find("{x}") != std::string::npos &&
-                     url.find("{y}") != std::string::npos &&
-                     url.find("{z}") != std::string::npos;
-
-        std::shared_ptr<DataSource> sourcePtr;
-
-        if (type == "GeoJSONTiles") {
-            if (tiled) {
-                sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url));
-            } else {
-                sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url));
-            }
-        } else if (type == "TopoJSONTiles") {
-            logMsg("Scene: TopoJSON data sources not yet implemented\n"); // TODO
-        } else if (type == "MVT") {
-            sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url));
-        } else {
-            logMsg("Scene: Unrecognized data source type '%s', skipping\n", type.c_str());
-        }
-
-        if (sourcePtr) {
-            sourcePtr->setCacheSize(CACHE_SIZE);
-            _scene.dataSources().push_back(sourcePtr);
-        }
+    if (sourcePtr) {
+        sourcePtr->setCacheSize(CACHE_SIZE);
+        _scene.dataSources().push_back(sourcePtr);
     }
 }
 
-void SceneLoader::loadLights(Node lights, Scene& scene) {
+void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
 
-    if (!lights) {
+    const Node light = node.second;
+    const std::string name = node.first.Scalar();
+    const std::string type = light["type"].as<std::string>();
 
-        // Add an ambient light if nothing else is specified
-        std::unique_ptr<AmbientLight> amb(new AmbientLight("defaultLight"));
-        amb->setAmbientColor({ .5f, .5f, .5f, 1.f });
-        scene.lights().push_back(std::move(amb));
+    std::unique_ptr<Light> lightPtr;
 
-        return;
+    if (type == "ambient") {
+
+        lightPtr = std::make_unique<AmbientLight>(name);
+
+    } else if (type == "directional") {
+
+        auto dLightPtr(std::make_unique<DirectionalLight>(name));
+        Node direction = light["direction"];
+        if (direction) {
+            dLightPtr->setDirection(parseVec<glm::vec3>(direction));
+        }
+        lightPtr = std::move(dLightPtr);
+
+    } else if (type == "point") {
+
+        auto pLightPtr(std::make_unique<PointLight>(name));
+        Node position = light["position"];
+        if (position) {
+            pLightPtr->setPosition(parseVec<glm::vec3>(position));
+        }
+        Node radius = light["radius"];
+        if (radius) {
+            if (radius.size() > 1) {
+                pLightPtr->setRadius(radius[0].as<float>(), radius[1].as<float>());
+            } else {
+                pLightPtr->setRadius(radius.as<float>());
+            }
+        }
+        Node att = light["attenuation"];
+        if (att) {
+            pLightPtr->setAttenuation(att.as<float>());
+        }
+        lightPtr = std::move(pLightPtr);
+
+    } else if (type == "spotlight") {
+
+        auto sLightPtr(std::make_unique<SpotLight>(name));
+        Node position = light["position"];
+        if (position) {
+            sLightPtr->setPosition(parseVec<glm::vec3>(position));
+        }
+        Node direction = light["direction"];
+        if (direction) {
+            sLightPtr->setDirection(parseVec<glm::vec3>(direction));
+        }
+        Node radius = light["radius"];
+        if (radius) {
+            if (radius.size() > 1) {
+                sLightPtr->setRadius(radius[0].as<float>(), radius[1].as<float>());
+            } else {
+                sLightPtr->setRadius(radius.as<float>());
+            }
+        }
+        Node angle = light["angle"];
+        if (angle) {
+            sLightPtr->setCutoffAngle(angle.as<float>());
+        }
+        Node exponent = light["exponent"];
+        if (exponent) {
+            sLightPtr->setCutoffExponent(exponent.as<float>());
+        }
+
+        lightPtr = std::move(sLightPtr);
     }
 
-    for (const auto& lt : lights) {
-
-        const Node light = lt.second;
-        const std::string name = lt.first.Scalar();
-        const std::string type = light["type"].as<std::string>();
-
-        std::unique_ptr<Light> lightPtr;
-
-        if (type == "ambient") {
-
-            lightPtr = std::make_unique<AmbientLight>(name);
-
-        } else if (type == "directional") {
-
-            auto dLightPtr(std::make_unique<DirectionalLight>(name));
-            Node direction = light["direction"];
-            if (direction) {
-                dLightPtr->setDirection(parseVec<glm::vec3>(direction));
-            }
-            lightPtr = std::move(dLightPtr);
-
-        } else if (type == "point") {
-
-            auto pLightPtr(std::make_unique<PointLight>(name));
-            Node position = light["position"];
-            if (position) {
-                pLightPtr->setPosition(parseVec<glm::vec3>(position));
-            }
-            Node radius = light["radius"];
-            if (radius) {
-                if (radius.size() > 1) {
-                    pLightPtr->setRadius(radius[0].as<float>(), radius[1].as<float>());
-                } else {
-                    pLightPtr->setRadius(radius.as<float>());
-                }
-            }
-            Node att = light["attenuation"];
-            if (att) {
-                pLightPtr->setAttenuation(att.as<float>());
-            }
-            lightPtr = std::move(pLightPtr);
-
-        } else if (type == "spotlight") {
-
-            auto sLightPtr(std::make_unique<SpotLight>(name));
-            Node position = light["position"];
-            if (position) {
-                sLightPtr->setPosition(parseVec<glm::vec3>(position));
-            }
-            Node direction = light["direction"];
-            if (direction) {
-                sLightPtr->setDirection(parseVec<glm::vec3>(direction));
-            }
-            Node radius = light["radius"];
-            if (radius) {
-                if (radius.size() > 1) {
-                    sLightPtr->setRadius(radius[0].as<float>(), radius[1].as<float>());
-                } else {
-                    sLightPtr->setRadius(radius.as<float>());
-                }
-            }
-            Node angle = light["angle"];
-            if (angle) {
-                sLightPtr->setCutoffAngle(angle.as<float>());
-            }
-            Node exponent = light["exponent"];
-            if (exponent) {
-                sLightPtr->setCutoffExponent(exponent.as<float>());
-            }
-
-            lightPtr = std::move(sLightPtr);
+    Node origin = light["origin"];
+    if (origin) {
+        const std::string originStr = origin.as<std::string>();
+        if (originStr == "world") {
+            lightPtr->setOrigin(LightOrigin::world);
+        } else if (originStr == "camera") {
+            lightPtr->setOrigin(LightOrigin::camera);
+        } else if (originStr == "ground") {
+            lightPtr->setOrigin(LightOrigin::ground);
         }
-
-        Node origin = light["origin"];
-        if (origin) {
-            const std::string originStr = origin.as<std::string>();
-            if (originStr == "world") {
-                lightPtr->setOrigin(LightOrigin::world);
-            } else if (originStr == "camera") {
-                lightPtr->setOrigin(LightOrigin::camera);
-            } else if (originStr == "ground") {
-                lightPtr->setOrigin(LightOrigin::ground);
-            }
-        }
-
-        Node ambient = light["ambient"];
-        if (ambient) {
-            lightPtr->setAmbientColor(parseVec<glm::vec4>(ambient));
-        }
-
-        Node diffuse = light["diffuse"];
-        if (diffuse) {
-            lightPtr->setDiffuseColor(parseVec<glm::vec4>(diffuse));
-        }
-
-        Node specular = light["specular"];
-        if (specular) {
-            lightPtr->setSpecularColor(parseVec<glm::vec4>(specular));
-        }
-
-        scene.lights().push_back(std::move(lightPtr));
     }
+
+    Node ambient = light["ambient"];
+    if (ambient) {
+        lightPtr->setAmbientColor(parseVec<glm::vec4>(ambient));
+    }
+
+    Node diffuse = light["diffuse"];
+    if (diffuse) {
+        lightPtr->setDiffuseColor(parseVec<glm::vec4>(diffuse));
+    }
+
+    Node specular = light["specular"];
+    if (specular) {
+        lightPtr->setSpecularColor(parseVec<glm::vec4>(specular));
+    }
+
+    scene.lights().push_back(std::move(lightPtr));
 }
 
 void SceneLoader::loadCameras(Node _cameras, Scene& _scene) {
@@ -1171,27 +1197,20 @@ SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& name, Scene&
     return { name, filter, rules, sublayers };
 }
 
-void SceneLoader::loadLayers(Node layers, Scene& scene) {
+void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
 
-    if (!layers) {
-        return;
-    }
+    std::string name = layer.first.as<std::string>();
 
-    for (const auto& layer : layers) {
+    Node data = layer.second["data"];
+    Node data_layer = data["layer"];
+    Node data_source = data["source"];
 
-        std::string name = layer.first.as<std::string>();
+    std::string collection = data_layer ? data_layer.as<std::string>() : name;
+    std::string source = data_source ? data_source.as<std::string>() : "";
 
-        Node data = layer.second["data"];
-        Node data_layer = data["layer"];
-        Node data_source = data["source"];
+    auto sublayer = loadSublayer(layer.second, name, scene);
 
-        std::string collection = data_layer ? data_layer.as<std::string>() : name;
-        std::string source = data_source ? data_source.as<std::string>() : "";
-
-        auto sublayer = loadSublayer(layer.second, name, scene);
-
-        scene.layers().push_back({ sublayer, source, collection });
-    }
+    scene.layers().push_back({ sublayer, source, collection });
 }
 
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -146,6 +146,8 @@ void loadMaterialProperty(const Node& prop, Scene& scene,
                           std::function<void(MaterialTexture)> texFunc,
                           std::function<void(glm::vec4)> vecFunc) {
 
+    if (!prop) { return; }
+
     switch (prop.Type()) {
     case NodeType::Map:
         texFunc(SceneLoader::loadMaterialTexture(prop, scene));
@@ -155,13 +157,15 @@ void loadMaterialProperty(const Node& prop, Scene& scene,
         break;
     case NodeType::Scalar:
         try {
-            float difValue = prop.as<float>();
-            vecFunc(glm::vec4(difValue, difValue, difValue, 1.0));
+            float value = prop.as<float>();
+            vecFunc(glm::vec4(value, value, value, 1.0));
         } catch (const BadConversion& e) {
             // TODO: css color parser and hex_values
         }
         break;
     default:
+        logMsg("Warning: Unexpected value for material '%s'",
+               Dump(prop).c_str());
         break;
     }
 }
@@ -169,33 +173,21 @@ void loadMaterialProperty(const Node& prop, Scene& scene,
 void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
     using namespace std::placeholders;
 
-    Node emission = matNode["emission"];
-    if (emission) {
-        loadMaterialProperty(emission, scene, material,
-                             std::bind(&Material::setEmissionTex, &material, _1),
-                             std::bind(&Material::setEmission, &material, _1));
-    }
+    loadMaterialProperty(matNode["emission"], scene, material,
+                         std::bind(&Material::setEmissionTex, &material, _1),
+                         std::bind(&Material::setEmission, &material, _1));
 
-    Node diffuse = matNode["diffuse"];
-    if (diffuse) {
-        loadMaterialProperty(diffuse, scene, material,
-                             std::bind(&Material::setDiffuseTex, &material, _1),
-                             std::bind(&Material::setDiffuse, &material, _1));
-    }
+    loadMaterialProperty(matNode["diffuse"], scene, material,
+                         std::bind(&Material::setDiffuseTex, &material, _1),
+                         std::bind(&Material::setDiffuse, &material, _1));
 
-    Node ambient = matNode["ambient"];
-    if (ambient) {
-        loadMaterialProperty(ambient, scene, material,
-                             std::bind(&Material::setAmbientTex, &material, _1),
-                             std::bind(&Material::setAmbient, &material, _1));
-    }
+    loadMaterialProperty(matNode["ambient"], scene, material,
+                         std::bind(&Material::setAmbientTex, &material, _1),
+                         std::bind(&Material::setAmbient, &material, _1));
 
-    Node specular = matNode["specular"];
-    if (specular) {
-        loadMaterialProperty(specular, scene, material,
-                             std::bind(&Material::setSpecularTex, &material, _1),
-                             std::bind(&Material::setSpecular, &material, _1));
-    }
+    loadMaterialProperty(matNode["specular"], scene, material,
+                         std::bind(&Material::setSpecularTex, &material, _1),
+                         std::bind(&Material::setSpecular, &material, _1));
 
     Node shininess = matNode["shininess"];
 
@@ -207,16 +199,14 @@ void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
         }
     }
 
-    Node normal = matNode["normal"];
-    if (normal) {
-        material.setNormal(loadMaterialTexture(normal, scene));
-    }
+    material.setNormal(loadMaterialTexture(matNode["normal"], scene));
 }
 
 MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene) {
 
-    MaterialTexture matTex;
+    if (!matCompNode) { return MaterialTexture{}; }
 
+    MaterialTexture matTex;
     Node textureNode = matCompNode["texture"];
     Node mappingNode = matCompNode["mapping"];
     Node scaleNode = matCompNode["scale"];

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -870,80 +870,79 @@ void SceneLoader::loadCameras(Node _cameras, Scene& _scene) {
 
 Filter SceneLoader::generateFilter(Node _filter, Scene& scene) {
 
-    if (!_filter) {
-        return Filter();
-    }
+    if (!_filter) {  return Filter(); }
 
     std::vector<Filter> filters;
 
-    if (_filter.IsScalar()) {
+    switch (_filter.Type()) {
+    case NodeType::Scalar: {
+
         auto& val = _filter.as<std::string>();
 
         if (val.compare(0, 8, "function") == 0) {
-            filters.emplace_back(scene.functions().size());
             scene.functions().push_back(val);
+            return Filter::MatchFunction(scene.functions().size()-1);
         }
-    } else {
+        break;
+    }
+    case NodeType::Sequence: {
         for (const auto& filtItr : _filter) {
-            Filter filter;
-
-            if (_filter.IsSequence()) {
-                filter = generateFilter(filtItr, scene);
-
-            } else if (filtItr.first.as<std::string>() == "none") {
-                filter = generateNoneFilter(_filter["none"], scene);
-
-            } else if (filtItr.first.as<std::string>() == "not") {
-                filter = generateNoneFilter(_filter["not"], scene);
-
-            } else if (filtItr.first.as<std::string>() == "any") {
-                filter = generateAnyFilter(_filter["any"], scene);
-
-            } else if (filtItr.first.as<std::string>() == "all") {
-                filter = generateFilter(_filter["all"], scene);
-
-            } else {
-
-                std::string key = filtItr.first.as<std::string>();
-                filter = generatePredicate(_filter[key], key);
-
-            }
-            filters.push_back(filter);
+            filters.push_back(generateFilter(filtItr, scene));
         }
+        break;
+    }
+    case NodeType::Map: {
+        for (const auto& filtItr : _filter) {
+            std::string key = filtItr.first.as<std::string>();
+            Node node = _filter[key];
+
+            if (key == "none") {
+                filters.push_back(generateNoneFilter(node, scene));
+            } else if (key == "not") {
+                filters.push_back(generateNoneFilter(node, scene));
+            } else if (key == "any") {
+                filters.push_back(generateAnyFilter(node, scene));
+            } else if (key == "all") {
+                filters.push_back(generateFilter(node, scene));
+            } else {
+                filters.push_back(generatePredicate(node, key));
+            }
+        }
+        break;
+    }
+    default:
+        // logMsg
+        break;
     }
 
-    if (filters.size() == 1) {
-        return filters.front();
-    } else if (filters.size() > 0) {
-        return (Filter(Operators::all, filters));
-    } else {
-        return Filter();
-    }
-
+    if (filters.size() == 0) { return Filter(); }
+    if (filters.size() == 1) { return filters.front(); }
+    return (Filter::MatchAll(filters));
 }
 
 Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
 
-    if (_node.IsScalar()) {
+    switch (_node.Type()) {
+    case NodeType::Scalar:
         if (_node.Tag() == "tag:yaml.org,2002:str") {
             // Node was explicitly tagged with '!!str' or the canonical tag
             // 'tag:yaml.org,2002:str' yaml-cpp normalizes the tag value to the
             // canonical form
-            return Filter(_key, { Value(_node.as<std::string>()) });
+            return Filter::MatchEquality(_key, { Value(_node.as<std::string>()) });
         }
         try {
-            return Filter(_key, { Value(_node.as<float>()) });
+            return Filter::MatchEquality(_key, { Value(_node.as<float>()) });
         } catch (const BadConversion& e) {
             std::string value = _node.as<std::string>();
             if (value == "true") {
-                return Filter(_key, true);
+                return Filter::MatchExistence(_key, true);
             } else if (value == "false") {
-                return Filter(_key, false);
+                return Filter::MatchExistence(_key, false);
             } else {
-                return Filter(_key, { Value(value) });
+                return Filter::MatchEquality(_key, { Value(value) });
             }
         }
-    } else if (_node.IsSequence()) {
+    case NodeType::Sequence: {
         std::vector<Value> values;
         for (const auto& valItr : _node) {
             try {
@@ -953,8 +952,9 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
                 values.emplace_back(value);
             }
         }
-        return Filter(_key, std::move(values));
-    } else if (_node.IsMap()) {
+        return Filter::MatchEquality(_key, std::move(values));
+    }
+    case NodeType::Map: {
         float minVal = -std::numeric_limits<float>::infinity();
         float maxVal = std::numeric_limits<float>::infinity();
 
@@ -978,10 +978,10 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
                 return Filter();
             }
         }
-        return Filter(_key, minVal, maxVal);
-
-    } else {
-        logMsg("Scene: Badly formed Filter\n");
+        return Filter::MatchRange(_key, minVal, maxVal);
+    }
+    default:
+        logMsg("Scene: Badly formed Filter '%s'\n", Dump(_node).c_str());
         return Filter();
     }
 }
@@ -996,7 +996,7 @@ Filter SceneLoader::generateAnyFilter(Node _filter, Scene& scene) {
     for (const auto& filt : _filter) {
         filters.emplace_back(generateFilter(filt, scene));
     }
-    return Filter(Operators::any, std::move(filters));
+    return Filter::MatchAny(std::move(filters));
 }
 
 Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
@@ -1017,7 +1017,7 @@ Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
         return Filter();
     }
 
-    return Filter(Operators::none, std::move(filters));
+    return Filter::MatchNone(std::move(filters));
 }
 
 void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string& prefix,

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -2,8 +2,6 @@
 #include "platform.h"
 #include "scene.h"
 #include "sceneLoader.h"
-#include "tileManager.h"
-#include "view.h"
 #include "lights.h"
 #include "clientGeoJsonSource.h"
 #include "geoJsonSource.h"
@@ -36,17 +34,16 @@ namespace Tangram {
 // TODO: make this configurable: 16MB default in-memory DataSource cache:
 constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
-void SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene,
-                            TileManager& _tileManager, View& _view) {
+bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
 
     try {
         Node config = YAML::Load(_sceneString);
 
-        loadSources(config["sources"], _tileManager);
+        loadSources(config["sources"], _scene);
         loadTextures(config["textures"], _scene);
         loadStyles(config["styles"], _scene);
-        loadLayers(config["layers"], _scene, _tileManager);
-        loadCameras(config["cameras"], _view);
+        loadLayers(config["layers"], _scene);
+        loadCameras(config["cameras"], _scene);
         loadLights(config["lights"], _scene);
 
         for (auto& style : _scene.styles()) {
@@ -59,11 +56,14 @@ void SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene,
                       return a->blendMode() == Blending::none;
                   });
 
+        return true;
+
     } catch (YAML::ParserException e) {
         logMsg("Error: Parsing scene config '%s'\n", e.what());
     } catch (YAML::RepresentationException e) {
         logMsg("Error: Parsing scene config '%s'\n", e.what());
     }
+    return false;
 }
 
 void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
@@ -602,7 +602,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
     }
 }
 
-void SceneLoader::loadSources(Node sources, TileManager& tileManager) {
+void SceneLoader::loadSources(Node sources, Scene& _scene) {
 
     if (!sources) {
         logMsg("Warning: No source defined in the yaml scene configuration.\n");
@@ -639,7 +639,7 @@ void SceneLoader::loadSources(Node sources, TileManager& tileManager) {
 
         if (sourcePtr) {
             sourcePtr->setCacheSize(CACHE_SIZE);
-            tileManager.addDataSource(std::move(sourcePtr));
+            _scene.dataSources().push_back(sourcePtr);
         }
     }
 }
@@ -758,19 +758,17 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
         }
 
         scene.lights().push_back(std::move(lightPtr));
-
     }
-
 }
 
-void SceneLoader::loadCameras(Node cameras, View& view) {
+void SceneLoader::loadCameras(Node _cameras, Scene& _scene) {
 
     // To correctly match the behavior of the webGL library we'll need a place
     // to store multiple view instances.  Since we only have one global view
     // right now, we'll just apply the settings from the first active camera we
     // find.
 
-    for (const auto& cam : cameras) {
+    for (const auto& cam : _cameras) {
 
         const Node camera = cam.second;
 
@@ -813,14 +811,14 @@ void SceneLoader::loadCameras(Node cameras, View& view) {
                 z = position[2].as<float>();
             }
         }
-        glm::dvec2 projPos = view.getMapProjection().LonLatToMeters(glm::dvec2(x, y));
-        view.setPosition(projPos.x, projPos.y);
 
         Node zoom = camera["zoom"];
         if (zoom) {
             z = zoom.as<float>();
         }
-        view.setZoom(z);
+
+        _scene.startPosition = glm::dvec2(x, y);
+        _scene.startZoom = z;
 
         Node active = camera["active"];
         if (active) {
@@ -1158,7 +1156,7 @@ SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& name, Scene&
     return { name, filter, rules, sublayers };
 }
 
-void SceneLoader::loadLayers(Node layers, Scene& scene, TileManager& tileManager) {
+void SceneLoader::loadLayers(Node layers, Scene& scene) {
 
     if (!layers) {
         return;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -213,58 +213,68 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
     }
 }
 
-void loadMaterialProperty(const Node& prop, Scene& scene,
-                          Material& material,
-                          std::function<void(MaterialTexture)> texFunc,
-                          std::function<void(glm::vec4)> vecFunc) {
-
-    if (!prop) { return; }
+glm::vec4 parseMaterialVec(const Node& prop) {
 
     switch (prop.Type()) {
-    case NodeType::Map:
-        texFunc(SceneLoader::loadMaterialTexture(prop, scene));
-        break;
     case NodeType::Sequence:
-        vecFunc(parseVec<glm::vec4>(prop));
-        break;
+        return parseVec<glm::vec4>(prop);
     case NodeType::Scalar:
         try {
             float value = prop.as<float>();
-            vecFunc(glm::vec4(value, value, value, 1.0));
+            return glm::vec4(value, value, value, 1.0);
         } catch (const BadConversion& e) {
+            logMsg("Scene: Invalid material value:\n'%s'\n",
+                   Dump(prop).c_str());
             // TODO: css color parser and hex_values
         }
         break;
+    case NodeType::Map:
+        // Handled as texture
+        break;
     default:
-        logMsg("Scene: Unexpected value for material '%s'",
+        logMsg("Scene: Invalid material value:\n'%s'\n",
                Dump(prop).c_str());
         break;
     }
+    return glm::vec4(0.0);
 }
 
 void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
-    using namespace std::placeholders;
 
-    loadMaterialProperty(matNode["emission"], scene, material,
-                         std::bind(&Material::setEmissionTex, &material, _1),
-                         std::bind(&Material::setEmission, &material, _1));
-
-    loadMaterialProperty(matNode["diffuse"], scene, material,
-                         std::bind(&Material::setDiffuseTex, &material, _1),
-                         std::bind(&Material::setDiffuse, &material, _1));
-
-    loadMaterialProperty(matNode["ambient"], scene, material,
-                         std::bind(&Material::setAmbientTex, &material, _1),
-                         std::bind(&Material::setAmbient, &material, _1));
-
-    loadMaterialProperty(matNode["specular"], scene, material,
-                         std::bind(&Material::setSpecularTex, &material, _1),
-                         std::bind(&Material::setSpecular, &material, _1));
+    if (Node n = matNode["emission"]) {
+        if (n.IsMap()) {
+            material.setEmission(loadMaterialTexture(n, scene));
+        } else {
+            material.setEmission(parseMaterialVec(n));
+        }
+    }
+    if (Node n = matNode["diffuse"]) {
+        if (n.IsMap()) {
+            material.setDiffuse(loadMaterialTexture(n, scene));
+        } else {
+            material.setDiffuse(parseMaterialVec(n));
+        }
+    }
+    if (Node n = matNode["ambient"]) {
+        if (n.IsMap()) {
+            material.setAmbient(loadMaterialTexture(n, scene));
+        } else {
+            material.setAmbient(parseMaterialVec(n));
+        }
+    }
+    if (Node n = matNode["specular"]) {
+        if (n.IsMap()) {
+            material.setSpecular(loadMaterialTexture(n, scene));
+        } else {
+            material.setSpecular(parseMaterialVec(n));
+        }
+    }
 
     if (Node shininess = matNode["shininess"]) {
         try { material.setShininess(shininess.as<float>()); }
         catch(const BadConversion& e) {
-            logMsg("Scene: Float value expected for shininess material parameter");
+            logMsg("Scene: Expected float value for 'shininess':\n'%s'\n",
+                Dump(matNode).c_str());
         }
     }
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -32,49 +32,46 @@ using StyleUniforms = std::pair<std::string, std::vector<UniformValue>>;
 
 class SceneLoader {
 
-    void loadSources(YAML::Node sources, Scene& scene);
-    void loadFont(YAML::Node fontProps);
-    void loadLights(YAML::Node lights, Scene& scene);
-    void loadCameras(YAML::Node cameras, Scene& scene);
-    void loadLayers(YAML::Node layers, Scene& scene);
-    void loadStyles(YAML::Node styles, Scene& scene);
-    void loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene);
-    void loadTextures(YAML::Node textures, Scene& scene);
+    static void loadSources(YAML::Node sources, Scene& scene);
+    static void loadFont(YAML::Node fontProps);
+    static void loadLights(YAML::Node lights, Scene& scene);
+    static void loadCameras(YAML::Node cameras, Scene& scene);
+    static void loadLayers(YAML::Node layers, Scene& scene);
+    static void loadStyles(YAML::Node styles, Scene& scene);
+    static void loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene);
+    static void loadTextures(YAML::Node textures, Scene& scene);
     /* loads a texture with default texture properties */
-    void loadTexture(const std::string& url, Scene& scene);
-    void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
-    void loadShaderConfig(YAML::Node shaders, Style& style, Scene& scene);
-    SceneLayer loadSublayer(YAML::Node layer, const std::string& name, Scene& scene);
-    Filter generateAnyFilter(YAML::Node filter, Scene& scene);
-    Filter generateNoneFilter(YAML::Node filter, Scene& scene);
-    Filter generatePredicate(YAML::Node filter, std::string _key);
+    static void loadTexture(const std::string& url, Scene& scene);
+    static void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
+    static void loadShaderConfig(YAML::Node shaders, Style& style, Scene& scene);
+    static SceneLayer loadSublayer(YAML::Node layer, const std::string& name, Scene& scene);
+    static Filter generateAnyFilter(YAML::Node filter, Scene& scene);
+    static Filter generateNoneFilter(YAML::Node filter, Scene& scene);
+    static Filter generatePredicate(YAML::Node filter, std::string _key);
 
     // Style Mixing helper methods
-    YAML::Node mixStyle(const Mixes& mixes);
+    static YAML::Node mixStyle(const Mixes& mixes);
 
 public:
+    SceneLoader() = delete;
 
-    SceneLoader() {};
-
-    virtual ~SceneLoader() {};
-
-    bool loadScene(const std::string& _sceneString, Scene& _scene);
+    static bool loadScene(const std::string& _sceneString, Scene& _scene);
 
     static MaterialTexture loadMaterialTexture(YAML::Node matCompNode, Scene& scene);
 
     // public for testing
-    std::vector<StyleParam> parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix = "");
-    StyleUniforms parseStyleUniforms(const YAML::Node& uniform, Scene& scene);
+    static std::vector<StyleParam> parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix = "");
+    static StyleUniforms parseStyleUniforms(const YAML::Node& uniform, Scene& scene);
 
     // Generic methods to merge properties
-    YAML::Node propMerge(const std::string& propStr, const Mixes& mixes);
+    static YAML::Node propMerge(const std::string& propStr, const Mixes& mixes);
 
     // Methods to merge shader blocks
-    YAML::Node shaderBlockMerge(const Mixes& mixes);
+    static YAML::Node shaderBlockMerge(const Mixes& mixes);
 
     // Methods to merge shader extensions
-    YAML::Node shaderExtMerge(const Mixes& mixes);
-    Tangram::Filter generateFilter(YAML::Node filter, Scene& scene);
+    static YAML::Node shaderExtMerge(const Mixes& mixes);
+    static Tangram::Filter generateFilter(YAML::Node filter, Scene& scene);
 };
 
 }

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -30,7 +30,11 @@ using Mixes = std::vector<YAML::Node>;
 // 0: type, 1: values
 using StyleUniforms = std::pair<std::string, std::vector<UniformValue>>;
 
-class SceneLoader {
+struct SceneLoader {
+
+    static bool loadScene(const std::string& _sceneString, Scene& _scene);
+
+    /*** public for testing ***/
 
     static void loadSources(YAML::Node sources, Scene& scene);
     static void loadFont(YAML::Node fontProps);
@@ -52,14 +56,8 @@ class SceneLoader {
     // Style Mixing helper methods
     static YAML::Node mixStyle(const Mixes& mixes);
 
-public:
-    SceneLoader() = delete;
-
-    static bool loadScene(const std::string& _sceneString, Scene& _scene);
-
     static MaterialTexture loadMaterialTexture(YAML::Node matCompNode, Scene& scene);
 
-    // public for testing
     static void parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix,
                                  std::vector<StyleParam>& out);
 
@@ -74,6 +72,8 @@ public:
     // Methods to merge shader extensions
     static YAML::Node shaderExtMerge(const Mixes& mixes);
     static Tangram::Filter generateFilter(YAML::Node filter, Scene& scene);
+
+    SceneLoader() = delete;
 };
 
 }

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -45,7 +45,6 @@ class SceneLoader {
     void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
     void loadShaderConfig(YAML::Node shaders, Style& style, Scene& scene);
     SceneLayer loadSublayer(YAML::Node layer, const std::string& name, Scene& scene);
-    MaterialTexture loadMaterialTexture(YAML::Node matCompNode, Scene& scene);
     Filter generateAnyFilter(YAML::Node filter, Scene& scene);
     Filter generateNoneFilter(YAML::Node filter, Scene& scene);
     Filter generatePredicate(YAML::Node filter, std::string _key);
@@ -60,6 +59,8 @@ public:
     virtual ~SceneLoader() {};
 
     bool loadScene(const std::string& _sceneString, Scene& _scene);
+
+    static MaterialTexture loadMaterialTexture(YAML::Node matCompNode, Scene& scene);
 
     // public for testing
     std::vector<StyleParam> parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix = "");

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -44,7 +44,7 @@ struct SceneLoader {
     static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
     static void loadFont(Node fontProps);
     static void loadCameras(Node cameras, Scene& scene);
-    static void loadStyleProps(Style* style, Node styleNode, Scene& scene);
+    static void loadStyleProps(Style& style, Node styleNode, Scene& scene);
     static void loadMaterial(Node matNode, Material& material, Scene& scene);
     static void loadShaderConfig(Node shaders, Style& style, Scene& scene);
     static SceneLayer loadSublayer(Node layer, const std::string& name, Scene& scene);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -60,7 +60,9 @@ public:
     static MaterialTexture loadMaterialTexture(YAML::Node matCompNode, Scene& scene);
 
     // public for testing
-    static std::vector<StyleParam> parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix = "");
+    static void parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix,
+                                 std::vector<StyleParam>& out);
+
     static StyleUniforms parseStyleUniforms(const YAML::Node& uniform, Scene& scene);
 
     // Generic methods to merge properties

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -31,47 +31,48 @@ using Mixes = std::vector<YAML::Node>;
 using StyleUniforms = std::pair<std::string, std::vector<UniformValue>>;
 
 struct SceneLoader {
+    using Node = YAML::Node;
 
     static bool loadScene(const std::string& _sceneString, Scene& _scene);
 
     /*** public for testing ***/
 
-    static void loadSources(YAML::Node sources, Scene& scene);
-    static void loadFont(YAML::Node fontProps);
-    static void loadLights(YAML::Node lights, Scene& scene);
-    static void loadCameras(YAML::Node cameras, Scene& scene);
-    static void loadLayers(YAML::Node layers, Scene& scene);
-    static void loadStyles(YAML::Node styles, Scene& scene);
-    static void loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene);
-    static void loadTextures(YAML::Node textures, Scene& scene);
+    static void loadSource(const std::pair<Node, Node>& source, Scene& scene);
+    static void loadTexture(const std::pair<Node, Node>& texture, Scene& scene);
+    static void loadStyle(const std::pair<Node, Node>& style, Node styles, Scene& scene);
+    static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
+    static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
+    static void loadFont(Node fontProps);
+    static void loadCameras(Node cameras, Scene& scene);
+    static void loadStyleProps(Style* style, Node styleNode, Scene& scene);
+    static void loadMaterial(Node matNode, Material& material, Scene& scene);
+    static void loadShaderConfig(Node shaders, Style& style, Scene& scene);
+    static SceneLayer loadSublayer(Node layer, const std::string& name, Scene& scene);
+    static Filter generateAnyFilter(Node filter, Scene& scene);
+    static Filter generateNoneFilter(Node filter, Scene& scene);
+    static Filter generatePredicate(Node filter, std::string _key);
     /* loads a texture with default texture properties */
     static void loadTexture(const std::string& url, Scene& scene);
-    static void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
-    static void loadShaderConfig(YAML::Node shaders, Style& style, Scene& scene);
-    static SceneLayer loadSublayer(YAML::Node layer, const std::string& name, Scene& scene);
-    static Filter generateAnyFilter(YAML::Node filter, Scene& scene);
-    static Filter generateNoneFilter(YAML::Node filter, Scene& scene);
-    static Filter generatePredicate(YAML::Node filter, std::string _key);
 
     // Style Mixing helper methods
-    static YAML::Node mixStyle(const Mixes& mixes);
+    static Node mixStyle(const Mixes& mixes);
 
-    static MaterialTexture loadMaterialTexture(YAML::Node matCompNode, Scene& scene);
+    static MaterialTexture loadMaterialTexture(Node matCompNode, Scene& scene);
 
-    static void parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix,
+    static void parseStyleParams(Node params, Scene& scene, const std::string& propPrefix,
                                  std::vector<StyleParam>& out);
 
     static StyleUniforms parseStyleUniforms(const YAML::Node& uniform, Scene& scene);
 
     // Generic methods to merge properties
-    static YAML::Node propMerge(const std::string& propStr, const Mixes& mixes);
+    static Node propMerge(const std::string& propStr, const Mixes& mixes);
 
     // Methods to merge shader blocks
-    static YAML::Node shaderBlockMerge(const Mixes& mixes);
+    static Node shaderBlockMerge(const Mixes& mixes);
 
     // Methods to merge shader extensions
-    static YAML::Node shaderExtMerge(const Mixes& mixes);
-    static Tangram::Filter generateFilter(YAML::Node filter, Scene& scene);
+    static Node shaderExtMerge(const Mixes& mixes);
+    static Tangram::Filter generateFilter(Node filter, Scene& scene);
 
     SceneLoader() = delete;
 };

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -32,11 +32,11 @@ using StyleUniforms = std::pair<std::string, std::vector<UniformValue>>;
 
 class SceneLoader {
 
-    void loadSources(YAML::Node sources, TileManager& tileManager);
+    void loadSources(YAML::Node sources, Scene& scene);
     void loadFont(YAML::Node fontProps);
     void loadLights(YAML::Node lights, Scene& scene);
-    void loadCameras(YAML::Node cameras, View& view);
-    void loadLayers(YAML::Node layers, Scene& scene, TileManager& tileManager);
+    void loadCameras(YAML::Node cameras, Scene& scene);
+    void loadLayers(YAML::Node layers, Scene& scene);
     void loadStyles(YAML::Node styles, Scene& scene);
     void loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene);
     void loadTextures(YAML::Node textures, Scene& scene);
@@ -59,7 +59,7 @@ public:
 
     virtual ~SceneLoader() {};
 
-    void loadScene(const std::string& _sceneString, Scene& _scene, TileManager& _tileManager, View& _view);
+    bool loadScene(const std::string& _sceneString, Scene& _scene);
 
     // public for testing
     std::vector<StyleParam> parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix = "");

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -42,7 +42,6 @@ struct SceneLoader {
     static void loadStyle(const std::pair<Node, Node>& style, Node styles, Scene& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
-    static void loadFont(Node fontProps);
     static void loadCameras(Node cameras, Scene& scene);
     static void loadStyleProps(Style& style, Node styleNode, Scene& scene);
     static void loadMaterial(Node matNode, Material& material, Scene& scene);

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -6,14 +6,14 @@
 
 namespace Tangram {
 
-DebugTextStyle::DebugTextStyle(const std::string& _fontName, std::string _name, float _fontSize, bool _sdf, bool _sdfMultisampling, Blending _blendMode, GLenum _drawMode)
-: TextStyle(_name, _sdf, _sdfMultisampling, _blendMode, _drawMode), m_fontName(_fontName), m_fontSize(_fontSize) {
+DebugTextStyle::DebugTextStyle(FontID _fontId, std::string _name, float _fontSize, bool _sdf, bool _sdfMultisampling, Blending _blendMode, GLenum _drawMode)
+: TextStyle(_name, _sdf, _sdfMultisampling, _blendMode, _drawMode), m_font(_fontId), m_fontSize(_fontSize) {
 }
 
 void DebugTextStyle::onBeginBuildTile(Tangram::Tile &_tile) const {
 
     Parameters params;
-    params.fontKey = m_fontName;
+    params.fontId = m_font;
     params.fontSize = m_fontSize * m_pixelScale;
     params.blurSpread = m_sdf ? 2.5f : 0.0f;
 

--- a/core/src/style/debugTextStyle.h
+++ b/core/src/style/debugTextStyle.h
@@ -13,9 +13,9 @@ protected:
 
 public:
 
-    DebugTextStyle(const std::string& _fontName, std::string _name, float _fontSize, bool _sdf = false, bool _sdfMultisampling = false, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
+    DebugTextStyle(FontID _fontId, std::string _name, float _fontSize, bool _sdf = false, bool _sdfMultisampling = false, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
 
-    std::string m_fontName;
+    FontID m_font;
     float m_fontSize;
 };
 

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -15,7 +15,7 @@ void Material::setEmission(glm::vec4 _emission){
     setEmissionEnabled(true);
 }
 
-void Material::setEmissionTex(MaterialTexture _emissionTexture){
+void Material::setEmission(MaterialTexture _emissionTexture){
     m_emission_texture = _emissionTexture;
     m_emission = glm::vec4(m_emission_texture.amount, 1.f);
     setEmissionEnabled((bool)m_emission_texture.tex);
@@ -27,7 +27,7 @@ void Material::setAmbient(glm::vec4 _ambient){
     setAmbientEnabled(true);
 }
 
-void Material::setAmbientTex(MaterialTexture _ambientTexture){
+void Material::setAmbient(MaterialTexture _ambientTexture){
     m_ambient_texture = _ambientTexture;
     m_ambient = glm::vec4(m_ambient_texture.amount, 1.f);
     setAmbientEnabled((bool)m_ambient_texture.tex);
@@ -39,7 +39,7 @@ void Material::setDiffuse(glm::vec4 _diffuse){
     setDiffuseEnabled(true);
 }
 
-void Material::setDiffuseTex(MaterialTexture _diffuseTexture){
+void Material::setDiffuse(MaterialTexture _diffuseTexture){
     m_diffuse_texture = _diffuseTexture;
     m_diffuse = glm::vec4(m_diffuse_texture.amount, 1.f);
     setDiffuseEnabled((bool)m_diffuse_texture.tex);
@@ -51,7 +51,7 @@ void Material::setSpecular(glm::vec4 _specular){
     setSpecularEnabled(true);
 }
 
-void Material::setSpecularTex(MaterialTexture _specularTexture){
+void Material::setSpecular(MaterialTexture _specularTexture){
     m_specular_texture = _specularTexture;
     m_specular = glm::vec4(m_specular_texture.amount, 1.f);
     setSpecularEnabled((bool)m_specular_texture.tex);

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -93,7 +93,8 @@ std::string Material::getDefinesBlock(){
         defines += "#define TANGRAM_MATERIAL_EMISSION\n";
         if (m_emission_texture.tex) {
             defines += "#define TANGRAM_MATERIAL_EMISSION_TEXTURE\n";
-            defines += "#define TANGRAM_MATERIAL_EMISSION_TEXTURE_" + mappingTypeToString(m_emission_texture.mapping) + "\n";
+            defines += "#define TANGRAM_MATERIAL_EMISSION_TEXTURE_" +
+                mappingTypeToString(m_emission_texture.mapping) + "\n";
             mappings[(int)m_emission_texture.mapping] = true;
         }
     }
@@ -102,7 +103,8 @@ std::string Material::getDefinesBlock(){
         defines += "#define TANGRAM_MATERIAL_AMBIENT\n";
         if (m_ambient_texture.tex) {
             defines += "#define TANGRAM_MATERIAL_AMBIENT_TEXTURE\n";
-            defines += "#define TANGRAM_MATERIAL_AMBIENT_TEXTURE_" + mappingTypeToString(m_ambient_texture.mapping) + "\n";
+            defines += "#define TANGRAM_MATERIAL_AMBIENT_TEXTURE_" +
+                mappingTypeToString(m_ambient_texture.mapping) + "\n";
             mappings[(int)m_ambient_texture.mapping] = true;
         }
     }
@@ -111,7 +113,8 @@ std::string Material::getDefinesBlock(){
         defines += "#define TANGRAM_MATERIAL_DIFFUSE\n";
         if (m_diffuse_texture.tex) {
             defines += "#define TANGRAM_MATERIAL_DIFFUSE_TEXTURE\n";
-            defines += "#define TANGRAM_MATERIAL_DIFFUSE_TEXTURE_" + mappingTypeToString(m_diffuse_texture.mapping) + "\n";
+            defines += "#define TANGRAM_MATERIAL_DIFFUSE_TEXTURE_" +
+                mappingTypeToString(m_diffuse_texture.mapping) + "\n";
             mappings[(int)m_diffuse_texture.mapping] = true;
         }
     }
@@ -120,14 +123,16 @@ std::string Material::getDefinesBlock(){
         defines += "#define TANGRAM_MATERIAL_SPECULAR\n";
         if (m_specular_texture.tex) {
             defines += "#define TANGRAM_MATERIAL_SPECULAR_TEXTURE\n";
-            defines += "#define TANGRAM_MATERIAL_SPECULAR_TEXTURE_" + mappingTypeToString(m_specular_texture.mapping) + "\n";
+            defines += "#define TANGRAM_MATERIAL_SPECULAR_TEXTURE_" +
+                mappingTypeToString(m_specular_texture.mapping) + "\n";
             mappings[(int)m_specular_texture.mapping] = true;
         }
     }
 
     if (m_normal_texture.tex){
         defines += "#define TANGRAM_MATERIAL_NORMAL_TEXTURE\n";
-        defines += "#define TANGRAM_MATERIAL_NORMAL_TEXTURE_" + mappingTypeToString(m_normal_texture.mapping) + "\n";
+        defines += "#define TANGRAM_MATERIAL_NORMAL_TEXTURE_" +
+            mappingTypeToString(m_normal_texture.mapping) + "\n";
         mappings[(int)m_specular_texture.mapping] = true;
     }
 

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -9,49 +9,49 @@ namespace Tangram {
 Material::Material() {
 }
 
-void Material::setEmission(const glm::vec4 _emission){
+void Material::setEmission(glm::vec4 _emission){
     m_emission = _emission;
     m_emission_texture.tex.reset();
     setEmissionEnabled(true);
 }
 
-void Material::setEmission(MaterialTexture _emissionTexture){
+void Material::setEmissionTex(MaterialTexture _emissionTexture){
     m_emission_texture = _emissionTexture;
     m_emission = glm::vec4(m_emission_texture.amount, 1.f);
     setEmissionEnabled((bool)m_emission_texture.tex);
 }
 
-void Material::setAmbient(const glm::vec4 _ambient){
+void Material::setAmbient(glm::vec4 _ambient){
     m_ambient = _ambient;
     m_ambient_texture.tex.reset();
     setAmbientEnabled(true);
 }
 
-void Material::setAmbient(MaterialTexture _ambientTexture){
+void Material::setAmbientTex(MaterialTexture _ambientTexture){
     m_ambient_texture = _ambientTexture;
     m_ambient = glm::vec4(m_ambient_texture.amount, 1.f);
     setAmbientEnabled((bool)m_ambient_texture.tex);
 }
 
-void Material::setDiffuse(const glm::vec4 _diffuse){
+void Material::setDiffuse(glm::vec4 _diffuse){
     m_diffuse = _diffuse;
     m_diffuse_texture.tex.reset();
     setDiffuseEnabled(true);
 }
 
-void Material::setDiffuse(MaterialTexture _diffuseTexture){
+void Material::setDiffuseTex(MaterialTexture _diffuseTexture){
     m_diffuse_texture = _diffuseTexture;
     m_diffuse = glm::vec4(m_diffuse_texture.amount, 1.f);
     setDiffuseEnabled((bool)m_diffuse_texture.tex);
 }
 
-void Material::setSpecular(const glm::vec4 _specular){
+void Material::setSpecular(glm::vec4 _specular){
     m_specular = _specular;
     m_specular_texture.tex.reset();
     setSpecularEnabled(true);
 }
 
-void Material::setSpecular(MaterialTexture _specularTexture){
+void Material::setSpecularTex(MaterialTexture _specularTexture){
     m_specular_texture = _specularTexture;
     m_specular = glm::vec4(m_specular_texture.amount, 1.f);
     setSpecularEnabled((bool)m_specular_texture.tex);

--- a/core/src/style/material.h
+++ b/core/src/style/material.h
@@ -39,23 +39,23 @@ public:
 
     /*  Emission color is by default disabled and vec4(0.0).
      *  Setting this property enables it and changes require reloading the shader. */
-    void setEmission(const glm::vec4 _emission);
-    void setEmission(MaterialTexture _emissionTexture);
+    void setEmission(glm::vec4 _emission);
+    void setEmissionTex(MaterialTexture _emissionTexture);
 
     /*  Ambient color is by default disabled and vec4(1.0).
      *  Setting this property enables it and changes require reloading the shader. */
-    void setAmbient(const glm::vec4 _ambient);
-    void setAmbient(MaterialTexture _ambientTexture);
+    void setAmbient(glm::vec4 _ambient);
+    void setAmbientTex(MaterialTexture _ambientTexture);
 
     /*  Diffuse color is by default enabled and vec4(1.0).
      *  Changes require reloading the shader. */
-    void setDiffuse(const glm::vec4 _diffuse);
-    void setDiffuse(MaterialTexture _diffuseTexture);
+    void setDiffuse(glm::vec4 _diffuse);
+    void setDiffuseTex(MaterialTexture _diffuseTexture);
 
     /*  Specular color is by default disabled and vec4(0.2) with a shininess factor of 0.2.
      *  Setting this property enables it and changes require reloading the shader. */
-    void setSpecular(const glm::vec4 _specular);
-    void setSpecular(MaterialTexture _specularTexture);
+    void setSpecular(glm::vec4 _specular);
+    void setSpecularTex(MaterialTexture _specularTexture);
 
     void setShininess(float _shiny);
 

--- a/core/src/style/material.h
+++ b/core/src/style/material.h
@@ -79,6 +79,11 @@ public:
     /*  Method to pass it self as a uniform to the shader program */
     virtual void setupProgram(ShaderProgram& _shader);
 
+    bool hasEmission() const { return m_bEmission; }
+    bool hasAmbient() const { return m_bAmbient; }
+    bool hasDiffuse() const { return m_bDiffuse; }
+    bool hasSpecular() const { return m_bSpecular; }
+
 private:
 
     /* Get defines that need to be injected on top of the shader */
@@ -102,7 +107,7 @@ private:
     bool m_bSpecular = false;
     glm::vec4 m_specular = glm::vec4(.2f);
     MaterialTexture m_specular_texture;
-    
+
     MaterialTexture m_normal_texture;
 
     float m_shininess = .2f;

--- a/core/src/style/material.h
+++ b/core/src/style/material.h
@@ -40,22 +40,22 @@ public:
     /*  Emission color is by default disabled and vec4(0.0).
      *  Setting this property enables it and changes require reloading the shader. */
     void setEmission(glm::vec4 _emission);
-    void setEmissionTex(MaterialTexture _emissionTexture);
+    void setEmission(MaterialTexture _emissionTexture);
 
     /*  Ambient color is by default disabled and vec4(1.0).
      *  Setting this property enables it and changes require reloading the shader. */
     void setAmbient(glm::vec4 _ambient);
-    void setAmbientTex(MaterialTexture _ambientTexture);
+    void setAmbient(MaterialTexture _ambientTexture);
 
     /*  Diffuse color is by default enabled and vec4(1.0).
      *  Changes require reloading the shader. */
     void setDiffuse(glm::vec4 _diffuse);
-    void setDiffuseTex(MaterialTexture _diffuseTexture);
+    void setDiffuse(MaterialTexture _diffuseTexture);
 
     /*  Specular color is by default disabled and vec4(0.2) with a shininess factor of 0.2.
      *  Setting this property enables it and changes require reloading the shader. */
     void setSpecular(glm::vec4 _specular);
-    void setSpecularTex(MaterialTexture _specularTexture);
+    void setSpecular(MaterialTexture _specularTexture);
 
     void setShininess(float _shiny);
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -8,6 +8,7 @@
 #include "labels/textLabel.h"
 #include "glm/gtc/type_ptr.hpp"
 #include "tangram.h"
+#include "text/fontContext.h"
 
 namespace Tangram {
 
@@ -55,6 +56,17 @@ Parameters TextStyle::parseRule(const DrawRule& _rule) const {
     _rule.get(StyleParamKey::font_family, fontFamily);
     _rule.get(StyleParamKey::font_weight, fontWeight);
     _rule.get(StyleParamKey::font_style, fontStyle);
+    std::string fontKey = fontFamily + "_" + fontWeight + "_" + fontStyle;
+    {
+        auto fontContext = FontContext::GetInstance();
+        if (!fontContext->lock()) { return p; }
+
+        p.fontId = fontContext->addFont(fontFamily, fontWeight, fontStyle);
+
+        fontContext->unlock();
+        if(p.fontId < 0) { return p; }
+    }
+
     _rule.get(StyleParamKey::font_size, p.fontSize);
     _rule.get(StyleParamKey::font_fill, p.fill);
     _rule.get(StyleParamKey::offset, p.offset);
@@ -76,8 +88,6 @@ Parameters TextStyle::parseRule(const DrawRule& _rule) const {
     } else if (transform == "uppercase") {
         p.transform = TextTransform::uppercase;
     }
-
-    p.fontKey = fontFamily + "_" + fontWeight + "_" + fontStyle;
 
     /* Global operations done for fontsize and sdfblur */
     float emSize = p.fontSize / 16.f;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -55,7 +55,6 @@ void initialize(const char* _scenePath) {
 
         // Pass references to the view and scene into the tile manager
         m_tileManager->setView(m_view);
-        m_tileManager->setScene(m_scene);
 
         // label setup
         m_labels = std::unique_ptr<Labels>(new Labels());
@@ -65,11 +64,16 @@ void initialize(const char* _scenePath) {
 
         SceneLoader loader;
 
-        loader.loadScene(sceneString, *m_scene, *m_tileManager, *m_view);
+        if (loader.loadScene(sceneString, *m_scene)) {
+            m_tileManager->setScene(m_scene);
+
+            glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
+            m_view->setPosition(projPos.x, projPos.y);
+            m_view->setZoom(m_scene->startZoom);
+        }
 
         m_skybox = std::unique_ptr<Skybox>(new Skybox("img/cubemap.png"));
         m_skybox->init();
-
     }
 
     logMsg("finish initialize\n");

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -35,44 +35,49 @@ static std::bitset<8> g_flags = 0;
 
 void initialize(const char* _scenePath) {
 
+    if (m_tileManager) {
+        logMsg("Notice: Already initialized\n");
+        return;
+    }
+
     logMsg("initialize\n");
 
     auto sceneRelPath = setResourceRoot(_scenePath);
 
-    if (!m_tileManager) {
+    // Create view
+    m_view = std::make_shared<View>();
 
-        // Create view
-        m_view = std::make_shared<View>();
+    // Create a scene object
+    m_scene = std::make_shared<Scene>();
 
-        // Create a scene object
-        m_scene = std::make_shared<Scene>();
+    // Input handler
+    m_inputHandler = std::unique_ptr<InputHandler>(new InputHandler(m_view));
 
-        // Input handler
-        m_inputHandler = std::unique_ptr<InputHandler>(new InputHandler(m_view));
+    // Create a tileManager
+    m_tileManager = TileManager::GetInstance();
 
-        // Create a tileManager
-        m_tileManager = TileManager::GetInstance();
+    // Pass references to the view and scene into the tile manager
+    m_tileManager->setView(m_view);
 
-        // Pass references to the view and scene into the tile manager
-        m_tileManager->setView(m_view);
+    // label setup
+    m_labels = std::unique_ptr<Labels>(new Labels());
 
-        // label setup
-        m_labels = std::unique_ptr<Labels>(new Labels());
+    // To add font for debugTextStyle
+    FontContext::GetInstance()->addFont("FiraSans", "Medium", "");
 
-        logMsg("Loading Tangram scene file: %s\n", sceneRelPath.c_str());
-        auto sceneString = stringFromResource(sceneRelPath.c_str());
+    logMsg("Loading Tangram scene file: %s\n", sceneRelPath.c_str());
+    auto sceneString = stringFromResource(sceneRelPath.c_str());
 
-        if (SceneLoader::loadScene(sceneString, *m_scene)) {
-            m_tileManager->setScene(m_scene);
+    if (SceneLoader::loadScene(sceneString, *m_scene)) {
+        m_tileManager->setScene(m_scene);
 
-            glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
-            m_view->setPosition(projPos.x, projPos.y);
-            m_view->setZoom(m_scene->startZoom);
-        }
-
-        m_skybox = std::unique_ptr<Skybox>(new Skybox("img/cubemap.png"));
-        m_skybox->init();
+        glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
+        m_view->setPosition(projPos.x, projPos.y);
+        m_view->setZoom(m_scene->startZoom);
     }
+
+    m_skybox = std::unique_ptr<Skybox>(new Skybox("img/cubemap.png"));
+    m_skybox->init();
 
     logMsg("finish initialize\n");
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -62,9 +62,7 @@ void initialize(const char* _scenePath) {
         logMsg("Loading Tangram scene file: %s\n", sceneRelPath.c_str());
         auto sceneString = stringFromResource(sceneRelPath.c_str());
 
-        SceneLoader loader;
-
-        if (loader.loadScene(sceneString, *m_scene)) {
+        if (SceneLoader::loadScene(sceneString, *m_scene)) {
             m_tileManager->setScene(m_scene);
 
             glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -78,6 +78,18 @@ void initialize(const char* _scenePath) {
 
 }
 
+void loadScene(const char* _scenePath) {
+
+    m_scene = std::make_shared<Scene>();
+
+    logMsg("Loading Tangram scene file: %s\n", _scenePath);
+    auto sceneString = stringFromResource(_scenePath);
+
+    if (SceneLoader::loadScene(sceneString, *m_scene)) {
+        m_tileManager->setScene(m_scene);
+    }
+}
+
 void resize(int _newWidth, int _newHeight) {
 
     logMsg("resize: %d x %d\n", _newWidth, _newHeight);
@@ -233,7 +245,6 @@ void setPixelScale(float _pixelsPerPoint) {
     for (auto& style : m_scene->styles()) {
         style->setPixelScale(_pixelsPerPoint);
     }
-
 }
 
 int addDataSource(const char* _name) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -262,7 +262,7 @@ void clearSourceData(int _sourceId) {
     if (!m_tileManager) { return; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);
     for (auto& set : m_tileManager->getTileSets()) {
-        if (set.id == _sourceId) {
+        if (set.source->id() == _sourceId) {
             set.source->clearData();
             m_tileManager->clearTileSet(_sourceId);
         }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -239,7 +239,9 @@ int addDataSource(const char* _name) {
     if (!m_tileManager) { return -1; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);
     auto source = std::make_shared<ClientGeoJsonSource>(std::string(_name), "");
-    return m_tileManager->addDataSource(source);
+    m_tileManager->addDataSource(source);
+
+    return source->id();
 }
 
 void clearSourceData(int _sourceId) {

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -103,5 +103,7 @@ bool getDebugFlag(DebugFlags _flag);
 // Toggle the boolean state of a debug feature (see debug.h)
 void toggleDebugFlag(DebugFlags _flag);
 
+void loadScene(const char* _scenePath);
+
 }
 

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -55,6 +55,9 @@ bool FontContext::addFont(const std::string& _family, const std::string& _weight
     if ( !(data = bytesFromResource(bundledFontPath.c_str(), &dataSize))) {
         const std::string sysFontPath = systemFontPath(_family, _weight, _style);
         if ( !(data = bytesFromFileSystem(sysFontPath.c_str(), &dataSize)) ) {
+
+            logMsg("[FontContext] Error loading font file %s\n", fontKey.c_str());
+            m_fonts.emplace(std::move(fontKey), FONS_INVALID);
             return false;
         }
     }
@@ -63,6 +66,7 @@ bool FontContext::addFont(const std::string& _family, const std::string& _weight
 
     if (font == FONS_INVALID) {
         logMsg("[FontContext] Error loading font %s\n", fontKey.c_str());
+        m_fonts.emplace(std::move(fontKey), FONS_INVALID);
         return false;
     }
 

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -2,6 +2,9 @@
 #define FONTSTASH_IMPLEMENTATION
 #include "fontstash.h"
 
+#define LOGE(fmt, ...) do { logMsg("FontContext/Error: " fmt "\n", ## __VA_ARGS__); } while(0)
+#define LOGW(fmt, ...) do { logMsg("FontContext/Warn: " fmt "\n", ## __VA_ARGS__); } while(0)
+
 namespace Tangram {
 
 #define INVALID_FONT -2
@@ -32,7 +35,7 @@ bool FontContext::lock() {
     try {
         m_contextMutex.lock();
     } catch (std::system_error& e) {
-        logMsg("Dead lock: aborting\n");
+        LOGE("Dead lock: aborting!");
         return false;
     }
     return true;
@@ -66,7 +69,7 @@ FontID FontContext::addFont(const std::string& _family, const std::string& _weig
             const std::string sysFontPath = systemFontPath(_family, _weight, _style);
             if ( !(data = bytesFromFileSystem(sysFontPath.c_str(), &dataSize)) ) {
 
-                logMsg("[FontContext] Error loading font file %s\n", fontKey.c_str());
+                LOGE("Could not load font file %s", fontKey.c_str());
                 m_fonts.emplace(std::move(fontKey), INVALID_FONT);
                 goto fallback;
             }
@@ -76,7 +79,7 @@ FontID FontContext::addFont(const std::string& _family, const std::string& _weig
     font = fonsAddFont(m_fsContext, fontKey.c_str(), data, dataSize);
 
     if (font == FONS_INVALID) {
-        logMsg("[FontContext] Error loading font %s\n", fontKey.c_str());
+        LOGE("Could not load font %s", fontKey.c_str());
         m_fonts.emplace(std::move(fontKey), INVALID_FONT);
         goto fallback;
     }
@@ -99,7 +102,7 @@ void FontContext::setFont(const std::string& _key, int size) {
         fonsSetSize(m_fsContext, size);
         fonsSetFont(m_fsContext, id);
     } else {
-        logMsg("[FontContext] Could not find font %s\n", _key.c_str());
+        LOGW("Could not find font %s", _key.c_str());
     }
 }
 
@@ -112,16 +115,17 @@ FontID FontContext::getFontID(const std::string& _key) {
 
     if (m_fonts.size() > 0) {
         // sceneLoader makes sure that first loaded font is the default bundled font
-        logMsg("Warning: Using default font for '%s'.\n", _key.c_str());
+        LOGW("Using default font for '%s'.", _key.c_str());
         m_fonts.emplace(_key, 0);
         return 0;
     } else {
-        logMsg("Error: No default font loaded.\n");
+        LOGE("No default font loaded.");
         return -1;
     }
 }
 
-std::vector<FONSquad>& FontContext::rasterize(const std::string& _text, FontID _fontID, float _fontSize, float _sdf) {
+std::vector<FONSquad>& FontContext::rasterize(const std::string& _text, FontID _fontID,
+                                              float _fontSize, float _sdf) {
 
     m_quadBuffer.clear();
 
@@ -167,6 +171,21 @@ void FontContext::renderUpdate(void* _userPtr, int* _rect, const unsigned char* 
     fontContext->m_atlas->setSubData(subdata, xoff, yoff, width, height);
 }
 
+void FontContext::fontstashError(void* uptr, int error, int val) {
+    switch(error) {
+    case FONS_ATLAS_FULL:
+        LOGE("Texture Atlas full!");
+        break;
+
+    case FONS_SCRATCH_FULL:
+    case FONS_STATES_OVERFLOW:
+    case FONS_STATES_UNDERFLOW:
+    default:
+        LOGE("Unexpected error in Fontstash %d:%d!", error, val);
+        break;
+    }
+}
+
 void FontContext::initFontContext(int _atlasSize) {
     m_atlas = std::unique_ptr<Texture>(new Texture(_atlasSize, _atlasSize));
 
@@ -183,7 +202,9 @@ void FontContext::initFontContext(int _atlasSize) {
     params.pushQuad = pushQuad;
     params.userPtr = (void*) this;
 
-    m_fsContext = fonsCreateInternal(&params);;
+    m_fsContext = fonsCreateInternal(&params);
+
+    fonsSetErrorCallback(m_fsContext, &fontstashError, (void*) this);
 }
 
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -4,6 +4,8 @@
 
 namespace Tangram {
 
+#define INVALID_FONT -2
+
 FontContext::FontContext() : FontContext(512) {}
 
 FontContext::FontContext(int _atlasSize) {
@@ -40,39 +42,54 @@ void FontContext::unlock() {
     m_contextMutex.unlock();
 }
 
-bool FontContext::addFont(const std::string& _family, const std::string& _weight, const std::string& _style) {
+FontID FontContext::addFont(const std::string& _family, const std::string& _weight,
+                            const std::string& _style, bool _tryFallback) {
+
+    unsigned int dataSize = 0;
+    unsigned char* data = nullptr;
+    int font = FONS_INVALID;
 
     std::string fontKey = _family + "_" + _weight + "_" + _style;
-    if (m_fonts.find(fontKey) != m_fonts.end()) {
-        return true;
+
+    auto it = m_fonts.find(fontKey);
+    if (it != m_fonts.end()) {
+        if (it->second < 0) {
+            goto fallback;
+        }
+        return it->second;
     }
 
-    unsigned int dataSize;
-    unsigned char* data = nullptr;
+    {
+        // Assuming bundled ttf file follows this convention
+        auto bundledFontPath = "fonts/" + _family + "-" + _weight + _style + ".ttf";
+        if ( !(data = bytesFromResource(bundledFontPath.c_str(), &dataSize))) {
+            const std::string sysFontPath = systemFontPath(_family, _weight, _style);
+            if ( !(data = bytesFromFileSystem(sysFontPath.c_str(), &dataSize)) ) {
 
-    // Assuming bundled ttf file follows this convention
-    auto bundledFontPath = "fonts/" + _family + "-" + _weight + _style + ".ttf";
-    if ( !(data = bytesFromResource(bundledFontPath.c_str(), &dataSize))) {
-        const std::string sysFontPath = systemFontPath(_family, _weight, _style);
-        if ( !(data = bytesFromFileSystem(sysFontPath.c_str(), &dataSize)) ) {
-
-            logMsg("[FontContext] Error loading font file %s\n", fontKey.c_str());
-            m_fonts.emplace(std::move(fontKey), FONS_INVALID);
-            return false;
+                logMsg("[FontContext] Error loading font file %s\n", fontKey.c_str());
+                m_fonts.emplace(std::move(fontKey), INVALID_FONT);
+                goto fallback;
+            }
         }
     }
 
-    int font = fonsAddFont(m_fsContext, fontKey.c_str(), data, dataSize);
+    font = fonsAddFont(m_fsContext, fontKey.c_str(), data, dataSize);
 
     if (font == FONS_INVALID) {
         logMsg("[FontContext] Error loading font %s\n", fontKey.c_str());
-        m_fonts.emplace(std::move(fontKey), FONS_INVALID);
-        return false;
+        m_fonts.emplace(std::move(fontKey), INVALID_FONT);
+        goto fallback;
     }
 
     m_fonts.emplace(std::move(fontKey), font);
 
-    return true;
+    return font;
+
+fallback:
+    if (_tryFallback && m_fonts.size() > 0) {
+        return 0;
+    }
+    return INVALID_FONT;
 }
 
 void FontContext::setFont(const std::string& _key, int size) {

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -26,7 +26,8 @@ public:
     ~FontContext();
 
     /* adds a font from a .ttf font file using "family", "weight" and "style" font properties*/
-    bool addFont(const std::string& _family, const std::string& _weight, const std::string& _style);
+    FontID addFont(const std::string& _family, const std::string& _weight,
+                   const std::string& _style, bool _tryFallback = true);
 
     /* sets the current font for a size in pixels */
     void setFont(const std::string& _key, int size);

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -56,6 +56,7 @@ private:
     static void renderUpdate(void* _userPtr, int* _rect, const unsigned char* _data);
     static int renderCreate(void* _userPtr, int _width, int _height);
     static void pushQuad(void* _userPtr, const FONSquad* _quad);
+    static void fontstashError(void* uptr, int error, int val);
 
     FontContext();
     FontContext(int _atlasSize);

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -15,21 +15,15 @@ TextBuffer::TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout)
 TextBuffer::~TextBuffer() {
 }
 
-bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform, Label::Type _type, const Parameters& _params, Label::Options _options) {
-    if (_params.fontSize <= 0.f || _text.size() == 0) {
+bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform, Label::Type _type,
+                          const Parameters& _params, Label::Options _options) {
+    if (_params.fontId < 0 || _params.fontSize <= 0.f || _text.size() == 0) {
         return false;
     }
 
     auto fontContext = FontContext::GetInstance();
 
     if (!fontContext->lock()) {
-        return false;
-    }
-
-    auto fontID = fontContext->getFontID(_params.fontKey);
-
-    if(fontID < 0) {
-        fontContext->unlock();
         return false;
     }
 
@@ -71,7 +65,9 @@ bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform,
     }
 
     // rasterize glyphs
-    std::vector<FONSquad>& quads = fontContext->rasterize(*text, fontID, _params.fontSize, _params.blurSpread);
+    std::vector<FONSquad>& quads = fontContext->rasterize(*text, _params.fontId,
+                                                          _params.fontSize,
+                                                          _params.blurSpread);
     size_t numGlyphs = quads.size();
 
     if (numGlyphs == 0) {
@@ -103,7 +99,9 @@ bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform,
 
     glm::vec2 size((x1 - x0), (y1 - y0));
 
-    m_labels.emplace_back(new TextLabel(_text, _transform, _type, size, *this, { vertexOffset, numVertices }, _options));
+    m_labels.emplace_back(new TextLabel(_text, _transform, _type, size,
+                                        *this, { vertexOffset, numVertices },
+                                        _options));
 
     // TODO: change this in TypeMesh::adVertices()
     m_nVertices = vertices.size();

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -22,7 +22,7 @@ enum class TextTransform {
 };
 
 struct Parameters {
-    std::string fontKey = "";
+    FontID fontId = -1;
     uint32_t fill = 0xff000000;
     uint32_t strokeColor = 0xffffffff;
     float strokeWidth = 0.0f;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -40,9 +40,8 @@ TileManager::~TileManager() {
     m_tileSets.clear();
 }
 
-int32_t TileManager::addDataSource(std::shared_ptr<DataSource>&& dataSource) {
-    m_tileSets.push_back({++m_tileSetSerial, dataSource});
-    return m_tileSetSerial;
+void TileManager::addDataSource(std::shared_ptr<DataSource>&& dataSource) {
+    m_tileSets.push_back({dataSource->id(), dataSource});
 }
 
 std::shared_ptr<ClientGeoJsonSource> TileManager::getClientSourceById(int32_t _id) {

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -40,7 +40,15 @@ TileManager::~TileManager() {
     m_tileSets.clear();
 }
 
-void TileManager::addDataSource(std::shared_ptr<DataSource>&& dataSource) {
+void TileManager::setScene(std::shared_ptr<Scene> _scene) {
+    m_scene = _scene;
+
+    for (auto& source : _scene->dataSources()) {
+        addDataSource(source);
+    }
+}
+
+void TileManager::addDataSource(std::shared_ptr<DataSource> dataSource) {
     m_tileSets.push_back({dataSource->id(), dataSource});
 }
 

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -86,12 +86,12 @@ void TileManager::setScene(std::shared_ptr<Scene> _scene) {
 }
 
 void TileManager::addDataSource(std::shared_ptr<DataSource> dataSource) {
-    m_tileSets.push_back({dataSource->id(), dataSource});
+    m_tileSets.push_back({ dataSource });
 }
 
 std::shared_ptr<ClientGeoJsonSource> TileManager::getClientSourceById(int32_t _id) {
     for (auto& set : m_tileSets) {
-        if (set.id == _id) {
+        if (set.source->id() == _id) {
             return std::dynamic_pointer_cast<ClientGeoJsonSource>(set.source);
         }
     }
@@ -171,7 +171,7 @@ void TileManager::clearTileSets() {
 
 void TileManager::clearTileSet(int32_t _id) {
     for (auto& tileSet : m_tileSets) {
-        if (tileSet.id != _id) { continue; }
+        if (tileSet.source->id() != _id) { continue; }
         for (auto& tile : tileSet.tiles) {
             setTileState(*tile.second, TileState::canceled);
         }
@@ -366,7 +366,7 @@ void TileManager::loadTiles() {
 
 bool TileManager::addTile(TileSet& tileSet, const TileID& _tileID) {
 
-    auto tile = m_tileCache->get(tileSet.id, _tileID);
+    auto tile = m_tileCache->get(tileSet.source->id(), _tileID);
     bool fromCache = false;
 
     if (tile) {
@@ -402,7 +402,7 @@ void TileManager::removeTile(TileSet& tileSet, std::map<TileID,
 
     if (tile->hasState(TileState::ready)) {
         // Add to cache
-        m_tileCache->put(tileSet.id, tile);
+        m_tileCache->put(tileSet.source->id(), tile);
     }
 
     // Remove tile from set
@@ -430,7 +430,7 @@ void TileManager::updateProxyTiles(TileSet& tileSet, Tile& _tile) {
     }
     // Get parent proxy from cache
     {
-        auto parent = m_tileCache->get(tileSet.id, parentID);
+        auto parent = m_tileCache->get(tileSet.source->id(), parentID);
         if (parent) {
             _tile.setProxy(Tile::parent);
             parent->incProxyCounter();
@@ -458,7 +458,7 @@ void TileManager::updateProxyTiles(TileSet& tileSet, Tile& _tile) {
                     }
                 }
             } else {
-                auto child = m_tileCache->get(tileSet.id, childID);
+                auto child = m_tileCache->get(tileSet.source->id(), childID);
                 if (child) {
                     _tile.setProxy(static_cast<Tile::ProxyID>(1 << i));
                     child->incProxyCounter();

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -51,12 +51,14 @@ void TileManager::setScene(std::shared_ptr<Scene> _scene) {
         [&](auto& tileSet) {
             auto sIt = std::find_if(
                 sources.begin(), sources.end(),
-                [&](auto& s){ return tileSet.source->name() == s->name(); });
+                [&](auto& s){ return tileSet.source->equals(*s); });
 
             if (sIt != sources.end()) {
+                // Cancel pending  tiles
                 for_each(tileSet.tiles.begin(), tileSet.tiles.end(),
                          [&](auto& tile){ this->setTileState(*tile.second, TileState::canceled);});
 
+                // Clear cache
                 tileSet.tiles.clear();
                 return false;
             }

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -74,7 +74,7 @@ public:
 
     bool hasTileSetChanged() { return m_tileSetChanged; }
 
-    int32_t addDataSource(std::shared_ptr<DataSource>&& dataSource);
+    void addDataSource(std::shared_ptr<DataSource>&& dataSource);
 
     const auto getTileSets() { return m_tileSets; }
 
@@ -136,7 +136,6 @@ private:
     int32_t m_loadPending;
 
     std::vector<TileSet> m_tileSets;
-    int32_t m_tileSetSerial = 0;
 
     /* Current tiles ready for rendering */
     std::vector<std::shared_ptr<Tile>> m_tiles;

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -48,7 +48,7 @@ public:
     void setView(std::shared_ptr<View> _view) { m_view = _view; }
 
     /* Sets the scene which the TileManager will use to style tiles */
-    void setScene(std::shared_ptr<Scene> _scene) { m_scene = _scene; }
+    void setScene(std::shared_ptr<Scene> _scene);
 
     std::shared_ptr<Scene>& getScene() { return m_scene; }
 
@@ -74,7 +74,7 @@ public:
 
     bool hasTileSetChanged() { return m_tileSetChanged; }
 
-    void addDataSource(std::shared_ptr<DataSource>&& dataSource);
+    void addDataSource(std::shared_ptr<DataSource> dataSource);
 
     const auto getTileSets() { return m_tileSets; }
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -88,7 +88,6 @@ public:
 private:
 
     struct TileSet {
-        int32_t id;
         std::shared_ptr<DataSource> source;
         std::map<TileID, std::shared_ptr<Tile>> tiles;
     };

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -88,7 +88,7 @@ public:
 private:
 
     struct TileSet {
-        const int32_t id;
+        int32_t id;
         std::shared_ptr<DataSource> source;
         std::map<TileID, std::shared_ptr<Tile>> tiles;
     };

--- a/core/src/tile/tileTask.h
+++ b/core/src/tile/tileTask.h
@@ -14,12 +14,14 @@ class TileTask {
 
 public:
     std::shared_ptr<Tile> tile;
-    /*const*/ DataSource* source;
+
+    // NB: Save shared reference to Datasource while building tile
+    std::shared_ptr<DataSource> source;
 
     // Raw tile data that will be processed by DataSource.
     std::shared_ptr<std::vector<char>> rawTileData;
 
-    TileTask(std::shared_ptr<Tile> _tile, DataSource* _source) :
+    TileTask(std::shared_ptr<Tile> _tile, std::shared_ptr<DataSource> _source) :
         tile(_tile),
         source(_source) {
     }

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -77,12 +77,13 @@ void TileWorker::run() {
 
         auto tileData = task->process();
 
-        auto& scene = *m_tileManager.getScene();
+        // NB: Save shared reference to Scene while building tile
+        auto scene = m_tileManager.getScene();
 
-        context.initFunctions(scene);
+        context.initFunctions(*scene);
 
         if (tileData) {
-            task->tile->build(context, scene, *tileData, *task->source);
+            task->tile->build(context, *scene, *tileData, *task->source);
         }
 
         m_tileManager.tileProcessed(std::move(task));

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -7,6 +7,8 @@
 // Forward declaration
 void init_main_window();
 
+const char* sceneFile = "scene.yaml";
+
 // Input handling
 // ==============
 
@@ -106,6 +108,9 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             case GLFW_KEY_5:
                 Tangram::toggleDebugFlag(Tangram::DebugFlags::labels);
                 break;
+            case GLFW_KEY_R:
+                Tangram::loadScene(sceneFile);
+                break;
             case GLFW_KEY_BACKSPACE:
                 init_main_window(); // Simulate GL context loss
                 break;
@@ -131,7 +136,7 @@ void window_size_callback(GLFWwindow* window, int width, int height) {
 void init_main_window() {
 
     // Setup tangram
-    Tangram::initialize("scene.yaml");
+    Tangram::initialize(sceneFile);
 
     // Destroy old window
     if (main_window != nullptr) {

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -6,6 +6,8 @@
 // Forward declaration
 void init_main_window();
 
+const char* sceneFile = "scene.yaml";
+
 // Input handling
 // ==============
 
@@ -115,7 +117,10 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             case GLFW_KEY_BACKSPACE:
                 init_main_window(); // Simulate GL context loss
                 break;
-            default:
+            case GLFW_KEY_R:
+                Tangram::loadScene(sceneFile);
+                break;
+        default:
                 break;
         }
     }
@@ -137,7 +142,7 @@ void window_size_callback(GLFWwindow* window, int width, int height) {
 void init_main_window() {
 
     // Setup tangram
-    Tangram::initialize("scene.yaml");
+    Tangram::initialize(sceneFile);
 
     // Destroy old window
     if (main_window != nullptr) {

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -10,13 +10,9 @@
 
 using namespace Tangram;
 
-SceneLoader sceneLoader;
-
-
 TEST_CASE( "", "[Duktape][init]") {
     StyleContext();
 }
-
 
 TEST_CASE( "Test filter without feature being set", "[Duktape][evalFilterFn]") {
     StyleContext ctx;
@@ -202,8 +198,8 @@ TEST_CASE( "Test evalFilter - Init filter function from yaml", "[Duktape][evalFi
     YAML::Node n0 = YAML::Load(R"(filter: function() { return feature.sort_key === 2; })");
     YAML::Node n1 = YAML::Load(R"(filter: function() { return feature.name === 'test'; })");
 
-    Filter filter0 = sceneLoader.generateFilter(n0["filter"], scene);
-    Filter filter1 = sceneLoader.generateFilter(n1["filter"], scene);
+    Filter filter0 = SceneLoader::generateFilter(n0["filter"], scene);
+    Filter filter1 = SceneLoader::generateFilter(n1["filter"], scene);
 
     REQUIRE(scene.functions().size() == 2);
 
@@ -248,7 +244,7 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
                 cap: function() { return 'round'; }
             )");
 
-    std::vector<StyleParam> styles(sceneLoader.parseStyleParams(n0["draw"], scene));
+    std::vector<StyleParam> styles(SceneLoader::parseStyleParams(n0["draw"], scene));
 
     REQUIRE(scene.functions().size() == 3);
 

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -244,7 +244,9 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
                 cap: function() { return 'round'; }
             )");
 
-    std::vector<StyleParam> styles(SceneLoader::parseStyleParams(n0["draw"], scene));
+    std::vector<StyleParam> styles;
+
+    SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
 
     REQUIRE(scene.functions().size() == 3);
 

--- a/tests/unit/layerTests.cpp
+++ b/tests/unit/layerTests.cpp
@@ -20,7 +20,7 @@ SceneLayer instance_a() {
 
 SceneLayer instance_b() {
 
-    Filter f = Filter(Operators::any, {}); // passes nothing
+    Filter f = Filter::MatchAny({}); // passes nothing
 
     DrawRule rule = { "style_1", { { StyleParamKey::order, "value_b" } } };
 

--- a/tests/unit/sceneLoaderTests.cpp
+++ b/tests/unit/sceneLoaderTests.cpp
@@ -1,0 +1,147 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "yaml-cpp/yaml.h"
+#include "sceneLoader.h"
+#include "scene/scene.h"
+#include "style/style.h"
+#include "style/polylineStyle.h"
+#include "style/polygonStyle.h"
+
+#include "platform.h"
+
+using namespace Tangram;
+using YAML::Node;
+
+TEST_CASE( "Test style loading" ) {
+    Scene scene;
+
+    scene.styles().emplace_back(new PolygonStyle("polygons"));
+    scene.styles().emplace_back(new PolylineStyle("lines"));
+
+    YAML::Node node = YAML::Load(R"END(
+    roads:
+      animated: true
+      texcoords: true
+      base: lines
+      mix: tools
+      material:
+        diffuse: .9
+        emission: 0.0
+     )END");
+
+    REQUIRE(node.IsMap());
+    REQUIRE(node.size() == 1);
+
+    // logMsg("Node:\n'%s'\n", Dump(node).c_str());
+
+    const auto& n = node.begin();
+
+    SceneLoader::loadStyle(*n, node, scene);
+
+    auto& styles = scene.styles();
+
+    REQUIRE(styles.size() == 3);
+    REQUIRE(styles[0]->getName() == "polygons");
+    REQUIRE(styles[1]->getName() == "lines");
+    REQUIRE(styles[2]->getName() == "roads");
+
+    REQUIRE(styles[2]->isAnimated() == true);
+
+    REQUIRE(styles[2]->getMaterial()->hasEmission() == true);
+    REQUIRE(styles[2]->getMaterial()->hasDiffuse() == true);
+    REQUIRE(styles[2]->getMaterial()->hasAmbient() == true);
+    REQUIRE(styles[2]->getMaterial()->hasSpecular() == false);
+}
+
+TEST_CASE( "Test style merging - shader global" ) {
+
+    Scene scene;
+    scene.styles().emplace_back(new PolygonStyle("polygons"));
+
+    YAML::Node node = YAML::Load(R"END(
+    styles:
+      mixedstyle:
+        base: polygons
+        mix: tools
+        shaders:
+          blocks:
+            global: mixed
+      tools:
+        shaders:
+          blocks:
+            global: tools
+     )END");
+
+    {
+        auto styles = node["styles"];
+
+        for (const auto& style : styles) {
+            SceneLoader::loadStyle(style, styles, scene);
+        }
+    }
+
+    auto& styles = scene.styles();
+
+    REQUIRE(styles.size() == 2);
+
+    for (auto& style : styles) {
+    for (auto& block : style->getShaderProgram()->getSourceBlocks()) {
+        logMsg("block '%s'\n", block.first.c_str());
+        for (auto& val : block.second)
+            logMsg("- '%s'\n", val.c_str());
+
+    }
+    }
+
+    REQUIRE(styles[1]->getShaderProgram()->getSourceBlocks()["global"].empty() == false);
+}
+
+TEST_CASE( "Test style merging two levels - shader global" ) {
+
+    Scene scene;
+    scene.styles().emplace_back(new PolygonStyle("polygons"));
+
+    YAML::Node node = YAML::Load(R"END(
+    styles:
+      mixedstyle:
+        base: polygons
+        mix: [ kitchensink, toolbox ]
+        shaders:
+          blocks:
+            global: mixed
+      toolbox:
+        mix: kitchensink
+        shaders:
+          blocks:
+            global: toolbox
+      kitchensink:
+        shaders:
+          blocks:
+            global: kitchensink
+     )END");
+
+    {
+        auto styles = node["styles"];
+
+        for (const auto& style : styles) {
+            SceneLoader::loadStyle(style, styles, scene);
+        }
+    }
+
+    auto& styles = scene.styles();
+
+    REQUIRE(styles.size() == 2);
+
+    for (auto& style : styles) {
+    for (auto& block : style->getShaderProgram()->getSourceBlocks()) {
+        logMsg("block '%s'\n", block.first.c_str());
+        for (auto& val : block.second)
+            logMsg("- '%s'\n", val.c_str());
+
+    }
+    }
+
+    REQUIRE(styles[1]->getShaderProgram()->getSourceBlocks()["global"].empty() == false);
+    REQUIRE(styles[1]->getShaderProgram()->getSourceBlocks()["global"][0] == "\nkitchensink\ntoolbox\nmixed");
+}

--- a/tests/unit/styleMixTests.cpp
+++ b/tests/unit/styleMixTests.cpp
@@ -14,7 +14,6 @@ using namespace Tangram;
 using YAML::Node;
 
 TEST_CASE( "Style Mixing Test: Shader Extensions Merging", "[mixing][core][yaml]") {
-    SceneLoader sceneLoader;
     Node node = YAML::Load(R"END(
         Node1:
             shaders:
@@ -32,12 +31,12 @@ TEST_CASE( "Style Mixing Test: Shader Extensions Merging", "[mixing][core][yaml]
 
     Node extNode;
 
-    extNode = sceneLoader.shaderExtMerge( { node["Node1"] } );
+    extNode = SceneLoader::shaderExtMerge( { node["Node1"] } );
     // extNode: [extension1]
     REQUIRE(extNode.size() == 1);
     REQUIRE(extNode[0].as<std::string>() == "extension1");
 
-    extNode = sceneLoader.shaderExtMerge( { node["Node1"], node["Node2"], node["Node3"], node["Node4"] } );
+    extNode = SceneLoader::shaderExtMerge( { node["Node1"], node["Node2"], node["Node3"], node["Node4"] } );
     // extNode: [extension1, extension2, extension3, extension4]
     REQUIRE(extNode.size() == 4);
     REQUIRE(extNode[0].as<std::string>() == "extension1");
@@ -48,7 +47,6 @@ TEST_CASE( "Style Mixing Test: Shader Extensions Merging", "[mixing][core][yaml]
 }
 
 TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
-    SceneLoader sceneLoader;
 
     Node node = YAML::Load(R"END(
         Node1:
@@ -69,7 +67,7 @@ TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
                     filter: filterBlockC;
         )END");
 
-    Node shaderBlocksNode = sceneLoader.shaderBlockMerge( { node["Node1"] } );
+    Node shaderBlocksNode = SceneLoader::shaderBlockMerge( { node["Node1"] } );
     // shaderBlocksNode:
     //          color: colorBlockA;
     //          normal: normalBlockA;
@@ -78,7 +76,7 @@ TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
     REQUIRE(shaderBlocksNode["normal"].as<std::string>() == "normalBlockA;");
     REQUIRE(!shaderBlocksNode["global"]);
 
-    shaderBlocksNode = sceneLoader.shaderBlockMerge( { node["Node1"], node["Node2"], node["Node3"] } );
+    shaderBlocksNode = SceneLoader::shaderBlockMerge( { node["Node1"], node["Node2"], node["Node3"] } );
 
     // shaderBlocksNode:
     //          color: colorBlockA;\ncolorBlockB;
@@ -95,7 +93,6 @@ TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
 }
 
 TEST_CASE( "Style Mixing Test: propMerge Tests (recursive overWrite properties)", "[mixing][core][yaml]") {
-    SceneLoader sceneLoader;
 
     Node node = YAML::Load(R"END(
         Node1:
@@ -136,7 +133,7 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (recursive overWrite properties)"
     Node mixedNode;
 
     for (auto& property : {"prop1", "prop2"}) {
-        mixedNode[property] = sceneLoader.propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
+        mixedNode[property] = SceneLoader::propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
     }
 
     REQUIRE(mixedNode["prop1"].IsMap());
@@ -153,7 +150,6 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (recursive overWrite properties)"
 }
 
 TEST_CASE( "Style Mixing Test: propMerge Tests (overWrite properties)", "[mixing][core][yaml]") {
-    SceneLoader sceneLoader;
 
     Node node = YAML::Load(R"END(
         Node1:
@@ -171,7 +167,7 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (overWrite properties)", "[mixing
 
     Node mixedNode;
     for (auto& property : {"prop1", "prop2"}) {
-        mixedNode[property] = sceneLoader.propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
+        mixedNode[property] = SceneLoader::propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
     }
 
     REQUIRE(mixedNode["prop1"].as<std::string>() == "value1_3");
@@ -179,8 +175,6 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (overWrite properties)", "[mixing
 }
 
 TEST_CASE( "Style Mixing Test: propMerge Tests (boolean properties)", "[mixing][core][yaml]") {
-
-    SceneLoader sceneLoader;
 
     Node node = YAML::Load(R"END(
         Node1:
@@ -196,7 +190,7 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (boolean properties)", "[mixing][
 
     Node mixedNode;
     for (auto& property : {"prop1"}) {
-        mixedNode[property] = sceneLoader.propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
+        mixedNode[property] = SceneLoader::propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
     }
 
     REQUIRE(mixedNode["prop1"].as<bool>());

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -15,7 +15,6 @@ using namespace Tangram;
 using YAML::Node;
 
 Scene scene;
-SceneLoader sceneLoader;
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[StyleUniforms][core][yaml]") {
 
@@ -23,7 +22,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
         u_float: 0.5
         )END");
 
-    auto uniformValues = sceneLoader.parseStyleUniforms(node["u_float"], scene);
+    auto uniformValues = SceneLoader::parseStyleUniforms(node["u_float"], scene);
     REQUIRE(uniformValues.second.size() == 1);
     REQUIRE(uniformValues.second[0].is<float>());
     REQUIRE(uniformValues.second[0].get<float>() == 0.5);
@@ -37,13 +36,13 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
         u_false: false
         )END");
 
-    auto uniformValues = sceneLoader.parseStyleUniforms(node["u_true"], scene);
+    auto uniformValues = SceneLoader::parseStyleUniforms(node["u_true"], scene);
     REQUIRE(uniformValues.second.size() == 1);
     REQUIRE(uniformValues.second[0].is<bool>());
     REQUIRE(uniformValues.second[0].get<bool>() == 1);
     REQUIRE(uniformValues.first == "bool");
 
-    uniformValues = sceneLoader.parseStyleUniforms(node["u_false"], scene);
+    uniformValues = SceneLoader::parseStyleUniforms(node["u_false"], scene);
     REQUIRE(uniformValues.second.size() == 1);
     REQUIRE(uniformValues.second[0].is<bool>());
     REQUIRE(uniformValues.second[0].get<bool>() == 0);
@@ -59,14 +58,14 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
         )END");
 
 
-    auto uniformValues = sceneLoader.parseStyleUniforms(node["u_vec2"], scene);
+    auto uniformValues = SceneLoader::parseStyleUniforms(node["u_vec2"], scene);
     REQUIRE(uniformValues.second.size() == 1);
     REQUIRE(uniformValues.second[0].is<glm::vec2>());
     REQUIRE(uniformValues.second[0].get<glm::vec2>().x == 0.1f);
     REQUIRE(uniformValues.second[0].get<glm::vec2>().y == 0.2f);
     REQUIRE(uniformValues.first == "vec2");
 
-    uniformValues = sceneLoader.parseStyleUniforms(node["u_vec3"], scene);
+    uniformValues = SceneLoader::parseStyleUniforms(node["u_vec3"], scene);
     REQUIRE(uniformValues.second.size() == 1);
     REQUIRE(uniformValues.second[0].is<glm::vec3>());
     REQUIRE(uniformValues.second[0].get<glm::vec3>().x == 0.1f);
@@ -74,7 +73,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
     REQUIRE(uniformValues.second[0].get<glm::vec3>().z == 0.3f);
     REQUIRE(uniformValues.first == "vec3");
 
-    uniformValues = sceneLoader.parseStyleUniforms(node["u_vec4"], scene);
+    uniformValues = SceneLoader::parseStyleUniforms(node["u_vec4"], scene);
     REQUIRE(uniformValues.second.size() == 1);
     REQUIRE(uniformValues.second[0].is<glm::vec4>());
     REQUIRE(uniformValues.second[0].get<glm::vec4>().x == 0.1f);
@@ -91,13 +90,13 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
         u_tex2 : [texture2.png, texture3.png, texture4.png]
         )END");
 
-    auto uniformValues = sceneLoader.parseStyleUniforms(node["u_tex"], scene);
+    auto uniformValues = SceneLoader::parseStyleUniforms(node["u_tex"], scene);
     REQUIRE(uniformValues.second.size() == 1);
     REQUIRE(uniformValues.second[0].is<std::string>());
     REQUIRE(uniformValues.second[0].get<std::string>() == "texture1.png");
     REQUIRE(uniformValues.first == "sampler2D");
 
-    uniformValues = sceneLoader.parseStyleUniforms(node["u_tex2"], scene);
+    uniformValues = SceneLoader::parseStyleUniforms(node["u_tex2"], scene);
     REQUIRE(uniformValues.second.size() == 3);
     REQUIRE(uniformValues.second[0].is<std::string>());
     REQUIRE(uniformValues.second[1].is<std::string>());

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -14,7 +14,6 @@ using YAML::Node;
 
 using Context = StyleContext;
 
-SceneLoader sceneLoader;
 Context ctx;
 
 Feature civic, bmw1, bike;
@@ -22,7 +21,7 @@ Feature civic, bmw1, bike;
 Filter load(const std::string& filterYaml) {
     Scene scene;
     YAML::Node node = YAML::Load(filterYaml);
-    return sceneLoader.generateFilter(node["filter"], scene);
+    return SceneLoader::generateFilter(node["filter"], scene);
 }
 
 void init() {


### PR DESCRIPTION
First step for reloading scenes at runtime (and on a worker thread). Enable loading of scenes without modifying tangrams state. 

Update: Scene reloading at runtime works!

This is a big refactoring of SceneLoader. Please have a look when you have time! Merging can wait until  the uniform-injection branch is done