### PR TITLE
non-proxy tiles labels win over proxy tile label

### DIFF
--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -21,9 +21,14 @@ Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, LabelMesh
     m_occlusionSolved = false;
     m_updateMeshVisibility = true;
     m_dirty = true;
+    m_proxy = false;
 }
 
 Label::~Label() {}
+
+void Label::setProxy(bool _proxy) {
+    m_proxy = _proxy;
+}
 
 bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize, bool _testVisibility) {
 
@@ -207,6 +212,7 @@ void Label::resetState() {
     m_occlusionSolved = false;
     m_updateMeshVisibility = true;
     m_dirty = true;
+    m_proxy = false;
     enterState(State::wait_occ, 0.0);
 }
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -129,8 +129,11 @@ public:
     bool visibleState() const;
 
     void resetState();
+
     void setProxy(bool _proxy);
-    bool proxy() const { return m_proxy; }
+
+    /* Whether the label belongs to a proxy tile */
+    bool isProxy() const { return m_proxy; }
 
 private:
 
@@ -143,8 +146,6 @@ private:
     void setAlpha(float _alpha);
 
     bool m_proxy;
-
-
     // the current label state
     State m_currentState;
     // the label fade effect

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -129,6 +129,8 @@ public:
     bool visibleState() const;
 
     void resetState();
+    void setProxy(bool _proxy);
+    bool proxy() const { return m_proxy; }
 
 private:
 
@@ -139,6 +141,9 @@ private:
     bool updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt, float _zoomFract);
 
     void setAlpha(float _alpha);
+
+    bool m_proxy;
+
 
     // the current label state
     State m_currentState;

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -99,9 +99,10 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
 
     for (auto& pair : occlusions) {
         if (!pair.first->occludedLastFrame() || !pair.second->occludedLastFrame()) {
-            if (pair.first->proxy() && !pair.second->proxy() ) {
+            // check first is the label belongs to a proxy tile
+            if (pair.first->isProxy() && !pair.second->isProxy()) {
                 pair.first->setOcclusion(true);
-            } else if (!pair.first->proxy() && pair.second->proxy() ) {
+            } else if (!pair.first->isProxy() && pair.second->isProxy()) {
                 pair.second->setOcclusion(true);
             } else {
                 // lower numeric priority means higher priority

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -55,6 +55,8 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
         //     continue;
         // }
 
+        bool proxyTile = tile->getProxyCounter() > 0;
+
         glm::mat4 mvp = _view.getViewProjectionMatrix() * tile->getModelMatrix();
 
         for (const auto& style : _styles) {
@@ -66,6 +68,8 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
 
             for (auto& label : labelMesh->getLabels()) {
                 m_needUpdate |= label->update(mvp, screenSize, _dt, dz);
+
+                label->setProxy(proxyTile);
 
                 if (label->canOcclude()) {
                     m_aabbs.push_back(label->getAABB());
@@ -95,11 +99,17 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
 
     for (auto& pair : occlusions) {
         if (!pair.first->occludedLastFrame() || !pair.second->occludedLastFrame()) {
-            // lower numeric priority means higher priority
-            if (pair.first->getOptions().priority < pair.second->getOptions().priority) {
+            if (pair.first->proxy() && !pair.second->proxy() ) {
+                pair.first->setOcclusion(true);
+            } else if (!pair.first->proxy() && pair.second->proxy() ) {
                 pair.second->setOcclusion(true);
             } else {
-                pair.first->setOcclusion(true);
+                // lower numeric priority means higher priority
+                if (pair.first->getOptions().priority < pair.second->getOptions().priority) {
+                    pair.second->setOcclusion(true);
+                } else {
+                    pair.first->setOcclusion(true);
+                }
             }
         }
     }


### PR DESCRIPTION
fixes an issue when proxy tiles labels were causing non proxy tiles label to be not drawn on collision