### PR TITLE
[WIP] Inlay blend mode

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -7,14 +7,14 @@ cameras:
         position: [-74.00976419448854, 40.70532700869127, 16]
         type: isometric
         axis: [0, 1]
-        active: false
-    perspective-camera:
-        # Manhattan
-        position: [-74.00976419448854, 40.70532700869127, 16]
-        type: perspective #currently ignored
-        focal_length: [[16, 2], [20, 6]] # currently ignored
-        vanishing_point: [-250, -250] # currently ignored
         active: true
+    #perspective-camera:
+    #    # Manhattan
+    #    position: [-74.00976419448854, 40.70532700869127, 16]
+    #    type: perspective #currently ignored
+    #    focal_length: [[16, 2], [20, 6]] # currently ignored
+    #    vanishing_point: [-250, -250] # currently ignored
+    #    active: true
 
 lights:
     light1:

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -56,6 +56,9 @@ styles:
     heightglowline:
         base: lines
         mix: heightglow
+    textinlay:
+        base: text
+        blend: inlay
     icons:
         base: points
         texture: pois
@@ -351,7 +354,7 @@ layers:
         data: {source: osm, layer: roads}
         filter: { name: true, aeroway: false, tunnel: false, railway: false, not: { kind: rail }, $zoom: { min: 10 } }
         draw:
-            text:
+            textinlay:
                 interactive: true
                 visible: true
                 priority: 2
@@ -366,7 +369,7 @@ layers:
         highway:
             filter: { kind: highway }
             draw:
-                text:
+                textinlay:
                     visible: true
                     offset: [0px, 5px]
                     priority: 1
@@ -380,7 +383,7 @@ layers:
         major_road:
             filter: { kind: major_road }
             draw:
-                text:
+                textinlay:
                     interactive: true
                     visible: true
                     priority: 3
@@ -404,7 +407,7 @@ layers:
                 # this function matches the "cities" sublayer
                 #- function() {return (feature.scalerank * .75) <= ($zoom - 4); }
         draw:
-            text:
+            textinlay:
                 interactive: true
                 priority: 5
                 font:

--- a/core/resources/shaders/stencilPolygon.fs
+++ b/core/resources/shaders/stencilPolygon.fs
@@ -5,9 +5,9 @@ precision highp float;
 varying vec4 v_world_position;
 
 void main(void) {
-    //if (v_world_position.z < 0.0) {
+    if (v_world_position.z > 0.0) {
         gl_FragColor = vec4(1.0);
-    //} else {
-    //    discard;
-    //}
+    } else {
+        discard;
+    }
 }

--- a/core/resources/shaders/stencilPolygon.fs
+++ b/core/resources/shaders/stencilPolygon.fs
@@ -1,0 +1,13 @@
+#ifdef GL_ES
+precision highp float;
+#endif
+
+varying vec4 v_world_position;
+
+void main(void) {
+    //if (v_world_position.z < 0.0) {
+        gl_FragColor = vec4(1.0);
+    //} else {
+    //    discard;
+    //}
+}

--- a/core/resources/shaders/stencilPolygon.vs
+++ b/core/resources/shaders/stencilPolygon.vs
@@ -1,0 +1,33 @@
+#ifdef GL_ES
+precision highp float;
+#endif
+
+uniform mat4 u_model;
+uniform mat4 u_view;
+uniform mat4 u_proj;
+uniform vec3 u_map_position;
+//uniform vec3 u_tile_origin;
+
+attribute vec4 a_position;
+//attribute float a_layer;
+
+varying vec4 v_world_position;
+
+void main() {
+    // World coordinates for 3d procedural textures
+    vec4 local_origin = vec4(u_map_position.xy, 0., 0.);
+    #ifdef TANGRAM_WORLD_POSITION_WRAP
+        local_origin = mod(local_origin, TANGRAM_WORLD_POSITION_WRAP);
+    #endif
+    v_world_position = a_position + local_origin;
+
+    gl_Position = u_proj * u_view * u_model * a_position;
+
+    // Proxy tiles have u_tile_origin.z < 0, so this adjustment will place proxy tiles
+    // deeper in the depth buffer than non-proxy tiles
+    // gl_Position.z += TANGRAM_DEPTH_DELTA * gl_Position.w * (1. - sign(u_tile_origin.z));
+
+    // #ifdef TANGRAM_DEPTH_DELTA
+    //     gl_Position.z -= a_layer * TANGRAM_DEPTH_DELTA * gl_Position.w;
+    // #endif
+}

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -43,6 +43,8 @@ namespace RenderState {
     void bindTexture(GLenum _target, GLuint _textureId) { glBindTexture(_target, _textureId); }
 
     void configure() {
+        unsigned int max = std::numeric_limits<unsigned int>::max();
+
         blending.init(GL_FALSE);
         blendingFunc.init(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         culling.init(GL_TRUE);
@@ -50,19 +52,19 @@ namespace RenderState {
         frontFace.init(GL_CCW);
         depthTest.init(GL_TRUE);
         depthWrite.init(GL_TRUE);
+        stencilTest.init(GL_FALSE);
 
-        glDisable(GL_STENCIL_TEST);
+        clearColor.init(0.0, 0.0, 0.0, 0.0);
+        shaderProgram.init(max, false);
+        vertexBuffer.init(max, false);
+        indexBuffer.init(max, false);
+        texture.init(GL_TEXTURE_2D, max, false);
+        texture.init(GL_TEXTURE_CUBE_MAP, max, false);
+        textureUnit.init(max, false);
+
         glDepthFunc(GL_LEQUAL);
         glClearDepthf(1.0);
         glDepthRangef(0.0, 1.0);
-
-        clearColor.init(0.0, 0.0, 0.0, 0.0);
-        shaderProgram.init(std::numeric_limits<unsigned int>::max(), false);
-        vertexBuffer.init(std::numeric_limits<unsigned int>::max(), false);
-        indexBuffer.init(std::numeric_limits<unsigned int>::max(), false);
-        texture.init(GL_TEXTURE_2D, std::numeric_limits<unsigned int>::max(), false);
-        texture.init(GL_TEXTURE_CUBE_MAP, std::numeric_limits<unsigned int>::max(), false);
-        textureUnit.init(std::numeric_limits<unsigned int>::max(), false);
     }
 
 }

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -32,6 +32,9 @@ const Style* Scene::findStyle(const std::string &_name) const {
     for (auto& style : m_styles) {
         if (style->getName() == _name) { return style.get(); }
     }
+    for (auto& style : m_stencilStyles) {
+        if (style->getName() == _name) { return style.get(); }
+    }
     return nullptr;
 }
 
@@ -40,6 +43,15 @@ const Light* Scene::findLight(const std::string &_name) const {
         if (light->getInstanceName() == _name) { return light.get(); }
     }
     return nullptr;
+}
+
+bool Scene::containsStyleWithBlend(Blending _blend) const {
+     for (auto& style : m_styles) {
+        if (style->blendMode() == _blend) {
+            return true;
+        }
+    }
+    return false;
 }
 
 }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -8,10 +8,10 @@
 #include <unordered_map>
 
 #include "glm/vec2.hpp"
+#include "style/style.h"
 
 namespace Tangram {
 
-class Style;
 class Texture;
 class DataSource;
 class DataLayer;
@@ -36,6 +36,7 @@ public:
     auto& dataSources() { return m_dataSources; };
     auto& layers() { return m_layers; };
     auto& styles() { return m_styles; };
+    auto& stencilStyles() { return m_stencilStyles; }
     auto& lights() { return m_lights; };
     auto& textures() { return m_textures; };
     auto& functions() { return m_jsFunctions; };
@@ -60,6 +61,8 @@ public:
     glm::dvec2 startPosition = { 0, 0 };
     float startZoom = 0;
 
+    bool containsStyleWithBlend(Blending _blend) const;
+
 private:
 
     std::unique_ptr<MapProjection> m_mapProjection;
@@ -68,6 +71,7 @@ private:
     std::vector<DataLayer> m_layers;
     std::vector<std::shared_ptr<DataSource>> m_dataSources;
     std::vector<std::unique_ptr<Style>> m_styles;
+    std::vector<std::unique_ptr<Style>> m_stencilStyles;
     std::vector<std::unique_ptr<Light>> m_lights;
     std::unordered_map<std::string, std::shared_ptr<Texture>> m_textures;
     std::unordered_map<std::string, std::shared_ptr<SpriteAtlas>> m_spriteAtlases;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -14,6 +14,7 @@
 #include "style/debugStyle.h"
 #include "style/debugTextStyle.h"
 #include "style/pointStyle.h"
+#include "style/stencilPolygonStyle.h"
 #include "scene/dataLayer.h"
 #include "scene/filters.h"
 #include "scene/sceneLayer.h"
@@ -61,6 +62,7 @@ bool SceneLoader::loadScene(Node& config, Scene& _scene) {
     _scene.styles().emplace_back(new DebugTextStyle(_scene.fontContext(), 0, "debugtext", 30.0f, true, false));
     _scene.styles().emplace_back(new DebugStyle("debug"));
     _scene.styles().emplace_back(new PointStyle("points"));
+    _scene.styles().emplace_back(new StencilPolygonStyle("stencilPolygons"));
 
     if (Node sources = config["sources"]) {
         for (const auto& source : sources) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -781,7 +781,7 @@ bool SceneLoader::loadStyle(const std::string& styleName, Node styles, Scene& sc
     if (baseStyle == "polygons") {
         style = std::make_unique<PolygonStyle>(styleName);
         // create corresponding stencil style
-        stencilStyle = std::make_unique<PolygonStyle>(styleName + "_stencil");
+        stencilStyle = std::make_unique<StencilPolygonStyle>(styleName + "_stencil");
         style->setStyleDependency(stencilStyle->getName());
     } else if (baseStyle == "lines") {
         style = std::make_unique<PolylineStyle>(styleName);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -61,7 +61,7 @@ bool SceneLoader::loadScene(Node& config, Scene& _scene) {
     _scene.styles().emplace_back(new DebugTextStyle(_scene.fontContext(), 0, "debugtext", 30.0f, true, false));
     _scene.styles().emplace_back(new DebugStyle("debug"));
     _scene.styles().emplace_back(new PointStyle("points"));
-    _scene.styles().emplace_back(new StencilPolygonStyle("stencilPolygons"));
+    _scene.stencilStyles().emplace_back(new StencilPolygonStyle("stencilPolygons"));
 
     std::unique_ptr<PolygonStyle> polygon = std::make_unique<PolygonStyle>("polygons");
     polygon->setStyleDependency("stencilPolygons");
@@ -135,6 +135,10 @@ bool SceneLoader::loadScene(Node& config, Scene& _scene) {
 
     for (auto& style : _scene.styles()) {
         style->build(_scene.lights());
+    }
+
+    for (auto& style : _scene.stencilStyles()) {
+        style->build({});
     }
 
     // Styles that are opaque must be ordered first in the scene so that
@@ -799,7 +803,7 @@ bool SceneLoader::loadStyle(const std::string& styleName, Node styles, Scene& sc
     scene.styles().push_back(std::move(style));
 
     if (stencilStyle) {
-        scene.styles().push_back(std::move(stencilStyle));
+        scene.stencilStyles().push_back(std::move(stencilStyle));
     }
 
     return true;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -773,9 +773,12 @@ bool SceneLoader::loadStyle(const std::string& styleName, Node styles, Scene& sc
 
     // Construct style instance using the merged properties
     std::unique_ptr<Style> style;
+    std::unique_ptr<Style> stencilStyle;
     std::string baseStyle = baseNode.as<std::string>();
     if (baseStyle == "polygons") {
         style = std::make_unique<PolygonStyle>(styleName);
+        // create corresponding stencil style
+        stencilStyle = std::make_unique<PolygonStyle>(styleName + "_stencil");
     } else if (baseStyle == "lines") {
         style = std::make_unique<PolylineStyle>(styleName);
     } else if (baseStyle == "text") {
@@ -790,6 +793,10 @@ bool SceneLoader::loadStyle(const std::string& styleName, Node styles, Scene& sc
     loadStyleProps(*style.get(), styleNode, scene);
 
     scene.styles().push_back(std::move(style));
+
+    if (stencilStyle) {
+        scene.styles().push_back(std::move(stencilStyle));
+    }
 
     return true;
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -56,13 +56,16 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
 bool SceneLoader::loadScene(Node& config, Scene& _scene) {
 
     // Instantiate built-in styles
-    _scene.styles().emplace_back(new PolygonStyle("polygons"));
     _scene.styles().emplace_back(new PolylineStyle("lines"));
     _scene.styles().emplace_back(new TextStyle("text", _scene.fontContext(), true, false));
     _scene.styles().emplace_back(new DebugTextStyle(_scene.fontContext(), 0, "debugtext", 30.0f, true, false));
     _scene.styles().emplace_back(new DebugStyle("debug"));
     _scene.styles().emplace_back(new PointStyle("points"));
     _scene.styles().emplace_back(new StencilPolygonStyle("stencilPolygons"));
+
+    std::unique_ptr<PolygonStyle> polygon = std::make_unique<PolygonStyle>("polygons");
+    polygon->setStyleDependency("stencilPolygons");
+    _scene.styles().push_back(std::move(polygon));
 
     if (Node sources = config["sources"]) {
         for (const auto& source : sources) {
@@ -779,6 +782,7 @@ bool SceneLoader::loadStyle(const std::string& styleName, Node styles, Scene& sc
         style = std::make_unique<PolygonStyle>(styleName);
         // create corresponding stencil style
         stencilStyle = std::make_unique<PolygonStyle>(styleName + "_stencil");
+        style->setStyleDependency(stencilStyle->getName());
     } else if (baseStyle == "lines") {
         style = std::make_unique<PolylineStyle>(styleName);
     } else if (baseStyle == "text") {

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -33,6 +33,8 @@ protected:
     virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     virtual bool checkRule(const DrawRule& _rule) const override;
 
+    virtual bool noDepth() const override { return true; }
+
     void pushQuad(std::vector<Label::Vertex>& _vertices, const glm::vec2& _size, const glm::vec2& _uvBL,
             const glm::vec2& _uvTR, unsigned int _color, float _extrudeScale) const;
     bool getUVQuad(Parameters& _params, glm::vec4& _quad) const;

--- a/core/src/style/stencilPolygonStyle.cpp
+++ b/core/src/style/stencilPolygonStyle.cpp
@@ -2,6 +2,7 @@
 
 #include "gl/shaderProgram.h"
 #include "gl/typedMesh.h"
+#include "scene/scene.h"
 
 #include <memory>
 
@@ -10,6 +11,10 @@ namespace Tangram {
 StencilPolygonStyle::StencilPolygonStyle(std::string _name, Blending _blendMode, GLenum _drawMode)
     : PolygonStyle(_name, _blendMode, _drawMode)
 {
+}
+
+bool StencilPolygonStyle::shouldBuild(const Scene& _scene) const {
+    return _scene.containsStyleWithBlend(Blending::inlay);
 }
 
 void StencilPolygonStyle::constructShaderProgram() {

--- a/core/src/style/stencilPolygonStyle.cpp
+++ b/core/src/style/stencilPolygonStyle.cpp
@@ -1,0 +1,22 @@
+#include "stencilPolygonStyle.h"
+
+#include "gl/shaderProgram.h"
+#include "gl/typedMesh.h"
+
+#include <memory>
+
+namespace Tangram {
+
+StencilPolygonStyle::StencilPolygonStyle(std::string _name, Blending _blendMode, GLenum _drawMode)
+    : PolygonStyle(_name, _blendMode, _drawMode)
+{
+}
+
+void StencilPolygonStyle::constructShaderProgram() {
+    std::string vertShaderSrcStr = stringFromFile("shaders/stencilPolygon.vs", PathType::internal);
+    std::string fragShaderSrcStr = stringFromFile("shaders/stencilPolygon.fs", PathType::internal);
+
+    m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+}
+
+}

--- a/core/src/style/stencilPolygonStyle.h
+++ b/core/src/style/stencilPolygonStyle.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "polygonStyle.h"
+
+namespace Tangram {
+
+class StencilPolygonStyle : public PolygonStyle {
+
+protected:
+
+    virtual void constructShaderProgram() override;
+
+public:
+
+    StencilPolygonStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
+
+    virtual ~StencilPolygonStyle() {}
+
+};
+
+}

--- a/core/src/style/stencilPolygonStyle.h
+++ b/core/src/style/stencilPolygonStyle.h
@@ -12,9 +12,11 @@ protected:
 
 public:
 
-    StencilPolygonStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
+    StencilPolygonStyle(std::string _name, Blending _blendMode = Blending::stencil, GLenum _drawMode = GL_TRIANGLES);
 
     virtual ~StencilPolygonStyle() {}
+
+    virtual bool shouldBuild(const Scene& _scene) const override;
 
 };
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -192,39 +192,52 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
     setupShaderUniforms(_textureUnit, contextLost, _scene);
 
     // Configure render state
+
+    // Disable writing to the stencil buffer
+    RenderState::stencilWrite(0x00);
+
     switch (m_blend) {
         case Blending::none:
             RenderState::blending(GL_FALSE);
             RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             RenderState::depthTest(GL_TRUE);
             RenderState::depthWrite(GL_TRUE);
+            RenderState::stencilTest(GL_FALSE);
             break;
         case Blending::add:
             RenderState::blending(GL_TRUE);
             RenderState::blendingFunc(GL_ONE, GL_ONE);
             RenderState::depthTest(GL_FALSE);
             RenderState::depthWrite(GL_TRUE);
+            RenderState::stencilTest(GL_FALSE);
             break;
         case Blending::multiply:
             RenderState::blending(GL_TRUE);
             RenderState::blendingFunc(GL_ZERO, GL_SRC_COLOR);
             RenderState::depthTest(GL_FALSE);
             RenderState::depthWrite(GL_TRUE);
+            RenderState::stencilTest(GL_FALSE);
             break;
         case Blending::overlay:
             RenderState::blending(GL_TRUE);
             RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             RenderState::depthTest(GL_FALSE);
             RenderState::depthWrite(GL_FALSE);
+            RenderState::stencilTest(GL_FALSE);
             break;
         case Blending::inlay:
+            RenderState::blending(GL_TRUE);
+            RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            RenderState::depthTest(GL_TRUE);
+
             if (noDepth()) {
+                RenderState::stencilTest(GL_TRUE);
+                RenderState::stencilFunc(GL_NOTEQUAL, 1, 0xFF);
             } else {
-                RenderState::blending(GL_TRUE);
-                RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-                RenderState::depthTest(GL_TRUE);
                 RenderState::depthWrite(GL_FALSE);
+                RenderState::stencilTest(GL_FALSE);
             }
+
             break;
         default:
             break;

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -218,11 +218,13 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
             RenderState::depthWrite(GL_FALSE);
             break;
         case Blending::inlay:
-            // TODO: inlay does not behave correctly for labels because they don't have a z position
-            RenderState::blending(GL_TRUE);
-            RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            RenderState::depthTest(GL_TRUE);
-            RenderState::depthWrite(GL_FALSE);
+            if (noDepth()) {
+            } else {
+                RenderState::blending(GL_TRUE);
+                RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+                RenderState::depthTest(GL_TRUE);
+                RenderState::depthWrite(GL_FALSE);
+            }
             break;
         default:
             break;

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -192,17 +192,22 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
     setupShaderUniforms(_textureUnit, contextLost, _scene);
 
     // Configure render state
-
-    // Disable writing to the stencil buffer
-    RenderState::stencilWrite(0x00);
-
     switch (m_blend) {
+        case Blending::stencil:
+            RenderState::stencilTest(GL_TRUE);
+            RenderState::stencilFunc(GL_ALWAYS, 1, 0xFF);
+            RenderState::stencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+            RenderState::stencilWrite(0xFF);
+            RenderState::depthWrite(GL_FALSE);
+            RenderState::depthTest(GL_FALSE);
+            break;
         case Blending::none:
             RenderState::blending(GL_FALSE);
             RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             RenderState::depthTest(GL_TRUE);
             RenderState::depthWrite(GL_TRUE);
             RenderState::stencilTest(GL_FALSE);
+            RenderState::stencilWrite(0x00);
             break;
         case Blending::add:
             RenderState::blending(GL_TRUE);
@@ -210,6 +215,7 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
             RenderState::depthTest(GL_FALSE);
             RenderState::depthWrite(GL_TRUE);
             RenderState::stencilTest(GL_FALSE);
+            RenderState::stencilWrite(0x00);
             break;
         case Blending::multiply:
             RenderState::blending(GL_TRUE);
@@ -217,6 +223,7 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
             RenderState::depthTest(GL_FALSE);
             RenderState::depthWrite(GL_TRUE);
             RenderState::stencilTest(GL_FALSE);
+            RenderState::stencilWrite(0x00);
             break;
         case Blending::overlay:
             RenderState::blending(GL_TRUE);
@@ -224,19 +231,20 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
             RenderState::depthTest(GL_FALSE);
             RenderState::depthWrite(GL_FALSE);
             RenderState::stencilTest(GL_FALSE);
+            RenderState::stencilWrite(0x00);
             break;
         case Blending::inlay:
             RenderState::blending(GL_TRUE);
             RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            RenderState::depthWrite(GL_FALSE);
+            RenderState::stencilWrite(0x00);
 
             if (noDepth()) {
-                RenderState::depthWrite(GL_FALSE);
                 RenderState::depthTest(GL_FALSE);
                 RenderState::stencilTest(GL_TRUE);
                 RenderState::stencilFunc(GL_NOTEQUAL, 1, 0xFF);
             } else {
                 RenderState::depthTest(GL_TRUE);
-                RenderState::depthWrite(GL_FALSE);
                 RenderState::stencilTest(GL_FALSE);
             }
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -228,12 +228,14 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
         case Blending::inlay:
             RenderState::blending(GL_TRUE);
             RenderState::blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            RenderState::depthTest(GL_TRUE);
 
             if (noDepth()) {
+                RenderState::depthWrite(GL_FALSE);
+                RenderState::depthTest(GL_FALSE);
                 RenderState::stencilTest(GL_TRUE);
                 RenderState::stencilFunc(GL_NOTEQUAL, 1, 0xFF);
             } else {
+                RenderState::depthTest(GL_TRUE);
                 RenderState::depthWrite(GL_FALSE);
                 RenderState::stencilTest(GL_FALSE);
             }

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -106,6 +106,8 @@ protected:
        and bind textures starting at @_textureUnit */
     void setupShaderUniforms(int _textureUnit, bool _updateUniforms, Scene& _scene);
 
+    virtual bool noDepth() const { return false; }
+
 private:
 
     /* Whether the context has been lost on last frame */

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -111,6 +111,7 @@ private:
     /* Whether the context has been lost on last frame */
     bool m_contextLost;
     std::vector<StyleUniform> m_styleUniforms;
+    std::string m_styleDependency = "";
 
 public:
 
@@ -123,6 +124,12 @@ public:
     void viewportHasChanged() { m_dirtyViewport = true; }
 
     Blending blendMode() const { return m_blend; };
+
+    void setStyleDependency(std::string _dependency) { m_styleDependency = _dependency; }
+
+    std::string getStyleDependency() const { return m_styleDependency; }
+
+    bool hasStyleDependency() const { return m_styleDependency != ""; }
 
     void setBlendMode(Blending _blendMode) { m_blend = _blendMode; }
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -29,6 +29,7 @@ enum class LightingType : char {
 
 enum class Blending : char {
     none,
+    stencil,
     add,
     multiply,
     overlay,
@@ -124,6 +125,9 @@ public:
     void notifyGLContextLost() { m_contextLost = true; }
 
     void viewportHasChanged() { m_dirtyViewport = true; }
+
+    /* Whether or not the style should build considering the current scene */
+    virtual bool shouldBuild(const Scene& _scene) const { return true; }
 
     Blending blendMode() const { return m_blend; };
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -51,6 +51,8 @@ protected:
     virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     virtual bool checkRule(const DrawRule& _rule) const override;
 
+    virtual bool noDepth() const override { return true; }
+
     virtual VboMesh* newMesh() const override;
 
     Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -184,34 +184,14 @@ void render() {
 
     /// Setup rendering for stencil dependent styles
 
-    bool inlay = false;
-    for (const auto& style : m_scene->styles()) {
-        if (style->blendMode() == Blending::inlay) {
-            inlay = true;
-            break;
-        }
-    }
-
-    if (inlay) {
-        // Enable stencil buffer target
-        RenderState::stencilTest(GL_TRUE);
-        RenderState::stencilFunc(GL_ALWAYS, 1, 0xFF);
-        RenderState::stencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+    if (m_scene->containsStyleWithBlend(Blending::inlay)) {
         RenderState::stencilWrite(0xFF);
-        RenderState::depthWrite(GL_FALSE);
-        RenderState::depthTest(GL_FALSE);
         glClear(GL_STENCIL_BUFFER_BIT);
-
         {
             std::lock_guard<std::mutex> lock(m_tilesMutex);
 
-            for (const auto& style : m_scene->styles()) {
-                auto stencilStyle = dynamic_cast<StencilPolygonStyle*>(style.get());
-
-                if (!stencilStyle) {
-                    continue;
-                }
-
+            for (const auto& style : m_scene->stencilStyles()) {
+                style->onBeginDrawFrame(*m_view, *m_scene);
                 for (const auto& tile : m_tileManager->getVisibleTiles()) {
                     tile->draw(*style, *m_view);
                 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -184,36 +184,35 @@ void render() {
     {
         std::lock_guard<std::mutex> lock(m_tilesMutex);
 
-        // Setup rendering for stencil dependent styles
-        glEnable(GL_STENCIL_TEST);
-        // Write 1 to stencil buffer
-        glStencilFunc(GL_ALWAYS, 1, 0xFF);
-        glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
-        // Enale stencil writes
-        glStencilMask(0xFF);
+        /// Setup rendering for stencil dependent styles
+
+        // Enable stencil buffer target
+        RenderState::stencilTest(GL_TRUE);
+        RenderState::stencilFunc(GL_ALWAYS, 1, 0xFF);
+        RenderState::stencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+        RenderState::stencilWrite(0xFF);
         RenderState::depthWrite(GL_FALSE);
         RenderState::depthTest(GL_FALSE);
         glClear(GL_STENCIL_BUFFER_BIT);
 
         for (const auto& style : m_scene->styles()) {
             auto stencilStyle = dynamic_cast<StencilPolygonStyle*>(style.get());
-            if (!stencilStyle) { continue; }
+
+            if (!stencilStyle) {
+                continue;
+            }
+
             for (const auto& tile : m_tileManager->getVisibleTiles()) {
                 tile->draw(*style, *m_view);
             }
         }
-        glDisable(GL_STENCIL_TEST);
 
-        // Set up openGL for new frame
+        /// Set up openGL for new frame
+
         RenderState::depthWrite(GL_TRUE);
         auto& color = m_scene->background();
         RenderState::clearColor(color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-        // Pass if stencil is not 1
-        glStencilFunc(GL_NOTEQUAL, 1, 0xFF);
-        // Disable stencil writes
-        glStencilMask(0x00);
 
         // Loop over all styles
         for (const auto& style : m_scene->styles()) {
@@ -223,20 +222,12 @@ void render() {
 
             style->onBeginDrawFrame(*m_view, *m_scene);
 
-            if (style->getName() == "text") {
-                glEnable(GL_STENCIL_TEST);
-            }
-
             // Loop over all tiles in m_tileSet
             for (const auto& tile : m_tileManager->getVisibleTiles()) {
                 tile->draw(*style, *m_view);
             }
 
             style->onEndDrawFrame();
-
-            if (style->getName() == "text") {
-                glDisable(GL_STENCIL_TEST);
-            }
         }
     }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -79,6 +79,11 @@ void initialize(const char* _scenePath) {
 
     loadScene(_scenePath, true);
 
+    LOG("Scene styles:");
+    for (const auto& style : m_scene->styles()) {
+        LOG("\t - %s", style->getName().c_str());
+    }
+
     glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
     m_view->setPosition(projPos.x, projPos.y);
     m_view->setZoom(m_scene->startZoom);

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -84,10 +84,16 @@ void Tile::build(StyleContext& _ctx, const Scene& _scene, const TileData& _data,
 
                 for (auto& rule : rules) {
                     auto* style = _scene.findStyle(rule.getStyleName());
+                    const Style* styleDependency = nullptr;
 
                     if (style) {
                         if (!rule.eval(_ctx)) { continue; }
                         style->buildFeature(*this, feat, rule);
+
+                        if (style->hasStyleDependency()) {
+                            styleDependency = _scene.findStyle(style->getStyleDependency());
+                            styleDependency->buildFeature(*this, feat, rule);
+                        }
                     }
                 }
             }

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -92,7 +92,9 @@ void Tile::build(StyleContext& _ctx, const Scene& _scene, const TileData& _data,
 
                         if (style->hasStyleDependency()) {
                             styleDependency = _scene.findStyle(style->getStyleDependency());
-                            styleDependency->buildFeature(*this, feat, rule);
+                            if (styleDependency->shouldBuild(_scene)) {
+                                styleDependency->buildFeature(*this, feat, rule);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The technique to render inlay blend mode is here different than in tangram-js (https://github.com/tangrams/tangram/pull/161), since in tangram-es labels are rendered with no depth, in an orthographic camera (a different virtual camera than the one used to render usual world placed polygons), and have no information about the world position or actual depth at which they are attached to (a projection to the viewport, client-side, happens at an early stage before drawing in order to manage collisions in screen space). 
An alternative way to render the *inlay* blend mode uses the stencil buffer, which makes it a potentially more intensive blending mode to use.

The stencil render pass sets 1s in the stencil buffer whenever an occluding geometry for this blend mode appears (geometry _off_ the ground, should consider the *order* property), and 0s whenever there is no occluding geometry, which would output this in the stencil buffer (debug colors):
![screen shot 2015-11-23 at 2 46 46 pm](https://cloud.githubusercontent.com/assets/7061573/11351025/4e78b300-9202-11e5-95e9-6f1221549203.png)
The result of drawing *inlay* labels with this stencil technique is then the following:
![screen shot 2015-11-23 at 5 01 07 pm](https://cloud.githubusercontent.com/assets/7061573/11351495/04a73ea6-9205-11e5-846b-aa9fc052a78a.png)
Related design issue: https://github.com/tangrams/eraser-map/issues/74
Todo:
- [ ] Add stencil polyline style
- [ ] Benchmark on devices

Known issue, unfortunately (for now), this blend mode is incompatible with other transparent styles:

![screen shot 2015-11-23 at 5 07 33 pm](https://cloud.githubusercontent.com/assets/7061573/11351453/c8bbf9c2-9204-11e5-842c-6e9e4b458290.png)