### PR TITLE
Draw text stroke using SDF

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -312,7 +312,7 @@ layers:
                     style: normal
                     size: 1.em
                     fill: black
-
+                    stroke: { color: white, width: 1 }
         highway:
             filter: { kind: highway }
             draw:

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -312,7 +312,7 @@ layers:
                     style: normal
                     size: 1.em
                     fill: black
-                    stroke: { color: white, width: 1 }
+                    stroke: { color: white, width: 2 }
         highway:
             filter: { kind: highway }
             draw:

--- a/core/resources/shaders/point.vs
+++ b/core/resources/shaders/point.vs
@@ -15,6 +15,7 @@ attribute vec2 a_uv;
 attribute LOWP float a_alpha;
 attribute LOWP float a_rotation;
 attribute LOWP vec4 a_color;
+attribute LOWP vec4 a_stroke;
 
 uniform mat4 u_proj;
 
@@ -23,6 +24,8 @@ uniform mat4 u_proj;
 varying vec2 v_uv;
 varying float v_alpha;
 varying vec4 v_color;
+varying vec4 v_strokeColor;
+varying float v_strokeWidth;
 
 #pragma tangram: global
 
@@ -47,5 +50,7 @@ void main() {
 
     v_alpha = a_alpha;
     v_uv = a_uv;
-	v_color = a_color;
+    v_color = a_color;
+    v_strokeColor = vec4(a_stroke.rgb, v_color.a);
+    v_strokeWidth = a_stroke.a;
 }

--- a/core/resources/shaders/point.vs
+++ b/core/resources/shaders/point.vs
@@ -51,6 +51,9 @@ void main() {
     v_alpha = a_alpha;
     v_uv = a_uv;
     v_color = a_color;
-    v_strokeColor = vec4(a_stroke.rgb, v_color.a);
     v_strokeWidth = a_stroke.a;
+
+    // If width of stroke is zero, set the stroke color to the fill color -
+    // the border pixel of the fill is always slightly mixed with the stroke color
+    v_strokeColor.rgb = (v_strokeWidth > TANGRAM_EPSILON) ? a_stroke.rgb : a_color.rgb;
 }

--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -31,28 +31,28 @@ varying vec4 v_color;
 
 #pragma tangram: global
 
-float contour(in float d, in float w) {
-    return smoothstep(0.5 - w, 0.5 + w, d);
+float contour(in float d, in float w, float t) {
+    return smoothstep(t - w, t + w, d);
 }
 
-float sample(in vec2 uv, float w) {
-    return contour(texture2D(u_tex, uv).a, w);
+float sample(in vec2 uv, float w, float t) {
+    return contour(texture2D(u_tex, uv).a, w, t);
 }
 
-float sampleAlpha(in vec2 uv, float distance) {
-    const float smooth = 0.0625 * emSize; // 0.0625 = 1.0/1em ratio
-    float alpha = contour(distance, smooth);
+float sampleAlpha(in vec2 uv, float distance, float threshold) {
+    const float smoothing = 0.0625 * emSize; // 0.0625 = 1.0/1em ratio
+    float alpha = contour(distance, smoothing, threshold);
 
 #ifdef TANGRAM_SDF_MULTISAMPLING
-    const float aaSmooth = smooth / 2.0;
+    const float aaSmooth = smoothing / 2.0;
     float dscale = 0.354; // 1 / sqrt(2)
     vec2 duv = dscale * (dFdx(uv) + dFdy(uv));
     vec4 box = vec4(uv - duv, uv + duv);
 
-    float asum = sample(box.xy, aaSmooth)
-        + sample(box.zw, aaSmooth)
-        + sample(box.xw, aaSmooth)
-        + sample(box.zy, aaSmooth);
+    float asum = sample(box.xy, aaSmooth, threshold)
+               + sample(box.zw, aaSmooth, threshold)
+               + sample(box.xw, aaSmooth, threshold)
+               + sample(box.zy, aaSmooth, threshold);
 
     alpha = mix(alpha, asum, 0.25);
 #endif
@@ -64,14 +64,17 @@ void main(void) {
     if (v_alpha < TANGRAM_EPSILON) {
         discard;
     } else {
-        vec4 color;
 
         float distance = texture2D(u_tex, v_uv).a;
 
-        float alpha = sampleAlpha(v_uv, distance);
-        alpha = pow(alpha, 0.4545);
+        float alpha_fill = pow(sampleAlpha(v_uv, distance, 0.5), 0.4545);
+        float alpha_stroke = pow(sampleAlpha(v_uv, distance, 0.4), 0.4545);
 
-        color = vec4(v_color.rgb, v_alpha * alpha * v_color.a);
+        vec4 color_fill = v_color;
+        vec4 color_stroke = vec4(1.);
+
+        vec4 color = mix(color_stroke, color_fill, alpha_fill);
+        color.a = max(alpha_fill, alpha_stroke) * v_alpha;
 
         #pragma tangram: color
         #pragma tangram: filter

--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -28,6 +28,8 @@ uniform sampler2D u_tex;
 varying vec2 v_uv;
 varying float v_alpha;
 varying vec4 v_color;
+varying vec4 v_strokeColor;
+varying float v_strokeWidth;
 
 #pragma tangram: global
 
@@ -65,15 +67,15 @@ void main(void) {
         discard;
     } else {
 
+        float threshold_fill = 0.5;
+        float threshold_stroke = threshold_fill - 0.1 * v_strokeWidth;
+
         float distance = texture2D(u_tex, v_uv).a;
 
-        float alpha_fill = pow(sampleAlpha(v_uv, distance, 0.5), 0.4545);
-        float alpha_stroke = pow(sampleAlpha(v_uv, distance, 0.4), 0.4545);
+        float alpha_fill = pow(sampleAlpha(v_uv, distance, threshold_fill), 0.4545);
+        float alpha_stroke = pow(sampleAlpha(v_uv, distance, threshold_stroke), 0.4545);
 
-        vec4 color_fill = v_color;
-        vec4 color_stroke = vec4(1.);
-
-        vec4 color = mix(color_stroke, color_fill, alpha_fill);
+        vec4 color = mix(v_strokeColor, v_color, alpha_fill);
         color.a = max(alpha_fill, alpha_stroke) * v_alpha;
 
         #pragma tangram: color

--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -68,7 +68,7 @@ void main(void) {
     } else {
 
         float threshold_fill = 0.5;
-        float threshold_stroke = threshold_fill - 0.1 * v_strokeWidth;
+        float threshold_stroke = threshold_fill - v_strokeWidth;
 
         float distance = texture2D(u_tex, v_uv).a;
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -34,11 +34,12 @@ public:
     };
 
     struct Vertex {
-        Vertex(glm::vec2 pos, glm::vec2 uv, uint32_t color) : pos(pos), uv(uv), color(color) {}
+        Vertex(glm::vec2 pos, glm::vec2 uv, uint32_t color, uint32_t stroke = 0) : pos(pos), uv(uv), color(color), stroke(stroke) {}
 
         glm::vec2 pos;
         glm::vec2 uv;
         uint32_t color;
+        uint32_t stroke;
         struct State {
             glm::vec2 screenPos;
             float alpha = 0.f;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -537,7 +537,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
     // Instantiate built-in styles
     scene.styles().emplace_back(new PolygonStyle("polygons"));
     scene.styles().emplace_back(new PolylineStyle("lines"));
-    scene.styles().emplace_back(new TextStyle("text", true, true));
+    scene.styles().emplace_back(new TextStyle("text", true, false));
     scene.styles().emplace_back(new DebugTextStyle("FiraSans_Medium_", "debugtext", 30.0f, true, false));
     scene.styles().emplace_back(new DebugStyle("debug"));
     scene.styles().emplace_back(new SpriteStyle("sprites"));
@@ -586,7 +586,7 @@ void SceneLoader::loadStyles(Node styles, Scene& scene) {
             } else if (baseString == "lines") {
                 style = new PolylineStyle(styleName);
             } else if (baseString == "text") {
-                style = new TextStyle(styleName, true, true);
+                style = new TextStyle(styleName, true, false);
             } else if (baseString == "points") {
                 style = new SpriteStyle(styleName);
             } else {

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -233,7 +233,6 @@ bool StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
             case StyleParamKey::color:
             case StyleParamKey::outline_color:
             case StyleParamKey::font_fill:
-            case StyleParamKey::font_stroke:
             case StyleParamKey::font_stroke_color: {
                 if (len < 3 || len > 4) {
                     logMsg("Warning: Wrong array size for color: '%d'.\n", len);
@@ -283,7 +282,6 @@ bool StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
             case StyleParamKey::color:
             case StyleParamKey::outline_color:
             case StyleParamKey::font_fill:
-            case StyleParamKey::font_stroke:
             case StyleParamKey::font_stroke_color: {
                 _val = static_cast<uint32_t>(duk_get_uint(m_ctx, -1));
                 break;

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -18,9 +18,8 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"font:family", StyleParamKey::font_family},
     {"font:fill", StyleParamKey::font_fill},
     {"font:size", StyleParamKey::font_size},
-    {"font:stroke", StyleParamKey::font_stroke},
-    {"font:stroke_color", StyleParamKey::font_stroke_color},
-    {"font:stroke_width", StyleParamKey::font_stroke_width},
+    {"font:stroke:color", StyleParamKey::font_stroke_color},
+    {"font:stroke:width", StyleParamKey::font_stroke_width},
     {"font:style", StyleParamKey::font_style},
     {"font:weight", StyleParamKey::font_weight},
     {"join", StyleParamKey::join},
@@ -135,7 +134,6 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::color:
     case StyleParamKey::outline_color:
     case StyleParamKey::font_fill:
-    case StyleParamKey::font_stroke:
     case StyleParamKey::font_stroke_color:
         return parseColor(_value);
 
@@ -199,7 +197,6 @@ std::string StyleParam::toString() const {
     case StyleParamKey::color:
     case StyleParamKey::outline_color:
     case StyleParamKey::font_fill:
-    case StyleParamKey::font_stroke:
     case StyleParamKey::font_stroke_color:
     case StyleParamKey::cap:
     case StyleParamKey::outline_cap:
@@ -319,7 +316,6 @@ bool StyleParam::isColor(StyleParamKey _key) {
         case StyleParamKey::color:
         case StyleParamKey::outline_color:
         case StyleParamKey::font_fill:
-        case StyleParamKey::font_stroke:
         case StyleParamKey::font_stroke_color:
             return true;
         default:

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -16,7 +16,6 @@ enum class StyleParamKey : uint8_t {
     font_family,
     font_fill,
     font_size,
-    font_stroke,
     font_stroke_color,
     font_stroke_width,
     font_style,

--- a/core/src/style/spriteStyle.cpp
+++ b/core/src/style/spriteStyle.cpp
@@ -25,6 +25,7 @@ void SpriteStyle::constructVertexLayout() {
         {"a_position", 2, GL_FLOAT, false, 0},
         {"a_uv", 2, GL_FLOAT, false, 0},
         {"a_color", 4, GL_UNSIGNED_BYTE, true, 0},
+        {"a_stroke", 4, GL_UNSIGNED_BYTE, true, 0},
         {"a_screenPosition", 2, GL_FLOAT, false, 0},
         {"a_alpha", 1, GL_FLOAT, false, 0},
         {"a_rotation", 1, GL_FLOAT, false, 0},

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -23,6 +23,7 @@ void TextStyle::constructVertexLayout() {
         {"a_position", 2, GL_FLOAT, false, 0},
         {"a_uv", 2, GL_FLOAT, false, 0},
         {"a_color", 4, GL_UNSIGNED_BYTE, true, 0},
+        {"a_stroke", 4, GL_UNSIGNED_BYTE, true, 0},
         {"a_screenPosition", 2, GL_FLOAT, false, 0},
         {"a_alpha", 1, GL_FLOAT, false, 0},
         {"a_rotation", 1, GL_FLOAT, false, 0},
@@ -58,9 +59,7 @@ Parameters TextStyle::parseRule(const DrawRule& _rule) const {
     _rule.get(StyleParamKey::font_size, p.fontSize);
     _rule.get(StyleParamKey::font_fill, p.fill);
     _rule.get(StyleParamKey::offset, p.offset);
-    if (_rule.get(StyleParamKey::font_stroke, p.strokeColor)) {
-        _rule.get(StyleParamKey::font_stroke_color, p.strokeColor);
-    }
+    _rule.get(StyleParamKey::font_stroke_color, p.strokeColor);
     _rule.get(StyleParamKey::font_stroke_width, p.strokeWidth);
     _rule.get(StyleParamKey::transform, transform);
     _rule.get(StyleParamKey::visible, p.visible);

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -87,7 +87,11 @@ bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform,
     float inf = std::numeric_limits<float>::infinity();
     float x0 = inf, x1 = -inf, y0 = inf, y1 = -inf;
 
-    uint32_t strokeWidth = _params.strokeWidth * 255.;
+    // Stroke width is normalized by the distance of the SDF spread, then scaled
+    // to a char, then packed into the "alpha" channel of stroke. The .25 scaling
+    // probably has to do with how the SDF is generated, but honestly I'm not sure
+    // what it represents.
+    uint32_t strokeWidth = _params.strokeWidth / _params.blurSpread * 255. * .25;
     uint32_t stroke = (_params.strokeColor & 0x00ffffff) + (strokeWidth << 24);
 
     for (auto& q : quads) {

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -87,16 +87,19 @@ bool TextBuffer::addLabel(const std::string& _text, Label::Transform _transform,
     float inf = std::numeric_limits<float>::infinity();
     float x0 = inf, x1 = -inf, y0 = inf, y1 = -inf;
 
+    uint32_t strokeWidth = _params.strokeWidth * 255.;
+    uint32_t stroke = (_params.strokeColor & 0x00ffffff) + (strokeWidth << 24);
+
     for (auto& q : quads) {
         x0 = std::min(x0, std::min(q.x0, q.x1));
         x1 = std::max(x1, std::max(q.x0, q.x1));
         y0 = std::min(y0, std::min(q.y0, q.y1));
         y1 = std::max(y1, std::max(q.y0, q.y1));
 
-        vertices.push_back({{q.x0, q.y0}, {q.s0, q.t0}, _options.color});
-        vertices.push_back({{q.x0, q.y1}, {q.s0, q.t1}, _options.color});
-        vertices.push_back({{q.x1, q.y0}, {q.s1, q.t0}, _options.color});
-        vertices.push_back({{q.x1, q.y1}, {q.s1, q.t1}, _options.color});
+        vertices.push_back({{q.x0, q.y0}, {q.s0, q.t0}, _options.color, stroke});
+        vertices.push_back({{q.x0, q.y1}, {q.s0, q.t1}, _options.color, stroke});
+        vertices.push_back({{q.x1, q.y0}, {q.s1, q.t0}, _options.color, stroke});
+        vertices.push_back({{q.x1, q.y1}, {q.s1, q.t1}, _options.color, stroke});
     }
 
     fontContext->unlock();


### PR DESCRIPTION
<img width="912" alt="screen shot 2015-09-24 at 7 09 22 pm" src="https://cloud.githubusercontent.com/assets/3371850/10089287/ce506b50-62ef-11e5-9fba-1e8737e86d3b.png">

Text labels are starting to look quite nice! This is just using our current signed distance field technique and (basically) just drawing a stroke color between the "glyph interior" threshold and another threshold. 

Things to revisit later:

1. Sufficiently large strokes will encroach on neighboring glyphs. This is a little complicated to fix, we'll probably need another draw pass on text with stroke. 
2. Corners of strokes are round, as opposed to squared like a canvas-drawn stroke. This can be fixed with a small change to fontstash, but isn't a major issue for now. 
