### PR TITLE
Reduce flickering

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -252,7 +252,7 @@ layers:
                 collide: true
                 transition:
                     [show, hide]:
-                        time: .3s
+                        time: 1s
                 #size: [[13, 12px], [15, 18px]]
                 #interactive: true
 
@@ -351,7 +351,10 @@ layers:
                 interactive: true
                 visible: true
                 priority: 2
-                #offset: [0, 8px]
+                offset: [0, 8px]
+                transition:
+                    [show, hide]:
+                        time: 1s
                 font:
                     family: sans-serif
                     weight: 400
@@ -366,6 +369,9 @@ layers:
                     visible: true
                     #offset: [0px, 5px]
                     priority: 1
+                    transition:
+                        [show, hide]:
+                            time: 1s
                     font:
                         family: sans-serif
                         weight: 400
@@ -380,6 +386,9 @@ layers:
                     interactive: true
                     visible: true
                     priority: 3
+                    transition:
+                        [show, hide]:
+                            time: 1s
                     font:
                         family: sans-serif
                         weight: 400
@@ -403,6 +412,9 @@ layers:
             text:
                 interactive: true
                 priority: 5
+                transition:
+                    [show, hide]:
+                        time: 1s
                 font:
                     family: sans-serif
                     weight: 400
@@ -441,6 +453,9 @@ layers:
             text:
                 interactive: true
                 priority: 0
+                transition:
+                    [show, hide]:
+                        time: 1s
                 font:
                     family: sans-serif
                     weight: 400

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -59,7 +59,7 @@ public:
      */
     void setCacheSize(size_t _cacheSize);
 
-    int32_t id() { return m_id; }
+    int32_t id() const { return m_id; }
 
 
 protected:

--- a/core/src/labels/fadeEffect.h
+++ b/core/src/labels/fadeEffect.h
@@ -8,8 +8,10 @@ struct FadeEffect {
 
 public:
 
-    enum class Interpolation : char {
-        linear, pow, sine
+    enum Interpolation {
+        linear = 0,
+        pow,
+        sine
     };
 
     FadeEffect() {}
@@ -47,3 +49,4 @@ private:
 };
 
 }
+

--- a/core/src/labels/fadeEffect.h
+++ b/core/src/labels/fadeEffect.h
@@ -8,7 +8,7 @@ struct FadeEffect {
 
 public:
 
-    enum class Interpolation {
+    enum class Interpolation : char {
         linear, pow, sine
     };
 

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -223,6 +223,7 @@ void Label::pushTransform() {
 
 void Label::resetState() {
     m_occludedLastFrame = false;
+    m_skipTransitions = false;
     m_occlusionSolved = false;
     m_updateMeshVisibility = true;
     m_dirty = true;

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -27,6 +27,7 @@ Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, LabelMesh
     m_updateMeshVisibility = true;
     m_dirty = true;
     m_proxy = false;
+    m_skipTransitions = false;
 }
 
 Label::~Label() {}
@@ -171,6 +172,12 @@ void Label::occlusionSolved() {
     m_occlusionSolved = true;
 }
 
+void Label::skipTransitions() {
+    if (!m_occlusionSolved) {
+        m_skipTransitions = true;
+    }
+}
+
 void Label::enterState(const State& _state, float _alpha) {
     m_currentState = _state;
     setAlpha(_alpha);
@@ -218,6 +225,7 @@ void Label::resetState() {
     m_updateMeshVisibility = true;
     m_dirty = true;
     m_proxy = false;
+    m_skipTransitions = false;
     enterState(State::wait_occ, 0.0);
 }
 
@@ -287,9 +295,18 @@ bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
                 if (occludedLastFrame) {
                     enterState(State::dead, 0.0); // dead
                 }  else {
+<<<<<<< HEAD
                     m_fade = FadeEffect(true, m_options.showTransition.ease, m_options.showTransition.time);
                     enterState(State::fading_in, 0.0);
                     animate = true;
+=======
+                    if (m_skipTransitions) {
+                        enterState(State::visible, 1.0);
+                    } else {
+                        m_fade = FadeEffect(true, m_options.showTransition.ease, m_options.showTransition.time);
+                        enterState(State::fading_in, 0.0);
+                    }
+>>>>>>> Reduce flickering
                 }
             } else {
                 // request for occlusion solving

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -7,14 +7,16 @@
 
 namespace Tangram {
 
-Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, LabelMesh& _mesh, Range _vertexRange, Options _options) :
+Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, LabelMesh& _mesh,
+             Range _vertexRange, Options _options, size_t _hash) :
     m_options(_options),
+    m_hash(_hash),
     m_type(_type),
     m_transform(_transform),
     m_dim(_size),
     m_mesh(_mesh),
-    m_vertexRange(_vertexRange) {
-
+    m_vertexRange(_vertexRange)
+{
     if (!m_options.collide || m_type == Type::debug){
         enterState(State::visible, 1.0);
     } else {
@@ -294,19 +296,13 @@ bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
             if (m_occlusionSolved) {
                 if (occludedLastFrame) {
                     enterState(State::dead, 0.0); // dead
-                }  else {
-<<<<<<< HEAD
+                }  else if (m_skipTransitions) {
+                    enterState(State::visible, 1.0);
+                    animate = true;
+                } else {
                     m_fade = FadeEffect(true, m_options.showTransition.ease, m_options.showTransition.time);
                     enterState(State::fading_in, 0.0);
                     animate = true;
-=======
-                    if (m_skipTransitions) {
-                        enterState(State::visible, 1.0);
-                    } else {
-                        m_fade = FadeEffect(true, m_options.showTransition.ease, m_options.showTransition.time);
-                        enterState(State::fading_in, 0.0);
-                    }
->>>>>>> Reduce flickering
                 }
             } else {
                 // request for occlusion solving

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -122,6 +122,8 @@ public:
     /* Mark the label as resolved */
     void occlusionSolved();
 
+    void skipTransitions();
+
     bool occludedLastFrame() { return m_occludedLastFrame; }
 
     State getState() const { return m_currentState; }
@@ -159,6 +161,7 @@ private:
     bool m_updateMeshVisibility;
     // label options
     Options m_options;
+    bool m_skipTransitions;
 
 protected:
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -83,23 +83,13 @@ public:
         Transition showTransition;
     };
 
-    Label(Transform _transform, glm::vec2 _size, Type _type, LabelMesh& _mesh, Range _vertexRange, Options _options, size_t _hash);
+    Label(Transform _transform, glm::vec2 _size, Type _type, LabelMesh& _mesh, Range _vertexRange,
+            Options _options, size_t _hash);
 
     virtual ~Label();
 
-    const Transform& getTransform() const { return m_transform; }
-
     /* Update the transform of the label in world space, and project it to screen space */
     void updateTransform(const Transform& _transform, const glm::mat4& _mvp, const glm::vec2& _screenSize);
-
-    /* Gets the oriented bounding box of the label */
-    const OBB& getOBB() const { return m_obb; }
-
-    /* Gets the extent of the oriented bounding box of the label */
-    const AABB& getAABB() const { return m_aabb; }
-
-    /* Gets for label options: color and offset */
-    const Options& getOptions() const { return m_options; }
 
     bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt, float _zoomFract);
 
@@ -111,7 +101,6 @@ public:
                                bool _testVisibility = true);
 
     virtual void updateBBoxes(float _zoomFract) = 0;
-
 
     /* Sets the occlusion */
     void setOcclusion(bool _occlusion);
@@ -126,8 +115,6 @@ public:
 
     bool occludedLastFrame() { return m_occludedLastFrame; }
 
-    State getState() const { return m_currentState; }
-
     /* Checks whether the label is in a visible state */
     bool visibleState() const;
 
@@ -137,10 +124,16 @@ public:
 
     /* Whether the label belongs to a proxy tile */
     bool isProxy() const { return m_proxy; }
-
-    size_t getHash() { return m_hash; }
-
-    glm::vec2 getDimension() const { return m_dim; }
+    size_t hash() const { return m_hash; }
+    const glm::vec2& dimension() const { return m_dim; }
+    /* Gets for label options: color and offset */
+    const Options& options() const { return m_options; }
+    /* Gets the extent of the oriented bounding box of the label */
+    const AABB& aabb() const { return m_aabb; }
+    /* Gets the oriented bounding box of the label */
+    const OBB& obb() const { return m_obb; }
+    const Transform& transform() const { return m_transform; }
+    const State& state() const { return m_currentState; }
 
 private:
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -83,7 +83,7 @@ public:
         Transition showTransition;
     };
 
-    Label(Transform _transform, glm::vec2 _size, Type _type, LabelMesh& _mesh, Range _vertexRange, Options _options);
+    Label(Transform _transform, glm::vec2 _size, Type _type, LabelMesh& _mesh, Range _vertexRange, Options _options, size_t _hash);
 
     virtual ~Label();
 
@@ -138,6 +138,8 @@ public:
     /* Whether the label belongs to a proxy tile */
     bool isProxy() const { return m_proxy; }
 
+    size_t getHash() { return m_hash; }
+
 private:
 
     bool offViewport(const glm::vec2& _screenSize);
@@ -162,6 +164,7 @@ private:
     // label options
     Options m_options;
     bool m_skipTransitions;
+    size_t m_hash;
 
 protected:
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -140,6 +140,8 @@ public:
 
     size_t getHash() { return m_hash; }
 
+    glm::vec2 getDimension() const { return m_dim; }
+
 private:
 
     bool offViewport(const glm::vec2& _screenSize);

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -205,11 +205,11 @@ namespace std {
             hash_combine(seed, o.priority);
             hash_combine(seed, o.interactive);
             hash_combine(seed, o.collide);
-            hash_combine(seed, o.selectTransition.ease);
+            hash_combine(seed, (int)o.selectTransition.ease);
             hash_combine(seed, o.selectTransition.time);
-            hash_combine(seed, o.hideTransition.ease);
+            hash_combine(seed, (int)o.hideTransition.ease);
             hash_combine(seed, o.hideTransition.time);
-            hash_combine(seed, o.showTransition.ease);
+            hash_combine(seed, (int)o.showTransition.ease);
             hash_combine(seed, o.showTransition.time);
             return seed;
         }

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -165,7 +165,9 @@ private:
     bool m_updateMeshVisibility;
     // label options
     Options m_options;
+    // whether this label should skip transitions to move to first visible state
     bool m_skipTransitions;
+    // the label hash based on its styling parameters
     size_t m_hash;
 
 protected:

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -7,6 +7,7 @@
 #include "glm_vec.h" // for isect2d.h
 #include "fadeEffect.h"
 #include "util/types.h"
+#include "util/hash.h"
 #include "data/properties.h"
 
 #include <string>
@@ -183,3 +184,25 @@ protected:
 };
 
 }
+
+namespace std {
+    template <>
+    struct hash<Tangram::Label::Options> {
+        size_t operator() (const Tangram::Label::Options& o) const {
+            std::size_t seed = 0;
+            hash_combine(seed, o.offset.x);
+            hash_combine(seed, o.offset.y);
+            hash_combine(seed, o.priority);
+            hash_combine(seed, o.interactive);
+            hash_combine(seed, o.collide);
+            hash_combine(seed, o.selectTransition.ease);
+            hash_combine(seed, o.selectTransition.time);
+            hash_combine(seed, o.hideTransition.ease);
+            hash_combine(seed, o.hideTransition.time);
+            hash_combine(seed, o.showTransition.ease);
+            hash_combine(seed, o.showTransition.time);
+            return seed;
+        }
+    };
+}
+

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -8,6 +8,7 @@
 #include "style/material.h"
 #include "style/style.h"
 #include "tile/tile.h"
+#include "tile/tileCache.h"
 
 #include "glm/glm.hpp"
 #include "glm/gtc/matrix_transform.hpp"
@@ -26,7 +27,7 @@ int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
 
 
 void Labels::update(const View& _view, float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
-                    const std::vector<std::shared_ptr<Tile>>& _tiles) {
+                    const std::vector<std::shared_ptr<Tile>>& _tiles, std::unique_ptr<TileCache>& _cache) {
 
     m_needUpdate = false;
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -118,6 +118,9 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
 
     /// Mark labels to skip transitions
 
+    static float globalTime = 0.f;
+    static int cpt = 0;
+    time_t start = clock();
     for (const auto& t0 : _tiles) {
         TileID tileID = t0->getID();
         std::vector<std::shared_ptr<Tile>> tiles;
@@ -137,8 +140,7 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
                 if (!mesh0) { continue; }
                 const auto& m1 = t1->getMesh(*style);
                 if (!m1) { continue; }
-                const LabelMesh* mesh1 = dynamic_cast<const LabelMesh*>(m1.get());
-                if (!mesh1) { continue; }
+                const LabelMesh* mesh1 = static_cast<const LabelMesh*>(m1.get());
 
                 for (auto& l0 : mesh0->getLabels()) {
                     if (!l0->canOcclude()) { continue; }
@@ -153,6 +155,12 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
             }
         }
     }
+    time_t end = clock();
+    float t = float(end - start) / CLOCKS_PER_SEC * 1000.f;
+    globalTime += t;
+    cpt++;
+    LOG("T: %f", t);
+    LOG("AVG: %f", globalTime / float(cpt));
 
     //// Update label meshes
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -125,11 +125,16 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
         TileID tileID = t0->getID();
         std::vector<std::shared_ptr<Tile>> tiles;
 
-        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getParent()));
-        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(0)));
-        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(1)));
-        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(2)));
-        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(3)));
+        float currentZoom = _view.getZoom();
+
+        if (_view.getNextZoom() > currentZoom) {
+            tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getParent()));
+        } else {
+            tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(0)));
+            tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(1)));
+            tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(2)));
+            tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(3)));
+        }
 
         for (const auto& t1 : tiles) {
             if (!t1) { continue; }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -116,39 +116,37 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
         }
     }
 
+    /// Mark labels to skip transitions
 
-    for (const auto& tile : _tiles) {
-        TileID tileID = tile->getID();
-        TileID parent = tileID.getParent();
-        TileID child0 = tileID.getChild(0);
-        TileID child1 = tileID.getChild(1);
-        TileID child2 = tileID.getChild(2);
-        TileID child3 = tileID.getChild(3);
+    for (const auto& t0 : _tiles) {
+        TileID tileID = t0->getID();
+        std::vector<std::shared_ptr<Tile>> tiles;
 
-        auto pTile = _cache->contains(tile->getDataSourceSerial(), parent);
+        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getParent()));
+        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(0)));
+        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(1)));
+        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(2)));
+        tiles.push_back(_cache->contains(t0->getDataSourceSerial(), tileID.getChild(3)));
 
-        // check for parent tile
-        if (pTile) {
+        for (const auto& t1 : tiles) {
+            if (!t1) { continue; }
             for (const auto& style : _styles) {
-                const auto& mesh = tile->getMesh(*style);
-                if (!mesh) { continue; }
-                const LabelMesh* labelMesh = dynamic_cast<const LabelMesh*>(mesh.get());
-                if (!labelMesh) { continue; }
-                const auto& pMesh = pTile->getMesh(*style);
-                if (!pMesh) { continue; }
-                const LabelMesh* pLabelMesh = dynamic_cast<const LabelMesh*>(pMesh.get());
-                if (!pLabelMesh) { continue; }
+                const auto& m0 = t0->getMesh(*style);
+                if (!m0) { continue; }
+                const LabelMesh* mesh0 = dynamic_cast<const LabelMesh*>(m0.get());
+                if (!mesh0) { continue; }
+                const auto& m1 = t1->getMesh(*style);
+                if (!m1) { continue; }
+                const LabelMesh* mesh1 = dynamic_cast<const LabelMesh*>(m1.get());
+                if (!mesh1) { continue; }
 
-                for (auto& label : labelMesh->getLabels()) {
-                    TextLabel* textLabel = dynamic_cast<TextLabel*>(label.get());
-                    if (!textLabel) { continue; }
-                    if (!textLabel->canOcclude()) { continue; }
-                    for (auto& labelParent : pLabelMesh->getLabels()) {
-                        TextLabel* pTextLabel = dynamic_cast<TextLabel*>(labelParent.get());
-                        if (!pTextLabel) { continue; }
-                        if (!pTextLabel->canOcclude()) { continue; }
-                        if (textLabel->getHash() == pTextLabel->getHash()) {
-                            textLabel->skipTransitions();
+                for (auto& l0 : mesh0->getLabels()) {
+                    if (!l0->canOcclude()) { continue; }
+                    for (auto& l1 : mesh1->getLabels()) {
+                        if (!l1) { continue; }
+                        if (!l1->canOcclude()) { continue; }
+                        if (l0->getHash() == l1->getHash()) {
+                            l0->skipTransitions();
                         }
                     }
                 }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -152,8 +152,14 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
                     for (auto& l1 : mesh1->getLabels()) {
                         if (!l1) { continue; }
                         if (!l1->canOcclude()) { continue; }
+
                         if (l0->getHash() == l1->getHash()) {
-                            l0->skipTransitions();
+                            float d2 = glm::distance2(l0->getTransform().state.screenPos, l1->getTransform().state.screenPos);
+
+                            // The new label lies within the circle defined by the bounding box of the already visible label
+                            if (sqrt(d2) < std::max(l0->getDimension().x, l0->getDimension().y)) {
+                                l0->skipTransitions();
+                            }
                         }
                     }
                 }

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -19,6 +19,7 @@ class FontContext;
 class Tile;
 class View;
 class Style;
+class TileCache;
 struct TouchItem;
 
 /*
@@ -35,7 +36,7 @@ public:
     void drawDebug(const View& _view);
 
     void update(const View& _view, float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
-                const std::vector<std::shared_ptr<Tile>>& _tiles);
+                const std::vector<std::shared_ptr<Tile>>& _tiles, std::unique_ptr<TileCache>& _cache);
 
     const std::vector<TouchItem>& getFeaturesAtPoint(const View& _view, float _dt,
                                                      const std::vector<std::unique_ptr<Style>>& _styles,

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -62,7 +62,7 @@ private:
 
     std::vector<TouchItem> m_touchItems;
 
-    int m_lastZoom;
+    float m_lastZoom;
 };
 
 }

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -61,6 +61,8 @@ private:
     isect2d::ISect2D<glm::vec2> m_isect2d;
 
     std::vector<TouchItem> m_touchItems;
+
+    int m_lastZoom;
 };
 
 }

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -5,9 +5,9 @@ namespace Tangram {
 
 using namespace LabelProperty;
 
-SpriteLabel::SpriteLabel(Label::Transform _transform, glm::vec2 _size, LabelMesh& _mesh,
-    int _vertexOffset, Label::Options _options, float _extrudeScale, LabelProperty::Anchor _anchor) :
-    Label(_transform, _size, Label::Type::point, _mesh, {_vertexOffset, 4}, _options),
+SpriteLabel::SpriteLabel(Label::Transform _transform, glm::vec2 _size, LabelMesh& _mesh, int _vertexOffset,
+        Label::Options _options, float _extrudeScale, LabelProperty::Anchor _anchor, size_t _hash) :
+    Label(_transform, _size, Label::Type::point, _mesh, {_vertexOffset, 4}, _options, _hash),
     m_extrudeScale(_extrudeScale)
 {
     switch(_anchor) {

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -9,7 +9,7 @@ class SpriteLabel : public Label {
 public:
 
     SpriteLabel(Label::Transform _transform, glm::vec2 _size, LabelMesh& _mesh, int _vertexOffset,
-                Label::Options _options, float _extrudeScale, LabelProperty::Anchor _anchor);
+                Label::Options _options, float _extrudeScale, LabelProperty::Anchor _anchor, size_t _hash);
 
     void updateBBoxes(float _zoomFract) override;
     void align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) override;

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -6,8 +6,9 @@ using namespace LabelProperty;
 
 TextLabel::TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim, TextBuffer& _mesh, Range _vertexRange,
     Label::Options _options, FontContext::FontMetrics _metrics, int _nLines, Anchor _anchor, size_t _hash) :
-    Label(_transform, _dim, _type, static_cast<LabelMesh&>(_mesh), _vertexRange, _options),
-    m_metrics(_metrics), m_nLines(_nLines), m_hash(_hash)
+    Label(_transform, _dim, _type, static_cast<LabelMesh&>(_mesh), _vertexRange, _options, _hash),
+    m_metrics(_metrics),
+    m_nLines(_nLines)
 {
     if (m_type == Type::point) {
         glm::vec2 halfDim = m_dim * 0.5f;

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -5,9 +5,9 @@ namespace Tangram {
 using namespace LabelProperty;
 
 TextLabel::TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim, TextBuffer& _mesh, Range _vertexRange,
-    Label::Options _options, FontContext::FontMetrics _metrics, int _nLines, Anchor _anchor) :
+    Label::Options _options, FontContext::FontMetrics _metrics, int _nLines, Anchor _anchor, size_t _hash) :
     Label(_transform, _dim, _type, static_cast<LabelMesh&>(_mesh), _vertexRange, _options),
-    m_metrics(_metrics), m_nLines(_nLines)
+    m_metrics(_metrics), m_nLines(_nLines), m_hash(_hash)
 {
     if (m_type == Type::point) {
         glm::vec2 halfDim = m_dim * 0.5f;

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -16,8 +16,6 @@ public:
 
     void updateBBoxes(float _zoomFract) override;
 
-    size_t getHash() { return m_hash; };
-
 protected:
 
     void align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const glm::vec2& _ap2) override;
@@ -28,7 +26,6 @@ private:
 
     glm::vec2 m_anchor;
     glm::vec2 m_perpAxis;
-    size_t m_hash;
 
 };
 

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -11,9 +11,12 @@ class TextLabel : public Label {
 
 public:
     TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim, TextBuffer& _mesh, Range _vertexRange,
-              Label::Options _options, FontContext::FontMetrics _metrics, int _nLines, LabelProperty::Anchor _anchor);
+              Label::Options _options, FontContext::FontMetrics _metrics, int _nLines, LabelProperty::Anchor _anchor,
+              size_t _hash);
 
     void updateBBoxes(float _zoomFract) override;
+
+    size_t getHash() { return m_hash; };
 
 protected:
 
@@ -25,6 +28,7 @@ private:
 
     glm::vec2 m_anchor;
     glm::vec2 m_perpAxis;
+    size_t m_hash;
 
 };
 

--- a/core/src/style/labelProperty.h
+++ b/core/src/style/labelProperty.h
@@ -16,7 +16,7 @@ inline bool tryFind(M& _map, const std::string& _transform, T& _out) {
 
 namespace LabelProperty {
 
-enum class Anchor {
+enum Anchor {
     center,
     top,
     bottom,
@@ -34,14 +34,14 @@ bool anchor(const std::string& _transform, Anchor& _out);
 
 namespace TextLabelProperty {
 
-enum class Transform {
+enum Transform {
     none,
     capitalize,
     uppercase,
     lowercase,
 };
 
-enum class Align : char {
+enum Align {
     right,
     left,
     center,

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -65,6 +65,11 @@ bool PointStyle::checkRule(const DrawRule& _rule) const {
     return true;
 }
 
+size_t PointStyle::hashParams(const Parameters& _params) const {
+    std::hash<Parameters> hash;
+    return hash(_params);
+}
+
 PointStyle::Parameters PointStyle::applyRule(const DrawRule& _rule, const Properties& _props, float _zoom) const {
 
     Parameters p;
@@ -162,7 +167,7 @@ void PointStyle::buildPoint(const Point& _point, const DrawRule& _rule, const Pr
     Label::Transform transform = { glm::vec2(_point) };
 
     mesh.addLabel(std::make_unique<SpriteLabel>(transform, p.size, mesh, _mesh.numVertices(),
-                p.labelOptions, p.extrudeScale, p.anchor));
+                p.labelOptions, p.extrudeScale, p.anchor, hashParams(p)));
 
     std::vector<Label::Vertex> vertices;
 
@@ -190,7 +195,7 @@ void PointStyle::buildLine(const Line& _line, const DrawRule& _rule, const Prope
         Label::Transform transform = { glm::vec2(_line[i]) };
 
         mesh.addLabel(std::make_unique<SpriteLabel>(transform, p.size, mesh, _mesh.numVertices(),
-                    p.labelOptions, p.extrudeScale, p.anchor));
+                    p.labelOptions, p.extrudeScale, p.anchor, hashParams(p)));
         pushQuad(vertices, p.size, {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w},
                 p.color, p.extrudeScale);
     }
@@ -222,7 +227,7 @@ void PointStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, co
                 Label::Transform transform = { glm::vec2(point) };
 
                 mesh.addLabel(std::make_unique<SpriteLabel>(transform, p.size, mesh, _mesh.numVertices(),
-                            p.labelOptions, p.extrudeScale, p.anchor));
+                            p.labelOptions, p.extrudeScale, p.anchor, hashParams(p)));
                 pushQuad(vertices, p.size, {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w},
                         p.color, p.extrudeScale);
             }
@@ -233,7 +238,7 @@ void PointStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, co
         Label::Transform transform = { c };
 
         mesh.addLabel(std::make_unique<SpriteLabel>(transform, p.size, mesh, _mesh.numVertices(),
-                    p.labelOptions, p.extrudeScale, p.anchor));
+                    p.labelOptions, p.extrudeScale, p.anchor, hashParams(p)));
         pushQuad(vertices, p.size,
                 {uvsQuad.x, uvsQuad.y}, {uvsQuad.z, uvsQuad.w}, p.color, p.extrudeScale);
     }

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -13,8 +13,15 @@ class SpriteAtlas;
 
 class PointStyle : public Style {
 
-protected:
+public:
 
+    virtual void onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit = 0) override;
+
+    PointStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
+    void setSpriteAtlas(std::shared_ptr<SpriteAtlas> _spriteAtlas) { m_spriteAtlas = _spriteAtlas; }
+    void setTexture(std::shared_ptr<Texture> _texture) { m_texture = _texture; }
+
+    virtual ~PointStyle();
     struct Parameters {
         bool centroid = false;
         std::string sprite;
@@ -25,6 +32,8 @@ protected:
         LabelProperty::Anchor anchor = LabelProperty::Anchor::center;
         float extrudeScale = 1.f;
     };
+
+protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
@@ -44,16 +53,25 @@ protected:
     std::shared_ptr<SpriteAtlas> m_spriteAtlas;
     std::shared_ptr<Texture> m_texture;
 
-public:
-
-    virtual void onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit = 0) override;
-
-    PointStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
-    void setSpriteAtlas(std::shared_ptr<SpriteAtlas> _spriteAtlas) { m_spriteAtlas = _spriteAtlas; }
-    void setTexture(std::shared_ptr<Texture> _texture) { m_texture = _texture; }
-
-    virtual ~PointStyle();
+    inline size_t hashParams(const Parameters& _params) const;
 
 };
 
 }
+
+namespace std {
+    template <>
+    struct hash<Tangram::PointStyle::Parameters> {
+        size_t operator() (const Tangram::PointStyle::Parameters& p) const {
+            std::hash<Tangram::Label::Options> optionsHash;
+            std::size_t seed = 0;
+            hash_combine(seed, p.sprite);
+            hash_combine(seed, p.spriteDefault);
+            hash_combine(seed, p.size.x);
+            hash_combine(seed, p.size.y);
+            hash_combine(seed, optionsHash(p.labelOptions));
+            return seed;
+        }
+    };
+}
+

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -68,7 +68,7 @@ namespace std {
             hash_combine(seed, p.centroid);
             hash_combine(seed, p.sprite);
             hash_combine(seed, p.color);
-            hash_combine(seed, p.anchor);
+            hash_combine(seed, (int)p.anchor);
             hash_combine(seed, p.size.x);
             hash_combine(seed, p.size.y);
             hash_combine(seed, optionsHash(p.labelOptions));

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -65,9 +65,8 @@ namespace std {
         size_t operator() (const Tangram::PointStyle::Parameters& p) const {
             std::hash<Tangram::Label::Options> optionsHash;
             std::size_t seed = 0;
-            hash_combine(seed, p.centroid);;
+            hash_combine(seed, p.centroid);
             hash_combine(seed, p.sprite);
-            hash_combine(seed, p.spriteDefault);
             hash_combine(seed, p.color);
             hash_combine(seed, p.anchor);
             hash_combine(seed, p.size.x);

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -65,8 +65,11 @@ namespace std {
         size_t operator() (const Tangram::PointStyle::Parameters& p) const {
             std::hash<Tangram::Label::Options> optionsHash;
             std::size_t seed = 0;
+            hash_combine(seed, p.centroid);;
             hash_combine(seed, p.sprite);
             hash_combine(seed, p.spriteDefault);
+            hash_combine(seed, p.color);
+            hash_combine(seed, p.anchor);
             hash_combine(seed, p.size.x);
             hash_combine(seed, p.size.y);
             hash_combine(seed, optionsHash(p.labelOptions));

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -155,6 +155,10 @@ void TextStyle::buildPoint(const Point& _point, const DrawRule& _rule, const Pro
 
     Parameters params = applyRule(_rule, _props);
 
+   // std::hash<Parameters> hash;
+   // auto h = hash(params);
+   // LOG("Hash %d", h);
+
     if (!params.visible || !params.isValid()) { return; }
 
     buffer.addLabel(params, { glm::vec2(_point), glm::vec2(_point) },

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -3,6 +3,7 @@
 #include "style.h"
 #include "labels/label.h"
 #include "labelProperty.h"
+#include "util/hash.h"
 
 #include <memory>
 
@@ -80,3 +81,29 @@ private:
 };
 
 }
+
+namespace std {
+    template <>
+    struct hash<Tangram::TextStyle::Parameters> {
+        size_t operator() (const Tangram::TextStyle::Parameters& p) const {
+            std::hash<Tangram::Label::Options> optionsHash;
+            std::size_t seed = 0;
+            hash_combine(seed, p.fontId);
+            hash_combine(seed, p.text);
+            hash_combine(seed, p.interactive);
+            hash_combine(seed, p.fill);
+            hash_combine(seed, p.strokeColor);
+            hash_combine(seed, p.strokeWidth);
+            hash_combine(seed, p.fontSize);
+            hash_combine(seed, p.visible);
+            hash_combine(seed, p.wordWrap);
+            hash_combine(seed, p.maxLineWidth);
+            hash_combine(seed, p.transform);
+            hash_combine(seed, p.align);
+            hash_combine(seed, p.anchor);
+            hash_combine(seed, optionsHash(p.labelOptions));
+            return seed;
+        }
+    };
+}
+

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -98,9 +98,9 @@ namespace std {
             hash_combine(seed, p.visible);
             hash_combine(seed, p.wordWrap);
             hash_combine(seed, p.maxLineWidth);
-            hash_combine(seed, p.transform);
-            hash_combine(seed, p.align);
-            hash_combine(seed, p.anchor);
+            hash_combine(seed, (int)p.transform);
+            hash_combine(seed, (int)p.align);
+            hash_combine(seed, (int)p.anchor);
             hash_combine(seed, optionsHash(p.labelOptions));
             return seed;
         }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -151,7 +151,8 @@ void update(float _dt) {
                 tile->update(_dt, *m_view);
             }
 
-            m_labels->update(*m_view, _dt, m_scene->styles(), tiles);
+            auto& cache = m_tileManager->getTileCache();
+            m_labels->update(*m_view, _dt, m_scene->styles(), tiles, cache);
         }
 
         bool animated = false;

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -255,10 +255,8 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
 
 
     std::hash<TextStyle::Parameters> hash;
-    size_t hashCode = hash(_params);
-    LOG("%s %d", _params.text.c_str(), hashCode);
     m_labels.emplace_back(new TextLabel(_transform, _type, bbox, *this, { vertexOffset, numVertices },
-                                        _params.labelOptions, metrics, nLine, _params.anchor, hashCode));
+                                        _params.labelOptions, metrics, nLine, _params.anchor, hash(_params)));
 
     // TODO: change this in TypeMesh::adVertices()
     m_nVertices = vertices.size();

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -11,9 +11,12 @@ namespace Tangram {
 TextBuffer::TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout)
     : LabelMesh(_vertexLayout, GL_TRIANGLES) {
     addVertices({}, {});
+    LOG("Buffer created");
 }
 
-TextBuffer::~TextBuffer() {}
+TextBuffer::~TextBuffer() {
+    LOG("Buffer destroyed");
+}
 
 std::vector<TextBuffer::WordBreak> TextBuffer::findWords(const std::string& _text) {
     std::vector<WordBreak> words;
@@ -252,8 +255,9 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
 
     _fontContext.unlock();
 
+    std::hash<TextStyle::Parameters> hash;
     m_labels.emplace_back(new TextLabel(_transform, _type, bbox, *this, { vertexOffset, numVertices },
-                                        _params.labelOptions, metrics, nLine, _params.anchor));
+                                        _params.labelOptions, metrics, nLine, _params.anchor, hash(_params)));
 
     // TODO: change this in TypeMesh::adVertices()
     m_nVertices = vertices.size();

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -11,11 +11,9 @@ namespace Tangram {
 TextBuffer::TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout)
     : LabelMesh(_vertexLayout, GL_TRIANGLES) {
     addVertices({}, {});
-    LOG("Buffer created");
 }
 
 TextBuffer::~TextBuffer() {
-    LOG("Buffer destroyed");
 }
 
 std::vector<TextBuffer::WordBreak> TextBuffer::findWords(const std::string& _text) {
@@ -255,9 +253,12 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
 
     _fontContext.unlock();
 
+
     std::hash<TextStyle::Parameters> hash;
+    size_t hashCode = hash(_params);
+    LOG("%s %d", _params.text.c_str(), hashCode);
     m_labels.emplace_back(new TextLabel(_transform, _type, bbox, *this, { vertexOffset, numVertices },
-                                        _params.labelOptions, metrics, nLine, _params.anchor, hash(_params)));
+                                        _params.labelOptions, metrics, nLine, _params.anchor, hashCode));
 
     // TODO: change this in TypeMesh::adVertices()
     m_nVertices = vertices.size();

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -64,6 +64,8 @@ void Tile::build(StyleContext& _ctx, const Scene& _scene, const TileData& _data,
     // Initialize m_geometry
     initGeometry(_scene.styles().size());
 
+    m_dataSourceSerial = _source.id();
+
     const auto& layers = _scene.layers();
 
     _ctx.setGlobalZoom(m_id.z);

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -149,6 +149,8 @@ public:
     /* Get the sum in bytes of all <VboMesh>es */
     size_t getMemoryUsage() const;
 
+    int32_t getDataSourceSerial() { return m_dataSourceSerial; }
+
 private:
 
     const TileID m_id;
@@ -171,6 +173,8 @@ private:
     float m_scale = 1;
 
     float m_inverseScale = 1;
+
+    int32_t m_dataSourceSerial;
 
     std::atomic<double> m_priority;
 

--- a/core/src/tile/tileCache.h
+++ b/core/src/tile/tileCache.h
@@ -66,6 +66,17 @@ public:
         return tile;
     }
 
+    std::shared_ptr<Tile> contains(int32_t _source, TileID _tileID) {
+        std::shared_ptr<Tile> tile;
+        TileCacheKey k(_source, _tileID);
+
+        auto it = m_cacheMap.find(k);
+        if (it != m_cacheMap.end()) {
+            return it->second->tile;
+        }
+        return nullptr;
+    }
+
     void limitCacheSize(size_t _cacheSizeBytes) {
         m_cacheMaxUsage = _cacheSizeBytes;
 

--- a/core/src/tile/tileHash.h
+++ b/core/src/tile/tileHash.h
@@ -1,16 +1,7 @@
 #pragma once
 
 #include "tileID.h"
-
-#include <functional> // for hash function
-
-// The generic hash_combine used in Boost
-// http://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
-template <class T>
-inline void hash_combine(std::size_t & seed, const T & v) {
-    std::hash<T> hasher;
-    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-}
+#include "util/hash.h"
 
 namespace std {
     template <>

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -68,6 +68,8 @@ public:
 
     void addDataSource(std::shared_ptr<DataSource> dataSource);
 
+    std::unique_ptr<TileCache>& getTileCache() { return m_tileCache; }
+
     const auto& getTileSets() { return m_tileSets; }
 
     /* @_cacheSize: Set size of in-memory tile cache in bytes.

--- a/core/src/util/hash.h
+++ b/core/src/util/hash.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <functional> // for hash function
+
+// The generic hash_combine used in Boost
+// http://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+template <class T>
+inline void hash_combine(std::size_t & seed, const T & v) {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -116,12 +116,17 @@ void View::setPosition(double _x, double _y) {
 }
 
 void View::setZoom(float _z) {
+    static float lastZoom = 0.f;
 
     // ensure zoom value is allowed
     m_zoom = glm::clamp(_z, s_minZoom, s_maxZoom);
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
 
+    float zoomDir = copysign(1.0, lastZoom - m_zoom);
+    m_next_zoom = floor(m_zoom - zoomDir);
+
+    lastZoom = m_zoom;
 }
 
 void View::setRoll(float _roll) {

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -116,17 +116,10 @@ void View::setPosition(double _x, double _y) {
 }
 
 void View::setZoom(float _z) {
-    static float lastZoom = 0.f;
-
     // ensure zoom value is allowed
     m_zoom = glm::clamp(_z, s_minZoom, s_maxZoom);
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
-
-    float zoomDir = copysign(1.0, lastZoom - m_zoom);
-    m_next_zoom = floor(m_zoom - zoomDir);
-
-    lastZoom = m_zoom;
 }
 
 void View::setRoll(float _roll) {

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -140,6 +140,9 @@ public:
 
     float pixelsPerMeter() const;
 
+    /* Get the next zoom level based on the zoom direction */
+    int getNextZoom() const { return m_next_zoom; }
+
 protected:
 
     void updateMatrices();
@@ -172,6 +175,7 @@ protected:
 
     float m_zoom;
     float m_zoom_prev = 0.0f;
+    int m_next_zoom;
     float m_initZoom = 16.0;
 
     float m_width;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -140,9 +140,6 @@ public:
 
     float pixelsPerMeter() const;
 
-    /* Get the next zoom level based on the zoom direction */
-    int getNextZoom() const { return m_next_zoom; }
-
 protected:
 
     void updateMatrices();
@@ -175,7 +172,6 @@ protected:
 
     float m_zoom;
     float m_zoom_prev = 0.0f;
-    int m_next_zoom;
     float m_initZoom = 16.0;
 
     float m_width;

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -15,7 +15,7 @@ TextBuffer dummy(nullptr);
 TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
     Label::Options options;
     options.offset = {0.0f, 0.0f};
-    return TextLabel(_transform, _type, {0, 0}, dummy, {0, 0}, options, {}, 1, LabelProperty::Anchor::center);
+    return TextLabel(_transform, _type, {0, 0}, dummy, {0, 0}, options, {}, 1, LabelProperty::Anchor::center, 0);
 }
 
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -21,42 +21,42 @@ TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
-    REQUIRE(l.getState() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::wait_occ);
     l.setOcclusion(true);
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0, 0);
 
-    REQUIRE(l.getState() != Label::State::sleep);
-    REQUIRE(l.getState() == Label::State::wait_occ);
+    REQUIRE(l.state() != Label::State::sleep);
+    REQUIRE(l.state() == Label::State::wait_occ);
     REQUIRE(l.canOcclude());
 
     l.setOcclusion(true);
     l.occlusionSolved();
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0, 0);
 
-    REQUIRE(l.getState() == Label::State::dead);
+    REQUIRE(l.state() == Label::State::dead);
     REQUIRE(!l.canOcclude());
 }
 
 TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
-    REQUIRE(l.getState() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::wait_occ);
 
     l.setOcclusion(false);
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0, 0);
 
-    REQUIRE(l.getState() != Label::State::sleep);
-    REQUIRE(l.getState() == Label::State::wait_occ);
+    REQUIRE(l.state() != Label::State::sleep);
+    REQUIRE(l.state() == Label::State::wait_occ);
 
     l.setOcclusion(false);
     l.occlusionSolved();
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0, 0);
 
-    REQUIRE(l.getState() == Label::State::fading_in);
+    REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 1.f, 0);
-    REQUIRE(l.getState() == Label::State::visible);
+    REQUIRE(l.state() == Label::State::visible);
     REQUIRE(l.canOcclude());
 }
 
@@ -67,54 +67,54 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
     l.occlusionSolved();
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
 
-    REQUIRE(l.getState() == Label::State::fading_in);
+    REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
     l.setOcclusion(true);
     l.occlusionSolved();
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
 
-    REQUIRE(l.getState() == Label::State::sleep);
+    REQUIRE(l.state() == Label::State::sleep);
     REQUIRE(l.canOcclude());
 }
 
 TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize*2.f}, Label::Type::point));
 
-    REQUIRE(l.getState() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::wait_occ);
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
 
-    REQUIRE(l.getState() == Label::State::out_of_screen);
+    REQUIRE(l.state() == Label::State::out_of_screen);
     REQUIRE(l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
-    REQUIRE(l.getState() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::wait_occ);
     REQUIRE(l.canOcclude());
 
     l.setOcclusion(false);
     l.occlusionSolved();
     l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
-    REQUIRE(l.getState() != Label::State::wait_occ);
+    REQUIRE(l.state() != Label::State::wait_occ);
 
-    REQUIRE(l.getState() == Label::State::fading_in);
+    REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 1.f, 0);
 
-    REQUIRE(l.getState() == Label::State::visible);
+    REQUIRE(l.state() == Label::State::visible);
     REQUIRE(l.canOcclude());
 }
 
 TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::debug));
 
-    REQUIRE(l.getState() == Label::State::visible);
+    REQUIRE(l.state() == Label::State::visible);
     REQUIRE(!l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 1.f, 0);
 
-    REQUIRE(l.getState() == Label::State::visible);
+    REQUIRE(l.state() == Label::State::visible);
     REQUIRE(!l.canOcclude());
 }
 

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<TextLabel> makeLabel(Label::Transform _transform, Label::Type _t
     options.properties->add("id", id);
     options.interactive = true;
 
-    return std::unique_ptr<TextLabel>(new TextLabel(_transform, _type, {10, 10},dummy, {0, 0}, options, {}, 1, LabelProperty::Anchor::center));
+    return std::unique_ptr<TextLabel>(new TextLabel(_transform, _type, {10, 10},dummy, {0, 0}, options, {}, 1, LabelProperty::Anchor::center, 0));
 }
 
 TEST_CASE("Test getFeaturesAtPoint", "[Labels][FeaturePicking]") {


### PR DESCRIPTION
Reduce flickering of labels already visible on the screen. This smoothen transition between zoom levels and gives better visual experience while zooming in or out.

This relies on the labels of the tile cache (the _parent_ cached tile for a _zoom in_, 4 _children_ cached tiles for a _zoom out_) to determine whether a label is already visible. Since labels are first compared with a hash based on the style parameters of the label, and this hash has no concept of location, a new label would be considered to be the same based on the hash first, and whether it lies or not within a screen space circle defined by the bounding box of the already visible label. The label would then be flagged to skip transitions whenever this test passes.

This adds complexity, but can be improved; I'm planning to improve labels iteration and sparse their memory locations to be contiguous for fast iterations.