### PR TITLE
Uniform caching

### DIFF
--- a/core/src/gl/primitives.cpp
+++ b/core/src/gl/primitives.cpp
@@ -3,7 +3,6 @@
 #include "debug.h"
 #include "glm/mat4x4.hpp"
 #include "glm/gtc/matrix_transform.hpp"
-#include "glm/gtc/type_ptr.hpp"
 #include "gl/shaderProgram.h"
 #include "gl/vertexLayout.h"
 #include "gl/renderState.h"
@@ -108,7 +107,7 @@ void setResolution(float _width, float _height) {
     init();
 
     glm::mat4 proj = glm::ortho(0.f, _width, _height, 0.f, -1.f, 1.f);
-    s_shader->setUniformMatrix4f("u_proj", glm::value_ptr(proj));
+    s_shader->setUniformMatrix4f("u_proj", proj);
 }
 
 }

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -390,7 +390,7 @@ void ShaderProgram::setUniformMatrix2f(const std::string& _name, const glm::mat2
     use();
     GLint location = getUniformLocation(_name);
     if (location >= 0) {
-        bool cached = getFromCache(location, _value);
+        bool cached = !_transpose && getFromCache(location, _value);
         if (!cached) { glUniformMatrix2fv(location, 1, _transpose, glm::value_ptr(_value)); }
     }
 }
@@ -399,7 +399,7 @@ void ShaderProgram::setUniformMatrix3f(const std::string& _name, const glm::mat3
     use();
     GLint location = getUniformLocation(_name);
     if (location >= 0) {
-        bool cached = getFromCache(location, _value);
+        bool cached = !_transpose && getFromCache(location, _value);
         if (!cached) { glUniformMatrix3fv(location, 1, _transpose, glm::value_ptr(_value)); }
     }
 }
@@ -408,7 +408,7 @@ void ShaderProgram::setUniformMatrix4f(const std::string& _name, const glm::mat4
     use();
     GLint location = getUniformLocation(_name);
     if (location >= 0) {
-        bool cached = getFromCache(location, _value);
+        bool cached = !_transpose && getFromCache(location, _value);
         if (!cached) { glUniformMatrix4fv(location, 1, _transpose, glm::value_ptr(_value)); }
     }
 }

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -3,6 +3,7 @@
 #include "platform.h"
 #include "scene/light.h"
 #include "gl/renderState.h"
+#include "glm/gtc/type_ptr.hpp"
 
 #include <sstream>
 #include <regex>
@@ -306,6 +307,7 @@ void ShaderProgram::checkValidity() {
         m_glVertexShader = 0;
         m_glProgram = 0;
         m_needsBuild = true;
+        m_uniformCache.clear();
     }
 }
 
@@ -318,67 +320,97 @@ void ShaderProgram::invalidateAllPrograms() {
 void ShaderProgram::setUniformi(const std::string& _name, int _value) {
     use();
     GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniform1i(location, _value); }
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniform1i(location, _value); }
+    }
 }
 
 void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1) {
-    use();
-    GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniform2i(location, _value0, _value1); }
+    setUniformf(_name, glm::vec2(_value0, _value1));
 }
 
 void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1, int _value2) {
-    use();
-    GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniform3i(location, _value0, _value1, _value2); }
+    setUniformf(_name, glm::vec3(_value0, _value1, _value2));
 }
 
 void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1, int _value2, int _value3) {
-    use();
-    GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniform4i(location, _value0, _value1, _value2, _value3); }
+    setUniformf(_name, glm::vec4(_value0, _value1, _value2, _value3));
 }
 
 void ShaderProgram::setUniformf(const std::string& _name, float _value) {
     use();
     GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniform1f(location, _value); }
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniform1f(location, _value); }
+    }
 }
 
 void ShaderProgram::setUniformf(const std::string& _name, float _value0, float _value1) {
-    use();
-    GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniform2f(location, _value0, _value1); }
+    setUniformf(_name, glm::vec2(_value0, _value1));
 }
 
 void ShaderProgram::setUniformf(const std::string& _name, float _value0, float _value1, float _value2) {
-    use();
-    GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniform3f(location, _value0, _value1, _value2); }
+    setUniformf(_name, glm::vec3(_value0, _value1, _value2));
 }
 
 void ShaderProgram::setUniformf(const std::string& _name, float _value0, float _value1, float _value2, float _value3) {
-    use();
-    GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniform4f(location, _value0, _value1, _value2, _value3); }
+    setUniformf(_name, glm::vec4(_value0, _value1, _value2, _value3));
 }
 
-void ShaderProgram::setUniformMatrix2f(const std::string& _name, const float* _value, bool _transpose) {
+void ShaderProgram::setUniformf(const std::string& _name, const glm::vec2& _value) {
     use();
     GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniformMatrix2fv(location, 1, _transpose, _value); }
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniform2f(location, _value.x, _value.y); }
+    }
 }
 
-void ShaderProgram::setUniformMatrix3f(const std::string& _name, const float* _value, bool _transpose) {
+void ShaderProgram::setUniformf(const std::string& _name, const glm::vec3& _value) {
     use();
     GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniformMatrix3fv(location, 1, _transpose, _value); }
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniform3f(location, _value.x, _value.y, _value.z); }
+    }
 }
 
-void ShaderProgram::setUniformMatrix4f(const std::string& _name, const float* _value, bool _transpose) {
+void ShaderProgram::setUniformf(const std::string& _name, const glm::vec4& _value) {
     use();
     GLint location = getUniformLocation(_name);
-    if (location >= 0) { glUniformMatrix4fv(location, 1, _transpose, _value); }
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniform4f(location, _value.x, _value.y, _value.z, _value.w); }
+    }
+}
+
+void ShaderProgram::setUniformMatrix2f(const std::string& _name, const glm::mat2& _value, bool _transpose) {
+    use();
+    GLint location = getUniformLocation(_name);
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniformMatrix2fv(location, 1, _transpose, glm::value_ptr(_value)); }
+    }
+}
+
+void ShaderProgram::setUniformMatrix3f(const std::string& _name, const glm::mat3& _value, bool _transpose) {
+    use();
+    GLint location = getUniformLocation(_name);
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniformMatrix3fv(location, 1, _transpose, glm::value_ptr(_value)); }
+    }
+}
+
+void ShaderProgram::setUniformMatrix4f(const std::string& _name, const glm::mat4& _value, bool _transpose) {
+    use();
+    GLint location = getUniformLocation(_name);
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniformMatrix4fv(location, 1, _transpose, glm::value_ptr(_value)); }
+    }
 }
 
 }

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -326,6 +326,33 @@ void ShaderProgram::setUniformi(const std::string& _name, int _value) {
     }
 }
 
+void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1) {
+    use();
+    GLint location = getUniformLocation(_name);
+    if (location >= 0) {
+        bool cached = getFromCache(location, glm::vec2(_value0, _value1));
+        if (!cached) { glUniform2i(location, _value0, _value1); }
+    }
+}
+
+void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1, int _value2) {
+    use();
+    GLint location = getUniformLocation(_name);
+    if (location >= 0) {
+        bool cached = getFromCache(location, glm::vec3(_value0, _value1, _value2));
+        if (!cached) { glUniform3i(location, _value0, _value1, _value2); }
+    }
+}
+
+void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1, int _value2, int _value3) {
+    use();
+    GLint location = getUniformLocation(_name);
+    if (location >= 0) {
+        bool cached = getFromCache(location, glm::vec4(_value0, _value1, _value2, _value3));
+        if (!cached) { glUniform4i(location, _value0, _value1, _value2, _value3); }
+    }
+}
+
 void ShaderProgram::setUniformf(const std::string& _name, float _value) {
     use();
     GLint location = getUniformLocation(_name);

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -326,18 +326,6 @@ void ShaderProgram::setUniformi(const std::string& _name, int _value) {
     }
 }
 
-void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1) {
-    setUniformf(_name, glm::vec2(_value0, _value1));
-}
-
-void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1, int _value2) {
-    setUniformf(_name, glm::vec3(_value0, _value1, _value2));
-}
-
-void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1, int _value2, int _value3) {
-    setUniformf(_name, glm::vec4(_value0, _value1, _value2, _value3));
-}
-
 void ShaderProgram::setUniformf(const std::string& _name, float _value) {
     use();
     GLint location = getUniformLocation(_name);

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -3,7 +3,7 @@
 #include "gl.h"
 #include "glm/glm.hpp"
 #include "util/fastmap.h"
-#include "util/variant.h"
+#include "util/uniform.h"
 
 #include <string>
 #include <vector>
@@ -111,6 +111,7 @@ private:
 
     static int s_validGeneration; // Incremented when GL context is invalidated
 
+    // Get a uniform value from the cache, and returns false when it's a cache miss
     template <class T>
     inline bool getFromCache(GLint _location, T _value) {
         const auto& v = m_uniformCache.find(_location);

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -132,7 +132,7 @@ private:
 
     fastmap<std::string, ShaderLocation> m_attribMap;
     fastmap<std::string, ShaderLocation> m_uniformMap;
-    std::map<GLint, UniformValue> m_uniformCache;
+    fastmap<GLint, UniformValue> m_uniformCache;
 
     std::string m_fragmentShaderSource;
     std::string m_vertexShaderSource;

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -65,6 +65,9 @@ public:
      * Ensures the program is bound and then sets the named uniform to the given value(s)
      */
     void setUniformi(const std::string& _name, int _value);
+    void setUniformi(const std::string& _name, int _value0, int _value1);
+    void setUniformi(const std::string& _name, int _value0, int _value1, int _value2);
+    void setUniformi(const std::string& _name, int _value0, int _value1, int _value2, int _value3);
 
     void setUniformf(const std::string& _name, float _value);
     void setUniformf(const std::string& _name, float _value0, float _value1);

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include "gl.h"
-#include "glm/vec2.hpp"
-#include "glm/vec3.hpp"
-#include "glm/vec4.hpp"
+#include "glm/glm.hpp"
 #include "util/fastmap.h"
+#include "util/variant.h"
 
 #include <string>
 #include <vector>
@@ -75,17 +74,17 @@ public:
     void setUniformf(const std::string& _name, float _value0, float _value1, float _value2);
     void setUniformf(const std::string& _name, float _value0, float _value1, float _value2, float _value3);
 
-    void setUniformf(const std::string& _name, const glm::vec2& _value){setUniformf(_name,_value.x,_value.y);}
-    void setUniformf(const std::string& _name, const glm::vec3& _value){setUniformf(_name,_value.x,_value.y,_value.z);}
-    void setUniformf(const std::string& _name, const glm::vec4& _value){setUniformf(_name,_value.x,_value.y,_value.z,_value.w);}
+    void setUniformf(const std::string& _name, const glm::vec2& _value);
+    void setUniformf(const std::string& _name, const glm::vec3& _value);
+    void setUniformf(const std::string& _name, const glm::vec4& _value);
 
     /*
      * Ensures the program is bound and then sets the named uniform to the values
      * beginning at the pointer _value; 4 values are used for a 2x2 matrix, 9 values for a 3x3, etc.
      */
-    void setUniformMatrix2f(const std::string& _name, const float* _value, bool transpose = false);
-    void setUniformMatrix3f(const std::string& _name, const float* _value, bool transpose = false);
-    void setUniformMatrix4f(const std::string& _name, const float* _value, bool transpose = false);
+    void setUniformMatrix2f(const std::string& _name, const glm::mat2& _value, bool transpose = false);
+    void setUniformMatrix3f(const std::string& _name, const glm::mat3& _value, bool transpose = false);
+    void setUniformMatrix4f(const std::string& _name, const glm::mat4& _value, bool transpose = false);
 
     /* Invalidates all managed ShaderPrograms
      *
@@ -95,6 +94,7 @@ public:
     static void invalidateAllPrograms();
 
     auto getSourceBlocks() const { return  m_sourceBlocks; }
+
 private:
 
     struct ShaderLocation {
@@ -111,6 +111,22 @@ private:
 
     static int s_validGeneration; // Incremented when GL context is invalidated
 
+    template <class T>
+    inline bool getFromCache(GLint _location, T _value) {
+        const auto& v = m_uniformCache.find(_location);
+        bool cached = false;
+        if (v != m_uniformCache.end()) {
+            if (v->second.is<T>()) {
+                T& value = v->second.get<T>();
+                cached = value == _value;
+                if (!cached) {
+                    value = _value;
+                }
+            }
+        } else { m_uniformCache[_location] = _value; }
+        return cached;
+    }
+
     int m_generation;
     GLuint m_glProgram;
     GLuint m_glFragmentShader;
@@ -118,6 +134,7 @@ private:
 
     fastmap<std::string, ShaderLocation> m_attribMap;
     fastmap<std::string, ShaderLocation> m_uniformMap;
+    std::map<GLint, UniformValue> m_uniformCache;
 
     std::string m_fragmentShaderSource;
     std::string m_vertexShaderSource;

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -65,9 +65,6 @@ public:
      * Ensures the program is bound and then sets the named uniform to the given value(s)
      */
     void setUniformi(const std::string& _name, int _value);
-    void setUniformi(const std::string& _name, int _value0, int _value1);
-    void setUniformi(const std::string& _name, int _value0, int _value1, int _value2);
-    void setUniformi(const std::string& _name, int _value0, int _value1, int _value2, int _value3);
 
     void setUniformf(const std::string& _name, float _value);
     void setUniformf(const std::string& _name, float _value0, float _value1);

--- a/core/src/scene/skybox.cpp
+++ b/core/src/scene/skybox.cpp
@@ -1,6 +1,5 @@
 #include "skybox.h"
 #include "view/view.h"
-#include "glm/gtc/type_ptr.hpp"
 #include "gl/renderState.h"
 #include "gl/shaderProgram.h"
 #include "gl/textureCube.h"
@@ -60,9 +59,9 @@ void Skybox::draw(const View& _view) {
     // Remove translation so that skybox is centered on view
     vp[3] = { 0, 0, 0, 0 };
 
-    m_shader->setUniformMatrix4f("u_modelViewProj", glm::value_ptr(vp));
+    m_shader->setUniformMatrix4f("u_modelViewProj", vp);
     m_shader->setUniformi("u_tex", 0);
-    
+
     RenderState::blending(GL_FALSE);
     RenderState::depthTest(GL_TRUE);
 

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -15,8 +15,6 @@
 #include "data/propertyItem.h" // Include wherever Properties is used!
 #include "scene/stops.h"
 
-#include "glm/gtc/type_ptr.hpp"
-
 namespace Tangram {
 
 PointStyle::PointStyle(std::string _name, Blending _blendMode, GLenum _drawMode) : Style(_name, _blendMode, _drawMode) {
@@ -244,8 +242,6 @@ void PointStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, co
 }
 
 void PointStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit) {
-    bool contextLost = Style::glContextLost();
-
     if (m_spriteAtlas) {
         m_spriteAtlas->bind(0);
     } else if (m_texture) {
@@ -253,17 +249,8 @@ void PointStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _texture
         m_texture->bind(0);
     }
 
-    static bool initUniformSampler = true;
-
-    if (initUniformSampler || contextLost) {
-        m_shaderProgram->setUniformi("u_tex", 0);
-        initUniformSampler = false;
-    }
-
-    if (m_dirtyViewport || contextLost) {
-        m_shaderProgram->setUniformMatrix4f("u_ortho", glm::value_ptr(_view.getOrthoViewportMatrix()));
-        m_dirtyViewport = false;
-    }
+    m_shaderProgram->setUniformi("u_tex", 0);
+    m_shaderProgram->setUniformMatrix4f("u_ortho", _view.getOrthoViewportMatrix());
 
     Style::onBeginDrawFrame(_view, _scene, 1);
 }

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -12,8 +12,6 @@
 #include "tile/tile.h"
 #include "view/view.h"
 
-#include "glm/gtc/type_ptr.hpp"
-
 namespace Tangram {
 
     Style::Style(std::string _name, Blending _blendMode, GLenum _drawMode) :
@@ -21,9 +19,8 @@ namespace Tangram {
     m_shaderProgram(std::make_unique<ShaderProgram>()),
     m_material(std::make_shared<Material>()),
     m_blend(_blendMode),
-    m_drawMode(_drawMode),
-    m_contextLost(true) {
-}
+    m_drawMode(_drawMode)
+{}
 
 Style::~Style() {}
 
@@ -119,7 +116,7 @@ void Style::buildFeature(Tile& _tile, const Feature& _feat, const DrawRule& _rul
 
 }
 
-void Style::setupShaderUniforms(int _textureUnit, bool _update, Scene& _scene) {
+void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
     for (const auto& uniformPair : m_styleUniforms) {
         const auto& name = uniformPair.first;
         const auto& value = uniformPair.second;
@@ -133,14 +130,11 @@ void Style::setupShaderUniforms(int _textureUnit, bool _update, Scene& _scene) {
             tex->update(_textureUnit);
             tex->bind(_textureUnit);
 
-            if (_update) {
-                m_shaderProgram->setUniformi(name, _textureUnit);
-            }
+            m_shaderProgram->setUniformi(name, _textureUnit);
 
             _textureUnit++;
 
         } else {
-            if (!_update) { continue; }
 
             if (value.is<bool>()) {
                 m_shaderProgram->setUniformi(name, value.get<bool>());
@@ -162,12 +156,7 @@ void Style::setupShaderUniforms(int _textureUnit, bool _update, Scene& _scene) {
 
 void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit) {
 
-    bool contextLost = glContextLost();
-
-    // Setup constant uniforms
-    if (contextLost) {
-        m_shaderProgram->setUniformf("u_device_pixel_ratio", m_pixelScale);
-    }
+    m_shaderProgram->setUniformf("u_device_pixel_ratio", m_pixelScale);
 
     m_material->setupProgram(*m_shaderProgram);
 
@@ -177,19 +166,17 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
     }
 
     // Set Map Position
-    if (m_dirtyViewport) {
-        m_shaderProgram->setUniformf("u_resolution", _view.getWidth(), _view.getHeight());
-    }
+    m_shaderProgram->setUniformf("u_resolution", _view.getWidth(), _view.getHeight());
 
     const auto& mapPos = _view.getPosition();
     m_shaderProgram->setUniformf("u_map_position", mapPos.x, mapPos.y, _view.getZoom());
-    m_shaderProgram->setUniformMatrix3f("u_normalMatrix", glm::value_ptr(_view.getNormalMatrix()));
-    m_shaderProgram->setUniformMatrix3f("u_inverseNormalMatrix", glm::value_ptr(glm::inverse(_view.getNormalMatrix())));
+    m_shaderProgram->setUniformMatrix3f("u_normalMatrix", _view.getNormalMatrix());
+    m_shaderProgram->setUniformMatrix3f("u_inverseNormalMatrix", glm::inverse(_view.getNormalMatrix()));
     m_shaderProgram->setUniformf("u_meters_per_pixel", 1.0 / _view.pixelsPerMeter());
-    m_shaderProgram->setUniformMatrix4f("u_view", glm::value_ptr(_view.getViewMatrix()));
-    m_shaderProgram->setUniformMatrix4f("u_proj", glm::value_ptr(_view.getProjectionMatrix()));
+    m_shaderProgram->setUniformMatrix4f("u_view", _view.getViewMatrix());
+    m_shaderProgram->setUniformMatrix4f("u_proj", _view.getProjectionMatrix());
 
-    setupShaderUniforms(_textureUnit, contextLost, _scene);
+    setupShaderUniforms(_textureUnit, _scene);
 
     // Configure render state
     switch (m_blend) {
@@ -247,14 +234,6 @@ void Style::buildLine(const Line& _line, const DrawRule& _rule, const Properties
 
 void Style::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
     // No-op by default
-}
-
-bool Style::glContextLost() {
-    bool contextLost = m_contextLost;
-    if (m_contextLost) {
-        m_contextLost = false;
-    }
-    return contextLost;
 }
 
 }

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -76,9 +76,6 @@ protected:
     /* Draw mode to pass into <VboMesh>es created with this style */
     GLenum m_drawMode;
 
-    /* Whether the viewport has changed size */
-    bool m_dirtyViewport = true;
-
     /* animated property */
     bool m_animated = false;
 
@@ -100,17 +97,12 @@ protected:
     /* Create a new mesh object using the vertex layout corresponding to this style */
     virtual VboMesh* newMesh() const = 0;
 
-    /* Toggle on read if true, checks whether the context has been lost on last frame */
-    bool glContextLost();
-
     /* Set uniform values when @_updateUniforms is true,
        and bind textures starting at @_textureUnit */
-    void setupShaderUniforms(int _textureUnit, bool _updateUniforms, Scene& _scene);
+    void setupShaderUniforms(int _textureUnit, Scene& _scene);
 
 private:
 
-    /* Whether the context has been lost on last frame */
-    bool m_contextLost;
     std::vector<StyleUniform> m_styleUniforms;
 
 public:
@@ -118,10 +110,6 @@ public:
     Style(std::string _name, Blending _blendMode, GLenum _drawMode);
 
     virtual ~Style();
-
-    void notifyGLContextLost() { m_contextLost = true; }
-
-    void viewportHasChanged() { m_dirtyViewport = true; }
 
     Blending blendMode() const { return m_blend; };
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -15,8 +15,6 @@
 #include "platform.h"
 #include "tangram.h"
 
-#include "glm/gtc/type_ptr.hpp"
-
 namespace Tangram {
 
 TextStyle::TextStyle(std::string _name, std::shared_ptr<FontContext> _fontContext, bool _sdf,
@@ -188,21 +186,12 @@ void TextStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule,
 }
 
 void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit) {
-    bool contextLost = Style::glContextLost();
-
     m_fontContext->bindAtlas(0);
 
     m_shaderProgram->setUniformf("u_uv_scale_factor",
                                  1.0f / m_fontContext->getAtlasResolution());
-
-    if (contextLost) {
-        m_shaderProgram->setUniformi("u_tex", 0);
-    }
-
-    if (m_dirtyViewport || contextLost) {
-        m_shaderProgram->setUniformMatrix4f("u_ortho", glm::value_ptr(_view.getOrthoViewportMatrix()));
-        m_dirtyViewport = false;
-    }
+    m_shaderProgram->setUniformi("u_tex", 0);
+    m_shaderProgram->setUniformMatrix4f("u_ortho", _view.getOrthoViewportMatrix());
 
     Style::onBeginDrawFrame(_view, _scene, 1);
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -120,10 +120,6 @@ void resize(int _newWidth, int _newHeight) {
         m_view->setSize(_newWidth, _newHeight);
     }
 
-    for (auto& style : m_scene->styles()) {
-        style->viewportHasChanged();
-    }
-
     Primitives::setResolution(_newWidth, _newHeight);
 
     while (Error::hadGlError("Tangram::resize()")) {}
@@ -430,10 +426,6 @@ void setupGL() {
 
     if (m_tileManager) {
         m_tileManager->clearTileSets();
-
-        for (auto& style : m_scene->styles()) {
-           style->notifyGLContextLost();
-        }
     }
 
     // The OpenGL context has been destroyed since the last time resources were created,

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -13,7 +13,6 @@
 #include "gl/shaderProgram.h"
 
 #include "glm/gtc/matrix_transform.hpp"
-#include "glm/gtc/type_ptr.hpp"
 
 #include <algorithm>
 
@@ -133,7 +132,7 @@ void Tile::draw(const Style& _style, const View& _view) {
 
         float zoomAndProxy = m_proxyCounter > 0 ? -m_id.z : m_id.z;
 
-        shader->setUniformMatrix4f("u_model", glm::value_ptr(m_modelMatrix));
+        shader->setUniformMatrix4f("u_model", m_modelMatrix);
         shader->setUniformf("u_tile_origin", m_tileOrigin.x, m_tileOrigin.y, zoomAndProxy);
 
         styleMesh->draw(*shader);

--- a/core/src/util/fastmap.h
+++ b/core/src/util/fastmap.h
@@ -45,7 +45,16 @@ struct fastmap {
     }
 
     iterator find(const K& key) {
-        return const_cast<iterator&>(static_cast<const iterator &>(find(key)));
+        iterator it = std::lower_bound(
+            map.begin(), map.end(), key,
+            [&](const auto& item, const auto& key) {
+                return item.first < key;
+            });
+
+        if (it == map.end() || it->first == key) {
+            return it;
+        }
+        return map.end();
     }
 
     iterator begin() { return map.begin(); }

--- a/core/src/util/fastmap.h
+++ b/core/src/util/fastmap.h
@@ -44,6 +44,10 @@ struct fastmap {
         return map.end();
     }
 
+    iterator find(const K& key) {
+        return const_cast<iterator&>(static_cast<const iterator &>(find(key)));
+    }
+
     iterator begin() { return map.begin(); }
     iterator end() { return map.end(); }
 

--- a/core/src/util/uniform.h
+++ b/core/src/util/uniform.h
@@ -2,15 +2,14 @@
 
 #include "util/variant.h"
 
-#include "glm/vec2.hpp"
-#include "glm/vec3.hpp"
-#include "glm/vec4.hpp"
+#include "glm/glm.hpp"
 
 #include <string>
 
 namespace Tangram {
 
 /* Style Block Uniform types */
-using UniformValue = variant<none_type, bool, std::string, float, glm::vec2, glm::vec3, glm::vec4>;
+using UniformValue = variant<none_type, bool, std::string, float, int, glm::vec2, glm::vec3,
+      glm::vec4, glm::mat2, glm::mat3, glm::mat4>;
 
 }

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -8,7 +8,6 @@
 #define NDEBUG
 #endif
 
-#include "glm/glm.hpp"
 #include "variant/variant.hpp"
 
 #ifndef KEEP_NDEBUG
@@ -40,7 +39,5 @@ class Value : public detail::Value {
     using Base::Base;
 };
 
-/* Style Block Uniform types */
-using UniformValue = variant<none_type, bool, std::string, float, int, glm::vec2, glm::vec3, glm::vec4, glm::mat2, glm::mat3, glm::mat4>;
 
 }

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -8,6 +8,7 @@
 #define NDEBUG
 #endif
 
+#include "glm/glm.hpp"
 #include "variant/variant.hpp"
 
 #ifndef KEEP_NDEBUG
@@ -38,5 +39,8 @@ class Value : public detail::Value {
     using Base = detail::Value;
     using Base::Base;
 };
+
+/* Style Block Uniform types */
+using UniformValue = variant<none_type, bool, std::string, float, int, glm::vec2, glm::vec3, glm::vec4, glm::mat2, glm::mat3, glm::mat4>;
 
 }

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -39,5 +39,4 @@ class Value : public detail::Value {
     using Base::Base;
 };
 
-
 }


### PR DESCRIPTION
Something interesting to have is shader uniform caching, which cleans up some part of the code. Before dispatching the uniform command to the GPU, we simply check if the uniform value has already been sent, on context loss, we simply clear the cache. 
On the current scene, this reduces the GL trace by ~40 GL calls per frame once tiles have been fetched, on the CPU side I didn't notice any increasing time on any of the `setUniform*` methods, and `getFromCache` takes a negligible amount of app time.

Current trace:
![screen shot 2015-11-10 at 6 38 44 pm](https://cloud.githubusercontent.com/assets/7061573/11079520/04158418-87db-11e5-9de8-9c8ab97b9ddd.png)

With uniform caching:
![screen shot 2015-11-10 at 6 37 33 pm](https://cloud.githubusercontent.com/assets/7061573/11079524/0b3ae0c6-87db-11e5-9082-e1cced956056.png)

