### PR TITLE
Anchor points for sprites/icons

### DIFF
--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -25,10 +25,6 @@ Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, LabelMesh
 
 Label::~Label() {}
 
-void Label::align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) {
-    // No-op by default
-}
-
 bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize, bool _testVisibility) {
 
     glm::vec2 screenPosition;
@@ -48,7 +44,7 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
 
             screenPosition = clipToScreenSpace(v1, _screenSize);
 
-            ap1 = screenPosition;
+            ap1 = ap2 = screenPosition;
 
             break;
         }

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -8,8 +8,8 @@
 namespace Tangram {
 
 Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, LabelMesh& _mesh, Range _vertexRange, Options _options) :
-    m_type(_type),
     m_options(_options),
+    m_type(_type),
     m_transform(_transform),
     m_dim(_size),
     m_mesh(_mesh),
@@ -25,10 +25,16 @@ Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, LabelMesh
 
 Label::~Label() {}
 
+void Label::align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) {
+    // No-op by default
+}
+
 bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize, bool _testVisibility) {
 
     glm::vec2 screenPosition;
     float rot = 0;
+
+    glm::vec2 ap1, ap2;
 
     switch (m_type) {
         case Type::debug:
@@ -42,8 +48,7 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
 
             screenPosition = clipToScreenSpace(v1, _screenSize);
 
-            // center on half the width
-            screenPosition.x -= m_dim.x * 0.5f;
+            ap1 = screenPosition;
 
             break;
         }
@@ -70,10 +75,7 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
                 std::swap(p1, p2);
             }
 
-            glm::vec2 p1p2 = p2 - p1;
-            glm::vec2 t = glm::normalize(-p1p2);
-
-            float length = glm::length(p1p2);
+            float length = glm::length(p2 - p1);
 
             float exceedHeuristic = 30; // default heuristic : 30%
 
@@ -84,11 +86,14 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
                 }
             }
 
-            screenPosition = (p1 + p2) * 0.5f + t * m_dim.x * 0.5f;
+            ap1 = p1;
+            ap2 = p2;
 
             break;
         }
     }
+
+    align(screenPosition, ap1, ap2);
 
     // update screen position
     glm::vec2 offset = m_options.offset;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -156,7 +156,7 @@ private:
 protected:
 
     // set alignment on _screenPosition based on anchor points _ap1, _ap2
-    virtual void align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2);
+    virtual void align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) = 0;
 
     // the label type (point/line)
     Type m_type;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -111,6 +111,7 @@ public:
 
     virtual void updateBBoxes(float _zoomFract) = 0;
 
+
     /* Sets the occlusion */
     void setOcclusion(bool _occlusion);
 
@@ -141,8 +142,6 @@ private:
 
     // the current label state
     State m_currentState;
-    // the label type (point/line)
-    Type m_type;
     // the label fade effect
     FadeEffect m_fade;
     // whether the label was occluded on the previous frame
@@ -156,6 +155,11 @@ private:
 
 protected:
 
+    // set alignment on _screenPosition based on anchor points _ap1, _ap2
+    virtual void align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2);
+
+    // the label type (point/line)
+    Type m_type;
     // the label oriented bounding box
     OBB m_obb;
     // the label axis aligned bounding box

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -1,19 +1,35 @@
 #include "labels/spriteLabel.h"
+#include "platform.h"
 
 namespace Tangram {
 
 SpriteLabel::SpriteLabel(Label::Transform _transform, glm::vec2 _size, LabelMesh& _mesh,
-                         int _vertexOffset, Label::Options _options, float _extrudeScale) :
+    int _vertexOffset, Label::Options _options, float _extrudeScale, glm::vec2 _anchor) :
     Label(_transform, _size, Label::Type::point, _mesh, {_vertexOffset, 4}, _options),
     m_extrudeScale(_extrudeScale)
 {}
 
 void SpriteLabel::updateBBoxes(float _zoomFract) {
+    glm::vec2 halfSize = m_dim * 0.5f;
     glm::vec2 sp = m_transform.state.screenPos;
     glm::vec2 dim = m_dim + glm::vec2(m_extrudeScale * 2.f * _zoomFract);
-
-    m_obb = OBB(sp.x, sp.y, m_transform.state.rotation, dim.x, dim.y);
+    m_obb = OBB(sp.x + halfSize.x, sp.y - halfSize.y, m_transform.state.rotation, dim.x, dim.y);
     m_aabb = m_obb.getExtent();
+}
+
+void SpriteLabel::align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) {
+
+    switch (m_type) {
+        case Type::debug:
+        case Type::point:
+            _screenPosition.x -= m_dim.x * m_anchor.x;
+            _screenPosition.y += m_dim.y * m_anchor.y;
+            break;
+        case Type::line:
+            LOGW("Line sprite labels not implemented yet");
+            break;
+    }
+
 }
 
 }

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -6,7 +6,7 @@ namespace Tangram {
 SpriteLabel::SpriteLabel(Label::Transform _transform, glm::vec2 _size, LabelMesh& _mesh,
     int _vertexOffset, Label::Options _options, float _extrudeScale, glm::vec2 _anchor) :
     Label(_transform, _size, Label::Type::point, _mesh, {_vertexOffset, 4}, _options),
-    m_extrudeScale(_extrudeScale)
+    m_extrudeScale(_extrudeScale), m_anchor(_anchor)
 {}
 
 void SpriteLabel::updateBBoxes(float _zoomFract) {

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -8,9 +8,13 @@ class SpriteLabel : public Label {
 public:
 
     SpriteLabel(Label::Transform _transform, glm::vec2 _size, LabelMesh& _mesh, int _vertexOffset,
-                Label::Options _options, float _extrudeScale);
+                Label::Options _options, float _extrudeScale, glm::vec2 _anchor = glm::vec2(0.5f));
 
     void updateBBoxes(float _zoomFract) override;
+    void align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) override;
+
+private:
+    glm::vec2 m_anchor;
 
 private:
 

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -13,12 +13,11 @@ public:
     void updateBBoxes(float _zoomFract) override;
     void align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) override;
 
-private:
-    glm::vec2 m_anchor;
 
 private:
 
     float m_extrudeScale;
+    glm::vec2 m_anchor;
 };
 
 }

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -8,30 +8,42 @@ TextLabel::TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim,
 {}
 
 void TextLabel::updateBBoxes(float _zoomFract) {
-    glm::vec2 t = glm::vec2(cos(m_transform.state.rotation), sin(m_transform.state.rotation));
+    // TODO could optimize this for point labels
+    glm::vec2 t = glm::vec2(cos(m_transform.state.rotation),
+                            sin(m_transform.state.rotation));
+
     glm::vec2 tperp = glm::vec2(-t.y, t.x);
     glm::vec2 obbCenter;
 
-    obbCenter = m_transform.state.screenPos + t * m_dim.x * 0.5f - tperp * (m_dim.y / 8);
+    obbCenter = m_transform.state.screenPos;
+    // move forward on line by half the text length
+    obbCenter += t * m_dim.x * 0.5f;
+    // TODO: use real font metrics
+    // move down on the perpendicular to estimated font baseline
+    obbCenter -= tperp * (m_dim.y / 8);
 
     m_obb = OBB(obbCenter.x, obbCenter.y, m_transform.state.rotation, m_dim.x, m_dim.y);
     m_aabb = m_obb.getExtent();
 }
 
 void TextLabel::align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) {
-    glm::vec2 ap1ap2 = _ap2 - _ap1;
-    glm::vec2 t = glm::normalize(-ap1ap2);
 
     switch (m_type) {
         case Type::debug:
         case Type::point:
+            // modify position set by updateScreenTransform()
             _screenPosition.x -= m_dim.x * 0.5f;
             break;
-        case Type::line:
-            _screenPosition = (_ap1 + _ap2) * 0.5f + t * m_dim.x * 0.5f;
-            break;
-    }
+        case Type::line: {
+            // anchor at line center
+            _screenPosition = (_ap1 + _ap2) * 0.5f;
 
+            // move back by half the length (so that text will be drawn centered)
+            glm::vec2 direction = glm::normalize(_ap1 - _ap2);
+            _screenPosition += direction * m_dim.x * 0.5f;
+            break;
+        }
+    }
 }
 
 }

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -18,4 +18,20 @@ void TextLabel::updateBBoxes(float _zoomFract) {
     m_aabb = m_obb.getExtent();
 }
 
+void TextLabel::align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) {
+    glm::vec2 ap1ap2 = _ap2 - _ap1;
+    glm::vec2 t = glm::normalize(-ap1ap2);
+
+    switch (m_type) {
+        case Type::debug:
+        case Type::point:
+            _screenPosition.x -= m_dim.x * 0.5f;
+            break;
+        case Type::line:
+            _screenPosition = (_ap1 + _ap2) * 0.5f + t * m_dim.x * 0.5f;
+            break;
+    }
+
+}
+
 }

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -8,12 +8,14 @@ TextLabel::TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim,
 {}
 
 void TextLabel::updateBBoxes(float _zoomFract) {
-    // TODO could optimize this for point labels
-    glm::vec2 t = glm::vec2(cos(m_transform.state.rotation),
-                            sin(m_transform.state.rotation));
-
-    glm::vec2 tperp = glm::vec2(-t.y, t.x);
+    glm::vec2 t(1.0, 0.0);
+    glm::vec2 tperp(0.0, 1.0);
     glm::vec2 obbCenter;
+
+    if (m_type == Type::line) {
+        t = glm::vec2(cos(m_transform.state.rotation), sin(m_transform.state.rotation));
+        tperp = glm::vec2(-t.y, t.x);
+    }
 
     obbCenter = m_transform.state.screenPos;
     // move forward on line by half the text length

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -13,6 +13,9 @@ public:
 
     void updateBBoxes(float _zoomFract) override;
 
+protected:
+
+    void align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) override;
 };
 
 }

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -110,10 +110,10 @@ PointStyle::Parameters PointStyle::applyRule(const DrawRule& _rule, const Proper
 void PointStyle::pushQuad(std::vector<Label::Vertex>& _vertices, const glm::vec2& _size, const glm::vec2& _uvBL,
                           const glm::vec2& _uvTR, unsigned int _color, float _extrudeScale) const {
 
-    _vertices.push_back({{-_size.x, -_size.y}, {_uvBL.x, _uvBL.y}, {-1.f, -1.f, _extrudeScale}, _color});
-    _vertices.push_back({{-_size.x,  _size.y}, {_uvBL.x, _uvTR.y}, {-1.f,  1.f, _extrudeScale}, _color});
-    _vertices.push_back({{_size.x,  -_size.y}, {_uvTR.x, _uvBL.y}, { 1.f, -1.f, _extrudeScale}, _color});
-    _vertices.push_back({{_size.x,   _size.y}, {_uvTR.x, _uvTR.y}, { 1.f,  1.f, _extrudeScale}, _color});
+    _vertices.push_back({{    0.0,       0.0}, {_uvBL.x, _uvTR.y}, {-1.f, -1.f, _extrudeScale}, _color});
+    _vertices.push_back({{_size.x,       0.0}, {_uvTR.x, _uvTR.y}, {-1.f,  1.f, _extrudeScale}, _color});
+    _vertices.push_back({{    0.0,  -_size.y}, {_uvBL.x, _uvBL.y}, { 1.f, -1.f, _extrudeScale}, _color});
+    _vertices.push_back({{_size.x,  -_size.y}, {_uvTR.x, _uvBL.y}, { 1.f,  1.f, _extrudeScale}, _color});
 }
 
 bool PointStyle::getUVQuad(Parameters& _params, glm::vec4& _quad) const {
@@ -165,7 +165,7 @@ void PointStyle::buildPoint(const Point& _point, const DrawRule& _rule, const Pr
     std::vector<Label::Vertex> vertices;
 
     vertices.reserve(4);
-    pushQuad(vertices, p.size * 0.5f, {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w},
+    pushQuad(vertices, p.size, {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w},
             p.color, p.extrudeScale);
     mesh.addVertices(std::move(vertices), {});
 }
@@ -189,7 +189,7 @@ void PointStyle::buildLine(const Line& _line, const DrawRule& _rule, const Prope
 
         mesh.addLabel(std::make_unique<SpriteLabel>(transform, p.size, mesh, _mesh.numVertices(),
                     p.labelOptions, p.extrudeScale));
-        pushQuad(vertices, p.size * 0.5f, {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w},
+        pushQuad(vertices, p.size, {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w},
                 p.color, p.extrudeScale);
     }
 
@@ -221,7 +221,7 @@ void PointStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, co
 
                 mesh.addLabel(std::make_unique<SpriteLabel>(transform, p.size, mesh, _mesh.numVertices(),
                             p.labelOptions, p.extrudeScale));
-                pushQuad(vertices, p.size * 0.5f, {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w},
+                pushQuad(vertices, p.size, {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w},
                         p.color, p.extrudeScale);
             }
         }
@@ -232,7 +232,7 @@ void PointStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, co
 
         mesh.addLabel(std::make_unique<SpriteLabel>(transform, p.size, mesh, _mesh.numVertices(),
                     p.labelOptions, p.extrudeScale));
-        pushQuad(vertices, p.size * 0.5f,
+        pushQuad(vertices, p.size,
                 {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w}, p.color, p.extrudeScale);
     }
 

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -88,7 +88,7 @@ PointStyle::Parameters PointStyle::applyRule(const DrawRule& _rule, const Proper
     if (sizeParam.stops && sizeParam.value.is<float>()) {
         float lowerSize = sizeParam.value.get<float>();
         float higherSize = sizeParam.stops->evalWidth(_zoom + 1);
-        p.extrudeScale = (higherSize - lowerSize) * 0.5f;
+        p.extrudeScale = (higherSize - lowerSize) * 0.5f - 1.f;
         p.size = glm::vec2(lowerSize);
     } else if (_rule.get(StyleParamKey::size, size)) {
         if (size.x == 0.f || std::isnan(size.y)) {
@@ -110,10 +110,10 @@ PointStyle::Parameters PointStyle::applyRule(const DrawRule& _rule, const Proper
 void PointStyle::pushQuad(std::vector<Label::Vertex>& _vertices, const glm::vec2& _size, const glm::vec2& _uvBL,
                           const glm::vec2& _uvTR, unsigned int _color, float _extrudeScale) const {
 
-    _vertices.push_back({{    0.0,       0.0}, {_uvBL.x, _uvTR.y}, {-1.f, -1.f, _extrudeScale}, _color});
-    _vertices.push_back({{_size.x,       0.0}, {_uvTR.x, _uvTR.y}, {-1.f,  1.f, _extrudeScale}, _color});
-    _vertices.push_back({{    0.0,  -_size.y}, {_uvBL.x, _uvBL.y}, { 1.f, -1.f, _extrudeScale}, _color});
-    _vertices.push_back({{_size.x,  -_size.y}, {_uvTR.x, _uvBL.y}, { 1.f,  1.f, _extrudeScale}, _color});
+    _vertices.push_back({{    0.0,       0.0}, {_uvBL.x, _uvTR.y}, {-1.f,  1.f, _extrudeScale}, _color});
+    _vertices.push_back({{_size.x,       0.0}, {_uvTR.x, _uvTR.y}, { 1.f,  1.f, _extrudeScale}, _color});
+    _vertices.push_back({{    0.0,  -_size.y}, {_uvBL.x, _uvBL.y}, {-1.f, -1.f, _extrudeScale}, _color});
+    _vertices.push_back({{_size.x,  -_size.y}, {_uvTR.x, _uvBL.y}, { 1.f, -1.f, _extrudeScale}, _color});
 }
 
 bool PointStyle::getUVQuad(Parameters& _params, glm::vec4& _quad) const {


### PR DESCRIPTION
Add anchor points for sprites (fixes some issues related to *you are here* icon when client data source was added on eraser-map)

Anchor points work as the following:
- **(0.5, 0.5)**: center of the sprite (*default*)
- **(0.0, 0.0)**: lower left corner of the sprite
- **(1.0, 1.0)**: upper right corner of the sprite

It would be nice to add a handle on this from the stylesheet.