### PR TITLE
Size stops

### DIFF
--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -89,6 +89,8 @@ void DrawRule::eval(const StyleContext& _ctx) {
         if (param.stops) {
             if (StyleParam::isColor(param.key)) {
                 param.value = param.stops->evalColor(_ctx.getGlobalZoom());
+            } else if (StyleParam::isWidth(param.key)) {
+                param.value = param.stops->evalWidth(_ctx.getGlobalZoom());
             } else {
                 param.value = param.stops->evalFloat(_ctx.getGlobalZoom());
             }

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -390,6 +390,7 @@ bool StyleParam::isWidth(StyleParamKey _key) {
     switch (_key) {
         case StyleParamKey::width:
         case StyleParamKey::outline_width:
+        case StyleParamKey::size:
             return true;
         default:
             return false;

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -65,7 +65,10 @@ PointStyle::Parameters PointStyle::applyRule(const DrawRule& _rule) const {
     _rule.get(StyleParamKey::centroid, p.centroid);
     _rule.get(StyleParamKey::interactive, p.interactive);
 
-    if (_rule.get(StyleParamKey::size, size)) {
+    auto sizeParam = _rule.findParameter(StyleParamKey::size);
+    if (sizeParam.stops && sizeParam.value.is<float>()) {
+        p.size = glm::vec2(sizeParam.value.get<float>());
+    } else if (_rule.get(StyleParamKey::size, size)) {
         if (size.x == 0.f || std::isnan(size.y)) {
             p.size = glm::vec2(size.x);
         } else {


### PR DESCRIPTION
Stops could maybe do with some refactoring, but should do the job for now. 

Icon sizes don't re-scale for continuity the way that roads do, but icons are also placed differently at each zoom level so it doesn't seem like continuity should be a concern.