### PR TITLE
Cameras can be perspective, isometric, or flat

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -2,10 +2,15 @@ scene:
     background:
         color: '#8db7d5'
 cameras:
-    camera1:
+    iso-camera:
+        type: isometric
+        axis: [0, 1]
+        active: false
+    perspective-camera:
         type: perspective #currently ignored
         focal_length: [[16, 2], [20, 6]] # currently ignored
         vanishing_point: [-250, -250] # currently ignored
+        active: true
 
 lights:
     light1:

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -3,10 +3,14 @@ scene:
         color: '#8db7d5'
 cameras:
     iso-camera:
+        # Manhattan
+        position: [-74.00976419448854, 40.70532700869127, 16]
         type: isometric
         axis: [0, 1]
         active: false
     perspective-camera:
+        # Manhattan
+        position: [-74.00976419448854, 40.70532700869127, 16]
         type: perspective #currently ignored
         focal_length: [[16, 2], [20, 6]] # currently ignored
         vanishing_point: [-250, -250] # currently ignored

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -10,6 +10,7 @@
 #include "scene/stops.h"
 #include "text/fontContext.h"
 #include "util/mapProjection.h"
+#include "view/view.h"
 
 #include <atomic>
 
@@ -19,6 +20,7 @@ static std::atomic<int32_t> s_serial;
 
 Scene::Scene() : id(s_serial++) {
     m_fontContext = std::make_shared<FontContext>();
+    m_view = std::make_shared<View>();
     // For now we only have one projection..
     // TODO how to share projection with view?
     m_mapProjection.reset(new MercatorProjection());

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -19,6 +19,7 @@ class FontContext;
 class Light;
 class MapProjection;
 class SpriteAtlas;
+class View;
 struct Stops;
 
 /* Singleton container of <Style> information
@@ -31,6 +32,7 @@ public:
     Scene();
     ~Scene();
 
+    auto& view() { return m_view; }
     auto& dataSources() { return m_dataSources; };
     auto& layers() { return m_layers; };
     auto& styles() { return m_styles; };
@@ -61,6 +63,7 @@ public:
 private:
 
     std::unique_ptr<MapProjection> m_mapProjection;
+    std::shared_ptr<View> m_view;
 
     std::vector<DataLayer> m_layers;
     std::vector<std::shared_ptr<DataSource>> m_dataSources;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -958,9 +958,10 @@ void SceneLoader::loadCameras(Node _cameras, Scene& _scene) {
 
         }
 
-        double x = -74.00976419448854;
-        double y = 40.70532700869127;
-        float z = 16;
+        // Default is world origin at 0 zoom
+        double x = 0;
+        double y = 0;
+        float z = 0;
 
         if (Node position = camera["position"]) {
             x = position[0].as<double>();

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -20,6 +20,7 @@
 #include "scene/spriteAtlas.h"
 #include "scene/stops.h"
 #include "util/yamlHelper.h"
+#include "view/view.h"
 
 #include "yaml-cpp/yaml.h"
 
@@ -916,43 +917,52 @@ void SceneLoader::loadCameras(Node _cameras, Scene& _scene) {
     // right now, we'll just apply the settings from the first active camera we
     // find.
 
-    for (const auto& cam : _cameras) {
+    auto& view = _scene.view();
 
-        const Node camera = cam.second;
+    for (const auto& entry : _cameras) {
 
-        const std::string type = camera["type"].as<std::string>();
+        const Node camera = entry.second;
+
+        if (Node active = camera["active"]) {
+            if (!active.as<bool>()) {
+                continue;
+            }
+        }
+
+        auto type = camera["type"].Scalar();
         if (type == "perspective") {
-            // The default camera
-            Node fov = camera["fov"];
-            if (fov) {
+
+            view->setCameraType(CameraType::perspective);
+
+            if (Node fov = camera["fov"]) {
                 // TODO
             }
 
-            Node focal = camera["focal_length"];
-            if (focal) {
+            if (Node focal = camera["focal_length"]) {
                 // TODO
             }
 
-            Node vanishing = camera["vanishing_point"];
-            if (vanishing) {
+            if (Node vanishing = camera["vanishing_point"]) {
                 // TODO
             }
         } else if (type == "isometric") {
-            // TODO
-            Node axis = camera["axis"];
-            if (axis) {
-                // TODO
+
+            view->setCameraType(CameraType::isometric);
+
+            if (Node axis = camera["axis"]) {
+                view->setObliqueAxis(axis[0].as<float>(), axis[1].as<float>());
             }
         } else if (type == "flat") {
-            // TODO
+
+            view->setCameraType(CameraType::flat);
+
         }
 
         double x = -74.00976419448854;
         double y = 40.70532700869127;
         float z = 16;
 
-        Node position = camera["position"];
-        if (position) {
+        if (Node position = camera["position"]) {
             x = position[0].as<double>();
             y = position[1].as<double>();
             if (position.size() > 2) {
@@ -960,18 +970,13 @@ void SceneLoader::loadCameras(Node _cameras, Scene& _scene) {
             }
         }
 
-        Node zoom = camera["zoom"];
-        if (zoom) {
+        if (Node zoom = camera["zoom"]) {
             z = zoom.as<float>();
         }
 
         _scene.startPosition = glm::dvec2(x, y);
         _scene.startZoom = z;
 
-        Node active = camera["active"];
-        if (active) {
-            break;
-        }
     }
 }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -46,8 +46,6 @@ void initialize(const char* _scenePath) {
 
     LOG("initialize");
 
-    auto sceneRelPath = setResourceRoot(_scenePath);
-
     // Create view
     m_view = std::make_shared<View>();
 
@@ -66,19 +64,11 @@ void initialize(const char* _scenePath) {
     // label setup
     m_labels = std::unique_ptr<Labels>(new Labels());
 
-    LOG("Loading Tangram scene file: %s", sceneRelPath.c_str());
-    auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource);
+    loadScene(_scenePath);
 
-    if (SceneLoader::loadScene(sceneString, *m_scene)) {
-        // To add font for debugTextStyle
-        m_scene->fontContext()->addFont("FiraSans", "Medium", "");
-
-        m_tileManager->setScene(m_scene);
-
-        glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
-        m_view->setPosition(projPos.x, projPos.y);
-        m_view->setZoom(m_scene->startZoom);
-    }
+    glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
+    m_view->setPosition(projPos.x, projPos.y);
+    m_view->setZoom(m_scene->startZoom);
 
     LOG("finish initialize");
 
@@ -94,7 +84,11 @@ void loadScene(const char* _scenePath) {
         m_scene = scene;
         m_scene->fontContext()->addFont("FiraSans", "Medium", "");
 
+        m_view = m_scene->view();
+        m_inputHandler->setView(m_view);
+        m_tileManager->setView(m_view);
         m_tileManager->setScene(scene);
+
     }
 }
 

--- a/core/src/util/inputHandler.h
+++ b/core/src/util/inputHandler.h
@@ -20,6 +20,8 @@ public:
 
     void update(float _dt);
 
+    void setView(std::shared_ptr<View> _view) { m_view = _view; }
+
 private:
 
     void setDeltas(float _zoom, glm::vec2 _translate);

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -175,6 +175,7 @@ void View::update() {
     if (m_dirtyMatrices) {
 
         updateMatrices(); // Resets dirty flag
+        setPitch(m_pitch); // Ensure pitch is still valid for viewport
         m_changed = true;
 
     }

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -135,7 +135,12 @@ void View::setRoll(float _roll) {
 
 void View::setPitch(float _pitch) {
 
-    m_pitch = glm::clamp(_pitch, 0.f, (float)HALF_PI);
+    float max_pitch = HALF_PI;
+    if (m_type != CameraType::perspective) {
+        // Prevent projection plane from intersecting ground plane
+        max_pitch = atan2(m_pos.z, m_height * .5f);
+    }
+    m_pitch = glm::clamp(_pitch, 0.f, max_pitch);
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
 
@@ -301,41 +306,36 @@ void View::updateMatrices() {
     // set camera z to produce desired viewable area
     m_pos.z = m_height * 0.5 / tan(fovy * 0.5);
 
-    // set near clipping distance as a function of camera z
-    // TODO: this is a simple heuristic that deserves more thought
-    float near = m_pos.z / 50.0;
-
-    // set far clipping distance to the distance of the intersection of
-    // the "top" face of the view frustum with the ground plane
-
-    // NOTE: far here can go to infinity and hence a std::min below!
-    float far = 4. * m_pos.z / std::max(0., cos(m_pitch + 0.5 * fovy));
-
-    // limit the far clipping distance to be no greater than the maximum
-    // distance of visible tiles
-    float maxTileDistance = worldTileSize * invLodFunc(MAX_LOD + 1);
-    far = std::min(far, maxTileDistance);
-
     m_eye = glm::rotateZ(glm::rotateX(glm::vec3(0.f, 0.f, m_pos.z), m_pitch), m_roll);
     glm::vec3 at = { 0.f, 0.f, 0.f };
     glm::vec3 up = glm::rotateZ(glm::rotateX(glm::vec3(0.f, 1.f, 0.f), m_pitch), m_roll);
 
-    // update view and projection matrices
+    // Generate view matrix
     m_view = glm::lookAt(m_eye, at, up);
 
-    // Generate perspective matrix based on camera type
+    float maxTileDistance = worldTileSize * invLodFunc(MAX_LOD + 1);
+    float near = m_pos.z / 50.f;
+    float far = 1;
+    float hw = 0.5 * m_width;
+    float hh = 0.5 * m_height;
+
+    // Generate projection matrix based on camera type
     switch (m_type) {
         case CameraType::perspective:
+            far = 2. * m_pos.z / std::max(0., cos(m_pitch + 0.5 * fovy));
+            far = std::min(far, maxTileDistance);
             m_proj = glm::perspective(fovy, m_aspect, near, far);
             break;
         case CameraType::isometric:
         case CameraType::flat:
-            m_proj = glm::ortho(-m_width * .5f, m_width * .5f, -m_height * .5f, m_height * .5f, near, far);
+            far = 2. * (m_pos.z + hh * std::abs(tan(m_pitch)));
+            far = std::min(far, maxTileDistance);
+            m_proj = glm::ortho(-hw, hw, -hh, hh, near, far);
             break;
     }
 
-    // Add the oblique projection scaling factors to the view matrix
     if (m_type == CameraType::isometric) {
+        // Add the oblique projection scaling factors to the view matrix
         m_view[2][0] += m_obliqueAxis.x;
         m_view[2][1] += m_obliqueAxis.y;
     }
@@ -456,33 +456,43 @@ void View::updateTiles() {
     // Location of the view center in tile space
     glm::dvec2 e = (glm::dvec2(m_pos.x, m_pos.y) - tileSpaceOrigin) * tileSpaceAxes;
 
-    // Determine zoom reduction for tiles far from the center of view
-    double tilesAtFullZoom = std::max(m_width, m_height) * invTileSize * 0.5;
-    double viewCenterX = (m_pos.x + hc) * invTileSize;
-    double viewCenterY = (m_pos.y - hc) * -invTileSize;
+    int imax = std::numeric_limits<int>::max();
+    int imin = std::numeric_limits<int>::min();
 
-    int x_l_pos[MAX_LOD] = { 0 };
-    int x_l_neg[MAX_LOD] = { 0 };
-    int y_l_pos[MAX_LOD] = { 0 };
-    int y_l_neg[MAX_LOD] = { 0 };
+    // Distance thresholds in tile space for levels of detail:
+    // Element [n] in each array is the minimum tile index at which level-of-detail n
+    // should be applied in that direction.
+    int x_limit_pos[MAX_LOD] = { imax };
+    int x_limit_neg[MAX_LOD] = { imin };
+    int y_limit_pos[MAX_LOD] = { imax };
+    int y_limit_neg[MAX_LOD] = { imin };
 
-    for (int i = 0; i < MAX_LOD; i++) {
-        int j = i + 1;
-        x_l_neg[i] = ((int(viewCenterX - tilesAtFullZoom - invLodFunc(i)) >> j) - 1) << j;
-        y_l_pos[i] = ((int(viewCenterY + tilesAtFullZoom + invLodFunc(i)) >> j) + 1) << j;
-        y_l_neg[i] = ((int(viewCenterY - tilesAtFullZoom - invLodFunc(i)) >> j) - 1) << j;
-        x_l_pos[i] = ((int(viewCenterX + tilesAtFullZoom + invLodFunc(i)) >> j) + 1) << j;
+    if (m_type == CameraType::perspective) {
+
+        // Determine zoom reduction for tiles far from the center of view
+        double tilesAtFullZoom = std::max(m_width, m_height) * invTileSize * 0.5;
+        double viewCenterX = (m_pos.x + hc) * invTileSize;
+        double viewCenterY = (m_pos.y - hc) * -invTileSize;
+
+        for (int i = 0; i < MAX_LOD; i++) {
+            int j = i + 1;
+            double r = invLodFunc(i) + tilesAtFullZoom;
+            x_limit_neg[i] = ((int(viewCenterX - r) >> j) - 1) << j;
+            y_limit_pos[i] = ((int(viewCenterY + r) >> j) + 1) << j;
+            y_limit_neg[i] = ((int(viewCenterY - r) >> j) - 1) << j;
+            x_limit_pos[i] = ((int(viewCenterX + r) >> j) + 1) << j;
+        }
     }
 
     Scan s = [&](int x, int y) {
 
         int lod = 0;
-        while (lod < MAX_LOD && x >= x_l_pos[lod]) { lod++; }
-        while (lod < MAX_LOD && x <  x_l_neg[lod]) { lod++; }
-        while (lod < MAX_LOD && y >= y_l_pos[lod]) { lod++; }
-        while (lod < MAX_LOD && y <  y_l_neg[lod]) { lod++; }
+        while (lod < MAX_LOD && x >= x_limit_pos[lod]) { lod++; }
+        while (lod < MAX_LOD && x <  x_limit_neg[lod]) { lod++; }
+        while (lod < MAX_LOD && y >= y_limit_pos[lod]) { lod++; }
+        while (lod < MAX_LOD && y <  y_limit_neg[lod]) { lod++; }
 
-        int z = int(m_zoom);
+        int z = (int)m_zoom;
 
         x >>= lod;
         y >>= lod;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -14,14 +14,16 @@
 
 namespace Tangram {
 
+enum class CameraType : uint8_t {
+    perspective,
+    isometric,
+    flat,
+};
+
 /* View
  * 1. Stores a representation of the current view into the map world
  * 2. Determines which tiles are visible in the current view
  * 3. Tracks changes in the view state to determine when new rendering is needed
- *
- * TODO: Make this into an interface for different implementations
- * For now, this is a simple implementation of the viewModule responsibilities
- * using a top-down axis-aligned orthographic view
 */
 
 class View {
@@ -35,6 +37,10 @@ public:
 
     /* Gets the current map projection */
     const MapProjection& getMapProjection() const;
+
+    void setCameraType(CameraType _type);
+
+    auto CameraType() const { return m_type; }
 
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
      *
@@ -166,6 +172,8 @@ protected:
     float m_aspect;
     float m_pixelScale = 1.0f;
     float m_pixelsPerTile = 256.0;
+
+    enum CameraType m_type;
 
     bool m_dirtyMatrices;
     bool m_dirtyTiles;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -39,8 +39,10 @@ public:
     const MapProjection& getMapProjection() const;
 
     void setCameraType(CameraType _type);
-
     auto cameraType() const { return m_type; }
+
+    void setObliqueAxis(float _x, float _y) { m_obliqueAxis = { _x, _y}; }
+    auto obliqueAxis() const { return m_obliqueAxis; }
 
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
      *
@@ -147,6 +149,7 @@ protected:
     glm::dvec3 m_pos;
     glm::dvec3 m_pos_prev = glm::dvec3(0.0, 0.0, 0.0);
     glm::vec3 m_eye;
+    glm::vec2 m_obliqueAxis;
 
     glm::mat4 m_view;
     glm::mat4 m_orthoViewport;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -38,7 +38,7 @@ public:
     /* Gets the current map projection */
     const MapProjection& getMapProjection() const;
 
-    void setCameraType(CameraType _type);
+    void setCameraType(CameraType _type) { m_type = _type; }
     auto cameraType() const { return m_type; }
 
     void setObliqueAxis(float _x, float _y) { m_obliqueAxis = { _x, _y}; }

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -15,7 +15,7 @@
 namespace Tangram {
 
 enum class CameraType : uint8_t {
-    perspective,
+    perspective = 0,
     isometric,
     flat,
 };
@@ -40,7 +40,7 @@ public:
 
     void setCameraType(CameraType _type);
 
-    auto CameraType() const { return m_type; }
+    auto cameraType() const { return m_type; }
 
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
      *
@@ -173,7 +173,7 @@ protected:
     float m_pixelScale = 1.0f;
     float m_pixelsPerTile = 256.0;
 
-    enum CameraType m_type;
+    CameraType m_type;
 
     bool m_dirtyMatrices;
     bool m_dirtyTiles;


### PR DESCRIPTION
Camera type can now be specified in scene file as `perspective`, `isometric`, or `flat` (currently `flat` is equivalent to `isometric` with an oblique axis of `[0, 0]`)

`isometric` with default axis of `[0, 1]`:

![screen shot 2015-10-19 at 12 55 34 pm](https://cloud.githubusercontent.com/assets/3371850/10584524/bbe31948-7660-11e5-8ac3-45a2e1aebcd3.png)
