### PR TITLE
Adjust bounding boxes

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -246,7 +246,7 @@ layers:
         draw:
             icons:
                 interactive: true
-                offset: [0px, -15px]
+                #offset: [0px, -15px]
                 size: 20px
                 priority: 5
                 collide: true
@@ -338,7 +338,7 @@ layers:
         draw:
             text:
                 interactive: true
-                offset: [0, 12px]
+                #offset: [0, 12px]
                 align: right
                 text_wrap: 20
                 font:
@@ -355,7 +355,7 @@ layers:
                 interactive: true
                 visible: true
                 priority: 2
-                offset: [0, 8px]
+                #offset: [0, 8px]
                 font:
                     family: sans-serif
                     weight: 400
@@ -368,7 +368,7 @@ layers:
             draw:
                 text:
                     visible: true
-                    offset: [0px, 5px]
+                    #offset: [0px, 5px]
                     priority: 1
                     font:
                         family: sans-serif

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -23,25 +23,27 @@ TextLabel::TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim, Te
             case Anchor::center: break;
         }
     }
+
+    m_perpAxis = glm::vec2(0.0, 1.0);
 }
 
 void TextLabel::updateBBoxes(float _zoomFract) {
     glm::vec2 t(1.0, 0.0);
-    glm::vec2 tperp(0.0, 1.0);
     glm::vec2 obbCenter;
 
     if (m_type == Type::line) {
         t = glm::vec2(cos(m_transform.state.rotation), sin(m_transform.state.rotation));
-        tperp = glm::vec2(-t.y, t.x);
+        m_perpAxis = glm::vec2(-t.y, t.x);
     }
 
     obbCenter = m_transform.state.screenPos;
     // move forward on line by half the text length
     obbCenter += t * m_dim.x * 0.5f;
     // move down on the perpendicular to estimated font baseline
-    obbCenter -= tperp * m_dim.y * 0.5f;
+    obbCenter -= m_perpAxis * m_dim.y * 0.5f;
     // ajdust with baseline
-    obbCenter += tperp * m_metrics.lineHeight * (float) m_nLines * 0.5f;
+    obbCenter += m_perpAxis * m_metrics.lineHeight * (float) (m_nLines - 1);
+    obbCenter -= m_perpAxis * m_metrics.descender;
 
     m_obb = OBB(obbCenter.x, obbCenter.y, m_transform.state.rotation, m_dim.x, m_dim.y);
     m_aabb = m_obb.getExtent();
@@ -63,6 +65,8 @@ void TextLabel::align(glm::vec2& _screenPosition, const glm::vec2& _ap1, const g
             // move back by half the length (so that text will be drawn centered)
             glm::vec2 direction = glm::normalize(_ap1 - _ap2);
             _screenPosition += direction * m_dim.x * 0.5f;
+
+            _screenPosition += m_perpAxis * (m_dim.y * 0.5f  + m_metrics.descender);
             break;
         }
     }

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -24,6 +24,7 @@ protected:
 private:
 
     glm::vec2 m_anchor;
+    glm::vec2 m_perpAxis;
 
 };
 

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -37,7 +37,7 @@ public:
 private:
     static int applyWordWrapping(std::vector<FONSquad>& _quads, const TextStyle::Parameters& _params,
                                  const FontContext::FontMetrics& _metrics, Label::Type _type,
-                                 glm::vec2* _bbox, std::vector<TextBuffer::WordBreak>& words);
+                                 std::vector<TextBuffer::WordBreak>& words);
 
     static std::string applyTextTransform(const TextStyle::Parameters& _params, const std::string& _string);
 


### PR DESCRIPTION
Adjust bounding boxes, and make a better adjustment on line labels on their geometry (issue-#412).
Before/After
<img width="701" alt="screen shot 2015-12-04 at 4 35 01 pm" src="https://cloud.githubusercontent.com/assets/7061573/11602002/141074ae-9aa5-11e5-9109-6c279f7cd57f.png">
<img width="709" alt="screen shot 2015-12-04 at 4 33 10 pm" src="https://cloud.githubusercontent.com/assets/7061573/11601958/cffae240-9aa4-11e5-9e13-4d87ee731053.png">