### PR TITLE
Recursive style mixing and mixed shader block

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -37,31 +37,6 @@ namespace Tangram {
 constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
 
-bool getFloat(const Node& node, float& value, const char* name = nullptr) {
-    try {
-        value = node.as<float>();
-        return true;
-    } catch (const BadConversion& e) {}
-
-    if (name) {
-        LOGNode("Expected a float value for '%s' property.", node, name);
-    }
-    return false;
-}
-
-bool getBool(const Node& node, bool& value, const char* name = nullptr) {
-    try {
-        value = node.as<bool>();
-        return true;
-    } catch (const BadConversion& e) {}
-
-    if (name) {
-        LOGNode("Expected a boolean value for '%s' property.", node, name);
-    }
-    return false;
-}
-
-
 bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
 
     Node config;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -577,21 +577,23 @@ Node SceneLoader::propMerge(const std::string& propName, const std::vector<Node>
     return result;
 }
 
-Node SceneLoader::shaderBlockMerge(const std::vector<Node>& mixes) {
+Node SceneLoader::shaderBlockMerge(const std::vector<Node>& styles) {
 
     Node result;
-    for (const auto& mixNode : mixes) {
-        if (!mixNode.IsMap()) {
-            LOGNode("Expected map for 'mix'", mixNode);
+
+    for (const auto& style : styles) {
+        if (!style.IsMap()) {
+            LOGNode("Expected map for 'style'", style);
             continue;
         }
 
-        Node shaderNode = mixNode["shaders"];
+        Node shaderNode = style["shaders"];
         if (!shaderNode) { continue; }
         if (!shaderNode.IsMap()) {
             LOGNode("Expected map for 'shader'", shaderNode);
             continue;
         }
+
         Node blocks = shaderNode["blocks"];
         if (!blocks) { continue; }
         if (!blocks.IsMap()) {
@@ -615,15 +617,18 @@ Node SceneLoader::shaderBlockMerge(const std::vector<Node>& mixes) {
     return result;
 }
 
-Node SceneLoader::shaderExtMerge(const std::vector<Node>& mixes) {
+Node SceneLoader::shaderExtMerge(const std::vector<Node>& styles) {
 
     Node result;
     std::unordered_set<std::string> uniqueList;
 
-    for (const auto& mixNode : mixes) {
-        if (!mixNode.IsMap()) { continue; }
+    for (const auto& style : styles) {
+        if (!style.IsMap()) {
+            LOGNode("Expected map for 'style'", style);
+            continue;
+        }
 
-        Node shaderNode = mixNode["shaders"];
+        Node shaderNode = style["shaders"];
         if (!shaderNode) { continue; }
         if (!shaderNode.IsMap()) {
             LOGNode("Expected map for 'shader'", shaderNode);
@@ -659,18 +664,18 @@ Node SceneLoader::shaderExtMerge(const std::vector<Node>& mixes) {
     return result;
 }
 
-Node SceneLoader::mixStyles(const std::vector<Node>& mixes) {
+Node SceneLoader::mixStyles(const std::vector<Node>& styles) {
 
     Node result;
 
     for (auto& property: {"animated", "texcoords"}) {
-        if (propOr(property, mixes)) {
+        if (propOr(property, styles)) {
             result[property] = true;
         }
     }
 
     for (auto& property : {"base", "lighting", "texture", "blend", "material", "shaders"}) {
-        Node node = propMerge(property, mixes);
+        Node node = propMerge(property, styles);
         if (!node.IsNull()) {
             result[property] = node;
         }
@@ -678,12 +683,12 @@ Node SceneLoader::mixStyles(const std::vector<Node>& mixes) {
 
     Node shaderNode = result["shaders"];
 
-    Node shaderExtNode = shaderExtMerge(mixes);
+    Node shaderExtNode = shaderExtMerge(styles);
     if (!shaderExtNode.IsNull()) {
         shaderNode["extensions"] = shaderExtNode;
     }
 
-    Node shaderBlocksNode = shaderBlockMerge(mixes);
+    Node shaderBlocksNode = shaderBlockMerge(styles);
     if (!shaderBlocksNode.IsNull()) {
         shaderNode["blocks"] = shaderBlocksNode;
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1057,14 +1057,12 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
         if (getFloat(_node, number)) {
             return Filter::MatchEquality(_key, { Value(number) });
         }
-        std::string value = _node.as<std::string>();
-        if (value == "true") {
-            return Filter::MatchExistence(_key, true);
-        } else if (value == "false") {
-            return Filter::MatchExistence(_key, false);
-        } else {
-            return Filter::MatchEquality(_key, { Value(value) });
+        bool existence;
+        if (getBool(_node, existence)) {
+            return Filter::MatchExistence(_key, existence);
         }
+        std::string value = _node.as<std::string>();
+        return Filter::MatchEquality(_key, { Value(std::move(value)) });
     }
     case NodeType::Sequence: {
         std::vector<Value> values;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -71,6 +71,10 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
         LOGE("Parsing scene config '%s'", e.what());
         return false;
     }
+    return loadScene(config, _scene);
+}
+
+bool SceneLoader::loadScene(Node& config, Scene& _scene) {
 
     // To add font for debugTextStyle
     FontContext::GetInstance()->addFont("FiraSans", "Medium", "");

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -40,8 +40,6 @@ struct SceneLoader {
     static void loadBackground(Node background, Scene& scene);
     static void loadSource(const std::pair<Node, Node>& source, Scene& scene);
     static void loadTexture(const std::pair<Node, Node>& texture, Scene& scene);
-    static void loadStyle(const std::pair<Node, Node>& style, Node styles, Scene& scene,
-                          std::unordered_set<std::string>& mixedStyles);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
     static void loadFont(Node fontProps);
@@ -64,16 +62,16 @@ struct SceneLoader {
     static StyleUniforms parseStyleUniforms(const Node& uniform, Scene& scene);
     static Node mixStyle(const std::vector<Node>& mixes);
 
+    static void loadStyle(const std::string& styleName, Node styles, Scene& scene,
+                          std::unordered_set<std::string>& mixedStyles);
+
     /* Generate style mixins for a given style node
      * @styleName: styleName to be mixed
      * @styles: YAML::Node for all styles
      * @uniqueStyles: to make sure Mixes returned is a uniqueSet
      */
-    static std::vector<Node> recursiveMixins(const std::string& styleName, const Node styles,
-                                             std::unordered_set<std::string>& uniqueStyles,
-                                             std::unordered_set<std::string>& mixedStyles);
 
-    static void addMixinNode(const Node mixNode, const Node styles, std::vector<Node>& mixes,
+    static void addMixinNode(const Node mixNode, const Node styles, Scene& scene, std::vector<Node>& mixes,
                       std::unordered_set<std::string>& uniqueStyles,
                       std::unordered_set<std::string>& mixedStyles);
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -34,6 +34,7 @@ struct SceneLoader {
     using Node = YAML::Node;
 
     static bool loadScene(const std::string& _sceneString, Scene& _scene);
+    static bool loadScene(Node& config, Scene& _scene);
 
     /*** all public for testing ***/
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -60,9 +60,9 @@ struct SceneLoader {
                                  std::vector<StyleParam>& out);
 
     static StyleUniforms parseStyleUniforms(const Node& uniform, Scene& scene);
-    static Node mixStyle(const std::vector<Node>& mixes);
+    static Node mixStyles(const std::vector<Node>& mixes);
 
-    static void loadStyle(const std::string& styleName, Node styles, Scene& scene,
+    static bool loadStyle(const std::string& styleName, Node styles, Scene& scene,
                           std::unordered_set<std::string>& mixedStyles);
 
     /* Generate style mixins for a given style node
@@ -70,10 +70,8 @@ struct SceneLoader {
      * @styles: YAML::Node for all styles
      * @uniqueStyles: to make sure Mixes returned is a uniqueSet
      */
-
-    static void addMixinNode(const Node mixNode, const Node styles, Scene& scene, std::vector<Node>& mixes,
-                      std::unordered_set<std::string>& uniqueStyles,
-                      std::unordered_set<std::string>& mixedStyles);
+    static std::vector<Node> getMixins(const Node& styleNode, const Node& styles, Scene& scene,
+                                       std::unordered_set<std::string>& mixedStyles);
 
     // Generic methods to merge properties
     static bool propOr(const std::string& propStr, const std::vector<Node>& mixes);

--- a/core/src/util/yamlHelper.cpp
+++ b/core/src/util/yamlHelper.cpp
@@ -1,0 +1,47 @@
+#include "util/yamlHelper.h"
+
+#include "platform.h"
+
+namespace Tangram {
+
+std::string parseSequence(const Node& node) {
+    std::stringstream sstream;
+    for (const auto& val : node) {
+        try {
+            sstream << val.as<float>() << ",";
+        } catch (const BadConversion& e) {
+            try {
+                sstream << val.as<std::string>() << ",";
+            } catch (const BadConversion& e) {
+                LOGE("Float or Unit expected for styleParam sequence value");
+            }
+        }
+    }
+    return sstream.str();
+}
+
+bool getFloat(const Node& node, float& value, const char* name) {
+    try {
+        value = node.as<float>();
+        return true;
+    } catch (const BadConversion& e) {}
+
+    if (name) {
+        LOGW("Expected a float value for '%s' property.:\n%s\n", name, Dump(node).c_str());
+    }
+    return false;
+}
+
+bool getBool(const Node& node, bool& value, const char* name) {
+    try {
+        value = node.as<bool>();
+        return true;
+    } catch (const BadConversion& e) {}
+
+    if (name) {
+        LOGW("Expected a boolean value for '%s' property.:\n%s\n", name, Dump(node).c_str());
+    }
+    return false;
+}
+
+}

--- a/core/src/util/yamlHelper.h
+++ b/core/src/util/yamlHelper.h
@@ -3,29 +3,15 @@
 
 #pragma once
 
+#include "yaml-cpp/yaml.h"
+
 using YAML::Node;
 using YAML::BadConversion;
 
 namespace Tangram {
 
-std::string parseSequence(const Node& node) {
-    std::stringstream sstream;
-    for (const auto& val : node) {
-        try {
-            sstream << val.as<float>() << ",";
-        } catch (const BadConversion& e) {
-            try {
-                sstream << val.as<std::string>() << ",";
-            } catch (const BadConversion& e) {
-                LOGE("Float or Unit expected for styleParam sequence value");
-            }
-        }
-    }
-    return sstream.str();
-}
-
 template<typename T>
-T parseVec(const Node& node) {
+inline T parseVec(const Node& node) {
     T vec;
     int i = 0;
     for (const auto& nodeVal : node) {
@@ -37,5 +23,11 @@ T parseVec(const Node& node) {
     }
     return vec;
 }
+
+std::string parseSequence(const Node& node);
+
+bool getFloat(const Node& node, float& value, const char* name = nullptr);
+
+bool getBool(const Node& node, bool& value, const char* name = nullptr);
 
 }

--- a/tests/unit/styleMixTests.cpp
+++ b/tests/unit/styleMixTests.cpp
@@ -375,3 +375,33 @@ TEST_CASE( "Style Mixing Test: Actual Property recursive merge check - part 2", 
     REQUIRE(mixNode["lighting"].as<std::string>() ==  "lighter");
 
 }
+
+TEST_CASE( "Style Mixing Test: Dont allow loops in mix inheritance", "[mixing][core][yaml]") {
+    std::unordered_set<std::string> mixedStyles;
+    Scene scene;
+
+    std::vector<Node> mix;
+    Node mixNode;
+    Node node = YAML::Load(R"END(
+        styleA:
+            mix: styleB
+            base: A
+        styleB:
+            mix: styleC
+            lighting: B
+        styleC:
+            mix: styleA
+            material: C
+        )END");
+
+    SceneLoader::loadStyle("styleA", node, scene, mixedStyles);
+    mixNode = node["styleA"];
+
+    REQUIRE(mixNode["base"].IsScalar());
+    REQUIRE(mixNode["lighting"].IsScalar());
+    REQUIRE(mixNode["material"].IsScalar());
+    REQUIRE(mixNode["base"].as<std::string>() ==  "A");
+    REQUIRE(mixNode["lighting"].as<std::string>() ==  "B");
+    REQUIRE(mixNode["material"].as<std::string>() ==  "C");
+
+}

--- a/tests/unit/styleMixTests.cpp
+++ b/tests/unit/styleMixTests.cpp
@@ -201,8 +201,8 @@ TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
     //          color: colorBlockA;
     //          normal: normalBlockA;
 
-    REQUIRE(shaderBlocksNode["color"].as<std::string>() == "colorBlockA;");
-    REQUIRE(shaderBlocksNode["normal"].as<std::string>() == "normalBlockA;");
+    REQUIRE(shaderBlocksNode["color"][0].as<std::string>() == "colorBlockA;");
+    REQUIRE(shaderBlocksNode["normal"][0].as<std::string>() == "normalBlockA;");
     REQUIRE(!shaderBlocksNode["global"]);
 
     shaderBlocksNode = SceneLoader::shaderBlockMerge( { node["Node1"], node["Node2"], node["Node3"] } );
@@ -214,11 +214,13 @@ TEST_CASE( "Style Mixing Test: Shader Blocks Merging", "[mixing][core][yaml]") {
     //          global: globalBlockB;\nglobalBlockC;
     //          filter: filterBlockC;
 
-    REQUIRE(shaderBlocksNode["color"].as<std::string>() == "colorBlockA;\ncolorBlockB;");
-    REQUIRE(shaderBlocksNode["normal"].as<std::string>() == "normalBlockA;");
-    REQUIRE(shaderBlocksNode["position"].as<std::string>() == "posBlockB;");
-    REQUIRE(shaderBlocksNode["global"].as<std::string>() == "globalBlockB;\nglobalBlockC;");
-    REQUIRE(shaderBlocksNode["filter"].as<std::string>() == "filterBlockC;");
+    REQUIRE(shaderBlocksNode["color"][0].as<std::string>() == "colorBlockA;");
+    REQUIRE(shaderBlocksNode["color"][1].as<std::string>() == "colorBlockB;");
+    REQUIRE(shaderBlocksNode["normal"][0].as<std::string>() == "normalBlockA;");
+    REQUIRE(shaderBlocksNode["position"][0].as<std::string>() == "posBlockB;");
+    REQUIRE(shaderBlocksNode["global"][0].as<std::string>() == "globalBlockB;");
+    REQUIRE(shaderBlocksNode["global"][1].as<std::string>() == "globalBlockC;");
+    REQUIRE(shaderBlocksNode["filter"][0].as<std::string>() == "filterBlockC;");
 }
 
 TEST_CASE( "Style Mixing Test: propMerge Tests (recursive overWrite properties)", "[mixing][core][yaml]") {


### PR DESCRIPTION
- The first patch modifies loadStyle to first load all mixins to avoid merging styles twice.
- The second patch add support for combining shader blocks while ensuring to filter out duplicates by collecting all blocks in a vector instead of concatenating block strings in shaderBlockMerge 