### PR TITLE
Ease rotation over minimum angular distance

### DIFF
--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -278,6 +278,12 @@ void setRotation(float _radians) {
 void setRotation(float _radians, float _duration, EaseType _e) {
 
     float radians_start = getRotation();
+
+    // Ease over the smallest angular distance needed
+    float radians_delta = glm::mod(_radians - radians_start, (float)TWO_PI);
+    if (radians_delta > PI) { radians_delta -= TWO_PI; }
+    _radians = radians_start + radians_delta;
+
     auto cb = [=](float t) { setRotationNow(ease(radians_start, _radians, t, _e)); };
     setEase(EaseField::rotation, { _duration, cb });
 

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -173,6 +173,9 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             case GLFW_KEY_BACKSPACE:
                 init_main_window(); // Simulate GL context loss
                 break;
+            case GLFW_KEY_N:
+                Tangram::setRotation(0.f, 1.f);
+                break;
             default:
                 break;
         }

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -157,6 +157,9 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             case GLFW_KEY_Z:
                 Tangram::setZoom(Tangram::getZoom() + 1.f, 1.5f);
                 break;
+            case GLFW_KEY_N:
+                Tangram::setRotation(0.f, 1.f);
+                break;
         default:
                 break;
         }


### PR DESCRIPTION
Since the view rotation is stored in radians wrapped to [0, 2 pi), the current implementation of rotation easing causes rotations over larger angular distances than necessary. For example, if the current view rotation is 6 radians and an ease is requested to 0 radians, the current implementation will rotate negative 6 radians to reach zero, when it is more desirable to rotate positive ~0.28 radians. This change ensures that rotation easing uses the smallest possible angular distance to reach the final rotation. 