### PR TITLE
Fix material textures on some devices

### DIFF
--- a/core/resources/shaders/lights.glsl
+++ b/core/resources/shaders/lights.glsl
@@ -1,4 +1,4 @@
-
+#if (defined(TANGRAM_VERTEX_SHADER) && defined(TANGRAM_LIGHTING_VERTEX)) || (defined(TANGRAM_FRAGMENT_SHADER) && defined(TANGRAM_LIGHTING_FRAGMENT))
 vec4 calculateLighting(in vec3 _eyeToPoint, in vec3 _normal, in vec4 _color) {
 
     // Do initial material calculations over normal, emission, ambient, diffuse and specular values
@@ -36,3 +36,4 @@ vec4 calculateLighting(in vec3 _eyeToPoint, in vec3 _normal, in vec4 _color) {
 
     return color;
 }
+#endif

--- a/core/resources/shaders/material.glsl
+++ b/core/resources/shaders/material.glsl
@@ -146,6 +146,7 @@ void calculateNormal (inout vec3 _normal) {
 }
 #endif
 
+#if (defined(TANGRAM_VERTEX_SHADER) && defined(TANGRAM_LIGHTING_VERTEX)) || (defined(TANGRAM_FRAGMENT_SHADER) && defined(TANGRAM_LIGHTING_FRAGMENT))
 void calculateMaterial (in vec3 _eyeToPoint, inout vec3 _normal) {
     // get EMISSION TEXTUREMAP
     //------------------------------------------------
@@ -227,3 +228,4 @@ void calculateMaterial (in vec3 _eyeToPoint, inout vec3 _normal) {
         #endif
     #endif
 }
+#endif


### PR DESCRIPTION
Accessing the texcoord varying in a function in the vertex shader seems to cause the varying to not be interpolated, even in the fragment shader later