### PR TITLE
Fix and refactor extrusion logic

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -300,31 +300,27 @@ layers:
         filter: { $zoom: { min: 14 } }
         draw:
             polygons:
-                style: polygons
+                style: heightglow
                 order: 50
-                color: [.85, .85, .83]
+                color: [.65, .65, .63]
         # turn interactive feature selection on for buildings with names
         interactive:
             filter: { name: true }
             draw:
                 polygons:
-                    style: heightglow
-                    color: [.65, .65, .63]
                     interactive: true
         extruded:
             filter: { $zoom: { min: 15 } }
             draw:
                 polygons:
-                    style: heightglow
-                    color: [.65, .65, .63]
-                    extrude: true
+                    extrude: 'function() { return feature.height || 20 }'
             draw:
                 lines:
                     style: heightglowline
                     width: 1.0
                     color: [.75, .75, .73]
                     order: 52
-                    extrude: true
+                    extrude: 'function() { return feature.height || 20 }'
         high-line:
             filter: {roof_material: grass}
             draw:

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -313,14 +313,14 @@ layers:
             filter: { $zoom: { min: 15 } }
             draw:
                 polygons:
-                    extrude: 'function() { return feature.height || 20 }'
+                    extrude: true
             draw:
                 lines:
                     style: heightglowline
                     width: 1.0
                     color: [.75, .75, .73]
                     order: 52
-                    extrude: 'function() { return feature.height || 20 }'
+                    extrude: true
         high-line:
             filter: {roof_material: grass}
             draw:

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -317,6 +317,9 @@ bool StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
     } else if (duk_is_number(m_ctx, -1)) {
 
         switch (_key) {
+            case StyleParamKey::extrude:
+                _val = glm::vec2(0.f, static_cast<float>(duk_get_number(m_ctx, -1)));
+                break;
             case StyleParamKey::width:
             case StyleParamKey::outline_width: {
                 // TODO more efficient way to return pixels.

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -3,6 +3,7 @@
 #include "csscolorparser.hpp"
 #include "platform.h"
 #include "util/builders.h" // for cap, join
+#include "util/extrude.h"
 #include "util/geom.h" // for CLAMP
 #include <algorithm>
 #include <map>
@@ -109,13 +110,7 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
 
     switch (key) {
     case StyleParamKey::extrude: {
-        if (_value == "true") { return glm::vec2(NAN, NAN); }
-        if (_value == "false") { return glm::vec2(0, 0) ; }
-        auto vec2 = glm::vec2(NAN, NAN);
-        if (!parseVec2(_value, { Unit::meter, Unit::pixel }, vec2)) {
-            LOGW("Invalid extrude parameter '%s'.", _value.c_str());
-        }
-        return vec2;
+        return parseExtrudeString(_value);
     }
     case StyleParamKey::text_wrap: {
         int textWrap;

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -4,6 +4,7 @@
 #include "platform.h"
 #include "material.h"
 #include "util/builders.h"
+#include "util/extrude.h"
 #include "gl/shaderProgram.h"
 #include "gl/typedMesh.h"
 #include "tile/tile.h"
@@ -90,21 +91,11 @@ void PolygonStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, 
 
     auto& mesh = static_cast<Mesh&>(_mesh);
 
-    float height = 0.0f, minHeight = 0.0f;
+    float tileUnitsPerMeter = _tile.getInverseScale();
+    float minHeight = getLowerExtrudeMeters(extrude, _props) * tileUnitsPerMeter;
+    float height = getUpperExtrudeMeters(extrude, _props) * tileUnitsPerMeter;
 
-    if (extrude[0] != 0.0f || extrude[1] != 0.0f) {
-
-        height = _props.getNumeric(key_height) * _tile.getInverseScale();
-        minHeight = _props.getNumeric(key_min_height) * _tile.getInverseScale();
-
-        if (std::isnan(extrude[1])) {
-            if (!std::isnan(extrude[0])) {
-                height = extrude[0];
-            }
-        } else {
-            minHeight = extrude[0] * _tile.getInverseScale();
-            height = extrude[1] * _tile.getInverseScale();
-        }
+    if (minHeight != height) {
 
         Builders::buildPolygonExtrusion(_polygon, minHeight, height, builder);
         mesh.addVertices(std::move(vertices), std::move(builder.indices));

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -102,8 +102,8 @@ void PolygonStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, 
                 height = extrude[0];
             }
         } else {
-            minHeight = extrude[0];
-            height = extrude[1];
+            minHeight = extrude[0] * _tile.getInverseScale();
+            height = extrude[1] * _tile.getInverseScale();
         }
 
         Builders::buildPolygonExtrusion(_polygon, minHeight, height, builder);

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -185,9 +185,9 @@ void PolylineStyle::buildLine(const Line& _line, const DrawRule& _rule, const Pr
         height = _props.getNumeric(key_height) * _tile.getInverseScale();
         if (std::isnan(extrude[1])) {
             if (!std::isnan(extrude[0])) {
-                height = extrude[0];
+                height = extrude[0] * _tile.getInverseScale();
             }
-        } else { height = extrude[1]; }
+        } else { height = extrude[1] * _tile.getInverseScale(); }
     }
 
     PolyLineBuilder builder {

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -9,6 +9,7 @@
 #include "scene/drawRule.h"
 #include "tile/tile.h"
 #include "util/mapProjection.h"
+#include "util/extrude.h"
 #include "glm/vec3.hpp"
 
 namespace Tangram {
@@ -176,19 +177,10 @@ void PolylineStyle::buildLine(const Line& _line, const DrawRule& _rule, const Pr
         abgr = abgr << (_tile.getID().z % 6);
     }
 
-    float height = 0.0f;
     auto& extrude = params.extrude;
 
-    if (extrude[0] != 0.0f || extrude[1] != 0.0f) {
-        const static std::string key_height("height");
-
-        height = _props.getNumeric(key_height) * _tile.getInverseScale();
-        if (std::isnan(extrude[1])) {
-            if (!std::isnan(extrude[0])) {
-                height = extrude[0] * _tile.getInverseScale();
-            }
-        } else { height = extrude[1] * _tile.getInverseScale(); }
-    }
+    float tileUnitsPerMeter = _tile.getInverseScale();
+    float height = getUpperExtrudeMeters(extrude, _props) * tileUnitsPerMeter;
 
     PolyLineBuilder builder {
         [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {

--- a/core/src/util/extrude.cpp
+++ b/core/src/util/extrude.cpp
@@ -1,0 +1,82 @@
+#include "extrude.h"
+#include <cmath>
+#include <cstdlib>
+
+namespace Tangram {
+
+Extrude parseExtrudeString(const std::string& _str) {
+
+    // Values specified from the stylesheet are assumed to be meters with no unit suffix
+    float first = 0, second = 0;
+
+    if (_str == "true") {
+        // "true" means use default properties for both heights, we indicate this with NANs
+        return Extrude(NAN, NAN);
+    }
+
+    if (_str == "false") {
+        // "false" means perform no extrusion
+        return Extrude(0, 0);
+    }
+
+    // Parse the first of two possible numbers
+    const char* pos = _str.c_str();
+    char* end = nullptr;
+
+    // Get a float if possible & advance pos to the end of the number
+    first = std::strtof(pos, &end);
+    if (pos == end) {
+        // No numbers found, return zero extrusion
+        return Extrude(0, 0);
+    }
+
+    // Advance and skip the delimiter character
+    pos = end + 1;
+
+    // Get a float if possible & advance pos to the end of the number
+    second = std::strtof(pos, &end);
+    if (pos == end) {
+        // No second number, so return an extrusion from 0 to the first number
+        return Extrude(0, first);
+    }
+
+    // Got two numbers, so return an extrusion from first to second
+    return Extrude(first, second);
+
+}
+
+float getLowerExtrudeMeters(const Extrude& _extrude, const Properties& _props) {
+
+    const static std::string key_min_height("min_height");
+
+    double lower = 0;
+
+    if (std::isnan(_extrude[0])) {
+        // A NAN indicates that the default property should be used for this height
+        _props.getNumeric(key_min_height, lower);
+    } else {
+        lower = _extrude[0];
+    }
+
+    return lower;
+
+}
+
+float getUpperExtrudeMeters(const Extrude& _extrude, const Properties& _props) {
+
+    const static std::string key_height("height");
+
+    double upper = 0;
+
+    if (std::isnan(_extrude[1])) {
+        // A NAN indicates that the default property should be used for this height
+        _props.getNumeric(key_height, upper);
+    } else {
+        upper = _extrude[1];
+    }
+
+    return upper;
+
+}
+
+}

--- a/core/src/util/extrude.h
+++ b/core/src/util/extrude.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "data/properties.h"
+#include "glm/vec2.hpp"
+#include <string>
+
+namespace Tangram {
+
+// Extrude is a 2-element vector that follows specific conventions to encode extrusion options
+using Extrude = glm::vec2;
+
+// Returns an Extrude to represent the extrusion option specified in the string, one of:
+// "true", "false", a single number, or a comma-separated pair of numbers
+Extrude parseExtrudeString(const std::string& _str);
+
+// Returns the lower or upper extrusion values for a given Extrude and set of feature properties
+float getLowerExtrudeMeters(const Extrude& _extrude, const Properties& _props);
+float getUpperExtrudeMeters(const Extrude& _extrude, const Properties& _props);
+
+}


### PR DESCRIPTION
Extrusion options are somewhat more complicated than one might expect. They're handled in a much clearer way now!

 - JS functions for `extrude` can now return single numbers as well as an array of two numbers
 - Numbers specified for `extrude` are now correctly interpreted as meters and scaled to match
 - Extrude parsing and evaluation is now contained in a separate file

This will fix the craziness demonstrated in https://github.com/tangrams/eraser-map/issues/109