### PR TITLE
Allow passing scene file path as command line argument

### DIFF
--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -197,7 +197,12 @@ void init_main_window() {
 // Main program
 // ============
 
-int main(void) {
+int main(int argc, char* argv[]) {
+
+    if (argc > 1) {
+        sceneFile = std::string(argv[1]);
+        logMsg("File from command line: %s\n", argv[1]);
+    }
 
     // Initialize the windowing library
     if (!glfwInit()) {

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -199,7 +199,12 @@ void init_main_window() {
 // Main program
 // ============
 
-int main(void) {
+int main(int argc, char* argv[]) {
+
+    if (argc > 1) {
+        sceneFile = std::string(argv[1]);
+        logMsg("File from command line: %s\n", argv[1]);
+    }
 
     // Initialize the windowing library
     if (!glfwInit()) {


### PR DESCRIPTION
Even faster than drag-n-drop!
```bash
./build/linux/bin/tangram ~/Development/styles/eraser-map/eraser-map.yaml
```
or on OS X:
```bash
open build/osx/bin/tangram.app --args  ~/Development/styles/eraser-map/eraser-map.yaml
```