### PR TITLE
Handle texture atlas resize

### DIFF
--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -28,6 +28,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
+uniform vec2 u_uv_scale_factor;
 
 #pragma tangram: uniforms
 
@@ -44,7 +45,7 @@ float contour(in float d, in float w, float t) {
 }
 
 float sample(in vec2 uv, float w, float t) {
-    return contour(texture2D(u_tex, uv).a, w, t);
+    return contour(texture2D(u_tex, uv * u_uv_scale_factor).a, w, t);
 }
 
 float sampleAlpha(in vec2 uv, float distance, float threshold) {
@@ -76,7 +77,7 @@ void main(void) {
         float threshold_fill = 0.5;
         float threshold_stroke = threshold_fill - v_strokeWidth;
 
-        float distance = texture2D(u_tex, v_texcoords).a;
+        float distance = texture2D(u_tex, v_texcoords * u_uv_scale_factor).a;
 
         float alpha_fill = pow(sampleAlpha(v_texcoords, distance, threshold_fill), 0.4545);
         float alpha_stroke = pow(sampleAlpha(v_texcoords, distance, threshold_stroke), 0.4545);

--- a/core/resources/shaders/text.fs
+++ b/core/resources/shaders/text.fs
@@ -16,6 +16,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
+uniform vec2 u_uv_scale_factor;
 
 #pragma tangram: uniforms
 
@@ -30,7 +31,7 @@ void main(void) {
         discard;
     } else {
         vec4 color;
-        vec4 texColor = texture2D(u_tex, v_uv);
+        vec4 texColor = texture2D(u_tex, v_uv * u_uv_scale_factor);
 
         color = vec4(v_color.rgb, texColor.a * v_alpha * v_color.a);
 

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -154,18 +154,16 @@ void Texture::update(GLuint _textureUnit) {
 
         m_shouldResize = false;
 
-        m_subData.clear();
+    }
 
-    } else {
-        // process queued sub data updates
-        while (m_subData.size() > 0) {
-            TextureSubData& subData = m_subData.front();
+    // process queued sub data updates
+    while (m_subData.size() > 0) {
+        TextureSubData& subData = m_subData.front();
 
-            glTexSubImage2D(m_target, 0, subData.m_xoff, subData.m_yoff, subData.m_width, subData.m_height,
-                            m_options.m_format, GL_UNSIGNED_BYTE, subData.m_data.data());
+        glTexSubImage2D(m_target, 0, subData.m_xoff, subData.m_yoff, subData.m_width, subData.m_height,
+                        m_options.m_format, GL_UNSIGNED_BYTE, subData.m_data.data());
 
-            m_subData.pop_front();
-        }
+        m_subData.pop_front();
     }
 
     m_dirty = false;

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -26,7 +26,9 @@ struct TextureOptions {
     TextureWrapping m_wrapping;
 };
 
-#define TANGRAM_MAX_TEXTURE_UNIT 6
+#define TANGRAM_MAX_TEXTURE_UNIT    6
+#define TANGRAM_MAX_TEXTURE_WIDTH   2048
+#define TANGRAM_MAX_TEXTURE_HEIGHT  2048
 
 class Texture {
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -227,6 +227,10 @@ void Style::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const P
     // No-op by default
 }
 
+void Style::onBeginDrawMesh(VboMesh& _mesh) const {
+    // No-op by default
+}
+
 bool Style::glContextLost() {
     bool contextLost = m_contextLost;
     if (m_contextLost) {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -145,6 +145,8 @@ public:
      */
     virtual void onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit = 0);
 
+    virtual void onBeginDrawMesh(VboMesh& _mesh) const;
+
     /* Perform any unsetup needed after drawing each frame */
     virtual void onEndDrawFrame() {}
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -161,6 +161,12 @@ void TextStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule,
     buildPoint(p, _rule, _props, _mesh, _tile);
 }
 
+void TextStyle::onBeginDrawMesh(VboMesh& _mesh) const {
+    auto& buffer = static_cast<TextBuffer&>(_mesh);
+    glm::vec2 uvScaleFactor = buffer.getAtlasResolution() / m_fontContext->getAtlasResolution();
+    m_shaderProgram->setUniformf("u_uv_scale_factor", uvScaleFactor);
+}
+
 void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit) {
     bool contextLost = Style::glContextLost();
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -51,6 +51,8 @@ protected:
     virtual void buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
 
+    virtual void onBeginDrawMesh(VboMesh& _mesh) const override;
+
     virtual VboMesh* newMesh() const override;
 
     Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -185,9 +185,12 @@ void FontContext::fontstashError(void* _uptr, int _error, int _val) {
         if (nw > TANGRAM_MAX_TEXTURE_WIDTH || nh > TANGRAM_MAX_TEXTURE_HEIGHT) {
             LOGE("Full font texture atlas size reached!");
         } else {
-            fonsExpandAtlas(fontContext->m_fsContext, nw, nh, 1);
-            tex->resize(nw, nh);
-            LOGW("Texture Atlas resize to %d %d", nw, nh);
+            if (fonsExpandAtlas(fontContext->m_fsContext, nw, nh, 1)) {
+                tex->resize(nw, nh);
+                LOGW("Texture Atlas resized to %d %d", nw, nh);
+            } else {
+                LOGE("Unexpected error while expanding the font atlas");
+            }
         }
         break;
     }
@@ -198,6 +201,10 @@ void FontContext::fontstashError(void* _uptr, int _error, int _val) {
         LOGE("Unexpected error in Fontstash %d:%d!", _error, _val);
         break;
     }
+}
+
+glm::vec2 FontContext::getAtlasResolution() const {
+    return glm::vec2(m_atlas->getWidth(), m_atlas->getHeight());
 }
 
 void FontContext::initFontContext(int _atlasSize) {

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -4,6 +4,7 @@
 #include "gl/texture.h"
 #include "fontstash.h"
 
+#include "glm/vec2.hpp"
 #include <memory>
 #include <mutex>
 #include <string>
@@ -48,6 +49,7 @@ public:
      */
     std::vector<FONSquad>& rasterize(const std::string& _text, FontID _fontID, float _fontSize, float _sdf);
 
+    glm::vec2 getAtlasResolution() const;
 
 private:
     static void renderUpdate(void* _userPtr, int* _rect, const unsigned char* _data);

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -53,7 +53,7 @@ private:
     static void renderUpdate(void* _userPtr, int* _rect, const unsigned char* _data);
     static int renderCreate(void* _userPtr, int _width, int _height);
     static void pushQuad(void* _userPtr, const FONSquad* _quad);
-    static void fontstashError(void* uptr, int error, int val);
+    static void fontstashError(void* _uptr, int _error, int _val);
 
     FontContext(int _atlasSize);
 

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -7,8 +7,7 @@
 namespace Tangram {
 
 TextBuffer::TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout)
-    : LabelMesh(_vertexLayout, GL_TRIANGLES) {
-    m_dirtyTransform = false;
+    : LabelMesh(_vertexLayout, GL_TRIANGLES), m_atlasRes({0.0, 0.0}) {
     addVertices({}, {});
 }
 

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -68,6 +68,12 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
     std::vector<FONSquad>& quads = _fontContext.rasterize(*renderText, _params.fontId,
                                                           _params.fontSize,
                                                           _params.blurSpread);
+
+    // the current atlas resolution
+    if (m_atlasRes.x == 0) {
+        m_atlasRes = _fontContext.getAtlasResolution();
+    }
+
     size_t numGlyphs = quads.size();
 
     if (numGlyphs == 0) {
@@ -90,15 +96,28 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
     uint32_t stroke = (_params.strokeColor & 0x00ffffff) + (strokeWidth << 24);
 
     for (auto& q : quads) {
+        // the atlas resolution at which the quad uvs have been generated onto
+        glm::vec2 atlasResolution(q.atlasWidth, q.atlasHeight);
+        glm::vec2 uvScaleFactor(1.f, 1.f);
+
+        if (atlasResolution != m_atlasRes) {
+            uvScaleFactor = atlasResolution / m_atlasRes;
+        }
+
         x0 = std::min(x0, std::min(q.x0, q.x1));
         x1 = std::max(x1, std::max(q.x0, q.x1));
         y0 = std::min(y0, std::min(q.y0, q.y1));
         y1 = std::max(y1, std::max(q.y0, q.y1));
 
-        vertices.push_back({{q.x0, q.y0}, {q.s0, q.t0}, _params.fill, stroke});
-        vertices.push_back({{q.x0, q.y1}, {q.s0, q.t1}, _params.fill, stroke});
-        vertices.push_back({{q.x1, q.y0}, {q.s1, q.t0}, _params.fill, stroke});
-        vertices.push_back({{q.x1, q.y1}, {q.s1, q.t1}, _params.fill, stroke});
+        glm::vec2 uvBL = glm::vec2(q.s0, q.t0) * uvScaleFactor;
+        glm::vec2 uvBR = glm::vec2(q.s0, q.t1) * uvScaleFactor;
+        glm::vec2 uvTL = glm::vec2(q.s1, q.t0) * uvScaleFactor;
+        glm::vec2 uvTR = glm::vec2(q.s1, q.t1) * uvScaleFactor;
+
+        vertices.push_back({{q.x0, q.y0}, uvBL, _params.fill, stroke});
+        vertices.push_back({{q.x0, q.y1}, uvBR, _params.fill, stroke});
+        vertices.push_back({{q.x1, q.y0}, uvTL, _params.fill, stroke});
+        vertices.push_back({{q.x1, q.y1}, uvTR, _params.fill, stroke});
     }
 
     _fontContext.unlock();

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -34,7 +34,6 @@ public:
 private:
 
     glm::vec2 m_atlasRes;
-    bool m_dirtyTransform;
 };
 
 }

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -29,9 +29,11 @@ public:
     bool addLabel(const TextStyle::Parameters& _params, Label::Transform _transform,
                   Label::Type _type, FontContext& _fontContext);
 
+    glm::vec2 getAtlasResolution() { return m_atlasRes; }
+
 private:
 
-
+    glm::vec2 m_atlasRes;
     bool m_dirtyTransform;
 };
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -113,6 +113,7 @@ void Tile::draw(const Style& _style, const View& _view) {
     const auto& styleMesh = m_geometry[_style.getName()];
 
     if (styleMesh) {
+        _style.onBeginDrawMesh(*styleMesh);
 
         auto& shader = _style.getShaderProgram();
 


### PR DESCRIPTION
Handle texture atlas resize when texture size is reached.

- [ ] ~~find reasonable raster ratio for retina screens~~ (adjusting with device pixel ratio would be ok until we find atlas size bottleneck on it)
- [x] fix degenerate UVs, or use a backup texture atlas