### PR TITLE
Delete index buffer

### DIFF
--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -2,25 +2,32 @@
 #include "labels/label.h"
 #include "gl/renderState.h"
 #include "gl/shaderProgram.h"
+#include <atomic>
 
 namespace Tangram {
 
 static GLuint s_quadIndexBuffer = 0;
 static int s_quadGeneration = -1;
+static std::atomic<int> s_meshCounter(0);
 
 const size_t maxVertices = 16384;
 
 LabelMesh::LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
-    : TypedMesh<Label::Vertex>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW) {
+    : TypedMesh<Label::Vertex>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW)
+{
+    s_meshCounter++;
 }
 
 LabelMesh::~LabelMesh() {
-    if (s_quadIndexBuffer != 0 && s_quadGeneration != s_validGeneration) {
+    s_meshCounter--;
+
+    if (s_quadIndexBuffer != 0 && (s_quadGeneration != s_validGeneration || s_meshCounter <= 0)) {
         if (RenderState::indexBuffer.compare(s_quadIndexBuffer)) {
             RenderState::indexBuffer.init(0, false);
         }
         glDeleteBuffers(1, &s_quadIndexBuffer);
         s_quadIndexBuffer = 0;
+        s_quadGeneration = -1;
     }
 }
 

--- a/core/src/labels/labelMesh.cpp
+++ b/core/src/labels/labelMesh.cpp
@@ -14,7 +14,15 @@ LabelMesh::LabelMesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMo
     : TypedMesh<Label::Vertex>(_vertexLayout, _drawMode, GL_DYNAMIC_DRAW) {
 }
 
-LabelMesh::~LabelMesh() {}
+LabelMesh::~LabelMesh() {
+    if (s_quadIndexBuffer != 0 && s_quadGeneration != s_validGeneration) {
+        if (RenderState::indexBuffer.compare(s_quadIndexBuffer)) {
+            RenderState::indexBuffer.init(0, false);
+        }
+        glDeleteBuffers(1, &s_quadIndexBuffer);
+        s_quadIndexBuffer = 0;
+    }
+}
 
 void LabelMesh::addLabel(std::unique_ptr<Label> _label) {
     m_labels.push_back(std::move(_label));


### PR DESCRIPTION
Currently, this index buffer is not deleted either on app destroy or context loss. 
We should probably have a `Tangram::teardown` to deallocate statically instantiated resources like this shared index buffer.