### PR TITLE
Vertex pipeline is compatible with web renderer

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -43,7 +43,7 @@ styles:
         lighting: vertex
         shaders:
             blocks:
-                color: "color.rgb += vec3(0.3 * position.z * exp2(16. - abs(u_tile_origin.z)));"
+                color: "color.rgb += vec3(position.z / 800.);"
     heightglowline:
         base: lines
         mix: heightglow

--- a/core/resources/shaders/point.fs
+++ b/core/resources/shaders/point.fs
@@ -9,17 +9,17 @@ precision mediump float;
 
 #pragma tangram: defines
 
-varying float v_alpha;
-varying vec2 v_texcoords;
-varying vec4 v_color;
-
-#pragma tangram: uniforms
-
 uniform vec3 u_map_position;
 uniform vec3 u_tile_origin;
 uniform vec2 u_resolution;
 uniform float u_time;
 uniform float u_meters_per_pixel;
+
+#pragma tangram: uniforms
+
+varying vec4 v_color;
+varying vec2 v_texcoords;
+varying float v_alpha;
 
 #ifndef TANGRAM_POINT
 uniform sampler2D u_tex;

--- a/core/resources/shaders/point.vs
+++ b/core/resources/shaders/point.vs
@@ -9,15 +9,7 @@ precision mediump float;
 
 #pragma tangram: defines
 
-attribute LOWP vec2 a_position;
-attribute LOWP vec2 a_screenPosition;
-attribute vec2 a_uv;
-attribute LOWP float a_alpha;
-attribute LOWP float a_rotation;
-attribute LOWP vec4 a_color;
-attribute LOWP vec4 a_stroke;
-
-uniform mat4 u_proj;
+uniform mat4 u_ortho;
 uniform vec3 u_map_position;
 uniform vec3 u_tile_origin;
 uniform vec2 u_resolution;
@@ -26,11 +18,19 @@ uniform float u_meters_per_pixel;
 
 #pragma tangram: uniforms
 
-varying float v_alpha;
-varying vec2 v_texcoords;
+attribute vec2 a_uv;
+attribute LOWP vec2 a_position;
+attribute LOWP vec2 a_screenPosition;
+attribute LOWP float a_alpha;
+attribute LOWP float a_rotation;
+attribute LOWP vec4 a_color;
+attribute LOWP vec4 a_stroke;
+
 varying vec4 v_color;
 varying vec4 v_strokeColor;
+varying vec2 v_texcoords;
 varying float v_strokeWidth;
+varying float v_alpha;
 
 #pragma tangram: global
 
@@ -54,7 +54,7 @@ void main() {
 
         #pragma tangram: position
 
-        gl_Position = u_proj * position;
+        gl_Position = u_ortho * position;
     } else {
         gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
     }

--- a/core/resources/shaders/polygon.fs
+++ b/core/resources/shaders/polygon.fs
@@ -6,8 +6,9 @@ precision highp float;
 
 #pragma tangram: defines
 
-uniform mat4 u_modelView;
-uniform mat4 u_modelViewProj;
+uniform mat4 u_model;
+uniform mat4 u_view;
+uniform mat4 u_proj;
 uniform mat3 u_normalMatrix;
 uniform vec2 u_resolution;
 uniform vec3 u_map_position;
@@ -15,8 +16,9 @@ uniform float u_time;
 
 #pragma tangram: uniforms
 
+varying vec4 v_world_position;
+varying vec4 v_position;
 varying vec4 v_color;
-varying vec3 v_eyeToPoint;
 varying vec3 v_normal;
 varying vec2 v_texcoord;
 
@@ -45,7 +47,7 @@ void main(void) {
     #endif
 
     #ifdef TANGRAM_LIGHTING_FRAGMENT
-        color = calculateLighting(v_eyeToPoint.xyz, normal, color);
+        color = calculateLighting(v_position.xyz, normal, color);
     #else
         #ifdef TANGRAM_LIGHTING_VERTEX
             color = v_lighting;

--- a/core/resources/shaders/polygon.vs
+++ b/core/resources/shaders/polygon.vs
@@ -39,11 +39,7 @@ vec4 modelPosition() {
 }
 
 vec4 worldPosition() {
-    vec4 worldPosition = a_position * u_model + vec4(u_map_position.xy, 0., 1.);
-    #ifdef TANGRAM_WORLD_POSITION_WRAP
-        worldPosition = mod(worldPosition, TANGRAM_WORLD_POSITION_WRAP);
-    #endif
-    return worldPosition;
+    return v_world_position;
 }
 
 #pragma tangram: material
@@ -56,11 +52,17 @@ void main() {
 
     v_color = a_color;
     v_texcoord = a_texcoord;
-    v_world_position = worldPosition();
     v_normal = normalize(u_normalMatrix * a_normal);
 
     // Transform position into meters relative to map center
     position = u_model * position;
+
+    // World coordinates for 3d procedural textures
+    vec4 local_origin = vec4(u_map_position.xy, 0., 0.);
+    #ifdef TANGRAM_WORLD_POSITION_WRAP
+        local_origin = mod(local_origin, TANGRAM_WORLD_POSITION_WRAP);
+    #endif
+    v_world_position = position + local_origin;
 
     // Modify position before lighting and camera projection
     #pragma tangram: position

--- a/core/resources/shaders/polygon.vs
+++ b/core/resources/shaders/polygon.vs
@@ -87,7 +87,7 @@ void main() {
 
     gl_Position = u_proj * v_position;
     
-    // Proxy tiles have u_tile_zoom < 0, so this re-scaling will place proxy tiles deeper in
+    // Proxy tiles have u_tile_origin.z < 0, so this re-scaling will place proxy tiles deeper in
     // the depth buffer than non-proxy tiles by a distance that increases with tile zoom
     gl_Position.z /= 1. + .1 * (abs(u_tile_origin.z) - u_tile_origin.z);
     

--- a/core/resources/shaders/polyline.fs
+++ b/core/resources/shaders/polyline.fs
@@ -6,8 +6,9 @@ precision highp float;
 
 #pragma tangram: defines
 
-uniform mat4 u_modelView;
-uniform mat4 u_modelViewProj;
+uniform mat4 u_model;
+uniform mat4 u_view;
+uniform mat4 u_proj;
 uniform mat3 u_normalMatrix;
 uniform vec3 u_map_position;
 uniform vec3 u_tile_origin;
@@ -17,8 +18,9 @@ uniform float u_meters_per_pixel;
 
 #pragma tangram: uniforms
 
+varying vec4 v_world_position;
+varying vec4 v_position;
 varying vec4 v_color;
-varying vec3 v_eyeToPoint;
 varying vec3 v_normal;
 varying vec2 v_texcoord;
 
@@ -47,7 +49,7 @@ void main(void) {
     #endif
 
     #ifdef TANGRAM_LIGHTING_FRAGMENT
-        color = calculateLighting(v_eyeToPoint.xyz, normal, color);
+        color = calculateLighting(v_position.xyz, normal, color);
     #else
         #ifdef TANGRAM_LIGHTING_VERTEX
             color = v_lighting;

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -6,8 +6,6 @@ precision highp float;
 
 #pragma tangram: defines
 
-#define TANGRAM_WORLD_POSITION_WRAP 100000.0
-
 uniform mat4 u_model;
 uniform mat4 u_view;
 uniform mat4 u_proj;
@@ -104,7 +102,7 @@ void main() {
 
     gl_Position = u_proj * v_position;
     
-    // Proxy tiles have u_tile_zoom < 0, so this re-scaling will place proxy tiles deeper in
+    // Proxy tiles have u_tile_origin.z < 0, so this re-scaling will place proxy tiles deeper in
     // the depth buffer than non-proxy tiles by a distance that increases with tile zoom
     gl_Position.z /= 1. + .1 * (abs(u_tile_origin.z) - u_tile_origin.z);
     

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -41,11 +41,7 @@ vec4 modelPosition() {
 }
 
 vec4 worldPosition() {
-    vec4 worldPosition = a_position * u_model + vec4(u_map_position.xy, 0., 1.);
-    #ifdef TANGRAM_WORLD_POSITION_WRAP
-        worldPosition = mod(worldPosition, TANGRAM_WORLD_POSITION_WRAP);
-    #endif
-    return worldPosition;
+    return v_world_position;
 }
 
 #pragma tangram: material
@@ -58,7 +54,6 @@ void main() {
 
     v_color = a_color;
     v_texcoord = a_texcoord;
-    v_world_position = worldPosition();
     v_normal = u_normalMatrix * vec3(0.,0.,1.);
 
     {
@@ -78,6 +73,13 @@ void main() {
 
     // Transform position into meters relative to map center
     position = u_model * position;
+
+    // World coordinates for 3d procedural textures
+    vec4 local_origin = vec4(u_map_position.xy, 0., 0.);
+    #ifdef TANGRAM_WORLD_POSITION_WRAP
+        local_origin = mod(local_origin, TANGRAM_WORLD_POSITION_WRAP);
+    #endif
+    v_world_position = position + local_origin;
 
     // Modify position before lighting and camera projection
     #pragma tangram: position

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -6,10 +6,11 @@ precision highp float;
 
 #pragma tangram: defines
 
-#define TANGRAM_WORLD_POSITION_WRAP vec3(100000.0)
+#define TANGRAM_WORLD_POSITION_WRAP 100000.0
 
-uniform mat4 u_modelView;
-uniform mat4 u_modelViewProj;
+uniform mat4 u_model;
+uniform mat4 u_view;
+uniform mat4 u_proj;
 uniform mat3 u_normalMatrix;
 uniform vec3 u_map_position;
 uniform vec3 u_tile_origin;
@@ -26,14 +27,26 @@ attribute vec2 a_texcoord;
 attribute float a_layer;
 
 varying vec4 v_world_position;
+varying vec4 v_position;
 varying vec4 v_color;
-varying vec3 v_eyeToPoint;
 varying vec3 v_normal;
 varying vec2 v_texcoord;
 
 #ifdef TANGRAM_LIGHTING_VERTEX
     varying vec4 v_lighting;
 #endif
+
+vec4 modelPosition() {
+    return a_position;
+}
+
+vec4 worldPosition() {
+    vec4 worldPosition = a_position * u_model + vec4(u_map_position.xy, 0., 1.);
+    #ifdef TANGRAM_WORLD_POSITION_WRAP
+        worldPosition = mod(worldPosition, TANGRAM_WORLD_POSITION_WRAP);
+    #endif
+    return worldPosition;
+}
 
 #pragma tangram: material
 #pragma tangram: lighting
@@ -43,15 +56,18 @@ void main() {
 
     vec4 position = a_position;
 
+    v_color = a_color;
     v_texcoord = a_texcoord;
+    v_world_position = worldPosition();
+    v_normal = u_normalMatrix * vec3(0.,0.,1.);
 
     {
         float width = a_extrude.z;
         float dwdz = a_extrude.w;
-        float dz =  u_map_position.z - abs(u_tile_origin.z);
-        // interpolate between zoom levels
+        float dz = u_map_position.z - abs(u_tile_origin.z);
+        // Interpolate between zoom levels
         width += dwdz * dz;
-        // scale to screen-space
+        // Scale to screen-space
         width *= exp2(-dz);
 
         // Modify line width before extrusion
@@ -60,12 +76,14 @@ void main() {
         position.xy += a_extrude.xy * width;
     }
 
-    // Modify position before camera projection
+    // Transform position into meters relative to map center
+    position = u_model * position;
+
+    // Modify position before lighting and camera projection
     #pragma tangram: position
 
-    v_color = a_color;
-    v_eyeToPoint = vec3(u_modelView * a_position);
-    v_normal = u_normalMatrix * vec3(0.,0.,1.);
+    // Set position varying to the camera-space vertex position
+    v_position = u_view * position;
         
     #ifdef TANGRAM_LIGHTING_VERTEX
         vec4 color = v_color;
@@ -74,16 +92,15 @@ void main() {
         // Modify normal before lighting
         #pragma tangram: normal
 
-        v_normal = normal;
-
         // Modify color and material properties before lighting
         #pragma tangram: color
 
-        v_lighting = calculateLighting(v_eyeToPoint.xyz, normal, color);
+        v_lighting = calculateLighting(v_position.xyz, normal, color);
         v_color = color;
+        v_normal = normal;
     #endif
 
-    gl_Position = u_modelViewProj * position;
+    gl_Position = u_proj * v_position;
     
     // Proxy tiles have u_tile_zoom < 0, so this re-scaling will place proxy tiles deeper in
     // the depth buffer than non-proxy tiles by a distance that increases with tile zoom

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -60,10 +60,10 @@ void main() {
         float dz = u_map_position.z - abs(u_tile_origin.z);
         // Interpolate between zoom levels
         width += dwdz * dz;
-        // Scale to screen-space
+        // Scale pixel dimensions to be consistent in screen space
         width *= exp2(-dz);
 
-        // Modify line width before extrusion
+        // Modify line width in model space before extrusion
         #pragma tangram: width
 
         position.xy += a_extrude.xy * width;

--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -28,14 +28,13 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform float u_meters_per_pixel;
 
-
 #pragma tangram: uniforms
 
-varying float v_alpha;
-varying vec2 v_texcoords;
 varying vec4 v_color;
 varying vec4 v_strokeColor;
+varying vec2 v_texcoords;
 varying float v_strokeWidth;
+varying float v_alpha;
 
 #pragma tangram: global
 

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -5,50 +5,53 @@
 
 #include <vector>
 #include <string>
-#include <unordered_map>
 
-/* Notes on TileData implementation:
+/*
 
 Tile Coordinates:
 
-  A point in the geometry of a tile is represented with 32-bit floating point x, y, and z coordinates. Coordinates represent
-  normalized displacement from the origin (i.e. center) of a tile.
+  A point in the geometry of a tile is represented with 32-bit floating point
+  x, y, and z coordinates. Coordinates represent normalized displacement from
+  the origin (i.e. lower-left corner) of a tile.
 
-  (-1.0, 1.0) -------------------- (1.0, 1.0)
-             |                    |
-             |      +y ^          |
-             |         | (0, 0)   |
-             |       ----- > +x   |
-             |         |          |
-             |                    |
-             |                    |
-  (-1.0, -1.0)-------------------- (1.0, -1.0)
+  (0.0, 1.0) ---------- (1.0, 1.0)
+            |          |             N
+            ^ +y       |          W <|> E
+            |          |             S
+            |    +x    |
+  (0.0, 0.0) ----->---- (1.0, 0.0)
 
-  Coordinates that fall outside the range [-1.0, 1.0] are permissible, as tile servers may chose not to clip certain geometries
-  to tile boundaries, but in the future these points may be clipped in the client-side geometry processing.
+  Coordinates that fall outside the range [0.0, 1.0] are permissible, as tile
+  servers may choose not to clip certain geometries to tile boundaries, but in
+  the future these points may be clipped in the client-side geometry processing.
 
-  Z coordinates are expected to be normalized to the same scale as x asnd y coordinates.
+  Z coordinates are expected to be normalized to the same scale as x, y coordinates.
 
 Data heirarchy:
 
-  TileData is a heirarchical container of structs modeled after the geoJSON spec: http://geojson.org/geojson-spec.html
+  TileData is a heirarchical container of structs modeled after the geoJSON spec:
+  http://geojson.org/geojson-spec.html
 
   A <TileData> contains a collection of <Layer>s
 
   A <Layer> contains a name and a collection of <Feature>s
 
-  A <Feature> contains a <GeometryType> denoting what variety of geometry is contained in the feature, a <Properties> struct
-  describing the feature, and one collection each of <Point>s, <Line>s, and <Polygon>s. Only the geometry collection corresponding
-  to the feature's geometryType should contain data.
+  A <Feature> contains a <GeometryType> denoting what variety of geometry is
+  contained in the feature, a <Properties> struct describing the feature, and
+  one collection each of <Point>s, <Line>s, and <Polygon>s. Only the geometry
+  collection corresponding to the feature's geometryType should contain data.
 
-  A <Properties> contains two key-value maps, one for string properties and one for numeric (floating point) properties.
+  A <Properties> contains a sorted vector of key-value pairs storing the
+  properties of a <Feature>
 
-  A <Polygon> is a collection of <Line>s representing the contours of a polygon. Contour winding rules follow the conventions of
-  the OpenGL red book described here: http://www.glprogramming.com/red/chapter11.html
+  A <Polygon> is a collection of <Line>s representing the contours of a polygon.
+  Contour winding rules follow the conventions of the OpenGL red book described
+  here: http://www.glprogramming.com/red/chapter11.html
 
   A <Line> is a collection of <Point>s.
 
-  A <Point> is 3 32-bit floating point coordinates representing x, y, and z (in that order).
+  A <Point> is 3 32-bit floating point coordinates representing x, y, and z
+  (in that order).
 
 */
 namespace Tangram {

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -242,6 +242,7 @@ std::string ShaderProgram::applySourceBlocks(const std::string& source, bool fra
         float depthDelta = 1.f / (1 << 16);
         sourceOut << "#define TANGRAM_DEPTH_DELTA " << std::to_string(depthDelta) << '\n';
         sourceOut << "#define TANGRAM_VERTEX_SHADER\n";
+        sourceOut << "#define TANGRAM_WORLD_POSITION_WRAP 100000\n";
     }
 
     auto sourcePos = source.begin();

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -235,6 +235,7 @@ std::string ShaderProgram::applySourceBlocks(const std::string& source, bool fra
     std::smatch sm;
 
     sourceOut << "#define TANGRAM_EPSILON 0.00001\n";
+    sourceOut << "#define TANGRAM_WORLD_POSITION_WRAP 100000.\n";
 
     if (fragShader) {
         sourceOut << "#define TANGRAM_FRAGMENT_SHADER\n";
@@ -242,7 +243,6 @@ std::string ShaderProgram::applySourceBlocks(const std::string& source, bool fra
         float depthDelta = 1.f / (1 << 16);
         sourceOut << "#define TANGRAM_DEPTH_DELTA " << std::to_string(depthDelta) << '\n';
         sourceOut << "#define TANGRAM_VERTEX_SHADER\n";
-        sourceOut << "#define TANGRAM_WORLD_POSITION_WRAP 100000\n";
     }
 
     auto sourcePos = source.begin();

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -173,17 +173,18 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
     if (Node definesNode = shaders["defines"]) {
         for (const auto& define : definesNode) {
             std::string name = define.first.as<std::string>();
+
+            // undefine any previous definitions
+            shader.addSourceBlock("defines", "#undef " + name);
+
             bool bValue;
 
             if (getBool(define.second, bValue)) {
-                if (!bValue) {
-                    // Explicitly set false defines (to make sure it overwrites a predefined define
-                    // Example: TANGRAM_WORLD_POSITION_WRAP
-                    shader.addSourceBlock("defines", "#define " + name + " " + "false");
-                }
                 // specifying a define to be 'true' means that it is simply
                 // defined and has no value
-                shader.addSourceBlock("defines", "#define " + name);
+                if (bValue) {
+                    shader.addSourceBlock("defines", "#define " + name);
+                }
             } else {
                 std::string value = define.second.as<std::string>();
                 shader.addSourceBlock("defines", "#define " + name + " " + value);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -177,9 +177,9 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
 
             if (getBool(define.second, bValue)) {
                 if (!bValue) {
-                    // specifying a define to be 'false' means that the define will
-                    // not be defined at all
-                    continue;
+                    // Explicitly set false defines (to make sure it overwrites a predefined define
+                    // Example: TANGRAM_WORLD_POSITION_WRAP
+                    shader.addSourceBlock("defines", "#define " + name + " " + "false");
                 }
                 // specifying a define to be 'true' means that it is simply
                 // defined and has no value

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -44,10 +44,10 @@ void DebugStyle::onBeginBuildTile(Tile &_tile) const {
         GLuint abgr = 0xff0000ff;
 
         vertices.reserve(4);
-        vertices.push_back({{ -1.f, -1.f, 0.f }, abgr });
-        vertices.push_back({{  1.f, -1.f, 0.f }, abgr });
-        vertices.push_back({{  1.f,  1.f, 0.f }, abgr });
-        vertices.push_back({{ -1.f,  1.f, 0.f }, abgr });
+        vertices.push_back({{ 0.f, 0.f, 0.f }, abgr });
+        vertices.push_back({{ 1.f, 0.f, 0.f }, abgr });
+        vertices.push_back({{ 1.f, 1.f, 0.f }, abgr });
+        vertices.push_back({{ 0.f, 1.f, 0.f }, abgr });
 
         mesh->addVertices(std::move(vertices), { 0, 1, 2, 3, 0 });
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -33,7 +33,7 @@ void DebugTextStyle::onBeginBuildTile(Tangram::Tile &_tile) const {
 
         auto& buffer = static_cast<TextBuffer&>(*mesh);
 
-        buffer.addLabel(params, { glm::vec2(0) }, Label::Type::debug, *m_fontContext);
+        buffer.addLabel(params, { glm::vec2(.5f) }, Label::Type::debug, *m_fontContext);
 
         onEndBuildTile(_tile);
 

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -244,7 +244,7 @@ void PointStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
     }
 
     if (m_dirtyViewport || contextLost) {
-        m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getOrthoViewportMatrix()));
+        m_shaderProgram->setUniformMatrix4f("u_ortho", glm::value_ptr(_view.getOrthoViewportMatrix()));
         m_dirtyViewport = false;
     }
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -146,7 +146,7 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene) {
     const auto& mapPos = _view.getPosition();
     m_shaderProgram->setUniformf("u_map_position", mapPos.x, mapPos.y, _view.getZoom());
     m_shaderProgram->setUniformMatrix3f("u_normalMatrix", glm::value_ptr(_view.getNormalMatrix()));
-    m_shaderProgram->setUniformf("u_meters_per_pixel", _view.pixelsPerMeter());
+    m_shaderProgram->setUniformf("u_meters_per_pixel", 1.0 / _view.pixelsPerMeter());
     m_shaderProgram->setUniformMatrix4f("u_view", glm::value_ptr(_view.getViewMatrix()));
     m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getProjectionMatrix()));
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -7,6 +7,8 @@
 #include "gl/vboMesh.h"
 #include "view/view.h"
 
+#include "glm/gtc/type_ptr.hpp"
+
 namespace Tangram {
 
     Style::Style(std::string _name, Blending _blendMode, GLenum _drawMode) :
@@ -138,10 +140,15 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene) {
 
     // Set Map Position
     if (m_dirtyViewport) {
-        const auto& mapPos = _view.getPosition();
         m_shaderProgram->setUniformf("u_resolution", _view.getWidth(), _view.getHeight());
-        m_shaderProgram->setUniformf("u_map_position", mapPos.x, mapPos.y, _view.getZoom());
     }
+
+    const auto& mapPos = _view.getPosition();
+    m_shaderProgram->setUniformf("u_map_position", mapPos.x, mapPos.y, _view.getZoom());
+    m_shaderProgram->setUniformMatrix3f("u_normalMatrix", glm::value_ptr(_view.getNormalMatrix()));
+    m_shaderProgram->setUniformf("u_meters_per_pixel", _view.pixelsPerMeter());
+    m_shaderProgram->setUniformMatrix4f("u_view", glm::value_ptr(_view.getViewMatrix()));
+    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getProjectionMatrix()));
 
     setupShaderUniforms(0, contextLost, _scene);
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -154,7 +154,7 @@ void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
     }
 
     if (m_dirtyViewport || contextLost) {
-        m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getOrthoViewportMatrix()));
+        m_shaderProgram->setUniformMatrix4f("u_ortho", glm::value_ptr(_view.getOrthoViewportMatrix()));
         m_dirtyViewport = false;
     }
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -104,14 +104,11 @@ void Tile::draw(const Style& _style, const View& _view) {
 
         auto& shader = _style.getShaderProgram();
 
-        glm::mat4 modelViewMatrix = _view.getViewMatrix() * m_modelMatrix;
         glm::mat4 modelViewProjMatrix = _view.getViewProjectionMatrix() * m_modelMatrix;
         float zoomAndProxy = m_proxyCounter > 0 ? -m_id.z : m_id.z;
 
-        shader->setUniformMatrix4f("u_modelView", glm::value_ptr(modelViewMatrix));
+        shader->setUniformMatrix4f("u_model", glm::value_ptr(m_modelMatrix));
         shader->setUniformMatrix4f("u_modelViewProj", glm::value_ptr(modelViewProjMatrix));
-        shader->setUniformMatrix3f("u_normalMatrix", glm::value_ptr(_view.getNormalMatrix()));
-        shader->setUniformf("u_meters_per_pixel", _view.pixelsPerMeter());
         shader->setUniformf("u_tile_origin", m_tileOrigin.x - m_scale, m_tileOrigin.y - m_scale, zoomAndProxy);
 
         styleMesh->draw(*shader);

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -24,10 +24,10 @@ Tile::Tile(TileID _id, const MapProjection& _projection) :
 
     BoundingBox bounds(_projection.TileBounds(_id));
 
-    m_scale = 0.5 * bounds.width();
+    m_scale = bounds.width();
     m_inverseScale = 1.0/m_scale;
 
-    m_tileOrigin = bounds.center();
+    m_tileOrigin = { bounds.min.x, bounds.max.y }; // South-West corner
     // negative y coordinate: to change from y down to y up (tile system has y down and gl context we use has y up).
     m_tileOrigin.y *= -1.0;
 

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -167,7 +167,7 @@ private:
 
     std::atomic<double> m_priority;
 
-    glm::dvec2 m_tileOrigin; // Center of the tile in 2D projection space in meters (e.g. mercator meters)
+    glm::dvec2 m_tileOrigin; // South-West corner of the tile in 2D projection space in meters (e.g. mercator meters)
 
     glm::mat4 m_modelMatrix; // Matrix relating tile-local coordinates to global projection space coordinates;
     // Note that this matrix does not contain the relative translation from the global origin to the tile origin.

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -37,10 +37,10 @@ void PbfParser::extractGeometry(ParserContext& _ctx, protobuf::message& _geomIn)
             x += _geomIn.svarint();
             y += _geomIn.svarint();
 
-            // bring the points in -1 to 1 space
+            // bring the points in 0 to 1 space
             Point p;
-            p.x = invTileExtent * (double)(2 * x - _ctx.tileExtent);
-            p.y = invTileExtent * (double)(_ctx.tileExtent - 2 * y);
+            p.x = invTileExtent * (double)x;
+            p.y = invTileExtent * (double)(_ctx.tileExtent - y);
 
             _ctx.coordinates.push_back(p);
             numCoordinates++;

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -40,8 +40,8 @@ TEST_CASE("Test getFeaturesAtPoint", "[Labels][FeaturePicking]") {
     auto labelMesh = std::unique_ptr<LabelMesh>(new LabelMesh(nullptr, 0));
     auto textStyle = std::unique_ptr<TextStyle>(new TextStyle("test", nullptr));
 
-    labelMesh->addLabel(makeLabel(glm::vec2{0,0}, Label::Type::point, "0"));
-    labelMesh->addLabel(makeLabel(glm::vec2{1,-1}, Label::Type::point, "1"));
+    labelMesh->addLabel(makeLabel(glm::vec2{.5f,.5f}, Label::Type::point, "0"));
+    labelMesh->addLabel(makeLabel(glm::vec2{1,0}, Label::Type::point, "1"));
     labelMesh->addLabel(makeLabel(glm::vec2{1,1}, Label::Type::point, "2"));
 
     std::shared_ptr<Tile> tile(new Tile({0,0,0}, view.getMapProjection()));


### PR DESCRIPTION
Supersedes #330 

 - Normalizes positions within tiles to the range [0, 1]
 - Provides modelPosition() and worldPosition() functions in vertex shaders
 - Sets u_model, u_view, and u_proj instead of combined matrices (turns out we actually need all of the intermediate values, so pre-multiplying won't save any work)
 - Rename v_eyeToPoint to v_position
 - Ensure v_world_position is set in all shaders
 - Use u_ortho for orthographic projection matrix, to distinguish from perspective u_proj
 - Organize variables in shaders
 - Hoist some uniform assignments out of Tile::draw and into Style::onBeginFrame