### PR TITLE
Use '-f' to specify scene files from command line

### DIFF
--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -234,9 +234,13 @@ void init_main_window() {
 
 int main(int argc, char* argv[]) {
 
-    if (argc > 1) {
-        sceneFile = std::string(argv[1]);
-        logMsg("File from command line: %s\n", argv[1]);
+    int argi = 0;
+    while (++argi < argc) {
+        if (strcmp(argv[argi - 1], "-f") == 0) {
+            sceneFile = std::string(argv[argi]);
+            logMsg("File from command line: %s\n", argv[argi]);
+            break;
+        }
     }
 
     // Initialize the windowing library

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -222,9 +222,13 @@ void init_main_window() {
 
 int main(int argc, char* argv[]) {
 
-    if (argc > 1) {
-        sceneFile = std::string(argv[1]);
-        logMsg("File from command line: %s\n", argv[1]);
+    int argi = 0;
+    while (++argi < argc) {
+        if (strcmp(argv[argi - 1], "-f") == 0) {
+            sceneFile = std::string(argv[argi]);
+            logMsg("File from command line: %s\n", argv[argi]);
+            break;
+        }
     }
 
     // Initialize the windowing library


### PR DESCRIPTION
Sometimes command-line arguments will be added automatically when the program is run (*cough* xcode *cough*) so this will ensure that we only try to read a scene file provided via:
```
tangram [blah blah blah] -f <path_to_scene_file> [blah blah blah]
```