### PR TITLE
Android native debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,12 @@ build
 cmake_install.cmake
 install_manifest.txt
 
+# Android debugging
+android/demo/jni
+android/*/libs
+android/*/obj
+*.mk
+
 # vim 
 *.swp
 *.swo

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ IOS_TARGET = tangram
 OSX_XCODE_PROJ = tangram.xcodeproj
 IOS_XCODE_PROJ = tangram.xcodeproj
 
+
 ifdef ANDROID_X86
 	ANDROID_BUILD_DIR = build/android-x86
 	ANDROID_TOOLCHAIN = x86-clang3.5
@@ -76,7 +77,7 @@ UNIT_TESTS_CMAKE_PARAMS = \
 
 ANDROID_CMAKE_PARAMS = \
 	-DPLATFORM_TARGET=android \
-	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_BUILD_TYPE=Debug \
 	-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_DIR}/android.toolchain.cmake \
 	-DMAKE_BUILD_TOOL=$$ANDROID_NDK/prebuilt/darwin-x86_64/bin/make \
 	-DANDROID_ABI=${ANDROID_ARCH} \

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ IOS_XCODE_PROJ = tangram.xcodeproj
 
 ifdef ANDROID_X86
 	ANDROID_BUILD_DIR = build/android-x86
-	ANDROID_TOOLCHAIN = x86-clang3.5
+	ANDROID_TOOLCHAIN = x86-clang3.6
 	ANDROID_ARCH = x86
 else
-	ANDROID_TOOLCHAIN = arm-linux-androideabi-clang3.5
+	ANDROID_TOOLCHAIN = arm-linux-androideabi-clang3.6
 endif
 
 ifndef ANDROID_ARCH

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,13 @@ cmake-android:
 	@cd ${ANDROID_BUILD_DIR} && \
 	cmake ../.. ${ANDROID_CMAKE_PARAMS}
 
+debug-android:
+	@cd android/demo &&           \
+	cp -a ../tangram/libs . &&    \
+	mkdir -p jni &&               \
+	cp ../tangram/jni/*.mk jni && \
+	python2 $$ANDROID_NDK/ndk-gdb.py --start --verbose
+
 osx: ${OSX_BUILD_DIR}/Makefile
 	@cd ${OSX_BUILD_DIR} && \
 	${MAKE}

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ IOS_TARGET = tangram
 OSX_XCODE_PROJ = tangram.xcodeproj
 IOS_XCODE_PROJ = tangram.xcodeproj
 
-
 ifdef ANDROID_X86
 	ANDROID_BUILD_DIR = build/android-x86
 	ANDROID_TOOLCHAIN = x86-clang3.6
@@ -156,13 +155,6 @@ cmake-android:
 	@cd ${ANDROID_BUILD_DIR} && \
 	cmake ../.. ${ANDROID_CMAKE_PARAMS}
 
-debug-android:
-	@cd android/demo &&           \
-	cp -a ../tangram/libs . &&    \
-	mkdir -p jni &&               \
-	cp ../tangram/jni/*.mk jni && \
-	python2 $$ANDROID_NDK/ndk-gdb.py --start --verbose
-
 osx: ${OSX_BUILD_DIR}/Makefile
 	@cd ${OSX_BUILD_DIR} && \
 	${MAKE}
@@ -255,3 +247,18 @@ swig-bindings:
 	@astyle --style=attach --indent=spaces=2 android/tangram/jni/jniGenerated.cpp
 	@astyle --style=java generated/*.java
 	@mv generated/*.java android/tangram/src/com/mapzen/tangram
+
+### Android Helpers
+android-install: android
+	@adb install -r android/demo/build/outputs/apk/demo-debug.apk
+
+android-debug:
+	@cd android/demo &&           \
+	cp -a ../tangram/libs . &&    \
+	mkdir -p jni &&               \
+	cp ../tangram/jni/*.mk jni && \
+	python2 $$ANDROID_NDK/ndk-gdb.py --verbose --start
+
+android-debug-attach:
+	@cd android/demo &&           \
+	python2 $$ANDROID_NDK/ndk-gdb.py --verbose

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ IOS_TARGET = tangram
 OSX_XCODE_PROJ = tangram.xcodeproj
 IOS_XCODE_PROJ = tangram.xcodeproj
 
+ifdef DEBUG
+	BUILD_TYPE = -DCMAKE_BUILD_TYPE=Debug
+endif
+ifdef RELEASE
+	BUILD_TYPE = -DCMAKE_BUILD_TYPE=Release
+endif
+
 ifdef ANDROID_X86
 	ANDROID_BUILD_DIR = build/android-x86
 	ANDROID_TOOLCHAIN = x86-clang3.6
@@ -75,38 +82,49 @@ UNIT_TESTS_CMAKE_PARAMS = \
 	-DCMAKE_BUILD_TYPE=Debug
 
 ANDROID_CMAKE_PARAMS = \
+        ${BUILD_TYPE} \
+        ${CMAKE_OPTIONS} \
 	-DPLATFORM_TARGET=android \
-	-DCMAKE_BUILD_TYPE=Debug \
 	-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_DIR}/android.toolchain.cmake \
 	-DMAKE_BUILD_TOOL=$$ANDROID_NDK/prebuilt/darwin-x86_64/bin/make \
 	-DANDROID_ABI=${ANDROID_ARCH} \
 	-DANDROID_STL=c++_shared \
 	-DANDROID_TOOLCHAIN_NAME=${ANDROID_TOOLCHAIN} \
 	-DANDROID_NATIVE_API_LEVEL=${ANDROID_API_LEVEL} \
-	-DLIBRARY_OUTPUT_PATH_ROOT=../../android/tangram
+	-DLIBRARY_OUTPUT_PATH_ROOT=../../android/tangram \
+	-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE
 
 IOS_CMAKE_PARAMS = \
+        ${BUILD_TYPE} \
+        ${CMAKE_OPTIONS} \
 	-DPLATFORM_TARGET=ios \
 	-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_DIR}/iOS.toolchain.cmake \
 	-G Xcode
 
 DARWIN_XCODE_CMAKE_PARAMS = \
-        ${TANGRAM_CMAKE_OPTIONS} \
+        ${BUILD_TYPE} \
+        ${CMAKE_OPTIONS} \
 	-DPLATFORM_TARGET=darwin \
 	-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="10.9" \
 	-G Xcode
 
 DARWIN_CMAKE_PARAMS = \
-        ${TANGRAM_CMAKE_OPTIONS} \
-	-DPLATFORM_TARGET=darwin
+        ${BUILD_TYPE} \
+        ${CMAKE_OPTIONS} \
+	-DPLATFORM_TARGET=darwin \
+	-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE
 
 RPI_CMAKE_PARAMS = \
-        ${TANGRAM_CMAKE_OPTIONS} \
-	-DPLATFORM_TARGET=raspberrypi
+        ${BUILD_TYPE} \
+        ${CMAKE_OPTIONS} \
+	-DPLATFORM_TARGET=raspberrypi \
+	-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE
 
 LINUX_CMAKE_PARAMS = \
-        ${TANGRAM_CMAKE_OPTIONS} \
-	-DPLATFORM_TARGET=linux
+        ${BUILD_TYPE} \
+        ${CMAKE_OPTIONS} \
+	-DPLATFORM_TARGET=linux \
+	-DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE
 
 clean: clean-android clean-osx clean-ios clean-rpi clean-tests clean-xcode clean-linux
 
@@ -140,6 +158,8 @@ clean-benchmark:
 android: android/tangram/libs/${ANDROID_ARCH}/libtangram.so android/build.gradle
 	@cd android/ && \
 	./gradlew demo:assembleDebug
+	@echo "run: 'adb install -r android/demo/build/outputs/apk/demo-debug.apk'"
+
 
 android/tangram/libs/${ANDROID_ARCH}/libtangram.so: install-android
 
@@ -249,7 +269,7 @@ swig-bindings:
 	@mv generated/*.java android/tangram/src/com/mapzen/tangram
 
 ### Android Helpers
-android-install: android
+android-install:
 	@adb install -r android/demo/build/outputs/apk/demo-debug.apk
 
 android-debug:

--- a/android/demo/AndroidManifest.xml
+++ b/android/demo/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
+    <application android:label="@string/app_name" android:icon="@drawable/ic_launcher" android:debuggable="true" >
         <activity android:name="MainActivity"
                   android:label="@string/app_name">
             <intent-filter>

--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -21,6 +21,12 @@ android {
     resources.srcDirs = ['src']
     res.srcDirs = ['res']
   }
+  buildTypes {
+    debug {
+      // applicationIdSuffix ".debug"
+      jniDebuggable true
+    }
+  }
 }
 
 dependencies {

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -36,6 +36,15 @@ android {
   }
 }
 
+// Add gdb server to apk
+afterEvaluate {
+    Sync packageTask = project.getTasks().findByName("packageReleaseJniLibs")
+    if (packageTask) { packageTask.include(['**/gdbserver', '**/gdb.setup']) }
+
+    packageTask = project.getTasks().findByName("packageDebugJniLibs")
+    if (packageTask) { packageTask.include(['**/gdbserver', '**/gdb.setup']) }
+}
+
 dependencies {
   compile 'com.squareup.okhttp:okhttp:2.5.0'
   compile 'xmlpull:xmlpull:1.1.3.1'

--- a/toolchains/android.cmake
+++ b/toolchains/android.cmake
@@ -18,8 +18,11 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/external)
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
 
 set(ANDROID_PROJECT_DIR ${PROJECT_SOURCE_DIR}/android/tangram)
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
 include(toolchains/android.gdb.cmake)
 android_ndk_gdb_enable()
+endif()
 
 set(LIB_NAME tangram) # in order to have libtangram.so
 
@@ -38,9 +41,9 @@ target_compile_options(${LIB_NAME}
   PUBLIC
   -fPIC)
 
+if(CMAKE_BUILD_TYPE MATCHES Debug)
 android_ndk_gdb_debuggable(${LIB_NAME})
-
-#add_dependencies(${LIB_NAME} NDK_GDB)
+endif()
 
 # install to android library dir
 set(LIB_INSTALLATION_PATH ${CMAKE_SOURCE_DIR}/android/tangram/libs/${ANDROID_ABI})

--- a/toolchains/android.cmake
+++ b/toolchains/android.cmake
@@ -8,18 +8,18 @@ else()
     message(STATUS "Will use make prebuilt tool located at : ${CMAKE_BUILD_TOOL}")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -pedantic")
-
 # configurations
-#set(CXX_FLAGS "${CXX_FLAGS} -Wall -std=c++1y -pedantic")
-#set(CXX_FLAGS_DEBUG "${CXX_FLAGS_DEBUG} -g -O0")
-#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -pedantic")
 
 # build external dependencies
 add_subdirectory(${PROJECT_SOURCE_DIR}/external)
 
 # load core library
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
+
+set(ANDROID_PROJECT_DIR ${PROJECT_SOURCE_DIR}/android/tangram)
+include(toolchains/android.gdb.cmake)
+android_ndk_gdb_enable()
 
 set(LIB_NAME tangram) # in order to have libtangram.so
 
@@ -38,35 +38,10 @@ target_compile_options(${LIB_NAME}
   PUBLIC
   -fPIC)
 
+android_ndk_gdb_debuggable(${LIB_NAME})
 
 # install to android library dir
 set(LIB_INSTALLATION_PATH ${CMAKE_SOURCE_DIR}/android/tangram/libs/${ANDROID_ABI})
 
-
-# from http://www.stellarium.org/wiki/index.php/Building_for_Android
-if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-  message(STATUS " >>> DEBUG <<< ")
-
-  # 1. generate a fake Android.mk
-  file(WRITE ${CMAKE_SOURCE_DIR}/android/tangram/jni/Android.mk "APP_ABI := ${ANDROID_ABI}\n")
-
-  # 2. generate gdb.setup
-  get_directory_property(INCLUDE_DIRECTORIES DIRECTORY . INCLUDE_DIRECTORIES)
-  message(STATUS "Directories >> ${INCLUDE_DIRECTORIES} <<")
-
-  string(REGEX REPLACE ";" " " INCLUDE_DIRECTORIES "${INCLUDE_DIRECTORIES}")
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/libs/${ARM_TARGET}/gdb.setup
-    "set solib-search-path ${CMAKE_CURRENT_BINARY_DIR}/obj/local/${ARM_TARGET}\n")
-
-  file(APPEND ${LIB_INSTALLATION_PATH}/gdb.setup
-    "directory ${INCLUDE_DIRECTORIES}\n")
-
-  # 3. copy gdbserver executable
-  file(COPY ${ANDROID_NDK}/prebuilt/android-arm/gdbserver/gdbserver
-    DESTINATION ${LIB_INSTALLATION_PATH}/)
-else()
-  message(STATUS " >>> NO DEBUG <<< ")
-
-endif()
 
 install(TARGETS ${LIB_NAME} DESTINATION ${LIB_INSTALLATION_PATH})

--- a/toolchains/android.cmake
+++ b/toolchains/android.cmake
@@ -36,8 +36,37 @@ target_link_libraries(${LIB_NAME}
 
 target_compile_options(${LIB_NAME}
   PUBLIC
-   -fPIC)
+  -fPIC)
+
 
 # install to android library dir
 set(LIB_INSTALLATION_PATH ${CMAKE_SOURCE_DIR}/android/tangram/libs/${ANDROID_ABI})
+
+
+# from http://www.stellarium.org/wiki/index.php/Building_for_Android
+if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+  message(STATUS " >>> DEBUG <<< ")
+
+  # 1. generate a fake Android.mk
+  file(WRITE ${CMAKE_SOURCE_DIR}/android/tangram/jni/Android.mk "APP_ABI := ${ANDROID_ABI}\n")
+
+  # 2. generate gdb.setup
+  get_directory_property(INCLUDE_DIRECTORIES DIRECTORY . INCLUDE_DIRECTORIES)
+  message(STATUS "Directories >> ${INCLUDE_DIRECTORIES} <<")
+
+  string(REGEX REPLACE ";" " " INCLUDE_DIRECTORIES "${INCLUDE_DIRECTORIES}")
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/libs/${ARM_TARGET}/gdb.setup
+    "set solib-search-path ${CMAKE_CURRENT_BINARY_DIR}/obj/local/${ARM_TARGET}\n")
+
+  file(APPEND ${LIB_INSTALLATION_PATH}/gdb.setup
+    "directory ${INCLUDE_DIRECTORIES}\n")
+
+  # 3. copy gdbserver executable
+  file(COPY ${ANDROID_NDK}/prebuilt/android-arm/gdbserver/gdbserver
+    DESTINATION ${LIB_INSTALLATION_PATH}/)
+else()
+  message(STATUS " >>> NO DEBUG <<< ")
+
+endif()
+
 install(TARGETS ${LIB_NAME} DESTINATION ${LIB_INSTALLATION_PATH})

--- a/toolchains/android.cmake
+++ b/toolchains/android.cmake
@@ -40,6 +40,8 @@ target_compile_options(${LIB_NAME}
 
 android_ndk_gdb_debuggable(${LIB_NAME})
 
+#add_dependencies(${LIB_NAME} NDK_GDB)
+
 # install to android library dir
 set(LIB_INSTALLATION_PATH ${CMAKE_SOURCE_DIR}/android/tangram/libs/${ANDROID_ABI})
 

--- a/toolchains/android.gdb.cmake
+++ b/toolchains/android.gdb.cmake
@@ -1,0 +1,96 @@
+# Copyright (c) 2014, Pavel Rojtberg
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# ------------------------------------------------------------------------------
+# Usage:
+# 1. place AndroidNdkGdb.cmake somewhere inside ${CMAKE_MODULE_PATH}
+# 2. inside your project add
+#
+#    include(AndroidNdkGdb)
+#    android_ndk_gdb_enable()
+#    # for each target
+#    add_library(MyLibrary ...)
+#    android_ndk_gdb_debuggable(MyLibrary)
+
+
+# add gdbserver and general gdb configuration to project
+# also create a mininal NDK skeleton so ndk-gdb finds the paths
+#
+# the optional parameter defines the path to the android project.
+# uses PROJECT_SOURCE_DIR by default.
+macro(android_ndk_gdb_enable)
+  if(ANDROID)
+    # create custom target that depends on the real target so it gets executed afterwards
+    add_custom_target(NDK_GDB ALL)
+
+    if(${ARGC})
+      set(ANDROID_PROJECT_DIR ${ARGV0})
+    else()
+      set(ANDROID_PROJECT_DIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    set(NDK_GDB_SOLIB_PATH ${ANDROID_PROJECT_DIR}/obj/local/${ANDROID_NDK_ABI_NAME}/)
+    file(MAKE_DIRECTORY ${NDK_GDB_SOLIB_PATH})
+
+    # 1. generate essential Android Makefiles
+    file(MAKE_DIRECTORY ${ANDROID_PROJECT_DIR}/jni)
+    if(NOT EXISTS ${ANDROID_PROJECT_DIR}/jni/Android.mk)
+      file(WRITE ${ANDROID_PROJECT_DIR}/jni/Android.mk "APP_ABI := ${ANDROID_NDK_ABI_NAME}\n")
+    endif()
+    if(NOT EXISTS ${ANDROID_PROJECT_DIR}/jni/Application.mk)
+      file(WRITE ${ANDROID_PROJECT_DIR}/jni/Application.mk "APP_ABI := ${ANDROID_NDK_ABI_NAME}\n")
+    endif()
+
+    # 2. generate gdb.setup
+    get_directory_property(PROJECT_INCLUDES DIRECTORY ${PROJECT_SOURCE_DIR} INCLUDE_DIRECTORIES)
+    string(REGEX REPLACE ";" " " PROJECT_INCLUDES "${PROJECT_INCLUDES}")
+    file(WRITE ${LIBRARY_OUTPUT_PATH}/gdb.setup "set solib-search-path ${NDK_GDB_SOLIB_PATH}\n")
+    file(APPEND ${LIBRARY_OUTPUT_PATH}/gdb.setup "directory ${PROJECT_INCLUDES}\n")
+
+    # 3. copy gdbserver executable
+    file(COPY ${ANDROID_NDK}/prebuilt/android-${ANDROID_ARCH_NAME}/gdbserver/gdbserver DESTINATION ${LIBRARY_OUTPUT_PATH})
+  endif()
+endmacro()
+
+# register a target for remote debugging
+# copies the debug version to NDK_GDB_SOLIB_PATH then strips symbols of original
+macro(android_ndk_gdb_debuggable TARGET_NAME)
+  if(ANDROID)
+    get_property(TARGET_LOCATION TARGET ${TARGET_NAME} PROPERTY LOCATION)
+
+    # create custom target that depends on the real target so it gets executed afterwards
+    add_dependencies(NDK_GDB ${TARGET_NAME})
+
+    # 4. copy lib to obj
+    add_custom_command(TARGET NDK_GDB POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TARGET_LOCATION} ${NDK_GDB_SOLIB_PATH})
+
+    # 5. strip symbols
+    add_custom_command(TARGET NDK_GDB POST_BUILD COMMAND ${CMAKE_STRIP} ${TARGET_LOCATION})
+  endif()
+endmacro()

--- a/toolchains/android.toolchain.cmake
+++ b/toolchains/android.toolchain.cmake
@@ -1042,7 +1042,7 @@ if( BUILD_WITH_ANDROID_NDK )
     # android support sfiles
     include_directories ( SYSTEM ${ANDROID_NDK}/sources/android/support/include )
     if( EXISTS "${ANDROID_LLVM_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/libc++_shared.so" )
-        set( __libstl                           "${ANDROID_LLVM_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/libc++_shared.so" )
+        set( __libstl "${ANDROID_LLVM_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/libc++_shared.so" )
     else()
         message( "c++ shared library doesn't exist" )
     endif()

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -7,7 +7,7 @@ if [[ ${PLATFORM} == "android" ]]; then
 
     # Install android ndk
     echo "Cloning mindk..."
-    git clone --quiet --depth 1 --branch tangram-es-travis-linux https://github.com/tangrams/mindk.git
+    git clone --quiet --depth 1 --branch clang-3.6 https://github.com/tangrams/mindk.git
     export ANDROID_NDK=$PWD/mindk/android-ndk-r10e
     echo "Done."
 

--- a/travis/script_build.sh
+++ b/travis/script_build.sh
@@ -6,13 +6,13 @@ set -o pipefail
 if [[ ${PLATFORM} == "osx" ]]; then
     # Build osx project
     echo "Building osx project"
-    TANGRAM_CMAKE_OPTIONS="-DUNIT_TESTS=1 -DBENCHMARK=1" make -j osx
+    CMAKE_OPTIONS="-DUNIT_TESTS=1 -DBENCHMARK=1" make -j osx
 fi
 
 if [[ ${PLATFORM} == "linux" ]]; then
     # Build linux project
     echo "Building linux project"
-    TANGRAM_CMAKE_OPTIONS="-DUNIT_TESTS=1 -DBENCHMARK=1" make -j 4 linux
+    CMAKE_OPTIONS="-DUNIT_TESTS=1 -DBENCHMARK=1" make -j 4 linux
 fi
 
 if [[ ${PLATFORM} == "ios" ]]; then


### PR DESCRIPTION
Enable native debugging. It should now be as simple as running:
```
[ANDROID_X86=1] DEBUG=1 make -j android
make android-install
make android-debug
```
to run the demo with gdb attached to it. After the first run of android-debug on can quit gdb and then re-attach to the running app with android-debug-attach. With a rooted device or emulator one can also use

    kill -SIGINT `ps | grep -m 1 tangram | awk -e '{print $2}'`

in adb shell to suspend the program to set breakpoints, etc.

TODO
- [X] separate Release/Debug builds
- [X] needs update of our stripped ndk to clang-3.6
- [X] cleanups