### PR TITLE
Fix lighting mix

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -410,9 +410,13 @@ Node SceneLoader::propOr(const std::string& propStr, const std::vector<Node>& mi
     for (const auto& mixNode: mixes) {
         if (Node propNode = mixNode[propStr]) {
             if (propNode.IsScalar()) {
-                if (propNode.as<std::string>() == "true") {
-                    node = true;
-                    break;
+                try {
+                    if (propNode.as<bool>()) {
+                        node = true;
+                        break;
+                    }
+                } catch (const BadConversion& e) {
+                    logMsg("Error: Expected a boolean value for %s.\n", propStr.c_str());
                 }
             }
         }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -418,10 +418,10 @@ Node SceneLoader::propMerge(const std::string& propStr, const std::vector<Node>&
         if (!mixNode.IsMap()) { continue; }
         if (Node propNode = mixNode[propStr]) {
             if (propNode.IsScalar() && propNode.as<std::string>() == "true") {      // OR Properties
-                node = propNode;
+                node = Clone(propNode);
                 break;
             } else if (propNode.IsScalar() || propNode.IsSequence()) {              // Overwrite Properties
-                node = propNode;
+                node = Clone(propNode);
             } else { // Map...
                 // Reset previous scalar/sequence node
                 node.reset();

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -403,6 +403,23 @@ void SceneLoader::loadStyleProps(Style* style, Node styleNode, Scene& scene) {
 
 }
 
+Node SceneLoader::propOr(const std::string& propStr, const std::vector<Node>& mixes) {
+
+    Node node;
+
+    for (const auto& mixNode: mixes) {
+        if (Node propNode = mixNode[propStr]) {
+            if (propNode.IsScalar()) {
+                if (propNode.as<std::string>() == "true") {
+                    node = true;
+                    break;
+                }
+            }
+        }
+    }
+    return node;
+}
+
 Node SceneLoader::propMerge(const std::string& propStr, const std::vector<Node>& mixes) {
 
     Node node;
@@ -417,17 +434,14 @@ Node SceneLoader::propMerge(const std::string& propStr, const std::vector<Node>&
     for (const auto& mixNode: mixes) {
         if (!mixNode.IsMap()) { continue; }
         if (Node propNode = mixNode[propStr]) {
-            if (propNode.IsScalar() && propNode.as<std::string>() == "true") {      // OR Properties
-                node = Clone(propNode);
-                break;
-            } else if (propNode.IsScalar() || propNode.IsSequence()) {              // Overwrite Properties
+            if (propNode.IsScalar() || propNode.IsSequence()) {              // Overwrite Properties
                 node = Clone(propNode);
             } else { // Map...
                 // Reset previous scalar/sequence node
                 node.reset();
                 for (const auto& tag : propNode) {
                     auto tagName = tag.first.as<std::string>();
-                    if (mapMixes.find(tagName) == mapMixes.end()) {                 // Deep Merge for all Map Props
+                    if (mapMixes.find(tagName) == mapMixes.end()) {          // Deep Merge for all Map Props
                         mapTags.push_back(tagName);
                     }
                     mapMixes[tagName].push_back(propNode);
@@ -510,7 +524,12 @@ Node SceneLoader::mixStyle(const std::vector<Node>& mixes) {
 
     Node styleNode;
 
-    for (auto& property : {"animated", "texcoords", "base", "lighting", "texture", "blend", "material", "shaders"}) {
+    for (auto& property: {"animated", "texcoords"}) {
+        Node node = propOr(property, mixes);
+        if (!node.IsNull()) { styleNode[property] = node; }
+    }
+
+    for (auto& property : {"base", "lighting", "texture", "blend", "material", "shaders"}) {
         Node node = propMerge(property, mixes);
         if (!node.IsNull()) { styleNode[property] = node; }
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -407,7 +407,8 @@ Node SceneLoader::propOr(const std::string& propStr, const std::vector<Node>& mi
 
     Node node;
 
-    for (const auto& mixNode: mixes) {
+    for (const auto& mixNode : mixes) {
+        if (!mixNode.IsMap()) { continue; }
         if (Node propNode = mixNode[propStr]) {
             if (propNode.IsScalar()) {
                 try {
@@ -440,7 +441,7 @@ Node SceneLoader::propMerge(const std::string& propStr, const std::vector<Node>&
         if (Node propNode = mixNode[propStr]) {
             if (propNode.IsScalar() || propNode.IsSequence()) {              // Overwrite Properties
                 node = Clone(propNode);
-            } else { // Map...
+            } else if (propNode.IsMap()) {
                 // Reset previous scalar/sequence node
                 node.reset();
                 for (const auto& tag : propNode) {

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -74,6 +74,7 @@ public:
             std::unordered_set<std::string>& uniqueStyles);
 
     // Generic methods to merge properties
+    YAML::Node propOr(const std::string& propStr, const std::vector<YAML::Node>& mixes);
     YAML::Node propMerge(const std::string& propStr, const std::vector<YAML::Node>& mixes);
 
     // Methods to merge shader blocks

--- a/tests/unit/styleMixTests.cpp
+++ b/tests/unit/styleMixTests.cpp
@@ -249,6 +249,13 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (overWrite properties)", "[mixing
 
     REQUIRE(mixedNode["prop1"].as<std::string>() == "value1_3");
     REQUIRE(mixedNode["prop2"].as<std::string>() == "value2");
+
+    // Verify that the original node was not modified
+    REQUIRE(node["Node1"]["prop1"].as<std::string>() == "value1");
+    REQUIRE(node["Node2"]["prop1"].as<std::string>() == "value1_2");
+    REQUIRE(node["Node2"]["prop2"].as<std::string>() == "value2");
+    REQUIRE(node["Node3"]["prop1"].as<std::string>() == "value1_3");
+
 }
 
 TEST_CASE( "Style Mixing Test: propOr Tests (boolean properties)", "[mixing][core][yaml]") {
@@ -273,6 +280,7 @@ TEST_CASE( "Style Mixing Test: propOr Tests (boolean properties)", "[mixing][cor
     }
 
     REQUIRE(mixedNode["prop1"].as<bool>());
+
 }
 
 

--- a/tests/unit/styleMixTests.cpp
+++ b/tests/unit/styleMixTests.cpp
@@ -251,7 +251,7 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (overWrite properties)", "[mixing
     REQUIRE(mixedNode["prop2"].as<std::string>() == "value2");
 }
 
-TEST_CASE( "Style Mixing Test: propMerge Tests (boolean properties)", "[mixing][core][yaml]") {
+TEST_CASE( "Style Mixing Test: propOr Tests (boolean properties)", "[mixing][core][yaml]") {
 
     SceneLoader sceneLoader;
 
@@ -269,7 +269,7 @@ TEST_CASE( "Style Mixing Test: propMerge Tests (boolean properties)", "[mixing][
 
     Node mixedNode;
     for (auto& property : {"prop1"}) {
-        mixedNode[property] = sceneLoader.propMerge(property, { node["Node1"], node["Node2"], node["Node3"] });
+        mixedNode[property] = sceneLoader.propOr(property, { node["Node1"], node["Node2"], node["Node3"] });
     }
 
     REQUIRE(mixedNode["prop1"].as<bool>());


### PR DESCRIPTION
This PR fixes a couple of things:

- Lighting property is special in the case that it can be boolean or scalar/string value. [`true`, `false`, `vertex`, `fragment`]. In which case it should be overwritten when mixing styles properties. This PR, explicitly calls either OR, or Merge methods to appropriate properties explicitly. (As has been done on the JS side). Hence handles `lighting` property correctly.

- Another issue which I noticed was this special behavior yamlcpp Nodes. Nodes are non-copyable and hence needs to be explicitly cloned. Since this was not being done, propMerge method was modifying the original scene yaml nodes. Refer: https://code.google.com/p/yaml-cpp/wiki/HowToParseADocument#Note_about_copying_YAML::Node.
