### PR TITLE
Uniform injection

### DIFF
--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -33,6 +33,11 @@ Texture::Texture(const std::string& _file, TextureOptions _options, bool _genera
     unsigned char* pixels;
     int width, height, comp;
 
+    if (data == nullptr || size == 0) {
+        logMsg("ERROR: Texture not found! '%s'\n", _file.c_str());
+        return;
+    }
+
     pixels = stbi_load_from_memory(data, size, &width, &height, &comp, STBI_rgb_alpha);
 
     resize(width, height);
@@ -143,10 +148,10 @@ void Texture::update(GLuint _textureUnit) {
         bind(_textureUnit);
     }
 
-    GLuint* data = m_data.size() > 0 ? m_data.data() : nullptr;
-
     // resize or push data
     if (m_shouldResize) {
+        GLuint* data = m_data.size() > 0 ? m_data.data() : nullptr;
+
         glTexImage2D(m_target, 0, m_options.m_internalFormat, m_width, m_height, 0,
                      m_options.m_format, GL_UNSIGNED_BYTE, data);
 

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -19,6 +19,11 @@ void TextureCube::load(const std::string& _file) {
     unsigned char* pixels;
     int width, height, comp;
 
+    if (data == nullptr || size == 0) {
+        logMsg("ERROR: Texture not found! '%s'\n", _file.c_str());
+        return;
+    }
+
     pixels = stbi_load_from_memory(data, size, &width, &height, &comp, STBI_rgb_alpha);
 
     size = width * height;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -119,17 +119,11 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
             if (size == 1) {
                 shader.addSourceBlock("uniforms", "uniform " + type + " " + name + ";");
                 style.styleUniforms().emplace_back(name, uniformValues[0]);
-                if (uniformValues[0].is<std::string>()) {
-                    auto textureName = uniformValues[0].get<std::string>();
-                }
             } else {
                 shader.addSourceBlock("uniforms", "uniform " + type + " " + name +
                                                         "[" + std::to_string(size) + "];");
                 for (int i = 0; i < size; i++) {
                     style.styleUniforms().emplace_back(name + "[" + std::to_string(i) + "]", uniformValues[i]);
-                    if (uniformValues[i].is<std::string>()) {
-                        auto textureName = uniformValues[i].get<std::string>();
-                    }
                 }
             }
         }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -70,9 +70,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
 
     auto& shader = *(style.getShaderProgram());
 
-    if (!shaders) {
-        return;
-    }
+    if (!shaders) { return; }
 
     if (Node extensionsNode = shaders["extensions"]) {
         std::vector<std::string> extensions;
@@ -92,8 +90,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
         }
     }
 
-    Node definesNode = shaders["defines"];
-    if (definesNode) {
+    if (Node definesNode = shaders["defines"]) {
         for (const auto& define : definesNode) {
             std::string name = define.first.as<std::string>();
             std::string value = define.second.as<std::string>();
@@ -108,8 +105,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
         }
     }
 
-    Node uniformsNode = shaders["uniforms"];
-    if (uniformsNode) {
+    if (Node uniformsNode = shaders["uniforms"]) {
         for (const auto& uniform : uniformsNode) {
             auto name = uniform.first.as<std::string>();
             auto uniforms = parseStyleUniforms(uniform.second, scene);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -121,7 +121,6 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
                 style.styleUniforms().emplace_back(name, uniformValues[0]);
                 if (uniformValues[0].is<std::string>()) {
                     auto textureName = uniformValues[0].get<std::string>();
-                    style.uniformTextures().emplace(textureName, scene.textures()[textureName]);
                 }
             } else {
                 shader.addSourceBlock("uniforms", "uniform " + type + " " + name +
@@ -130,7 +129,6 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
                     style.styleUniforms().emplace_back(name + "[" + std::to_string(i) + "]", uniformValues[i]);
                     if (uniformValues[i].is<std::string>()) {
                         auto textureName = uniformValues[i].get<std::string>();
-                        style.uniformTextures().emplace(textureName, scene.textures()[textureName]);
                     }
                 }
             }
@@ -1053,11 +1051,11 @@ StyleUniforms SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
                 uVal = 0;
             } else {
                 type = "sampler2D";
+                uVal = strVal;
                 auto texItr = scene.textures().find(strVal);
                 if (texItr == scene.textures().end()) {
                     loadDefaultTexture(strVal, scene);
                 }
-                uVal = strVal;
             }
         }
         uniformValues.push_back(uVal);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -19,6 +19,7 @@
 #include "sceneLayer.h"
 #include "scene/dataLayer.h"
 #include "text/fontContext.h"
+#include "util/yamlHelper.h"
 
 #include "yaml-cpp/yaml.h"
 
@@ -65,49 +66,9 @@ void SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene,
     }
 }
 
-std::string parseSequence(const Node& node) {
-    std::stringstream sstream;
-    for (const auto& val : node) {
-        try {
-            sstream << val.as<float>() << ",";
-        } catch (const BadConversion& e) {
-            try {
-                sstream << val.as<std::string>() << ",";
-            } catch (const BadConversion& e) {
-                logMsg("Error: Float or Unit expected for styleParam sequence value\n");
-            }
-        }
-    }
-    return sstream.str();
-}
+void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
 
-glm::vec4 parseVec4(const Node& node) {
-    glm::vec4 vec;
-    int i = 0;
-    for (const auto& nodeVal : node) {
-        if (i < 4) {
-            vec[i++] = nodeVal.as<float>();
-        } else {
-            break;
-        }
-    }
-    return vec;
-}
-
-glm::vec3 parseVec3(const Node& node) {
-    glm::vec3 vec;
-    int i = 0;
-    for (const auto& nodeVal : node) {
-        if (i < 3) {
-            vec[i++] = nodeVal.as<float>();
-        } else {
-            break;
-        }
-    }
-    return vec;
-}
-
-void SceneLoader::loadShaderConfig(Node shaders, ShaderProgram& shader) {
+    auto& shader = *(style.getShaderProgram());
 
     if (!shaders) {
         return;
@@ -150,9 +111,29 @@ void SceneLoader::loadShaderConfig(Node shaders, ShaderProgram& shader) {
     Node uniformsNode = shaders["uniforms"];
     if (uniformsNode) {
         for (const auto& uniform : uniformsNode) {
-            std::string name = uniform.first.as<std::string>();
-            std::string value = uniform.first.as<std::string>();
-            shader.addSourceBlock("uniforms", "uniform " + name + " = " + value + ";");
+            auto name = uniform.first.as<std::string>();
+            auto uniforms = parseStyleUniforms(uniform.second, scene);
+            auto& type = uniforms.first;
+            auto& uniformValues = uniforms.second;
+            int size = uniformValues.size();
+            if (size == 1) {
+                shader.addSourceBlock("uniforms", "uniform " + type + " " + name + ";");
+                style.styleUniforms().emplace_back(name, uniformValues[0]);
+                if (uniformValues[0].is<std::string>()) {
+                    auto textureName = uniformValues[0].get<std::string>();
+                    style.uniformTextures().emplace(textureName, scene.textures()[textureName]);
+                }
+            } else {
+                shader.addSourceBlock("uniforms", "uniform " + type + " " + name +
+                                                        "[" + std::to_string(size) + "];");
+                for (int i = 0; i < size; i++) {
+                    style.styleUniforms().emplace_back(name + "[" + std::to_string(i) + "]", uniformValues[i]);
+                    if (uniformValues[i].is<std::string>()) {
+                        auto textureName = uniformValues[i].get<std::string>();
+                        style.uniformTextures().emplace(textureName, scene.textures()[textureName]);
+                    }
+                }
+            }
         }
     }
 
@@ -173,7 +154,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
         if (diffuse.IsMap()) {
             material.setDiffuse(loadMaterialTexture(diffuse, scene));
         } else if (diffuse.IsSequence()) {
-            material.setDiffuse(parseVec4(diffuse));
+            material.setDiffuse(parseVec<glm::vec4>(diffuse));
         } else {
             try {
                 float difValue = diffuse.as<float>();
@@ -189,7 +170,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
         if (ambient.IsMap()) {
             material.setAmbient(loadMaterialTexture(ambient, scene));
         } else if (ambient.IsSequence()) {
-            material.setAmbient(parseVec4(ambient));
+            material.setAmbient(parseVec<glm::vec4>(ambient));
         } else {
             try {
                 float ambientValue = ambient.as<float>();
@@ -205,7 +186,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material, Scene& scene) {
         if (specular.IsMap()) {
             material.setSpecular(loadMaterialTexture(specular, scene));
         } else if (specular.IsSequence()) {
-            material.setSpecular(parseVec4(specular));
+            material.setSpecular(parseVec<glm::vec4>(specular));
         } else {
             try {
                 float specValue = specular.as<float>();
@@ -290,6 +271,12 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
     return matTex;
 }
 
+void SceneLoader::loadDefaultTexture(const std::string& url, Scene& scene) {
+    TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
+    std::shared_ptr<Texture> texture(new Texture(url, options, false));
+    scene.textures().emplace(url, texture);
+}
+
 void SceneLoader::loadTextures(Node textures, Scene& scene) {
 
     if (!textures) {
@@ -335,7 +322,7 @@ void SceneLoader::loadTextures(Node textures, Scene& scene) {
                 std::string spriteName = it->first.as<std::string>();
 
                 if (sprite) {
-                    glm::vec4 desc = parseVec4(sprite);
+                    glm::vec4 desc = parseVec<glm::vec4>(sprite);
                     glm::vec2 pos = glm::vec2(desc.x, desc.y);
                     glm::vec2 size = glm::vec2(desc.z, desc.w);
 
@@ -395,7 +382,7 @@ void SceneLoader::loadStyleProps(Style* style, YAML::Node styleNode, Scene& scen
 
     Node shadersNode = styleNode["shaders"];
     if (shadersNode) {
-        loadShaderConfig(shadersNode, *(style->getShaderProgram()));
+        loadShaderConfig(shadersNode, *style, scene);
     }
 
     Node materialNode = styleNode["material"];
@@ -698,7 +685,7 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
             DirectionalLight* dLightPtr = new DirectionalLight(name);
             Node direction = light["direction"];
             if (direction) {
-                dLightPtr->setDirection(parseVec3(direction));
+                dLightPtr->setDirection(parseVec<glm::vec3>(direction));
             }
             lightPtr = std::unique_ptr<Light>(dLightPtr);
 
@@ -707,7 +694,7 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
             PointLight* pLightPtr = new PointLight(name);
             Node position = light["position"];
             if (position) {
-                pLightPtr->setPosition(parseVec3(position));
+                pLightPtr->setPosition(parseVec<glm::vec3>(position));
             }
             Node radius = light["radius"];
             if (radius) {
@@ -728,11 +715,11 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
             SpotLight* sLightPtr = new SpotLight(name);
             Node position = light["position"];
             if (position) {
-                sLightPtr->setPosition(parseVec3(position));
+                sLightPtr->setPosition(parseVec<glm::vec3>(position));
             }
             Node direction = light["direction"];
             if (direction) {
-                sLightPtr->setDirection(parseVec3(direction));
+                sLightPtr->setDirection(parseVec<glm::vec3>(direction));
             }
             Node radius = light["radius"];
             if (radius) {
@@ -769,17 +756,17 @@ void SceneLoader::loadLights(Node lights, Scene& scene) {
 
         Node ambient = light["ambient"];
         if (ambient) {
-            lightPtr->setAmbientColor(parseVec4(ambient));
+            lightPtr->setAmbientColor(parseVec<glm::vec4>(ambient));
         }
 
         Node diffuse = light["diffuse"];
         if (diffuse) {
-            lightPtr->setDiffuseColor(parseVec4(diffuse));
+            lightPtr->setDiffuseColor(parseVec<glm::vec4>(diffuse));
         }
 
         Node specular = light["specular"];
         if (specular) {
-            lightPtr->setSpecularColor(parseVec4(specular));
+            lightPtr->setSpecularColor(parseVec<glm::vec4>(specular));
         }
 
         scene.lights().push_back(std::move(lightPtr));
@@ -1047,6 +1034,69 @@ std::vector<StyleParam> SceneLoader::parseStyleParams(Node params, Scene& scene,
     }
 
     return out;
+}
+
+StyleUniforms SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
+    std::string type = "";
+    std::vector<UniformValue> uniformValues;
+    if (value.IsScalar()) { //float, int (bool), string (texture)
+        UniformValue uVal;
+        try {
+            uVal = value.as<float>();
+            type = "float";
+        } catch (const BadConversion& e) {
+            auto strVal = value.as<std::string>();
+            type = "int";
+            if (strVal == "true") {
+                uVal = 1;
+            } else if (strVal == "false") {
+                uVal = 0;
+            } else {
+                type = "sampler2D";
+                auto texItr = scene.textures().find(strVal);
+                if (texItr == scene.textures().end()) {
+                    loadDefaultTexture(strVal, scene);
+                }
+                uVal = strVal;
+            }
+        }
+        uniformValues.push_back(uVal);
+    } else if (value.IsSequence()) {
+        int size = value.size();
+        try {
+            type = "vec" + std::to_string(size);
+            UniformValue uVal;
+            switch (size) {
+                case 2:
+                    uVal = parseVec<glm::vec2>(value);
+                    break;
+                case 3:
+                    uVal = parseVec<glm::vec3>(value);
+                    break;
+                case 4:
+                    uVal = parseVec<glm::vec4>(value);
+                    break;
+                default:
+                    break;
+                    // TODO: Handle numeric arrays past 4 elements
+            }
+            uniformValues.push_back(uVal);
+        } catch (const BadConversion& e) { // array of strings (textures)
+            uniformValues.reserve(size);
+            type = "sampler2D";
+            for (const auto& strVal : value) {
+                auto textureName = strVal.as<std::string>();
+                uniformValues.push_back(textureName);
+                auto texItr = scene.textures().find(textureName);
+                if (texItr == scene.textures().end()) {
+                    loadDefaultTexture(textureName, scene);
+                }
+            }
+        }
+    } else {
+        logMsg("Warning: Expected a scalar or sequence value for uniforms\n");
+    }
+    return std::make_pair(type, std::move(uniformValues));
 }
 
 void SceneLoader::loadFont(Node fontProps) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -259,7 +259,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene)
     return matTex;
 }
 
-void SceneLoader::loadDefaultTexture(const std::string& url, Scene& scene) {
+void SceneLoader::loadTexture(const std::string& url, Scene& scene) {
     TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
     std::shared_ptr<Texture> texture(new Texture(url, options, false));
     scene.textures().emplace(url, texture);
@@ -1033,18 +1033,16 @@ StyleUniforms SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
             uVal = value.as<float>();
             type = "float";
         } catch (const BadConversion& e) {
-            auto strVal = value.as<std::string>();
-            type = "int";
-            if (strVal == "true") {
-                uVal = 1;
-            } else if (strVal == "false") {
-                uVal = 0;
-            } else {
+            try {
+                uVal = value.as<bool>();
+                type = "bool";
+            } catch (const BadConversion& e) {
+                auto strVal = value.as<std::string>();
                 type = "sampler2D";
                 uVal = strVal;
                 auto texItr = scene.textures().find(strVal);
                 if (texItr == scene.textures().end()) {
-                    loadDefaultTexture(strVal, scene);
+                    loadTexture(strVal, scene);
                 }
             }
         }
@@ -1077,7 +1075,7 @@ StyleUniforms SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
                 uniformValues.push_back(textureName);
                 auto texItr = scene.textures().find(textureName);
                 if (texItr == scene.textures().end()) {
-                    loadDefaultTexture(textureName, scene);
+                    loadTexture(textureName, scene);
                 }
             }
         }

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -39,8 +39,9 @@ class SceneLoader {
     void loadLayers(YAML::Node layers, Scene& scene, TileManager& tileManager);
     void loadStyles(YAML::Node styles, Scene& scene);
     void loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene);
-    void loadDefaultTexture(const std::string& url, Scene& scene);
     void loadTextures(YAML::Node textures, Scene& scene);
+    /* loads a texture with default texture properties */
+    void loadTexture(const std::string& url, Scene& scene);
     void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
     void loadShaderConfig(YAML::Node shaders, Style& style, Scene& scene);
     SceneLayer loadSublayer(YAML::Node layer, const std::string& name, Scene& scene);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -3,11 +3,14 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <tuple>
 
-/* Forward Declaration of yaml-cpp node type */
-namespace YAML {
-    class Node;
-}
+#include "yaml-cpp/yaml.h"
+#include "glm/vec2.hpp"
+#include "glm/vec3.hpp"
+#include "glm/vec4.hpp"
+
+#include "util/variant.h"
 
 namespace Tangram {
 
@@ -24,6 +27,8 @@ struct MaterialTexture;
 struct Filter;
 
 using Mixes = std::vector<YAML::Node>;
+// 0: type, 1: values
+using StyleUniforms = std::pair<std::string, std::vector<UniformValue>>;
 
 class SceneLoader {
 
@@ -34,9 +39,10 @@ class SceneLoader {
     void loadLayers(YAML::Node layers, Scene& scene, TileManager& tileManager);
     void loadStyles(YAML::Node styles, Scene& scene);
     void loadStyleProps(Style* style, YAML::Node styleNode, Scene& scene);
+    void loadDefaultTexture(const std::string& url, Scene& scene);
     void loadTextures(YAML::Node textures, Scene& scene);
     void loadMaterial(YAML::Node matNode, Material& material, Scene& scene);
-    void loadShaderConfig(YAML::Node shaders, ShaderProgram& shader);
+    void loadShaderConfig(YAML::Node shaders, Style& style, Scene& scene);
     SceneLayer loadSublayer(YAML::Node layer, const std::string& name, Scene& scene);
     MaterialTexture loadMaterialTexture(YAML::Node matCompNode, Scene& scene);
     Filter generateAnyFilter(YAML::Node filter, Scene& scene);
@@ -56,6 +62,7 @@ public:
 
     // public for testing
     std::vector<StyleParam> parseStyleParams(YAML::Node params, Scene& scene, const std::string& propPrefix = "");
+    StyleUniforms parseStyleUniforms(const YAML::Node& uniform, Scene& scene);
 
     // Generic methods to merge properties
     YAML::Node propMerge(const std::string& propStr, const Mixes& mixes);

--- a/core/src/scene/spriteAtlas.h
+++ b/core/src/scene/spriteAtlas.h
@@ -23,7 +23,7 @@ public:
     bool getSpriteNode(const std::string& _name, SpriteNode& _node);
 
     /* Bind the atlas in the driver */
-    void bind(GLuint _slot = 0);
+    void bind(GLuint _slot);
 
 private:
     std::map<std::string, SpriteNode> m_spritesNodes;

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -114,7 +114,7 @@ void SpriteStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
     }
 
     m_spriteAtlas->bind(0);
-    setupShaderUniforms(0, contextLost, _scene);
+    setupShaderUniforms(1, contextLost, _scene);
 
     static bool initUniformSampler = true;
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -120,6 +120,7 @@ void SpriteStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
     if (initUniformSampler || contextLost) {
         m_shaderProgram->setUniformi("u_tex", 0);
         initUniformSampler = false;
+        setupShaderUniforms(0);
     }
 
     if (m_dirtyViewport || contextLost) {

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -113,7 +113,7 @@ void SpriteStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
         return;
     }
 
-    m_spriteAtlas->bind();
+    m_spriteAtlas->bind(0);
     setupShaderUniforms(0, contextLost, _scene);
 
     static bool initUniformSampler = true;

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -106,7 +106,7 @@ void SpriteStyle::buildPoint(const Point& _point, const DrawRule& _rule, const P
     mesh.addLabel(std::move(label));
 }
 
-void SpriteStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
+void SpriteStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
     bool contextLost = Style::glContextLost();
 
     if (!m_spriteAtlas) {
@@ -114,7 +114,7 @@ void SpriteStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
     }
 
     m_spriteAtlas->bind();
-    setupShaderUniforms(0, contextLost);
+    setupShaderUniforms(0, contextLost, _scene);
 
     static bool initUniformSampler = true;
 

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -114,13 +114,13 @@ void SpriteStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
     }
 
     m_spriteAtlas->bind();
+    setupShaderUniforms(0, contextLost);
 
     static bool initUniformSampler = true;
 
     if (initUniformSampler || contextLost) {
         m_shaderProgram->setUniformi("u_tex", 0);
         initUniformSampler = false;
-        setupShaderUniforms(0);
     }
 
     if (m_dirtyViewport || contextLost) {

--- a/core/src/style/spriteStyle.h
+++ b/core/src/style/spriteStyle.h
@@ -30,7 +30,7 @@ protected:
     virtual void buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
 
     Parameters parseRule(const DrawRule& _rule) const;
-    
+
     virtual VboMesh* newMesh() const override {
         return new LabelMesh(m_vertexLayout, m_drawMode);
     };
@@ -39,7 +39,7 @@ protected:
 
 public:
 
-    virtual void onBeginDrawFrame(const View& _view, const Scene& _scene) override;
+    virtual void onBeginDrawFrame(const View& _view, Scene& _scene) override;
 
     SpriteStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
     void setSpriteAtlas(std::shared_ptr<SpriteAtlas> _spriteAtlas) { m_spriteAtlas = _spriteAtlas; }

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -107,8 +107,8 @@ void Style::setupShaderUniforms(int _textureUnit, bool _update, Scene& _scene) {
         } else {
             if (!_update) { continue; }
 
-            if (value.is<int>()) {
-                m_shaderProgram->setUniformi(name, value.get<int>());
+            if (value.is<bool>()) {
+                m_shaderProgram->setUniformi(name, value.get<bool>());
             } else if(value.is<float>()) {
                 m_shaderProgram->setUniformf(name, value.get<float>());
             } else if(value.is<glm::vec2>()) {

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -84,15 +84,17 @@ void Style::buildFeature(Tile& _tile, const Feature& _feat, const DrawRule& _rul
 
 }
 
-void Style::setupShaderUniforms(int _lastBoundTex, bool _ctxLost) {
+void Style::setupShaderUniforms(int _lastBoundTex, bool _ctxLost, Scene& _scene) {
     for (const auto& uniformPair : m_styleUniforms) {
         const auto& name = uniformPair.first;
         const auto& value = uniformPair.second;
 
+        auto& textures = _scene.textures();
+
         if (value.is<std::string>()) {
             auto texName = value.get<std::string>();
-            m_uniformTextures[texName]->update(++_lastBoundTex);
-            m_uniformTextures[texName]->bind(_lastBoundTex);
+            textures[texName]->update(++_lastBoundTex);
+            textures[texName]->bind(_lastBoundTex);
             if (_ctxLost) {
                 m_shaderProgram->setUniformi(name, _lastBoundTex);
             }
@@ -116,8 +118,8 @@ void Style::setupShaderUniforms(int _lastBoundTex, bool _ctxLost) {
     }
 }
 
-void Style::onBeginDrawFrame(const View& _view, const Scene& _scene) {
-    
+void Style::onBeginDrawFrame(const View& _view, Scene& _scene) {
+
     bool contextLost = glContextLost();
 
     m_material->setupProgram(*m_shaderProgram);
@@ -129,7 +131,7 @@ void Style::onBeginDrawFrame(const View& _view, const Scene& _scene) {
 
     m_shaderProgram->setUniformf("u_zoom", _view.getZoom());
 
-    setupShaderUniforms(-1, contextLost);
+    setupShaderUniforms(-1, contextLost, _scene);
 
     // Configure render state
     switch (m_blend) {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -103,7 +103,9 @@ protected:
     /* Toggle on read if true, checks whether the context has been lost on last frame */
     bool glContextLost();
 
-    void setupShaderUniforms(int _lastBoundTex, bool _ctxLost, Scene& _scene);
+    /* Set uniform values when @_updateUniforms is true,
+       and bind textures starting at @_textureUnit */
+    void setupShaderUniforms(int _textureUnit, bool _updateUniforms, Scene& _scene);
 
 private:
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -103,7 +103,7 @@ protected:
     /* Toggle on read if true, checks whether the context has been lost on last frame */
     bool glContextLost();
 
-    void setupShaderUniforms(int _lastBoundTex);
+    void setupShaderUniforms(int _lastBoundTex, bool _ctxLost);
 
 private:
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -103,14 +103,13 @@ protected:
     /* Toggle on read if true, checks whether the context has been lost on last frame */
     bool glContextLost();
 
-    void setupShaderUniforms(int _lastBoundTex, bool _ctxLost);
+    void setupShaderUniforms(int _lastBoundTex, bool _ctxLost, Scene& _scene);
 
 private:
 
     /* Whether the context has been lost on last frame */
     bool m_contextLost;
     std::vector<StyleUniform> m_styleUniforms;
-    std::unordered_map<std::string, std::shared_ptr<Texture>> m_uniformTextures;
 
 public:
 
@@ -141,7 +140,7 @@ public:
     virtual void onEndBuildTile(Tile& _tile) const;
 
     /* Perform any setup needed before drawing each frame */
-    virtual void onBeginDrawFrame(const View& _view, const Scene& _scene);
+    virtual void onBeginDrawFrame(const View& _view, Scene& _scene);
 
     /* Perform any unsetup needed after drawing each frame */
     virtual void onEndDrawFrame() {}
@@ -161,7 +160,6 @@ public:
     const std::string& getName() const { return m_name; }
 
     std::vector<StyleUniform>& styleUniforms() { return m_styleUniforms; }
-    std::unordered_map<std::string, std::shared_ptr<Texture>>& uniformTextures() { return m_uniformTextures; }
 
 };
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -6,6 +6,7 @@
 #include "gl/shaderProgram.h"
 #include "gl/renderState.h"
 #include "scene/sceneLayer.h"
+#include "util/variant.h"
 
 #include <memory>
 #include <string>
@@ -35,6 +36,7 @@ enum class Blending : char {
     inlay,
 };
 
+
 /* Means of constructing and rendering map geometry
  *
  * A Style defines a way to
@@ -46,6 +48,8 @@ enum class Blending : char {
  * geometry into meshes. See <PolygonStyle> for a basic implementation.
  */
 class Style {
+
+using StyleUniform = std::pair< std::string, UniformValue >;
 
 protected:
 
@@ -66,7 +70,7 @@ protected:
 
     /* <LightingType> to determine how lighting will be calculated for this style */
     LightingType m_lightingType = LightingType::fragment;
-    
+
     Blending m_blend = Blending::none;
 
     /* Draw mode to pass into <VboMesh>es created with this style */
@@ -99,10 +103,14 @@ protected:
     /* Toggle on read if true, checks whether the context has been lost on last frame */
     bool glContextLost();
 
+    void setupShaderUniforms(int _lastBoundTex);
+
 private:
 
     /* Whether the context has been lost on last frame */
     bool m_contextLost;
+    std::vector<StyleUniform> m_styleUniforms;
+    std::unordered_map<std::string, std::shared_ptr<Texture>> m_uniformTextures;
 
 public:
 
@@ -151,6 +159,9 @@ public:
     const std::unique_ptr<ShaderProgram>& getShaderProgram() const { return m_shaderProgram; }
 
     const std::string& getName() const { return m_name; }
+
+    std::vector<StyleUniform>& styleUniforms() { return m_styleUniforms; }
+    std::unordered_map<std::string, std::shared_ptr<Texture>>& uniformTextures() { return m_uniformTextures; }
 
 };
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -195,7 +195,7 @@ void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
 
     FontContext::GetInstance()->bindAtlas(0);
 
-    setupShaderUniforms(0, contextLost, _scene);
+    setupShaderUniforms(1, contextLost, _scene);
 
     if (contextLost) {
         m_shaderProgram->setUniformi("u_tex", 0);

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -197,6 +197,7 @@ void TextStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
 
     if (contextLost) {
         m_shaderProgram->setUniformi("u_tex", 0);
+        setupShaderUniforms(0);
     }
 
     if (m_dirtyViewport || contextLost) {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -194,10 +194,11 @@ void TextStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
     bool contextLost = Style::glContextLost();
 
     FontContext::GetInstance()->bindAtlas(0);
-
+    
+    setupShaderUniforms(0, contextLost);
+    
     if (contextLost) {
         m_shaderProgram->setUniformi("u_tex", 0);
-        setupShaderUniforms(0);
     }
 
     if (m_dirtyViewport || contextLost) {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -190,13 +190,13 @@ void TextStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, con
     buffer.addLabel(text, { centroid, centroid }, Label::Type::point, params, optionsFromTextParams(params));
 }
 
-void TextStyle::onBeginDrawFrame(const View& _view, const Scene& _scene) {
+void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
     bool contextLost = Style::glContextLost();
 
     FontContext::GetInstance()->bindAtlas(0);
-    
-    setupShaderUniforms(0, contextLost);
-    
+
+    setupShaderUniforms(0, contextLost, _scene);
+
     if (contextLost) {
         m_shaderProgram->setUniformi("u_tex", 0);
     }

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -34,7 +34,7 @@ public:
 
     TextStyle(std::string _name, bool _sdf = false, bool _sdfMultisampling = false, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
 
-    virtual void onBeginDrawFrame(const View& _view, const Scene& _scene) override;
+    virtual void onBeginDrawFrame(const View& _view, Scene& _scene) override;
 
     virtual ~TextStyle();
 

--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -74,7 +74,7 @@ void Builders::buildPolygon(const Polygon& _polygon, float _height, PolygonBuild
 
         if (_ctx.useTexCoords) {
             glm::vec2 uv(mapValue(coord.x, min.x, max.x, 0., 1.),
-                         mapValue(coord.y, min.y, max.y, 0., 1.));
+                         mapValue(coord.y, min.y, max.y, 1., 0.));
 
             _ctx.addVertex(coord, normal, uv);
         } else {

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -24,6 +24,6 @@ using variant = mapbox::util::variant<Types...>;
 using Value = variant<none_type, std::string, float>;
 
 /* Style Block Uniform types */
-using UniformValue = variant<none_type, std::string, int, float, glm::vec2, glm::vec3, glm::vec4>;
+using UniformValue = variant<none_type, bool, std::string, float, glm::vec2, glm::vec3, glm::vec4>;
 
 }

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "variant/variant.hpp"
+#include "glm/vec2.hpp"
+#include "glm/vec3.hpp"
+#include "glm/vec4.hpp"
+
 
 namespace Tangram {
 struct none_type {
@@ -18,5 +22,8 @@ using variant = mapbox::util::variant<Types...>;
 
 /* Common Value type for Feature Properties and Filter Values */
 using Value = variant<none_type, std::string, float>;
+
+/* Style Block Uniform types */
+using UniformValue = variant<none_type, std::string, int, float, glm::vec2, glm::vec3, glm::vec4>;
 
 }

--- a/core/src/util/yamlHelper.h
+++ b/core/src/util/yamlHelper.h
@@ -1,0 +1,41 @@
+// Helper Functions for parsing YAML nodes
+// NOTE: To be used in multiple YAML parsing modules once SceneLoader aptly modularized
+
+#pragma once
+
+using YAML::Node;
+using YAML::BadConversion;
+
+namespace Tangram {
+
+std::string parseSequence(const Node& node) {
+    std::stringstream sstream;
+    for (const auto& val : node) {
+        try {
+            sstream << val.as<float>() << ",";
+        } catch (const BadConversion& e) {
+            try {
+                sstream << val.as<std::string>() << ",";
+            } catch (const BadConversion& e) {
+                logMsg("Error: Float or Unit expected for styleParam sequence value\n");
+            }
+        }
+    }
+    return sstream.str();
+}
+
+template<typename T>
+T parseVec(const Node& node) {
+    T vec;
+    int i = 0;
+    for (const auto& nodeVal : node) {
+        if (i < vec.length()) {
+            vec[i++] = nodeVal.as<float>();
+        } else {
+            break;
+        }
+    }
+    return vec;
+}
+
+}

--- a/tests/unit/styleMixTests.cpp
+++ b/tests/unit/styleMixTests.cpp
@@ -15,29 +15,20 @@ using YAML::Node;
 
 TEST_CASE( "Style Mixing Test: Shader Extensions Merging", "[mixing][core][yaml]") {
     SceneLoader sceneLoader;
-    Node node = YAML::Load("{ \
-                                Node1: { \
-                                    shaders: { \
-                                        extensions: extension1 \
-                                    } \
-                                }, \
-                                Node2: { \
-                                    shaders: { \
-                                        extensions: [extension1, extension2, extension3] \
-                                    } \
-                                }, \
-                                Node3: { \
-                                    shaders: { \
-                                        extensions: extension3 \
-                                        } \
-                                }, \
-                                Node4: { \
-                                    shaders: { \
-                                        extensions: [extension4] \
-                                        } \
-                                } \
-                            }");
-
+    Node node = YAML::Load(R"END(
+        Node1:
+            shaders:
+                extensions: extension1
+        Node2:
+            shaders:
+                extensions: [extension1, extension2, extension3]
+        Node3:
+            shaders:
+                extensions: extension3
+        Node4:
+            shaders:
+                extensions: [extension4]
+        )END");
 
     Node extNode;
 
@@ -58,33 +49,25 @@ TEST_CASE( "Style Mixing Test: Shader Extensions Merging", "[mixing][core][yaml]
 
 TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
     SceneLoader sceneLoader;
-    Node node = YAML::Load("{ \
-                                Node1: { \
-                                    shaders: { \
-                                        blocks: { \
-                                            color: colorBlockA; ,\
-                                            normal: normalBlockA; ,\
-                                        } \
-                                    } \
-                                }, \
-                                Node2: { \
-                                    shaders: { \
-                                        blocks: { \
-                                            color: colorBlockB; ,\
-                                            position: posBlockB; ,\
-                                            global: globalBlockB; \
-                                        } \
-                                    } \
-                                }, \
-                                Node3: { \
-                                    shaders: { \
-                                        blocks: { \
-                                            global: globalBlockC; ,\
-                                            filter: filterBlockC; \
-                                        } \
-                                    } \
-                                }, \
-                            }");
+
+    Node node = YAML::Load(R"END(
+        Node1:
+            shaders:
+                blocks:
+                    color: colorBlockA;
+                    normal: normalBlockA;
+        Node2:
+            shaders:
+                blocks:
+                    color: colorBlockB;
+                    position: posBlockB;
+                    global: globalBlockB;
+        Node3:
+            shaders:
+                blocks:
+                    global: globalBlockC;
+                    filter: filterBlockC;
+        )END");
 
     Node shaderBlocksNode = sceneLoader.shaderBlockMerge( { node["Node1"] } );
     // shaderBlocksNode:
@@ -113,41 +96,31 @@ TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
 
 TEST_CASE( "Style Mixing Test: propMerge Tests (recursive overWrite properties)", "[mixing][core][yaml]") {
     SceneLoader sceneLoader;
-    Node node = YAML::Load("{ \
-                                Node1: { \
-                                    prop1: { \
-                                        subProp1: { \
-                                            tag1: value1 } \
-                                    }, \
-                                    prop2: { \
-                                        subProp3: { \
-                                            tag2: value2 } \
-                                    } \
-                                }, \
-                                Node2: { \
-                                    prop1: { \
-                                        subProp1: { \
-                                            tag3: value3 } \
-                                    }, \
-                                    prop2: { \
-                                        subProp2: value_scalar, \
-                                        subProp3: value_scalar2 \
-                                    } \
-                                }, \
-                                Node3: { \
-                                    prop1: { \
-                                        subProp1: {\
-                                            tag1: value1_3 \
-                                        } \
-                                    }, \
-                                    prop2: { \
-                                        subProp2: [v1, v2], \
-                                        subProp3: { \
-                                            tag4: value4 \
-                                        } \
-                                   } \
-                                }, \
-                            }");
+
+    Node node = YAML::Load(R"END(
+        Node1:
+            prop1:
+                subProp1:
+                    tag1: value1
+            prop2:
+                subProp3:
+                    tag2: value2
+        Node2:
+            prop1:
+                subProp1:
+                    tag3: value3
+            prop2:
+                subProp2: value_scalar
+                subProp3: value_scalar2
+        Node3:
+            prop1:
+                subProp1:
+                    tag1: value1_3
+            prop2:
+                subProp2: [v1, v2]
+                subProp3:
+                    tag4: value4
+        )END");
 
     // NodeMix:
     //      prop1:
@@ -181,15 +154,16 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (recursive overWrite properties)"
 
 TEST_CASE( "Style Mixing Test: propMerge Tests (overWrite properties)", "[mixing][core][yaml]") {
     SceneLoader sceneLoader;
-    Node node = YAML::Load("{ \
-                                Node1: { \
-                                    prop1: value1 }, \
-                                Node2: { \
-                                    prop1: value1_2, \
-                                    prop2: value2 }, \
-                                Node3: { \
-                                    prop1: value1_3 } \
-                                }");
+
+    Node node = YAML::Load(R"END(
+        Node1:
+            prop1: value1
+        Node2:
+            prop1: value1_2
+            prop2: value2
+        Node3:
+            prop1: value1_3
+        )END");
 
     // NodeMix:
     //      prop1: value1_3
@@ -207,14 +181,15 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (overWrite properties)", "[mixing
 TEST_CASE( "Style Mixing Test: propMerge Tests (boolean properties)", "[mixing][core][yaml]") {
 
     SceneLoader sceneLoader;
-    Node node = YAML::Load("{ \
-                                Node1: { \
-                                    prop1: false }, \
-                                Node2: { \
-                                    prop1: true }, \
-                                Node3: { \
-                                    prop1: false } \
-                            }");
+
+    Node node = YAML::Load(R"END(
+        Node1:
+            prop1: false
+        Node2:
+            prop1: true
+        Node3:
+            prop1: false
+        )END");
 
     // NodeMix:
     //      prop1: true

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -17,7 +17,7 @@ using YAML::Node;
 Scene scene;
 SceneLoader sceneLoader;
 
-TEST_CASE( "Style Mixing Test: Float uniform value", "[mixing][core][yaml]") {
+TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[StyleUniforms][core][yaml]") {
 
     Node node = YAML::Load(R"END(
         u_float: 0.5
@@ -30,7 +30,7 @@ TEST_CASE( "Style Mixing Test: Float uniform value", "[mixing][core][yaml]") {
     REQUIRE(uniformValues.first == "float");
 }
 
-TEST_CASE( "Style Mixing Test: Boolean uniform value", "[mixing][core][yaml]") {
+TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "[StyleUniforms][core][yaml]") {
 
     Node node = YAML::Load(R"END(
         u_true: true
@@ -50,7 +50,7 @@ TEST_CASE( "Style Mixing Test: Boolean uniform value", "[mixing][core][yaml]") {
     REQUIRE(uniformValues.first == "bool");
 }
 
-TEST_CASE( "Style Mixing Test: vec2, vec3, vec4 uniform value", "[mixing][core][yaml]") {
+TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform value", "[StyleUniforms][core][yaml]") {
 
     Node node = YAML::Load(R"END(
         u_vec2: [0.1, 0.2]
@@ -84,7 +84,7 @@ TEST_CASE( "Style Mixing Test: vec2, vec3, vec4 uniform value", "[mixing][core][
     REQUIRE(uniformValues.first == "vec4");
 }
 
-TEST_CASE( "Style Mixing Test: textures uniform value", "[mixing][core][yaml]") {
+TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", "[StyleUniforms][core][yaml]") {
 
     Node node = YAML::Load(R"END(
         u_tex : texture1.png

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -39,15 +39,15 @@ TEST_CASE( "Style Mixing Test: Boolean uniform value", "[mixing][core][yaml]") {
 
     auto uniformValues = sceneLoader.parseStyleUniforms(node["u_true"], scene);
     REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<int>());
-    REQUIRE(uniformValues.second[0].get<int>() == 1);
-    REQUIRE(uniformValues.first == "int");
+    REQUIRE(uniformValues.second[0].is<bool>());
+    REQUIRE(uniformValues.second[0].get<bool>() == 1);
+    REQUIRE(uniformValues.first == "bool");
 
     uniformValues = sceneLoader.parseStyleUniforms(node["u_false"], scene);
     REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<int>());
-    REQUIRE(uniformValues.second[0].get<int>() == 0);
-    REQUIRE(uniformValues.first == "int");
+    REQUIRE(uniformValues.second[0].is<bool>());
+    REQUIRE(uniformValues.second[0].get<bool>() == 0);
+    REQUIRE(uniformValues.first == "bool");
 }
 
 TEST_CASE( "Style Mixing Test: vec2, vec3, vec4 uniform value", "[mixing][core][yaml]") {

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -1,0 +1,109 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include "data/filters.h"
+#include "yaml-cpp/yaml.h"
+#include "scene/sceneLoader.h"
+#include "scene/scene.h"
+#include "util/variant.h"
+
+using namespace Tangram;
+using YAML::Node;
+
+Scene scene;
+SceneLoader sceneLoader;
+
+TEST_CASE( "Style Mixing Test: Float uniform value", "[mixing][core][yaml]") {
+
+    Node node = YAML::Load(R"END(
+        u_float: 0.5
+        )END");
+
+    auto uniformValues = sceneLoader.parseStyleUniforms(node["u_float"], scene);
+    REQUIRE(uniformValues.second.size() == 1);
+    REQUIRE(uniformValues.second[0].is<float>());
+    REQUIRE(uniformValues.second[0].get<float>() == 0.5);
+    REQUIRE(uniformValues.first == "float");
+}
+
+TEST_CASE( "Style Mixing Test: Boolean uniform value", "[mixing][core][yaml]") {
+
+    Node node = YAML::Load(R"END(
+        u_true: true
+        u_false: false
+        )END");
+
+    auto uniformValues = sceneLoader.parseStyleUniforms(node["u_true"], scene);
+    REQUIRE(uniformValues.second.size() == 1);
+    REQUIRE(uniformValues.second[0].is<int>());
+    REQUIRE(uniformValues.second[0].get<int>() == 1);
+    REQUIRE(uniformValues.first == "int");
+
+    uniformValues = sceneLoader.parseStyleUniforms(node["u_false"], scene);
+    REQUIRE(uniformValues.second.size() == 1);
+    REQUIRE(uniformValues.second[0].is<int>());
+    REQUIRE(uniformValues.second[0].get<int>() == 0);
+    REQUIRE(uniformValues.first == "int");
+}
+
+TEST_CASE( "Style Mixing Test: vec2, vec3, vec4 uniform value", "[mixing][core][yaml]") {
+
+    Node node = YAML::Load(R"END(
+        u_vec2: [0.1, 0.2]
+        u_vec3: [0.1, 0.2, 0.3]
+        u_vec4: [0.1, 0.2, 0.3, 0.4]
+        )END");
+
+
+    auto uniformValues = sceneLoader.parseStyleUniforms(node["u_vec2"], scene);
+    REQUIRE(uniformValues.second.size() == 1);
+    REQUIRE(uniformValues.second[0].is<glm::vec2>());
+    REQUIRE(uniformValues.second[0].get<glm::vec2>().x == 0.1f);
+    REQUIRE(uniformValues.second[0].get<glm::vec2>().y == 0.2f);
+    REQUIRE(uniformValues.first == "vec2");
+
+    uniformValues = sceneLoader.parseStyleUniforms(node["u_vec3"], scene);
+    REQUIRE(uniformValues.second.size() == 1);
+    REQUIRE(uniformValues.second[0].is<glm::vec3>());
+    REQUIRE(uniformValues.second[0].get<glm::vec3>().x == 0.1f);
+    REQUIRE(uniformValues.second[0].get<glm::vec3>().y == 0.2f);
+    REQUIRE(uniformValues.second[0].get<glm::vec3>().z == 0.3f);
+    REQUIRE(uniformValues.first == "vec3");
+
+    uniformValues = sceneLoader.parseStyleUniforms(node["u_vec4"], scene);
+    REQUIRE(uniformValues.second.size() == 1);
+    REQUIRE(uniformValues.second[0].is<glm::vec4>());
+    REQUIRE(uniformValues.second[0].get<glm::vec4>().x == 0.1f);
+    REQUIRE(uniformValues.second[0].get<glm::vec4>().y == 0.2f);
+    REQUIRE(uniformValues.second[0].get<glm::vec4>().z == 0.3f);
+    REQUIRE(uniformValues.second[0].get<glm::vec4>().w == 0.4f);
+    REQUIRE(uniformValues.first == "vec4");
+}
+
+TEST_CASE( "Style Mixing Test: textures uniform value", "[mixing][core][yaml]") {
+
+    Node node = YAML::Load(R"END(
+        u_tex : texture1.png
+        u_tex2 : [texture2.png, texture3.png, texture4.png]
+        )END");
+
+    auto uniformValues = sceneLoader.parseStyleUniforms(node["u_tex"], scene);
+    REQUIRE(uniformValues.second.size() == 1);
+    REQUIRE(uniformValues.second[0].is<std::string>());
+    REQUIRE(uniformValues.second[0].get<std::string>() == "texture1.png");
+    REQUIRE(uniformValues.first == "sampler2D");
+
+    uniformValues = sceneLoader.parseStyleUniforms(node["u_tex2"], scene);
+    REQUIRE(uniformValues.second.size() == 3);
+    REQUIRE(uniformValues.second[0].is<std::string>());
+    REQUIRE(uniformValues.second[1].is<std::string>());
+    REQUIRE(uniformValues.second[2].is<std::string>());
+    REQUIRE(uniformValues.second[0].get<std::string>() == "texture2.png");
+    REQUIRE(uniformValues.second[1].get<std::string>() == "texture3.png");
+    REQUIRE(uniformValues.second[2].get<std::string>() == "texture4.png");
+}
+


### PR DESCRIPTION
Handles the injection of style uniforms and setting the uniform value on a draw call.

- Style Injection:
-- Handles float, boolean (0: false, 1: true), vec2, vec3, vec4, texture samplers.
-- `Style::setupShaderUniforms` sets the uniform value on draw frame call.

TODO Before this goes for final review:
- [x] Tests cases for parsing uniforms

TODO (Future):
- Arbitrary length numeric uniforms.