### PR TITLE
Normalize world normals

### DIFF
--- a/core/resources/shaders/polygon.fs
+++ b/core/resources/shaders/polygon.fs
@@ -35,7 +35,7 @@ varying vec2 v_texcoord;
 #pragma tangram: global
 
 vec3 worldNormal() {
-    return u_inverseNormalMatrix * v_normal;
+    return normalize(u_inverseNormalMatrix * v_normal);
 }
 
 void main(void) {

--- a/core/resources/shaders/polyline.fs
+++ b/core/resources/shaders/polyline.fs
@@ -31,7 +31,7 @@ varying vec2 v_texcoord;
 #endif
 
 vec3 worldNormal() {
-    return u_inverseNormalMatrix * v_normal;
+    return normalize(u_inverseNormalMatrix * v_normal);
 }
 
 #pragma tangram: material


### PR DESCRIPTION
Since our normal matrix is the rotation part of the view matrix, the inverse normal matrix contains non-uniform scaling, and unfortunately we do need to normalize again.. Also, I noticed normals were not normalized in fragment, so I guess they would be safe to use until we add any slope to geometry.
This does not apply to JS, but still something to adapt in the future.