### PR TITLE
Vertex array objects support

### DIFF
--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -2,6 +2,7 @@
 
 #include "platform.h"
 #include "tangram.h"
+#include "gl.h"
 
 #include <android/log.h>
 #include <android/asset_manager.h>
@@ -39,6 +40,10 @@ static AAssetManager* assetManager;
 static bool s_isContinuousRendering = false;
 static bool s_useInternalResources = true;
 static std::string s_resourceRoot;
+
+PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT = 0;
+PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
+PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOESEXT = 0;
 
 void setupJniEnv(JNIEnv* _jniEnv, jobject _tangramInstance, jobject _assetManager) {
     _jniEnv->GetJavaVM(&jvm);
@@ -291,6 +296,14 @@ void featureSelectionCallback(JNIEnv* jniEnv, const std::vector<Tangram::TouchIt
     jobject object = jniEnv->NewObject(propertiesClass, propertiesConstructorMID, jresult, true);
 
     jniEnv->CallVoidMethod(tangramInstance, featureSelectionCbMID, object);
+}
+
+void initGLExtensions() {
+    void* libhandle = dlopen("libGLESv2.so", RTLD_LAZY);
+
+    glBindVertexArrayOESEXT = (PFNGLBINDVERTEXARRAYOESPROC) dlsym(libhandle, "glBindVertexArrayOES");
+    glDeleteVertexArraysOESEXT = (PFNGLDELETEVERTEXARRAYSOESPROC) dlsym(libhandle, "glDeleteVertexArraysOES");
+    glGenVertexArraysOESEXT = (PFNGLGENVERTEXARRAYSOESPROC) dlsym(libhandle, "glGenVertexArraysOES");
 }
 
 

--- a/core/src/gl.h
+++ b/core/src/gl.h
@@ -6,12 +6,12 @@
 #endif
 
 #ifdef PLATFORM_ANDROID
+#include <GLES2/gl2platform.h>
 #ifndef GL_GLEXT_PROTOTYPES
 #define GL_GLEXT_PROTOTYPES 1
 #endif
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
-#include <GLES2/gl2platform.h>
 #endif
 
 #ifdef PLATFORM_IOS

--- a/core/src/gl.h
+++ b/core/src/gl.h
@@ -1,13 +1,26 @@
 #pragma once
 
+#if defined(PLATFORM_ANDROID) || defined(PLATFORM_IOS)
+#define glMapBuffer glMapBufferOES
+#define glUnmapBuffer glUnmapBufferOES
+#endif
+
 #ifdef PLATFORM_ANDROID
+#ifndef GL_GLEXT_PROTOTYPES
+#define GL_GLEXT_PROTOTYPES 1
+#endif
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+#include <GLES2/gl2platform.h>
 #endif
 
 #ifdef PLATFORM_IOS
 #include <OpenGLES/ES2/gl.h>
 #include <OpenGLES/ES2/glext.h>
+#endif
+
+#if defined(PLATFORM_ANDROID) || defined(PLATFORM_IOS)
+#define GL_WRITE_ONLY GL_WRITE_ONLY_OES
 #endif
 
 #ifdef PLATFORM_OSX
@@ -34,4 +47,6 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #endif
+
+#include "extension.h"
 

--- a/core/src/gl.h
+++ b/core/src/gl.h
@@ -12,11 +12,24 @@
 #endif
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+#include <dlfcn.h> // dlopen, dlsym
+
+extern PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT;
+extern PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT;
+extern PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOESEXT;
+
+#define glDeleteVertexArrays glDeleteVertexArraysOESEXT
+#define glGenVertexArrays glGenVertexArraysOESEXT
+#define glBindVertexArray glBindVertexArrayOESEXT
 #endif
 
 #ifdef PLATFORM_IOS
 #include <OpenGLES/ES2/gl.h>
 #include <OpenGLES/ES2/glext.h>
+
+#define glDeleteVertexArrays glDeleteVertexArraysOES
+#define glGenVertexArrays glGenVertexArraysOES
+#define glBindVertexArray glBindVertexArrayOES
 #endif
 
 #if defined(PLATFORM_ANDROID) || defined(PLATFORM_IOS)
@@ -31,6 +44,9 @@
  */
 #define glClearDepthf glClearDepth
 #define glDepthRangef glDepthRange
+#define glDeleteVertexArrays glDeleteVertexArraysAPPLE
+#define glGenVertexArrays glGenVertexArraysAPPLE
+#define glBindVertexArray glBindVertexArrayAPPLE
 #endif
 
 #ifdef PLATFORM_LINUX

--- a/core/src/gl.h
+++ b/core/src/gl.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#if defined(PLATFORM_OSX) || defined(PLATFORM_LINUX)
+#define DESKTOP_GL true
+#else
+#define DESKTOP_GL false
+#endif
+
 #if defined(PLATFORM_ANDROID) || defined(PLATFORM_IOS)
 #define glMapBuffer glMapBufferOES
 #define glUnmapBuffer glUnmapBufferOES

--- a/core/src/gl/extension.cpp
+++ b/core/src/gl/extension.cpp
@@ -15,7 +15,9 @@ bool supportsVAOs = false;
 static char* s_glExtensions;
 
 bool isAvailable(std::string _extension) {
-    return bool(s_glExtensions) ? strstr(s_glExtensions, _extension.c_str()) >= 0 : false;
+    return bool(s_glExtensions)
+      ? strstr(s_glExtensions, _extension.c_str()) != nullptr
+      : false;
 }
 
 void printAvailableExtensions() {

--- a/core/src/gl/extension.cpp
+++ b/core/src/gl/extension.cpp
@@ -38,6 +38,11 @@ void printAvailableExtensions() {
 void load() {
     s_glExtensions = (char*) glGetString(GL_EXTENSIONS);
 
+    if (s_glExtensions == NULL) {
+        LOGE("glGetString( GL_EXTENSIONS ) returned NULL");
+        return;
+    }
+
     supportsMapBuffer = isAvailable("mapbuffer");
     supportsVAOs = isAvailable("vertex_array_object");
 

--- a/core/src/gl/extension.cpp
+++ b/core/src/gl/extension.cpp
@@ -11,6 +11,7 @@ namespace Tangram {
 namespace GLExtensions {
 
 bool supportsMapBuffer = false;
+bool supportsVAOs = false;
 static char* s_glExtensions;
 
 bool isAvailable(std::string _extension) {
@@ -21,8 +22,13 @@ void load(bool _log) {
     s_glExtensions = (char*) glGetString(GL_EXTENSIONS);
 
     supportsMapBuffer = isAvailable("mapbuffer");
+    supportsVAOs = isAvailable("vertex_array_object");
 
-    LOG("Driver support map buffer %d", supportsMapBuffer);
+    LOG("Driver supports map buffer %d", supportsMapBuffer);
+    LOG("Driver supports vaos %d", supportsVAOs);
+
+    // find extension symbols if needed
+    initGLExtensions();
 
     if (!_log) {
         return;

--- a/core/src/gl/extension.cpp
+++ b/core/src/gl/extension.cpp
@@ -15,7 +15,7 @@ bool supportsVAOs = false;
 static char* s_glExtensions;
 
 bool isAvailable(std::string _extension) {
-    return strstr(s_glExtensions, _extension.c_str());
+    return bool(s_glExtensions) ? strstr(s_glExtensions, _extension.c_str()) >= 0 : false;
 }
 
 void printAvailableExtensions() {

--- a/core/src/gl/extension.cpp
+++ b/core/src/gl/extension.cpp
@@ -43,7 +43,7 @@ void load() {
         return;
     }
 
-    supportsMapBuffer = isAvailable("mapbuffer");
+    supportsMapBuffer = DESKTOP_GL || isAvailable("mapbuffer");
     supportsVAOs = isAvailable("vertex_array_object");
 
     LOG("Driver supports map buffer %d", supportsMapBuffer);

--- a/core/src/gl/extension.cpp
+++ b/core/src/gl/extension.cpp
@@ -18,7 +18,22 @@ bool isAvailable(std::string _extension) {
     return strstr(s_glExtensions, _extension.c_str());
 }
 
-void load(bool _log) {
+void printAvailableExtensions() {
+    std::string exts(s_glExtensions);
+    std::istringstream iss(exts);
+    std::vector<std::string> extensions;
+    auto s0 = std::istream_iterator<std::string>(iss);
+    auto s1 = std::istream_iterator<std::string>();
+
+    std::copy(s0, s1, back_inserter(extensions));
+
+    LOG("GL Extensions available: ");
+    for (auto ext : extensions) {
+        LOG("\t %s", ext.c_str());
+    }
+}
+
+void load() {
     s_glExtensions = (char*) glGetString(GL_EXTENSIONS);
 
     supportsMapBuffer = isAvailable("mapbuffer");
@@ -29,20 +44,6 @@ void load(bool _log) {
 
     // find extension symbols if needed
     initGLExtensions();
-
-    if (!_log) {
-        return;
-    }
-
-    std::string exts(s_glExtensions);
-    std::istringstream iss(exts);
-    std::vector<std::string> extensions;
-    std::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(), back_inserter(extensions));
-
-    LOG("GL Extensions available: ");
-    for (auto ext : extensions) {
-        LOG("\t %s", ext.c_str());
-    }
 }
 
 }

--- a/core/src/gl/extension.cpp
+++ b/core/src/gl/extension.cpp
@@ -1,0 +1,43 @@
+#include "extension.h"
+
+#include <cstring>
+#include <sstream>
+#include <algorithm>
+#include <iterator>
+#include "platform.h"
+#include "gl.h"
+
+namespace Tangram {
+namespace GLExtensions {
+
+bool supportsMapBuffer = false;
+static char* s_glExtensions;
+
+bool isAvailable(std::string _extension) {
+    return strstr(s_glExtensions, _extension.c_str());
+}
+
+void load(bool _log) {
+    s_glExtensions = (char*) glGetString(GL_EXTENSIONS);
+
+    supportsMapBuffer = isAvailable("mapbuffer");
+
+    LOG("Driver support map buffer %d", supportsMapBuffer);
+
+    if (!_log) {
+        return;
+    }
+
+    std::string exts(s_glExtensions);
+    std::istringstream iss(exts);
+    std::vector<std::string> extensions;
+    std::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(), back_inserter(extensions));
+
+    LOG("GL Extensions available: ");
+    for (auto ext : extensions) {
+        LOG("\t %s", ext.c_str());
+    }
+}
+
+}
+}

--- a/core/src/gl/extension.h
+++ b/core/src/gl/extension.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+namespace Tangram {
+namespace GLExtensions {
+
+extern bool supportsMapBuffer;
+    
+bool isAvailable(std::string _extension);
+void load(bool _log = false);
+
+}
+}

--- a/core/src/gl/extension.h
+++ b/core/src/gl/extension.h
@@ -6,6 +6,7 @@ namespace Tangram {
 namespace GLExtensions {
 
 extern bool supportsMapBuffer;
+extern bool supportsVAOs;
     
 bool isAvailable(std::string _extension);
 void load(bool _log = false);

--- a/core/src/gl/extension.h
+++ b/core/src/gl/extension.h
@@ -9,7 +9,8 @@ extern bool supportsMapBuffer;
 extern bool supportsVAOs;
     
 bool isAvailable(std::string _extension);
-void load(bool _log = false);
+void load();
+void printAvailableExtensions();
 
 }
 }

--- a/core/src/gl/typedMesh.h
+++ b/core/src/gl/typedMesh.h
@@ -42,7 +42,6 @@ public:
      */
     template<class A>
     void updateAttribute(Range _vertexRange, const A& _newAttributeValue, size_t _attribOffset = 0) {
-        return;
         if (m_glVertexData == nullptr) {
             assert(false);
             return;

--- a/core/src/gl/typedMesh.h
+++ b/core/src/gl/typedMesh.h
@@ -42,6 +42,7 @@ public:
      */
     template<class A>
     void updateAttribute(Range _vertexRange, const A& _newAttributeValue, size_t _attribOffset = 0) {
+        return;
         if (m_glVertexData == nullptr) {
             assert(false);
             return;

--- a/core/src/gl/vao.cpp
+++ b/core/src/gl/vao.cpp
@@ -26,8 +26,15 @@ void Vao::init(ShaderProgram& _program, const std::vector<std::pair<uint32_t, ui
 
     glGenVertexArrays(m_glnVAOs, m_glVAOs);
 
-    int vertexOffset = 0;
+    std::unordered_map<std::string, GLuint> locations;
 
+    // FIXME (use a bindAttrib instead of getLocation) to make those locations shader independent
+    for (auto& attrib : _layout.getAttribs()) {
+        GLint location = _program.getAttribLocation(attrib.name);
+        locations[attrib.name] = location;
+    }
+
+    int vertexOffset = 0;
     for (int i = 0; i < _vertexOffsets.size(); ++i) {
         auto vertexIndexOffset = _vertexOffsets[i];
         int nVerts = vertexIndexOffset.second;
@@ -39,16 +46,8 @@ void Vao::init(ShaderProgram& _program, const std::vector<std::pair<uint32_t, ui
             RenderState::indexBuffer.init(_indexBuffer, true);
         }
 
-        std::unordered_map<std::string, GLuint> locations;
-
-        // FIXME (use a bindAttrib instead of getLocation) to make those locations shader independent
-        for (auto& attrib : _layout.getAttribs()) {
-            GLint location = _program.getAttribLocation(attrib.name);
-            locations[attrib.name] = location;
-        }
-
         // Enable vertex layout on the specified locations
-        _layout.enable(locations, vertexOffset);
+        _layout.enable(locations, vertexOffset * _layout.getStride());
 
         vertexOffset += nVerts;
     }

--- a/core/src/gl/vao.cpp
+++ b/core/src/gl/vao.cpp
@@ -1,0 +1,69 @@
+#include "vao.h"
+#include "renderState.h"
+#include "shaderProgram.h"
+#include "vertexLayout.h"
+#include <unordered_map>
+
+namespace Tangram {
+
+Vao::Vao() {
+    m_glVAOs = nullptr;
+    m_glnVAOs = 0;
+}
+
+Vao::~Vao() {
+    if (m_glVAOs) {
+        glDeleteVertexArrays(m_glnVAOs, m_glVAOs);
+        delete[] m_glVAOs;
+    }
+}
+
+void Vao::init(ShaderProgram& _program, const std::vector<std::pair<uint32_t, uint32_t>>& _vertexOffsets,
+               VertexLayout& _layout, GLuint _vertexBuffer, GLuint _indexBuffer) {
+
+    m_glnVAOs = _vertexOffsets.size();
+    m_glVAOs = new GLuint[m_glnVAOs];
+
+    glGenVertexArrays(m_glnVAOs, m_glVAOs);
+
+    int vertexOffset = 0;
+
+    for (int i = 0; i < _vertexOffsets.size(); ++i) {
+        auto vertexIndexOffset = _vertexOffsets[i];
+        int nVerts = vertexIndexOffset.second;
+        glBindVertexArray(m_glVAOs[i]);
+
+        RenderState::vertexBuffer.init(_vertexBuffer, true);
+
+        if (_indexBuffer != -1) {
+            RenderState::indexBuffer.init(_indexBuffer, true);
+        }
+
+        std::unordered_map<std::string, GLuint> locations;
+
+        // FIXME (use a bindAttrib instead of getLocation) to make those locations shader independent
+        for (auto& attrib : _layout.getAttribs()) {
+            GLint location = _program.getAttribLocation(attrib.name);
+            locations[attrib.name] = location;
+        }
+
+        // Enable vertex layout on the specified locations
+        _layout.enable(locations, vertexOffset);
+
+        vertexOffset += nVerts;
+    }
+
+}
+
+void Vao::bind(unsigned int _index) {
+    if (_index < m_glnVAOs) {
+        glBindVertexArray(m_glVAOs[_index]);
+    }
+}
+
+void Vao::unbind() {
+    glBindVertexArray(0);
+}
+
+}
+

--- a/core/src/gl/vao.h
+++ b/core/src/gl/vao.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "gl.h"
+#include <vector>
+#include <string>
+
+namespace Tangram {
+
+class ShaderProgram;
+class VertexLayout;
+
+class Vao {
+
+public:
+    Vao();
+    ~Vao();
+
+    void init(ShaderProgram& _program, const std::vector<std::pair<uint32_t, uint32_t>>& _vertexOffsets,
+              VertexLayout& _layout, GLuint _vertexBuffer, GLuint _indexBuffer);
+
+    void bind(unsigned int _index);
+    void unbind();
+
+private:
+    GLuint* m_glVAOs;
+    GLuint m_glnVAOs;
+
+};
+
+}
+

--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -179,10 +179,10 @@ void VboMesh::draw(ShaderProgram& _shader) {
             glGenVertexArrays(1, &m_glVAO);
             glBindVertexArray(m_glVAO);
 
-            RenderState::vertexBuffer.init(m_glVertexBuffer);
+            RenderState::vertexBuffer.init(m_glVertexBuffer, true);
 
             if (m_nIndices > 0) {
-                RenderState::indexBuffer.init(m_glIndexBuffer);
+                RenderState::indexBuffer.init(m_glIndexBuffer, true);
             }
 
             for (auto& attrib : m_vertexLayout->getAttribs()) {

--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -41,7 +41,7 @@ VboMesh::~VboMesh() {
         glDeleteBuffers(1, &m_glIndexBuffer);
     }
     if (m_glVAOs) {
-        glDeleteVertexArrays(m_vertexOffsets.size(), m_glVAOs);
+        glDeleteVertexArrays(m_glnVAOs, m_glVAOs);
         delete[] m_glVAOs;
     }
 
@@ -156,8 +156,9 @@ void VboMesh::upload() {
 }
 
 void VboMesh::initVAO(ShaderProgram& _shader) {
-    m_glVAOs = new GLuint[m_vertexOffsets.size()];
-    glGenVertexArrays(m_vertexOffsets.size(), m_glVAOs);
+    m_glnVAOs = m_vertexOffsets.size();
+    m_glVAOs = new GLuint[m_glnVAOs];
+    glGenVertexArrays(m_glnVAOs, m_glVAOs);
     int vertexOffset = 0;
 
     for (int i = 0; i < m_vertexOffsets.size(); ++i) {

--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -169,13 +169,13 @@ void VboMesh::draw(ShaderProgram& _shader) {
         subDataUpload();
     }
 
-    if (GLExtensions::supportsVAOs) {
-        if (!m_vaos) {
-            m_vaos = std::unique_ptr<Vao>(new Vao());
-            // Capture vao state
-            GLuint indexBuffer = m_nIndices > 0 ? m_glIndexBuffer : -1;
-            m_vaos->init(_shader, m_vertexOffsets, *m_vertexLayout, m_glVertexBuffer, indexBuffer);
-        }
+    if (GLExtensions::supportsVAOs && !m_vaos) {
+        m_vaos = std::make_unique<Vao>();
+
+        // Capture vao state
+        GLuint indexBuffer = m_nIndices > 0 ? m_glIndexBuffer : -1;
+
+        m_vaos->init(_shader, m_vertexOffsets, *m_vertexLayout, m_glVertexBuffer, indexBuffer);
     } else {
         // Bind buffers for drawing
         RenderState::vertexBuffer(m_glVertexBuffer);

--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -82,12 +82,23 @@ void VboMesh::subDataUpload() {
     // when all vertices are modified, it's better to update the entire mesh
     if (vertexBytes - m_dirtySize < m_vertexLayout->getStride()) {
 
-        // invalidate the data store on the driver
-        glBufferData(GL_ARRAY_BUFFER, vertexBytes, NULL, m_hint);
+        if (GLExtensions::supportsMapBuffer) {
+            glBufferData(GL_ARRAY_BUFFER, vertexBytes, NULL, m_hint);
+            GLvoid* dataStore = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
 
-        // if this buffer is still used by gpu on current frame this call will not wait
-        // for the frame to finish using the vbo but "directly" send command to upload the data
-        glBufferData(GL_ARRAY_BUFFER, vertexBytes, m_glVertexData, m_hint);
+            // write memory client side
+            std::memcpy(dataStore, m_glVertexData, vertexBytes);
+
+            glUnmapBuffer(GL_ARRAY_BUFFER);
+        } else {
+
+            // invalidate the data store on the driver
+            glBufferData(GL_ARRAY_BUFFER, vertexBytes, NULL, m_hint);
+
+            // if this buffer is still used by gpu on current frame this call will not wait
+            // for the frame to finish using the vbo but "directly" send command to upload the data
+            glBufferData(GL_ARRAY_BUFFER, vertexBytes, m_glVertexData, m_hint);
+        }
     } else {
         // perform simple sub data upload for part of the buffer
         glBufferSubData(GL_ARRAY_BUFFER, m_dirtyOffset, m_dirtySize, m_glVertexData + m_dirtyOffset);

--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -79,28 +79,27 @@ void VboMesh::subDataUpload() {
 
     long vertexBytes = m_nVertices * m_vertexLayout->getStride();
 
-    // when all vertices are modified, it's better to update the entire mesh
-    if (vertexBytes - m_dirtySize < m_vertexLayout->getStride()) {
-
+    if (GLExtensions::supportsMapBuffer) {
         // invalidate/orphane the data store on the driver
         glBufferData(GL_ARRAY_BUFFER, vertexBytes, NULL, m_hint);
+        GLvoid* dataStore = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
 
-        if (GLExtensions::supportsMapBuffer) {
-            GLvoid* dataStore = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        // write memory client side
+        std::memcpy(dataStore, m_glVertexData, vertexBytes);
 
-            // write memory client side
-            std::memcpy(dataStore, m_glVertexData, vertexBytes);
-
-            glUnmapBuffer(GL_ARRAY_BUFFER);
-        } else {
-
+        glUnmapBuffer(GL_ARRAY_BUFFER);
+    } else {
+        // when all vertices are modified, it's better to update the entire mesh
+        if (vertexBytes - m_dirtySize < m_vertexLayout->getStride()) {
+            // invalidate/orphane the data store on the driver
+            glBufferData(GL_ARRAY_BUFFER, vertexBytes, NULL, m_hint);
             // if this buffer is still used by gpu on current frame this call will not wait
             // for the frame to finish using the vbo but "directly" send command to upload the data
             glBufferData(GL_ARRAY_BUFFER, vertexBytes, m_glVertexData, m_hint);
+        } else {
+            // perform simple sub data upload for part of the buffer
+            glBufferSubData(GL_ARRAY_BUFFER, m_dirtyOffset, m_dirtySize, m_glVertexData + m_dirtyOffset);
         }
-    } else {
-        // perform simple sub data upload for part of the buffer
-        glBufferSubData(GL_ARRAY_BUFFER, m_dirtyOffset, m_dirtySize, m_glVertexData + m_dirtyOffset);
     }
 
     m_dirtyOffset = 0;

--- a/core/src/gl/vboMesh.h
+++ b/core/src/gl/vboMesh.h
@@ -91,7 +91,8 @@ protected:
 
     size_t m_nVertices;
     GLuint m_glVertexBuffer;
-    GLuint m_glVAO;
+    GLuint* m_glVAOs;
+    GLuint m_glnVAOs;
     // Compiled vertices for upload
     GLbyte* m_glVertexData = nullptr;
 
@@ -112,6 +113,8 @@ protected:
     GLintptr m_dirtyOffset;
 
     void checkValidity();
+
+    void initVAO(ShaderProgram& _shader);
 
     template <typename T>
     void compile(std::vector<std::vector<T>>& _vertices,

--- a/core/src/gl/vboMesh.h
+++ b/core/src/gl/vboMesh.h
@@ -3,6 +3,7 @@
 #include "gl.h"
 #include "platform.h"
 #include "vertexLayout.h"
+#include "vao.h"
 
 #include <cstring> // for memcpy
 #include <vector>
@@ -91,8 +92,9 @@ protected:
 
     size_t m_nVertices;
     GLuint m_glVertexBuffer;
-    GLuint* m_glVAOs;
-    GLuint m_glnVAOs;
+
+    std::unique_ptr<Vao> m_vaos;
+
     // Compiled vertices for upload
     GLbyte* m_glVertexData = nullptr;
 

--- a/core/src/gl/vboMesh.h
+++ b/core/src/gl/vboMesh.h
@@ -114,9 +114,7 @@ protected:
     GLsizei m_dirtySize;
     GLintptr m_dirtyOffset;
 
-    void checkValidity();
-
-    void initVAO(ShaderProgram& _shader);
+    bool checkValidity();
 
     template <typename T>
     void compile(std::vector<std::vector<T>>& _vertices,

--- a/core/src/gl/vboMesh.h
+++ b/core/src/gl/vboMesh.h
@@ -91,6 +91,7 @@ protected:
 
     size_t m_nVertices;
     GLuint m_glVertexBuffer;
+    GLuint m_glVAO;
     // Compiled vertices for upload
     GLbyte* m_glVertexData = nullptr;
 

--- a/core/src/gl/vertexLayout.cpp
+++ b/core/src/gl/vertexLayout.cpp
@@ -56,7 +56,7 @@ size_t VertexLayout::getOffset(std::string _attribName) {
     return 0;
 }
 
-void VertexLayout::enable(const std::unordered_map<std::string, GLuint>& _locations, size_t _byteOffset, void* _ptr) {
+void VertexLayout::enable(const std::unordered_map<std::string, GLuint>& _locations, size_t _byteOffset) {
 
     for (auto& attrib : m_attribs) {
         auto it = _locations.find(attrib.name);

--- a/core/src/gl/vertexLayout.cpp
+++ b/core/src/gl/vertexLayout.cpp
@@ -45,7 +45,7 @@ VertexLayout::~VertexLayout() {
 }
 
 size_t VertexLayout::getOffset(std::string _attribName) {
-    
+
     for (auto& attrib : m_attribs) {
         if (attrib.name == _attribName) {
             return attrib.offset;
@@ -56,7 +56,27 @@ size_t VertexLayout::getOffset(std::string _attribName) {
     return 0;
 }
 
-void VertexLayout::enable(ShaderProgram& _program, size_t byteOffset, void* _ptr) {
+void VertexLayout::enable(const std::unordered_map<std::string, GLuint>& _locations, size_t _byteOffset, void* _ptr) {
+
+    for (auto& attrib : m_attribs) {
+        auto it = _locations.find(attrib.name);
+
+        if (it == _locations.end()) {
+            continue;
+        }
+
+        GLint location = it->second;;
+
+        if (location != -1) {
+            void* offset = ((unsigned char*) attrib.offset) + _byteOffset;
+            glEnableVertexAttribArray(location);
+            glVertexAttribPointer(location, attrib.size, attrib.type, attrib.normalized, m_stride, offset);
+        }
+    }
+
+}
+
+void VertexLayout::enable(ShaderProgram& _program, size_t _byteOffset, void* _ptr) {
 
     GLuint glProgram = _program.getGlProgram();
 
@@ -72,7 +92,7 @@ void VertexLayout::enable(ShaderProgram& _program, size_t byteOffset, void* _ptr
                 s_enabledAttribs[location] = glProgram;
             }
 
-            void* data = _ptr ? _ptr : ((unsigned char*) attrib.offset) + byteOffset;
+            void* data = _ptr ? _ptr : ((unsigned char*) attrib.offset) + _byteOffset;
             glVertexAttribPointer(location, attrib.size, attrib.type, attrib.normalized, m_stride, data);
         }
     }

--- a/core/src/gl/vertexLayout.h
+++ b/core/src/gl/vertexLayout.h
@@ -12,7 +12,7 @@ namespace Tangram {
 class ShaderProgram;
 
 class VertexLayout {
-    
+
 public:
 
     struct VertexAttrib {
@@ -27,12 +27,14 @@ public:
 
     virtual ~VertexLayout();
 
-    void enable(ShaderProgram& _program, size_t byteOffset, void* _ptr = nullptr);
+    void enable(ShaderProgram& _program, size_t _byteOffset, void* _ptr = nullptr);
+
+    void enable(const std::unordered_map<std::string, GLuint>& _locations, size_t _bytOffset, void* _ptr = nullptr);
 
     GLint getStride() const { return m_stride; };
 
     const std::vector<VertexAttrib> getAttribs() const { return m_attribs; }
-    
+
     size_t getOffset(std::string _attribName);
 
 private:

--- a/core/src/gl/vertexLayout.h
+++ b/core/src/gl/vertexLayout.h
@@ -30,6 +30,8 @@ public:
     void enable(ShaderProgram& _program, size_t byteOffset, void* _ptr = nullptr);
 
     GLint getStride() const { return m_stride; };
+
+    const std::vector<VertexAttrib> getAttribs() const { return m_attribs; }
     
     size_t getOffset(std::string _attribName);
 

--- a/core/src/gl/vertexLayout.h
+++ b/core/src/gl/vertexLayout.h
@@ -29,7 +29,7 @@ public:
 
     void enable(ShaderProgram& _program, size_t _byteOffset, void* _ptr = nullptr);
 
-    void enable(const std::unordered_map<std::string, GLuint>& _locations, size_t _bytOffset, void* _ptr = nullptr);
+    void enable(const std::unordered_map<std::string, GLuint>& _locations, size_t _bytOffset);
 
     GLint getStride() const { return m_stride; };
 

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -93,16 +93,16 @@ void LabelMesh::draw(ShaderProgram& _shader) {
 
     loadQuadIndices();
 
-    //if (GLExtensions::supportsVAOs) {
-    //    if (!m_vaos) {
-    //        m_vaos = std::make_unique<Vao>();
-    //        m_vaos->init(_shader, m_vertexOffsets, *m_vertexLayout, m_glVertexBuffer, s_quadIndexBuffer);
-    //    }
-    //} else {
+    if (GLExtensions::supportsVAOs) {
+        if (!m_vaos) {
+            m_vaos = std::make_unique<Vao>();
+            m_vaos->init(_shader, m_vertexOffsets, *m_vertexLayout, m_glVertexBuffer, s_quadIndexBuffer);
+        }
+    } else {
         // Bind buffers for drawing
         RenderState::vertexBuffer(m_glVertexBuffer);
         RenderState::indexBuffer(s_quadIndexBuffer);
-    //}
+    }
 
     // Enable shader program
     _shader.use();
@@ -114,23 +114,23 @@ void LabelMesh::draw(ShaderProgram& _shader) {
         uint32_t nIndices = o.first;
         uint32_t nVertices = o.second;
 
-        //if (!GLExtensions::supportsVAOs) {
+        if (!GLExtensions::supportsVAOs) {
             // Enable vertex attribs via vertex layout object
             size_t byteOffset = vertexOffset * m_vertexLayout->getStride();
             m_vertexLayout->enable(_shader, byteOffset);
-        //} else {
-        //    // Bind the corresponding vao relative to the current offset
-        //    m_vaos->bind(i);
-        //}
+        } else {
+            // Bind the corresponding vao relative to the current offset
+            m_vaos->bind(i);
+        }
 
         glDrawElements(m_drawMode, nIndices, GL_UNSIGNED_SHORT, 0);
 
         vertexOffset += nVertices;
     }
 
-    //if (GLExtensions::supportsVAOs) {
+    if (GLExtensions::supportsVAOs) {
         m_vaos->unbind();
-    //}
+    }
 }
 
 }

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -80,7 +80,6 @@ void LabelMesh::compileVertexBuffer() {
 }
 
 void LabelMesh::draw(ShaderProgram& _shader) {
-    return;
     checkValidity();
 
     if (!m_isCompiled) { return; }

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -79,7 +79,7 @@ void LabelMesh::compileVertexBuffer() {
 }
 
 void LabelMesh::draw(ShaderProgram& _shader) {
-    checkValidity();
+    bool valid = checkValidity();
 
     if (!m_isCompiled) { return; }
     if (m_nVertices == 0) { return; }
@@ -91,18 +91,13 @@ void LabelMesh::draw(ShaderProgram& _shader) {
         subDataUpload();
     }
 
-    loadQuadIndices();
-
-    if (GLExtensions::supportsVAOs) {
-        if (!m_vaos) {
-            m_vaos = std::make_unique<Vao>();
-            m_vaos->init(_shader, m_vertexOffsets, *m_vertexLayout, m_glVertexBuffer, s_quadIndexBuffer);
-        }
-    } else {
-        // Bind buffers for drawing
-        RenderState::vertexBuffer(m_glVertexBuffer);
-        RenderState::indexBuffer(s_quadIndexBuffer);
+    if (!valid) {
+        loadQuadIndices();
     }
+
+    // Bind buffers for drawing
+    RenderState::vertexBuffer(m_glVertexBuffer);
+    RenderState::indexBuffer(s_quadIndexBuffer);
 
     // Enable shader program
     _shader.use();
@@ -114,22 +109,13 @@ void LabelMesh::draw(ShaderProgram& _shader) {
         uint32_t nIndices = o.first;
         uint32_t nVertices = o.second;
 
-        if (!GLExtensions::supportsVAOs) {
-            // Enable vertex attribs via vertex layout object
-            size_t byteOffset = vertexOffset * m_vertexLayout->getStride();
-            m_vertexLayout->enable(_shader, byteOffset);
-        } else {
-            // Bind the corresponding vao relative to the current offset
-            m_vaos->bind(i);
-        }
+        size_t byteOffset = vertexOffset * m_vertexLayout->getStride();
+
+        m_vertexLayout->enable(_shader, byteOffset);
 
         glDrawElements(m_drawMode, nIndices, GL_UNSIGNED_SHORT, 0);
 
         vertexOffset += nVertices;
-    }
-
-    if (GLExtensions::supportsVAOs) {
-        m_vaos->unbind();
     }
 }
 

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -6,7 +6,6 @@
 namespace Tangram {
 
 static GLuint s_quadIndexBuffer = 0;
-static int s_quadGeneration = -1;
 
 const size_t maxVertices = 16384;
 
@@ -27,29 +26,22 @@ void LabelMesh::reset() {
 }
 
 void LabelMesh::loadQuadIndices() {
-    if (s_quadGeneration == s_validGeneration) {
-        RenderState::indexBuffer(s_quadIndexBuffer);
+    std::vector<GLushort> indices;
+    indices.reserve(maxVertices / 4 * 6);
 
-    } else {
-        s_quadGeneration = s_validGeneration;
-
-        std::vector<GLushort> indices;
-        indices.reserve(maxVertices / 4 * 6);
-
-        for (size_t i = 0; i < maxVertices; i += 4) {
-            indices.push_back(i + 2);
-            indices.push_back(i + 0);
-            indices.push_back(i + 1);
-            indices.push_back(i + 1);
-            indices.push_back(i + 3);
-            indices.push_back(i + 2);
-        }
-
-        glGenBuffers(1, &s_quadIndexBuffer);
-        RenderState::indexBuffer(s_quadIndexBuffer);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(GLushort),
-                     reinterpret_cast<GLbyte*>(indices.data()), GL_STATIC_DRAW);
+    for (size_t i = 0; i < maxVertices; i += 4) {
+        indices.push_back(i + 2);
+        indices.push_back(i + 0);
+        indices.push_back(i + 1);
+        indices.push_back(i + 1);
+        indices.push_back(i + 3);
+        indices.push_back(i + 2);
     }
+
+    glGenBuffers(1, &s_quadIndexBuffer);
+    RenderState::indexBuffer(s_quadIndexBuffer);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(GLushort),
+                 reinterpret_cast<GLbyte*>(indices.data()), GL_STATIC_DRAW);
 }
 
 void LabelMesh::compileVertexBuffer() {
@@ -80,7 +72,7 @@ void LabelMesh::compileVertexBuffer() {
 }
 
 void LabelMesh::draw(ShaderProgram& _shader) {
-    checkValidity();
+    bool valid = checkValidity();
 
     if (!m_isCompiled) { return; }
     if (m_nVertices == 0) { return; }
@@ -92,29 +84,49 @@ void LabelMesh::draw(ShaderProgram& _shader) {
         subDataUpload();
     }
 
-    // Bind buffers for drawing
-    RenderState::vertexBuffer(m_glVertexBuffer);
+    if (!valid) {
+        loadQuadIndices();
+    }
 
-    loadQuadIndices();
+    if (GLExtensions::supportsVAOs) {
+        if (!m_vaos) {
+            m_vaos = std::make_unique<Vao>();
+            m_vaos->init(_shader, m_vertexOffsets, *m_vertexLayout, m_glVertexBuffer, s_quadIndexBuffer);
+        }
+    } else {
+        // Bind buffers for drawing
+        RenderState::vertexBuffer(m_glVertexBuffer);
+        RenderState::indexBuffer(s_quadIndexBuffer);
+    }
 
     // Enable shader program
     _shader.use();
 
     size_t vertexOffset = 0;
 
-    for (auto& o : m_vertexOffsets) {
+    for (int i = 0; i < m_vertexOffsets.size(); ++i) {
+        auto& o = m_vertexOffsets[i];
         uint32_t nIndices = o.first;
         uint32_t nVertices = o.second;
 
-        size_t byteOffset = vertexOffset * m_vertexLayout->getStride();
-
-        // Enable vertex attribs via vertex layout object
-        m_vertexLayout->enable(_shader, byteOffset);
+        if (!GLExtensions::supportsVAOs) {
+            // Enable vertex attribs via vertex layout object
+            size_t byteOffset = vertexOffset * m_vertexLayout->getStride();
+            m_vertexLayout->enable(_shader, byteOffset);
+        } else {
+            // Bind the corresponding vao relative to the current offset
+            m_vaos->bind(i);
+        }
 
         glDrawElements(m_drawMode, nIndices, GL_UNSIGNED_SHORT, 0);
 
         vertexOffset += nVertices;
     }
+
+    if (GLExtensions::supportsVAOs) {
+        m_vaos->unbind();
+    }
 }
 
 }
+

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -27,6 +27,7 @@ void LabelMesh::reset() {
 }
 
 void LabelMesh::loadQuadIndices() {
+    return;
     if (s_quadGeneration == s_validGeneration) {
         RenderState::indexBuffer(s_quadIndexBuffer);
 
@@ -53,7 +54,7 @@ void LabelMesh::loadQuadIndices() {
 }
 
 void LabelMesh::compileVertexBuffer() {
-
+    return;
     size_t sumVertices = 0;
     int stride = m_vertexLayout->getStride();
     m_glVertexData = new GLbyte[stride * m_nVertices];
@@ -81,7 +82,7 @@ void LabelMesh::compileVertexBuffer() {
 }
 
 void LabelMesh::draw(ShaderProgram& _shader) {
-
+    return;
     checkValidity();
 
     if (!m_isCompiled) { return; }

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -27,7 +27,6 @@ void LabelMesh::reset() {
 }
 
 void LabelMesh::loadQuadIndices() {
-    return;
     if (s_quadGeneration == s_validGeneration) {
         RenderState::indexBuffer(s_quadIndexBuffer);
 
@@ -54,7 +53,6 @@ void LabelMesh::loadQuadIndices() {
 }
 
 void LabelMesh::compileVertexBuffer() {
-    return;
     size_t sumVertices = 0;
     int stride = m_vertexLayout->getStride();
     m_glVertexData = new GLbyte[stride * m_nVertices];

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -6,6 +6,7 @@
 namespace Tangram {
 
 static GLuint s_quadIndexBuffer = 0;
+static int s_quadGeneration = -1;
 
 const size_t maxVertices = 16384;
 
@@ -26,6 +27,12 @@ void LabelMesh::reset() {
 }
 
 void LabelMesh::loadQuadIndices() {
+    if (s_quadGeneration == s_validGeneration) {
+        return;
+    }
+
+    s_quadGeneration = s_validGeneration;
+
     std::vector<GLushort> indices;
     indices.reserve(maxVertices / 4 * 6);
 
@@ -72,7 +79,7 @@ void LabelMesh::compileVertexBuffer() {
 }
 
 void LabelMesh::draw(ShaderProgram& _shader) {
-    bool valid = checkValidity();
+    checkValidity();
 
     if (!m_isCompiled) { return; }
     if (m_nVertices == 0) { return; }
@@ -84,20 +91,18 @@ void LabelMesh::draw(ShaderProgram& _shader) {
         subDataUpload();
     }
 
-    if (!valid) {
-        loadQuadIndices();
-    }
+    loadQuadIndices();
 
-    if (GLExtensions::supportsVAOs) {
-        if (!m_vaos) {
-            m_vaos = std::make_unique<Vao>();
-            m_vaos->init(_shader, m_vertexOffsets, *m_vertexLayout, m_glVertexBuffer, s_quadIndexBuffer);
-        }
-    } else {
+    //if (GLExtensions::supportsVAOs) {
+    //    if (!m_vaos) {
+    //        m_vaos = std::make_unique<Vao>();
+    //        m_vaos->init(_shader, m_vertexOffsets, *m_vertexLayout, m_glVertexBuffer, s_quadIndexBuffer);
+    //    }
+    //} else {
         // Bind buffers for drawing
         RenderState::vertexBuffer(m_glVertexBuffer);
         RenderState::indexBuffer(s_quadIndexBuffer);
-    }
+    //}
 
     // Enable shader program
     _shader.use();
@@ -109,23 +114,23 @@ void LabelMesh::draw(ShaderProgram& _shader) {
         uint32_t nIndices = o.first;
         uint32_t nVertices = o.second;
 
-        if (!GLExtensions::supportsVAOs) {
+        //if (!GLExtensions::supportsVAOs) {
             // Enable vertex attribs via vertex layout object
             size_t byteOffset = vertexOffset * m_vertexLayout->getStride();
             m_vertexLayout->enable(_shader, byteOffset);
-        } else {
-            // Bind the corresponding vao relative to the current offset
-            m_vaos->bind(i);
-        }
+        //} else {
+        //    // Bind the corresponding vao relative to the current offset
+        //    m_vaos->bind(i);
+        //}
 
         glDrawElements(m_drawMode, nIndices, GL_UNSIGNED_SHORT, 0);
 
         vertexOffset += nVertices;
     }
 
-    if (GLExtensions::supportsVAOs) {
+    //if (GLExtensions::supportsVAOs) {
         m_vaos->unbind();
-    }
+    //}
 }
 
 }

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -106,6 +106,8 @@ void cancelUrlRequest(const std::string& _url);
  */
 void setCurrentThreadPriority(int priority);
 
+void initGLExtensions();
+
 /* Log utilities */
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -422,9 +422,13 @@ void setupGL() {
     // Reconfigure the render states
     RenderState::configure();
 
+    // Set default primitive render color
     Primitives::setColor(0xffffff);
 
-    GLExtensions::load(true);
+    // Load GL extensions
+    GLExtensions::load();
+
+    GLExtensions::printAvailableExtensions();
 
     while (Error::hadGlError("Tangram::setupGL()")) {}
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -424,6 +424,8 @@ void setupGL() {
 
     Primitives::setColor(0xffffff);
 
+    GLExtensions::load(true);
+
     while (Error::hadGlError("Tangram::setupGL()")) {}
 }
 

--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -177,4 +177,6 @@ void cancelUrlRequest(const std::string& _url) {
 
 void setCurrentThreadPriority(int priority) {}
 
+void initGLExtensions() {}
+
 #endif //PLATFORM_IOS

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -179,4 +179,6 @@ void setCurrentThreadPriority(int priority){
     //logMsg("set niceness: %d -> %d\n", p1, p2);
 }
 
+void initGLExtensions() {}
+
 #endif

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -18,6 +18,10 @@
 
 #define NUM_WORKERS 3
 
+PFNGLBINDVERTEXARRAYPROC glBindVertexArrayOESEXT = 0;
+PFNGLDELETEVERTEXARRAYSPROC glDeleteVertexArraysOESEXT = 0;
+PFNGLGENVERTEXARRAYSPROC glGenVertexArraysOESEXT = 0;
+
 static bool s_isContinuousRendering = false;
 static std::string s_resourceRoot;
 
@@ -100,6 +104,7 @@ std::string resolvePath(const char* _path, PathType _type) {
     case PathType::resource:
         return s_resourceRoot + _path;
     }
+    return "";
 }
 
 std::string stringFromFile(const char* _path, PathType _type) {
@@ -179,6 +184,11 @@ void setCurrentThreadPriority(int priority){
     //logMsg("set niceness: %d -> %d\n", p1, p2);
 }
 
-void initGLExtensions() {}
+void initGLExtensions() {
+     glBindVertexArrayOESEXT = (PFNGLBINDVERTEXARRAYPROC)glfwGetProcAddress("glBindVertexArray");
+     glDeleteVertexArraysOESEXT = (PFNGLDELETEVERTEXARRAYSPROC)glfwGetProcAddress("glDeleteVertexArrays");
+     glGenVertexArraysOESEXT = (PFNGLGENVERTEXARRAYSPROC)glfwGetProcAddress("glGenVertexArrays");
+
+}
 
 #endif

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -175,4 +175,6 @@ void setCurrentThreadPriority(int priority) {
     setpriority(PRIO_PROCESS, tid, priority);
 }
 
+void initGLExtensions() {}
+
 #endif //PLATFORM_OSX

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -162,4 +162,6 @@ void cancelUrlRequest(const std::string& _url) {
 
 void setCurrentThreadPriority(int priority) {}
 
+void initGLExtensions() {}
+
 #endif


### PR DESCRIPTION
Add support for VAOs with appropriate fallbacks when extension is not available.
VAOs are supported by ~63% of mobile devices according to [this dataset](http://delphigl.de/glcapsviewer/gles_extensions.php). 

The current frame trace before and after VAO support:
<img width="160" alt="screen shot 2015-10-05 at 3 13 23 pm" src="https://cloud.githubusercontent.com/assets/7061573/10290703/ae870676-6b73-11e5-89e0-60142b9076a8.png">
<img width="148" alt="screen shot 2015-10-05 at 3 13 32 pm" src="https://cloud.githubusercontent.com/assets/7061573/10290704/af976dc6-6b73-11e5-8e42-3d7107a36286.png">
By adding VAO binding to the render states, this trace would get even better.

This reduces GL calls whenever this extension is available, and remove the map access bottleneck when enabling the vertex layout that was pretty important.

Also add support for virtual pinned memory on client side for faster dynamic meshes update using `glMapBuffers`.

- [ ] Update label mesh to use VAOs
- [x] Fix byteOffset usage for VAOs
- [ ] Make VAO usage shader independent