### PR TITLE
File paths resolved as 'internal', 'resource', or 'absolute'

### DIFF
--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -162,25 +162,6 @@ unsigned char* bytesFromAssetManager(const char* _path, unsigned int* _size) {
     return data;
 }
 
-std::string stringFromResource(const char* _path) {
-
-    std::string path = s_resourceRoot + _path;
-    unsigned int length = 0;
-    unsigned char* bytes = nullptr;
-
-    if (s_useInternalResources) {
-        bytes = bytesFromResource(path.c_str(), &length);
-    } else {
-        bytes = bytesFromFileSystem(path.c_str(), &length);
-    }
-
-    std::string out(reinterpret_cast<char*>(bytes), length);
-    free(bytes);
-
-    return out;
-
-}
-
 unsigned char* bytesFromFileSystem(const char* _path, unsigned int* _size) {
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
@@ -204,13 +185,32 @@ unsigned char* bytesFromFileSystem(const char* _path, unsigned int* _size) {
 
 }
 
-unsigned char* bytesFromResource(const char* _path, unsigned int* _size) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
-    std::string path = s_resourceRoot + _path;
-    if (s_useInternalResources) {
-        return bytesFromAssetManager(path.c_str(), _size);
-    } else {
-        return bytesFromFileSystem(path.c_str(), _size);
+    unsigned int length = 0;
+    unsigned char* bytes = bytesFromFile(_path, _type, &length);
+    std::string out(reinterpret_cast<char*>(bytes), length);
+    free(bytes);
+
+    return out;
+
+}
+
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {
+
+    std::string resourcePath = s_resourceRoot + _path;
+
+    switch (_type) {
+    case PathType::absolute:
+        return bytesFromFileSystem(_path, _size);
+    case PathType::internal:
+        return bytesFromAssetManager(_path, _size);
+    case PathType::resource:
+        if (s_useInternalResources) {
+            return bytesFromAssetManager(resourcePath.c_str(), _size);
+        } else {
+            return bytesFromFileSystem(resourcePath.c_str(), _size);
+        }
     }
 
 }

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -24,7 +24,7 @@ ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::st
 
     if (!_url.empty()) {
         // Load from file
-        const auto& string = stringFromResource(_url.c_str());
+        const auto& string = stringFromFile(_url.c_str(), PathType::resource);
         addData(string);
     }
 }

--- a/core/src/gl/primitives.cpp
+++ b/core/src/gl/primitives.cpp
@@ -26,8 +26,8 @@ void init() {
         std::string vert, frag;
         s_shader = std::unique_ptr<ShaderProgram>(new ShaderProgram());
 
-        vert = stringFromResource("shaders/debugPrimitive.vs");
-        frag = stringFromResource("shaders/debugPrimitive.fs");
+        vert = stringFromFile("shaders/debugPrimitive.vs", PathType::internal);
+        frag = stringFromFile("shaders/debugPrimitive.fs", PathType::internal);
 
         s_shader->setSourceStrings(frag, vert);
 

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -29,7 +29,7 @@ Texture::Texture(const std::string& _file, TextureOptions _options, bool _genera
     : Texture(0, 0, _options, _generateMipmaps) {
 
     unsigned int size;
-    unsigned char* data = bytesFromResource(_file.c_str(), &size);
+    unsigned char* data = bytesFromFile(_file.c_str(), PathType::resource, &size);
     unsigned char* pixels;
     int width, height, comp;
 

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -15,7 +15,7 @@ TextureCube::TextureCube(std::string _file, TextureOptions _options) : Texture(0
 
 void TextureCube::load(const std::string& _file) {
     unsigned int size;
-    unsigned char* data = bytesFromResource(_file.c_str(), &size);
+    unsigned char* data = bytesFromFile(_file.c_str(), PathType::resource, &size);
     unsigned char* pixels;
     int width, height, comp;
 

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -54,34 +54,30 @@ bool isContinuousRendering();
 /* get system path of a font file */
 std::string systemFontPath(const std::string& _name, const std::string& _weight, const std::string& _face);
 
+enum class PathType : char {
+    absolute, // resolved relative to the filesystem root
+    internal, // resolved relative to the application storage directory
+    resource, // resolved relative to the resource root
+};
+
 /* Set a path to act as the resource root. All other resource paths will be resolved relative to this root. 
  * The string returned is the path to the given file relative to the new root resource directory. */
 std::string setResourceRoot(const char* _path);
 
-/* Read a bundled resource file as a string
+/* Read a file as a string
  *
- * Opens the file at the given relative path and returns a string with its contents.
- * _path is the location of the file within the core/resources folder. If the file
- * cannot be found or read, the returned string is empty.
+ * Opens the file at the _path, resolved with _type, and returns a string with its contents.
+ * If the file cannot be found or read, the returned string is empty.
  */
-std::string stringFromResource(const char* _path);
+std::string stringFromFile(const char* _path, PathType _type);
 
-/* Read and allocates size bytes of memory
+/* Read a file into memory
  *
- * Similarly to stringFromResource, _path is the location of file within
- * core/resources. If the file cannot be read nothing is allocated and
- * a nullptr is returned.
- * _size is is an in/out parameter to retrieve the size in bytes of the
- * allocated file
+ * Opens the file at _path, resolved with _type, then allocates and returns a pointer to memory
+ * containing the contents of the file. The size of the memory in bytes is written to _size.
+ * If the file cannot be read, nothing is allocated and nullptr is returned.
  */
-unsigned char* bytesFromResource(const char* _path, unsigned int* _size);
-
-/* Read and allocate size of bytes of memory
- *
- * Similar to bytesFromResource,
- * but reads External/System memory instead of the app->assets/resource memory
- */
-unsigned char* bytesFromFileSystem(const char* _path, unsigned int* _size);
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size);
 
 /* Function type for receiving data from a successful network request */
 using UrlCallback = std::function<void(std::vector<char>&&)>;

--- a/core/src/scene/ambientLight.cpp
+++ b/core/src/scene/ambientLight.cpp
@@ -27,7 +27,7 @@ void AmbientLight::setupProgram(const View& _view, ShaderProgram& _shader ) {
 
 std::string AmbientLight::getClassBlock() {
     if (s_classBlock.empty()) {
-        s_classBlock = stringFromResource("shaders/ambientLight.glsl")+"\n";
+        s_classBlock = stringFromFile("shaders/ambientLight.glsl", PathType::internal)+"\n";
     }
     return s_classBlock;
 }

--- a/core/src/scene/directionalLight.cpp
+++ b/core/src/scene/directionalLight.cpp
@@ -40,7 +40,7 @@ void DirectionalLight::setupProgram(const View& _view, ShaderProgram& _shader ) 
 
 std::string DirectionalLight::getClassBlock() {
     if (s_classBlock.empty()) {
-        s_classBlock = stringFromResource("shaders/directionalLight.glsl")+"\n";
+        s_classBlock = stringFromFile("shaders/directionalLight.glsl", PathType::internal)+"\n";
     }
     return s_classBlock;
 }

--- a/core/src/scene/light.cpp
+++ b/core/src/scene/light.cpp
@@ -78,7 +78,7 @@ void Light::assembleLights(std::map<std::string, std::vector<std::string>>& _sou
 
     // After lights definitions are all added, add the main lighting functions
     if (s_mainLightingBlock.empty()) {
-        s_mainLightingBlock = stringFromResource("shaders/lights.glsl");
+        s_mainLightingBlock = stringFromFile("shaders/lights.glsl", PathType::internal);
     }
     std::string lightingBlock = s_mainLightingBlock;
 

--- a/core/src/scene/pointLight.cpp
+++ b/core/src/scene/pointLight.cpp
@@ -90,7 +90,7 @@ void PointLight::setupProgram(const View& _view, ShaderProgram& _shader) {
 
 std::string PointLight::getClassBlock() {
     if (s_classBlock.empty()) {
-        s_classBlock = stringFromResource("shaders/pointLight.glsl")+"\n";
+        s_classBlock = stringFromFile("shaders/pointLight.glsl", PathType::internal)+"\n";
     }
     return s_classBlock;
 }

--- a/core/src/scene/skybox.cpp
+++ b/core/src/scene/skybox.cpp
@@ -11,8 +11,8 @@ Skybox::Skybox(std::string _file) : m_file(_file) {}
 
 void Skybox::init() {
 
-    std::string fragShaderSrcStr = stringFromResource("shaders/cubemap.fs");
-    std::string vertShaderSrcStr = stringFromResource("shaders/cubemap.vs");
+    std::string fragShaderSrcStr = stringFromFile("shaders/cubemap.fs", PathType::internal);
+    std::string vertShaderSrcStr = stringFromFile("shaders/cubemap.vs", PathType::internal);
 
     m_shader = std::make_unique<ShaderProgram>();
     m_shader->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);

--- a/core/src/scene/spotLight.cpp
+++ b/core/src/scene/spotLight.cpp
@@ -55,7 +55,7 @@ void SpotLight::setupProgram(const View& _view, ShaderProgram& _shader ) {
 
 std::string SpotLight::getClassBlock() {
     if (s_classBlock.empty()) {
-        s_classBlock = stringFromResource("shaders/spotLight.glsl")+"\n";
+        s_classBlock = stringFromFile("shaders/spotLight.glsl", PathType::internal)+"\n";
     }
     return s_classBlock;
 }

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -24,8 +24,8 @@ void DebugStyle::constructVertexLayout() {
 
 void DebugStyle::constructShaderProgram() {
 
-    std::string vertShaderSrcStr = stringFromResource("shaders/debug.vs");
-    std::string fragShaderSrcStr = stringFromResource("shaders/debug.fs");
+    std::string vertShaderSrcStr = stringFromFile("shaders/debug.vs", PathType::internal);
+    std::string fragShaderSrcStr = stringFromFile("shaders/debug.fs", PathType::internal);
 
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -146,7 +146,7 @@ std::string Material::getDefinesBlock(){
 }
 
 std::string Material::getClassBlock() {
-    return stringFromResource("shaders/material.glsl") + "\n";
+    return stringFromFile("shaders/material.glsl", PathType::internal) + "\n";
 }
 
 void Material::injectOnProgram(ShaderProgram& _shader ) {

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -33,8 +33,8 @@ void PointStyle::constructVertexLayout() {
 
 void PointStyle::constructShaderProgram() {
 
-    std::string fragShaderSrcStr = stringFromResource("shaders/point.fs");
-    std::string vertShaderSrcStr = stringFromResource("shaders/point.vs");
+    std::string fragShaderSrcStr = stringFromFile("shaders/point.fs", PathType::internal);
+    std::string vertShaderSrcStr = stringFromFile("shaders/point.vs", PathType::internal);
 
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -27,8 +27,8 @@ void PolygonStyle::constructVertexLayout() {
 
 void PolygonStyle::constructShaderProgram() {
 
-    std::string vertShaderSrcStr = stringFromResource("shaders/polygon.vs");
-    std::string fragShaderSrcStr = stringFromResource("shaders/polygon.fs");
+    std::string vertShaderSrcStr = stringFromFile("shaders/polygon.vs", PathType::internal);
+    std::string fragShaderSrcStr = stringFromFile("shaders/polygon.fs", PathType::internal);
 
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 }

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -26,8 +26,8 @@ void PolylineStyle::constructVertexLayout() {
 
 void PolylineStyle::constructShaderProgram() {
 
-    std::string vertShaderSrcStr = stringFromResource("shaders/polyline.vs");
-    std::string fragShaderSrcStr = stringFromResource("shaders/polyline.fs");
+    std::string vertShaderSrcStr = stringFromFile("shaders/polyline.vs", PathType::internal);
+    std::string fragShaderSrcStr = stringFromFile("shaders/polyline.fs", PathType::internal);
 
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -33,8 +33,8 @@ void TextStyle::constructVertexLayout() {
 void TextStyle::constructShaderProgram() {
     std::string frag = m_sdf ? "shaders/sdf.fs" : "shaders/text.fs";
 
-    std::string vertShaderSrcStr = stringFromResource("shaders/point.vs");
-    std::string fragShaderSrcStr = stringFromResource(frag.c_str());
+    std::string vertShaderSrcStr = stringFromFile("shaders/point.vs", PathType::internal);
+    std::string fragShaderSrcStr = stringFromFile(frag.c_str(), PathType::internal);
 
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -61,7 +61,7 @@ void initialize(const char* _scenePath) {
         m_labels = std::unique_ptr<Labels>(new Labels());
 
         LOG("Loading Tangram scene file: %s", sceneRelPath.c_str());
-        auto sceneString = stringFromResource(sceneRelPath.c_str());
+        auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource);
 
         if (SceneLoader::loadScene(sceneString, *m_scene)) {
             m_tileManager->setScene(m_scene);
@@ -80,7 +80,7 @@ void initialize(const char* _scenePath) {
 void loadScene(const char* _scenePath) {
     LOG("Loading scene file: %s", _scenePath);
 
-    auto sceneString = stringFromResource(setResourceRoot(_scenePath).c_str());
+    auto sceneString = stringFromFile(setResourceRoot(_scenePath).c_str(), PathType::resource);
 
     auto scene = std::make_shared<Scene>();
     if (SceneLoader::loadScene(sceneString, *scene)) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -52,9 +52,10 @@ bool FontContext::addFont(const std::string& _family, const std::string& _weight
 
     // Assuming bundled ttf file follows this convention
     auto bundledFontPath = "fonts/" + _family + "-" + _weight + _style + ".ttf";
-    if ( !(data = bytesFromResource(bundledFontPath.c_str(), &dataSize))) {
+    if (!(data = bytesFromFile(bundledFontPath.c_str(), PathType::resource, &dataSize)) &&
+        !(data = bytesFromFile(bundledFontPath.c_str(), PathType::internal, &dataSize))) {
         const std::string sysFontPath = systemFontPath(_family, _weight, _style);
-        if ( !(data = bytesFromFileSystem(sysFontPath.c_str(), &dataSize)) ) {
+        if ( !(data = bytesFromFile(sysFontPath.c_str(), PathType::absolute, &dataSize)) ) {
             return false;
         }
     }

--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -73,57 +73,55 @@ std::string setResourceRoot(const char* _path) {
 
 }
 
-NSString* resolveResourcePath(const char* _path) {
+NSString* resolvePath(const char* _path, PathType _type) {
 
     if (s_resourceRoot == NULL) {
         setResourceRoot(".");
     }
 
-    return [s_resourceRoot stringByAppendingPathComponent:[NSString stringWithUTF8String:_path]];
+    NSString* path = [NSString stringWithUTF8String:_path];
 
+    switch (_type) {
+    case PathType::internal:
+        return [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:path];
+    case PathType::resource:
+        return [s_resourceRoot stringByAppendingPathComponent:path];
+    case PathType::absolute:
+        return path;
+    }
 }
 
-std::string stringFromResource(const char* _path) {
+std::string stringFromFile(const char* _path, PathType _type) {
     
-    NSString* path = resolveResourcePath(_path);
+    NSString* path = resolvePath(_path, _type);
     NSString* str = [NSString stringWithContentsOfFile:path
                                               encoding:NSASCIIStringEncoding
                                                  error:NULL];
 
     if (str == nil) {
-        logMsg("Failed to read file at path: %s\n", _path);
+        logMsg("Failed to read file at path: %s\n", [path UTF8String]);
         return std::move(std::string());
     }
     
     return std::move(std::string([str UTF8String]));
 }
 
-unsigned char* bytesFromResource(const char* _path, unsigned int* _size) {
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {
 
-    NSString* path = resolveResourcePath(_path);
-    std::ifstream resource([path UTF8String], std::ifstream::ate | std::ifstream::binary);
+    NSString* path = resolvePath(_path, _type);
+    NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
-    if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", _path);
+    if (data == nil) {
+        logMsg("Failed to read file at path: %s\n", [path UTF8String]);
         *_size = 0;
         return nullptr;
     }
 
-    *_size = (unsigned int)resource.tellg();
+    *_size = data.length;
+    unsigned char* ptr = (unsigned char*)malloc(*_size);
+    [data getBytes:ptr length:*_size];
 
-    resource.seekg(std::ifstream::beg);
-
-    char* cdata = (char*) malloc(sizeof(char) * (*_size));
-
-    resource.read(cdata, *_size);
-    resource.close();
-
-    return reinterpret_cast<unsigned char *>(cdata);
-}
-
-// Does not provide implementation for this (yet!)
-unsigned char* bytesFromFileSystem(const char* _path, unsigned int* _size) {
-    return nullptr;
+    return ptr;
 }
 
 // No system fonts implementation (yet!)

--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -100,10 +100,10 @@ std::string stringFromFile(const char* _path, PathType _type) {
 
     if (str == nil) {
         logMsg("Failed to read file at path: %s\n", [path UTF8String]);
-        return std::move(std::string());
+        return std::string();
     }
     
-    return std::move(std::string([str UTF8String]));
+    return std::string([str UTF8String]);
 }
 
 unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -91,31 +91,36 @@ std::string setResourceRoot(const char* _path) {
 
 }
 
-std::string stringFromResource(const char* _path) {
+std::string resolvePath(const char* _path, PathType _type) {
+
+    switch (_type) {
+    case PathType::absolute:
+    case PathType::internal:
+        return std::string(_path);
+    case PathType::resource:
+        return s_resourceRoot + _path;
+    }
+}
+
+std::string stringFromFile(const char* _path, PathType _type) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromResource(_path, &length);
+    unsigned char* bytes = bytesFromFile(_path, _type, &length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
 
     return out;
-
 }
 
-unsigned char* bytesFromResource(const char* _path, unsigned int* _size) {
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {
 
-    std::string path = s_resourceRoot + _path;
-    return bytesFromFileSystem(path.c_str(), _size);
+    std::string path = resolvePath(_path, _type);
 
-}
-
-unsigned char* bytesFromFileSystem(const char* _path, unsigned int* _size) {
-
-    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
+    std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", _path);
+        logMsg("Failed to read file at path: %s\n", path.c_str());
         *_size = 0;
         return nullptr;
     }

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -85,10 +85,10 @@ std::string stringFromFile(const char* _path, PathType _type) {
 
     if (str == nil) {
         LOGW("Failed to read file at path: %s", [path UTF8String]);
-        return std::move(std::string());
+        return std::string();
     }
     
-    return std::move(std::string([str UTF8String]));
+    return std::string([str UTF8String]);
 }
 
 unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -82,31 +82,36 @@ std::string setResourceRoot(const char* _path) {
 
 }
 
-std::string stringFromResource(const char* _path) {
+std::string resolvePath(const char* _path, PathType _type) {
+
+    switch (_type) {
+    case PathType::absolute:
+    case PathType::internal:
+        return std::string(_path);
+    case PathType::resource:
+        return s_resourceRoot + _path;
+    }
+}
+
+std::string stringFromFile(const char* _path, PathType _type) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromResource(_path, &length);
+    unsigned char* bytes = bytesFromFile(_path, _type, &length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
 
     return out;
-
 }
 
-unsigned char* bytesFromResource(const char* _path, unsigned int* _size) {
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {
 
-    std::string path = s_resourceRoot + _path;
-    return bytesFromFileSystem(path.c_str(), _size);
+    std::string path = resolvePath(_path, _type);
 
-}
-
-unsigned char* bytesFromFileSystem(const char* _path, unsigned int* _size) {
-
-    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
+    std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", _path);
+        logMsg("Failed to read file at path: %s\n", path.c_str());
         *_size = 0;
         return nullptr;
     }

--- a/tests/unit/fileTests.cpp
+++ b/tests/unit/fileTests.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE( "Compare byte size of allocated resource to os file size", "[Core][bytesFromResource]" ) {
     unsigned int size;
-    unsigned char* data = bytesFromResource("shaders/polygon.fs", &size);
+    unsigned char* data = bytesFromFile("shaders/polygon.fs", PathType::internal, &size);
 
     // ask os for size
     struct stat st;

--- a/tests/unit/fontTests.cpp
+++ b/tests/unit/fontTests.cpp
@@ -38,7 +38,7 @@ FONScontext* initContext(void* _usrPtr) {
 
 int initFont(FONScontext* _context) {
     unsigned int dataSize;
-    unsigned char* data = bytesFromResource("fonts/Roboto-Regular.ttf", &dataSize);
+    unsigned char* data = bytesFromFile("fonts/Roboto-Regular.ttf", PathType::internal, &dataSize);
 
     return fonsAddFont(_context, "droid-serif", data, dataSize);
 }


### PR DESCRIPTION
This solves an issue with using scene files outside the application resource directory where tangram-internal files (like shaders) were trying to be located relative to the scene file, like all other resources. 

Now, whenever a file is accessed, you can specify whether the path is 'internal' (a bundled tangram file), 'absolute' (at an absolute path in the filesystem), or 'resource' (relative to the scene file).