### PR TITLE
Tilemanager handle failure

### DIFF
--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -262,16 +262,13 @@ bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
 }
 
 void cancelUrlRequest(const std::string& _url) {
-
     jstring jUrl = jniRenderThreadEnv->NewStringUTF(_url.c_str());
     jniRenderThreadEnv->CallVoidMethod(tangramInstance, cancelUrlRequestMID, jUrl);
-
 }
 
 void onUrlSuccess(JNIEnv* _jniEnv, jbyteArray _jBytes, jlong _jCallbackPtr) {
 
     size_t length = _jniEnv->GetArrayLength(_jBytes);
-
     std::vector<char> content;
     content.resize(length);
 
@@ -280,14 +277,14 @@ void onUrlSuccess(JNIEnv* _jniEnv, jbyteArray _jBytes, jlong _jCallbackPtr) {
     UrlCallback* callback = reinterpret_cast<UrlCallback*>(_jCallbackPtr);
     (*callback)(std::move(content));
     delete callback;
-
 }
 
 void onUrlFailure(JNIEnv* _jniEnv, jlong _jCallbackPtr) {
+    std::vector<char> empty;
 
     UrlCallback* callback = reinterpret_cast<UrlCallback*>(_jCallbackPtr);
+    (*callback)(std::move(empty));
     delete callback;
-
 }
 
 void setCurrentThreadPriority(int priority) {

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -106,18 +106,15 @@ void DataSource::clearData() {
 
 void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const {
     _url.assign(m_urlTemplate);
-
-    size_t xpos = _url.find("{x}");
-    _url.replace(xpos, 3, std::to_string(_tileCoord.x));
-
-    size_t ypos = _url.find("{y}");
-    _url.replace(ypos, 3, std::to_string(_tileCoord.y));
-
-    size_t zpos = _url.find("{z}");
-    _url.replace(zpos, 3, std::to_string(_tileCoord.z));
-
-    if (xpos == std::string::npos || ypos == std::string::npos || zpos == std::string::npos) {
-        LOGE("Bad URL template!!");
+    try {
+        size_t xpos = _url.find("{x}");
+        _url.replace(xpos, 3, std::to_string(_tileCoord.x));
+        size_t ypos = _url.find("{y}");
+        _url.replace(ypos, 3, std::to_string(_tileCoord.y));
+        size_t zpos = _url.find("{z}");
+        _url.replace(zpos, 3, std::to_string(_tileCoord.z));
+    } catch(...) {
+        LOGE("Bad URL template!");
     }
 }
 


### PR DESCRIPTION
Updated th last PR: an empty tile is now considered to be 'canceled'. This way it stays in the list of current tiles but will not be further processed or tried to become reloaded (as long as it stays in the list of current tiles).  