### PR TITLE
Stops for font properties

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1182,8 +1182,10 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
                         scene.stops().push_back(Stops::Widths(value, *scene.mapProjection()));
                         out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
 
-                    } else {
-                        // TODO other stops
+                    } else if (StyleParam::isFontSize(styleKey)){
+                        scene.stops().push_back(Stops::FontSize(value));
+                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
+
                     }
                 } else {
                     LOGW("Unknown style parameter %s", key.c_str());

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -27,6 +27,7 @@ struct Stops {
     std::vector<Frame> frames;
     static Stops Colors(const YAML::Node& _node);
     static Stops Widths(const YAML::Node& _node, const MapProjection& _projection);
+    static Stops FontSize(const YAML::Node& _node);
 
     Stops(const std::vector<Frame>& _frames) : frames(_frames) {}
     Stops() {}

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -457,11 +457,22 @@ bool StyleParam::isColor(StyleParamKey _key) {
             return false;
     }
 }
+
 bool StyleParam::isWidth(StyleParamKey _key) {
     switch (_key) {
         case StyleParamKey::width:
+        case StyleParamKey::font_stroke_width:
         case StyleParamKey::outline_width:
         case StyleParamKey::size:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool StyleParam::isFontSize(StyleParamKey _key) {
+    switch (_key) {
+        case StyleParamKey::font_size:
             return true;
         default:
             return false;

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -134,6 +134,7 @@ struct StyleParam {
 
     static bool isColor(StyleParamKey _key);
     static bool isWidth(StyleParamKey _key);
+    static bool isFontSize(StyleParamKey _key);
     static bool isRequired(StyleParamKey _key);
 
     static StyleParamKey getKey(const std::string& _key);


### PR DESCRIPTION
Stops for font properties including sizes, font fill/outline color as in https://github.com/tangrams/tangram/pull/214.
Will revert the scene once reviewed.