### PR TITLE
World normals

### DIFF
--- a/core/resources/shaders/polygon.fs
+++ b/core/resources/shaders/polygon.fs
@@ -16,6 +16,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
+uniform mat3 u_inverseNormalMatrix;
 
 #pragma tangram: uniforms
 
@@ -32,6 +33,10 @@ varying vec2 v_texcoord;
 #pragma tangram: material
 #pragma tangram: lighting
 #pragma tangram: global
+
+vec3 worldNormal() {
+    return u_inverseNormalMatrix * v_normal;
+}
 
 void main(void) {
 

--- a/core/resources/shaders/polygon.vs
+++ b/core/resources/shaders/polygon.vs
@@ -43,6 +43,10 @@ vec4 worldPosition() {
     return v_world_position;
 }
 
+vec3 worldNormal() {
+    return a_normal;
+}
+
 #pragma tangram: material
 #pragma tangram: lighting
 #pragma tangram: global

--- a/core/resources/shaders/polyline.fs
+++ b/core/resources/shaders/polyline.fs
@@ -10,6 +10,7 @@ uniform mat4 u_model;
 uniform mat4 u_view;
 uniform mat4 u_proj;
 uniform mat3 u_normalMatrix;
+uniform mat3 u_inverseNormalMatrix;
 uniform vec3 u_map_position;
 uniform vec3 u_tile_origin;
 uniform vec2 u_resolution;
@@ -28,6 +29,10 @@ varying vec2 v_texcoord;
 #ifdef TANGRAM_LIGHTING_VERTEX
     varying vec4 v_lighting;
 #endif
+
+vec3 worldNormal() {
+    return u_inverseNormalMatrix * v_normal;
+}
 
 #pragma tangram: material
 #pragma tangram: lighting

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -43,6 +43,10 @@ vec4 worldPosition() {
     return v_world_position;
 }
 
+vec3 worldNormal() {
+    return vec3(0.0, 0.0, 1.0);
+}
+
 #pragma tangram: material
 #pragma tangram: lighting
 #pragma tangram: global

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -184,6 +184,7 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
     const auto& mapPos = _view.getPosition();
     m_shaderProgram->setUniformf("u_map_position", mapPos.x, mapPos.y, _view.getZoom());
     m_shaderProgram->setUniformMatrix3f("u_normalMatrix", glm::value_ptr(_view.getNormalMatrix()));
+    m_shaderProgram->setUniformMatrix3f("u_inverseNormalMatrix", glm::value_ptr(glm::inverse(_view.getNormalMatrix())));
     m_shaderProgram->setUniformf("u_meters_per_pixel", 1.0 / _view.pixelsPerMeter());
     m_shaderProgram->setUniformMatrix4f("u_view", glm::value_ptr(_view.getViewMatrix()));
     m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getProjectionMatrix()));


### PR DESCRIPTION
Add `worldNormal()` access for both fragment and vertex shader. To easily detect up-pointing faces like roofs on tilted view.
Following of an issue related in https://github.com/tangrams/eraser-map/pull/56.
Once merged, update eraser-map stylesheet.

![screen shot 2015-11-02 at 1 34 32 pm](https://cloud.githubusercontent.com/assets/7061573/10890546/7d9ca7a6-8166-11e5-9fc3-7c5c4100dfd3.png)

- [x] revert stylesheet once reviewed
