### PR TITLE
Fix global initializers in shaders

### DIFF
--- a/core/resources/shaders/lights.glsl
+++ b/core/resources/shaders/lights.glsl
@@ -2,6 +2,7 @@
 vec4 calculateLighting(in vec3 _eyeToPoint, in vec3 _normal, in vec4 _color) {
 
     // Do initial material calculations over normal, emission, ambient, diffuse and specular values
+    material = u_material;
     calculateMaterial(_eyeToPoint,_normal);
    
 

--- a/core/resources/shaders/material.glsl
+++ b/core/resources/shaders/material.glsl
@@ -54,7 +54,7 @@ struct Material {
 
 // Note: uniform is copied to a global instance to allow modification
 uniform Material u_material;
-Material material = u_material;
+Material material;
 
 #ifdef TANGRAM_MATERIAL_EMISSION_TEXTURE
 uniform sampler2D u_material_emission_texture;

--- a/core/src/scene/light.cpp
+++ b/core/src/scene/light.cpp
@@ -119,7 +119,7 @@ std::string Light::getInstanceBlock() {
     if (m_dynamic) {
         //  If is dynamic, define the uniform and copy it to the global instance of the light struct
         block += "uniform " + typeName + " " + getUniformName() + ";\n";
-        block += typeName + " " + getInstanceName() + " = " + getUniformName() + ";\n";
+        block += typeName + " " + getInstanceName() + ";\n";
     } else {
         //  If is not dynamic define the global instance of the light struct and fill the variables
         block += typeName + " " + getInstanceName() + getInstanceAssignBlock() +";\n";
@@ -139,7 +139,11 @@ std::string Light::getInstanceAssignBlock() {
 }
 
 std::string Light::getInstanceComputeBlock() {
-    return "calculateLight("+getInstanceName()+", _eyeToPoint, _normal);\n";
+    std::string str = "";
+    if (m_dynamic) {
+        str += getInstanceName() + " = " + getUniformName() + ";\n";
+    }
+    return  str + "calculateLight(" + getInstanceName() + ", _eyeToPoint, _normal);\n";
 }
 
 }


### PR DESCRIPTION
In the GLSL ES 1.0 specification, section 4.3:
>Declarations of globals without a storage qualifier, or with just the const qualifier, may include initializers, in which case they will be initialized before the first line of main() is executed. Such initializers must be a constant expression.

And according to section 5.1:  
>The following may not be used in constant expressions:
>• User-defined functions
>• Uniforms, attributes and varyings

(https://www.khronos.org/registry/gles/specs/2.0/GLSL_ES_Specification_1.0.17.pdf)

Turns out the shaders in Tangram have been violating this part of the specification for a long time: global variables for materials and lights are initialized with uniforms (e.g. [this line](https://github.com/tangrams/tangram-es/blob/master/core/resources/shaders/material.glsl#L57))

It seems that the vast majority of GL ES implementations don't enforce this, but some Adreno drivers will not only fail to compile shaders that violate this, but will actually crash the entire program with an internal error. 

Fortunately, it isn't too difficult to circumvent this issue by refactoring our shaders just a bit. 