### PR TITLE
Remove now unused modelViewProj uniform

### DIFF
--- a/core/resources/shaders/cubemap.vs
+++ b/core/resources/shaders/cubemap.vs
@@ -9,8 +9,8 @@ attribute vec3 a_position;
 varying vec3 v_uv;
 
 const mat3 rotNegHalfPiAroundX = mat3( 1.0,  0.0,  0.0,
-                                       0.0,  0.0, -1.0,
-                                       0.0,  1.0,  0.0);
+        0.0,  0.0, -1.0,
+        0.0,  1.0,  0.0);
 
 void main() {
     // The map coordinates use +z as "up" instead of the cubemap convention of +y,
@@ -19,5 +19,5 @@ void main() {
     vec4 pos = u_modelViewProj * vec4(a_position, 1.0);
 
     // force depth to 1.0
-	gl_Position = pos.xyww;
+    gl_Position = pos.xyww;
 }

--- a/core/resources/shaders/debug.vs
+++ b/core/resources/shaders/debug.vs
@@ -2,7 +2,9 @@
 precision highp float;
 #endif
 
-uniform mat4 u_modelViewProj;
+uniform mat4 u_model;
+uniform mat4 u_view;
+uniform mat4 u_proj;
 
 attribute vec4 a_position;
 attribute vec4 a_color;
@@ -13,5 +15,5 @@ void main() {
 
     v_color = a_color;
 
-    gl_Position = u_modelViewProj * a_position;
+    gl_Position = u_proj * u_view * u_model * a_position;
 }

--- a/core/resources/shaders/polygon.vs
+++ b/core/resources/shaders/polygon.vs
@@ -95,7 +95,7 @@ void main() {
 
     gl_Position = u_proj * v_position;
 
-    // Proxy tiles have u_tile_origin.z < 0, so this adjustment will place proxy tiles 
+    // Proxy tiles have u_tile_origin.z < 0, so this adjustment will place proxy tiles
     // deeper in the depth buffer than non-proxy tiles
     gl_Position.z += TANGRAM_DEPTH_DELTA * gl_Position.w * (1. - sign(u_tile_origin.z));
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -128,11 +128,9 @@ void Tile::draw(const Style& _style, const View& _view) {
     if (styleMesh) {
         auto& shader = _style.getShaderProgram();
 
-        glm::mat4 modelViewProjMatrix = _view.getViewProjectionMatrix() * m_modelMatrix;
         float zoomAndProxy = m_proxyCounter > 0 ? -m_id.z : m_id.z;
 
         shader->setUniformMatrix4f("u_model", glm::value_ptr(m_modelMatrix));
-        shader->setUniformMatrix4f("u_modelViewProj", glm::value_ptr(modelViewProjMatrix));
         shader->setUniformf("u_tile_origin", m_tileOrigin.x, m_tileOrigin.y, zoomAndProxy);
 
         styleMesh->draw(*shader);


### PR DESCRIPTION
`u_modelViewProj` was only used in the debug shader, so we can easily remove it now.