### PR TITLE
Tilemanager tweaks

### DIFF
--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -57,19 +57,18 @@ void TileManager::setScene(std::shared_ptr<Scene> _scene) {
                 sources.begin(), sources.end(),
                 [&](auto& s){ return tileSet.source->equals(*s); });
 
-            if (sIt != sources.end()) {
-                // Cancel pending  tiles
-                for_each(tileSet.tiles.begin(), tileSet.tiles.end(), [&](auto& tile) {
-                        this->setTileState(*tile.second, TileState::canceled); });
-
-                // Clear cache
-                tileSet.tiles.clear();
-                return false;
+            if (sIt == sources.end()) {
+                LOG("remove source %s", tileSet.source->name().c_str());
+                return true;
             }
 
-            LOG("remove source %s", tileSet.source->name().c_str());
-            return true;
+            // Cancel pending  tiles
+            for_each(tileSet.tiles.begin(), tileSet.tiles.end(), [&](auto& tile) {
+                    this->setTileState(*tile.second, TileState::canceled); });
 
+            // Clear cache
+            tileSet.tiles.clear();
+            return false;
         });
 
     m_tileSets.erase(it, m_tileSets.end());

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -72,7 +72,7 @@ public:
 
     void addDataSource(std::shared_ptr<DataSource> dataSource);
 
-    const auto getTileSets() { return m_tileSets; }
+    const auto& getTileSets() { return m_tileSets; }
 
     /* @_cacheSize: Set size of in-memory tile cache in bytes.
      * This cache holds recently used <Tile>s that are ready for rendering.


### PR DESCRIPTION
- Cancel download of tiles that are 3 or more zoom-level above the current
- when a tile becomes available that can be used as proxy, update proxy tiles of pending tiles
- give higher priority to tiles from lower zoom-levels as they cover a larger visible area 