### PR TITLE
Clear vertex layout caching after context loss

### DIFF
--- a/core/src/gl/vboMesh.cpp
+++ b/core/src/gl/vboMesh.cpp
@@ -250,6 +250,7 @@ size_t VboMesh::bufferSize() {
 void VboMesh::invalidateAllVBOs() {
 
     ++s_validGeneration;
+    VertexLayout::clearCache();
 
 }
 

--- a/core/src/gl/vertexLayout.cpp
+++ b/core/src/gl/vertexLayout.cpp
@@ -76,6 +76,10 @@ void VertexLayout::enable(const fastmap<std::string, GLuint>& _locations, size_t
 
 }
 
+void VertexLayout::clearCache() {
+    s_enabledAttribs.clear();
+}
+
 void VertexLayout::enable(ShaderProgram& _program, size_t _byteOffset, void* _ptr) {
 
     GLuint glProgram = _program.getGlProgram();

--- a/core/src/gl/vertexLayout.h
+++ b/core/src/gl/vertexLayout.h
@@ -38,6 +38,8 @@ public:
 
     size_t getOffset(std::string _attribName);
 
+    static void clearCache();
+
 private:
 
     static fastmap<GLint, GLuint> s_enabledAttribs; // Map from attrib locations to bound shader program


### PR DESCRIPTION
The vertex layout cache of vbos not using vertex array objects needs to be cleared on context loss.

For the vbos not using vaos (labelMesh), the current flow makes the mesh not visible after a context loss (the enabled attributes are not being enabled again until a switch between two different shader program happens, since the caching of vertex layout is storing the enabled attributes for the last shader used), this should fix some of the issues being seen in https://github.com/tangrams/tangram-es/issues/390.