### PR TITLE
Be more diligent in setting animate for label

### DIFF
--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -251,6 +251,7 @@ bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
             if (occludedLastFrame) {
                 m_fade = FadeEffect(false, m_options.hideTransition.ease, m_options.hideTransition.time);
                 enterState(State::fading_out, 1.0);
+                animate = true;
             }
             break;
         case State::fading_in:
@@ -283,6 +284,7 @@ bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
                 }  else {
                     m_fade = FadeEffect(true, m_options.showTransition.ease, m_options.showTransition.time);
                     enterState(State::fading_in, 0.0);
+                    animate = true;
                 }
             }
             break;
@@ -290,6 +292,7 @@ bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
             if (!occludedLastFrame) {
                 m_fade = FadeEffect(true, m_options.showTransition.ease, m_options.showTransition.time);
                 enterState(State::fading_in, 0.0);
+                animate = true;
             }
             break;
         case State::dead:

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -286,6 +286,9 @@ bool Label::updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, flo
                     enterState(State::fading_in, 0.0);
                     animate = true;
                 }
+            } else {
+                // request for occlusion solving
+                animate = true;
             }
             break;
         case State::sleep:


### PR DESCRIPTION
every time a label enters a fading_in or fading_out or a visible state, animate should be set to true. This results in a
renderRequest, and hence also fixes the context loss issue.