### PR TITLE
Polyline extrusion fix

### DIFF
--- a/core/resources/shaders/point.vs
+++ b/core/resources/shaders/point.vs
@@ -52,7 +52,7 @@ void main() {
 
         if (de != 0.0) {
             float dz = u_map_position.z - abs(u_tile_origin.z);
-            vertexPos.xy += dz * a_extrude.xy * de;
+            vertexPos.xy += clamp(dz, 0.0, 1.0) * a_extrude.xy * de;
         }
 
         // rotates first around +z-axis (0,0,1) and then translates by (tx,ty,0)

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -58,7 +58,7 @@ void main() {
     {
         float width = a_extrude.z;
         float dwdz = a_extrude.w;
-        float dz = u_map_position.z - abs(u_tile_origin.z);
+        float dz = clamp(u_map_position.z - abs(u_tile_origin.z), 0.0, 1.0);
         // Interpolate between zoom levels
         width += dwdz * dz;
         // Scale pixel dimensions to be consistent in screen space


### PR DESCRIPTION
Really small fix on polyline extrusion, over extrusion was happening when a proxy tile was still being seen at really high zoom level while being on low zoom level:
![screen shot 2015-11-02 at 12 01 58 pm](https://cloud.githubusercontent.com/assets/7061573/10888371/cb8725fc-8159-11e5-9039-c7a1556ab84b.png)
