### PR TITLE
WIP Rework tile states

### DIFF
--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -8,6 +8,7 @@
 #include "scene/styleContext.h"
 #include "util/mapProjection.h"
 #include "tile/tile.h"
+#include "tile/tileTask.h"
 
 #include <vector>
 #include <iostream>
@@ -69,7 +70,13 @@ struct TestContext {
 
     void parseTile() {
         Tile tile({0,0,0}, s_projection);
-        tileData = source->parse(tile.getID(), s_projection, rawTileData);
+        source = scene->dataSources()[0];
+        auto task = source->createTask(tile.getID());
+        auto& t = dynamic_cast<DownloadTileTask&>(*task);
+        t.rawTileData = std::make_shared<std::vector<char>>();
+        std::swap(*t.rawTileData, rawTileData);
+
+        tileData = source->parse(*task, s_projection);
     }
 };
 
@@ -126,7 +133,12 @@ public:
 
         if (!scene->dataSources().empty()) {
             source = scene->dataSources()[0];
-            tileData = source->parse(tile.getID(), s_projection,rawTileData);
+            auto task = source->createTask(tile.getID());
+            auto& t = dynamic_cast<DownloadTileTask&>(*task);
+            t.rawTileData = std::make_shared<std::vector<char>>();
+            std::swap(*t.rawTileData, rawTileData);
+
+            tileData = source->parse(*task, s_projection);
         }
 
         LOG("Ready");

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -69,7 +69,7 @@ struct TestContext {
 
     void parseTile() {
         Tile tile({0,0,0}, s_projection);
-        tileData = source->parse(tile, rawTileData);
+        tileData = source->parse(tile.getID(), s_projection, rawTileData);
     }
 };
 
@@ -124,9 +124,10 @@ public:
 
         Tile tile({0,0,0}, s_projection);
 
-        source = scene->dataSources()[0];
-
-        tileData = source->parse(tile, rawTileData);
+        if (!scene->dataSources().empty()) {
+            source = scene->dataSources()[0];
+            tileData = source->parse(tile.getID(), s_projection,rawTileData);
+        }
 
         LOG("Ready");
     }

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -120,17 +120,16 @@ void ClientGeoJsonSource::addPoly(const Properties& _tags, const std::vector<Coo
     m_generation++;
 }
 
-std::shared_ptr<TileData> ClientGeoJsonSource::parse(const Tile& _tile, std::vector<char>& _rawData) const {
+std::shared_ptr<TileData> ClientGeoJsonSource::parse(const TileID& _tileId, const MapProjection& _projection,
+                                                     std::vector<char>& _rawData) const {
 
     auto data = std::make_shared<TileData>();
-
-    auto id = _tile.getID();
 
     geojsonvt::Tile tile;
     {
         std::lock_guard<std::mutex> lock(m_mutexStore);
         if (!m_store) { return nullptr; }
-        tile = m_store->getTile(id.z, id.x, id.y); // uses a mutex lock internally for thread-safety
+        tile = m_store->getTile(_tileId.z, _tileId.x, _tileId.y);
     }
 
     Layer layer(""); // empty name will skip filtering by 'collection'

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -39,7 +39,8 @@ public:
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const Tile& _tile, std::vector<char>& _rawData) const override;
+    virtual std::shared_ptr<TileData> parse(const TileID& _tileId, const MapProjection& _projection,
+                                            std::vector<char>& _rawData) const override;
 
     std::unique_ptr<GeoJSONVT> m_store;
     mutable std::mutex m_mutexStore;

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -33,14 +33,15 @@ public:
     void addPoly(const Properties& _tags, const std::vector<Coordinates>& _poly);
 
     virtual bool loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb) override;
-    virtual bool getTileData(std::shared_ptr<TileTask>& _task) override;
+    std::shared_ptr<TileTask> createTask(TileID _tileId) override;
+
     virtual void cancelLoadingTile(const TileID& _tile) override {};
     virtual void clearData() override;
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const TileID& _tileId, const MapProjection& _projection,
-                                            std::vector<char>& _rawData) const override;
+    virtual std::shared_ptr<TileData> parse(const TileTask& _task,
+                                            const MapProjection& _projection) const override;
 
     std::unique_ptr<GeoJSONVT> m_store;
     mutable std::mutex m_mutexStore;

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -31,12 +31,12 @@ struct RawCache {
     int m_usage = 0;
     int m_maxUsage = 0;
 
-    bool get(TileTask& _task) {
+    bool get(DownloadTileTask& _task) {
 
         if (m_maxUsage <= 0) { return false; }
 
         std::lock_guard<std::mutex> lock(m_mutex);
-        auto it = m_cacheMap.find(_task.tileId);
+        auto it = m_cacheMap.find(_task.tileId());
         if (it != m_cacheMap.end()) {
             // Move cached entry to start of list
             m_cacheList.splice(m_cacheList.begin(), m_cacheList, it->second);
@@ -97,6 +97,14 @@ DataSource::~DataSource() {
     clearData();
 }
 
+std::shared_ptr<TileTask> DataSource::createTask(TileID _tileId) {
+    auto task = std::make_shared<DownloadTileTask>(_tileId, shared_from_this());
+
+    m_cache->get(*task);
+
+    return task;
+}
+
 void DataSource::setCacheSize(size_t _cacheSize) {
     m_cache->m_maxUsage = _cacheSize;
 }
@@ -120,23 +128,16 @@ void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const
     }
 }
 
-bool DataSource::getTileData(std::shared_ptr<TileTask>& _task) {
-    if (m_cache->get(*_task)) {
-        _task->loaded = true;
-        return true;
-    }
-    return false;
-}
-
 void DataSource::onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<TileTask>& _task, TileTaskCb _cb) {
-    TileID tileID = _task->tileId;
+    TileID tileID = _task->tileId();
 
     if (!_rawData.empty()) {
-        _task->loaded = true;
 
         auto rawDataRef = std::make_shared<std::vector<char>>();
         std::swap(*rawDataRef, _rawData);
-        _task->rawTileData = rawDataRef;
+
+        auto& task = static_cast<DownloadTileTask&>(*_task);
+        task.rawTileData = rawDataRef;
 
         _cb.func(std::move(_task));
 
@@ -147,7 +148,7 @@ void DataSource::onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<Tile
 
 bool DataSource::loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb) {
 
-    std::string url(constructURL(_task->tileId));
+    std::string url(constructURL(_task->tileId()));
 
     // Using bind instead of lambda to be able to 'move' (until c++14)
     return startUrlRequest(url, std::bind(&DataSource::onTileLoaded,

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -1,5 +1,6 @@
 #pragma once
 
+
 #include <string>
 #include <memory>
 #include <vector>
@@ -15,7 +16,7 @@ struct RawCache;
 class TileTask;
 struct TileTaskCb;
 
-class DataSource {
+class DataSource : public std::enable_shared_from_this<DataSource> {
 
 public:
 
@@ -36,15 +37,12 @@ public:
      */
     virtual bool loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb);
 
-    /* Lookup TileData in cache and */
-    virtual bool getTileData(std::shared_ptr<TileTask>& _task);
 
     /* Stops any running I/O tasks pertaining to @_tile */
     virtual void cancelLoadingTile(const TileID& _tile);
 
-    /* Parse an I/O response into a <TileData>, returning an empty TileData on failure */
-    virtual std::shared_ptr<TileData> parse(const TileID& _tileId, const MapProjection& _projection,
-                                            std::vector<char>& _rawData) const = 0;
+    /* Parse a <TileTask> with data into a <TileData>, returning an empty TileData on failure */
+    virtual std::shared_ptr<TileData> parse(const TileTask& _task, const MapProjection& _projection) const = 0;
 
     /* Clears all data associated with this DataSource */
     virtual void clearData();
@@ -55,6 +53,8 @@ public:
         return m_name == _other.m_name &&
                m_urlTemplate == _other.m_urlTemplate;
     }
+
+    virtual std::shared_ptr<TileTask> createTask(TileID _tile);
 
     /* @_cacheSize: Set size of in-memory cache for tile data in bytes.
      * This cache holds unprocessed tile data for fast recreation of recently used tiles.

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -6,6 +6,7 @@
 
 namespace Tangram {
 
+class MapProjection;
 struct TileData;
 struct TileID;
 class Tile;
@@ -42,7 +43,8 @@ public:
     virtual void cancelLoadingTile(const TileID& _tile);
 
     /* Parse an I/O response into a <TileData>, returning an empty TileData on failure */
-    virtual std::shared_ptr<TileData> parse(const Tile& _tile, std::vector<char>& _rawData) const = 0;
+    virtual std::shared_ptr<TileData> parse(const TileID& _tileId, const MapProjection& _projection,
+                                            std::vector<char>& _rawData) const = 0;
 
     /* Clears all data associated with this DataSource */
     virtual void clearData();

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -19,15 +19,17 @@ GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTe
     DataSource(_name, _urlTemplate) {
 }
 
-std::shared_ptr<TileData> GeoJsonSource::parse(const TileID& _tileId, const MapProjection& _projection,
-                                               std::vector<char>& _rawData) const {
+std::shared_ptr<TileData> GeoJsonSource::parse(const TileTask& _task,
+                                               const MapProjection& _projection) const {
+
+    auto& task = static_cast<const DownloadTileTask&>(_task);
 
     std::shared_ptr<TileData> tileData = std::make_shared<TileData>();
 
     // parse written data into a JSON object
     rapidjson::Document doc;
 
-    rapidjson::MemoryStream ms(_rawData.data(), _rawData.size());
+    rapidjson::MemoryStream ms(task.rawTileData->data(), task.rawTileData->size());
     rapidjson::EncodedInputStream<rapidjson::UTF8<char>, rapidjson::MemoryStream> is(ms);
 
     doc.ParseStream(is);
@@ -36,12 +38,12 @@ std::shared_ptr<TileData> GeoJsonSource::parse(const TileID& _tileId, const MapP
 
         size_t offset = doc.GetErrorOffset();
         const char* error = rapidjson::GetParseError_En(doc.GetParseError());
-        LOGE("Json parsing failed on tile [%s]: %s (%u)", _tileId.toString().c_str(), error, offset);
+        LOGE("Json parsing failed on tile [%s]: %s (%u)", task.tileId().toString().c_str(), error, offset);
         return tileData;
 
     }
 
-    BoundingBox tileBounds(_projection.TileBounds(_tileId));
+    BoundingBox tileBounds(_projection.TileBounds(task.tileId()));
     glm::dvec2 tileOrigin = {tileBounds.min.x, tileBounds.max.y*-1.0};
     double tileInverseScale = 1.0 / tileBounds.width();
 

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -1,4 +1,5 @@
 #include "geoJsonSource.h"
+#include "util/mapProjection.h"
 
 #include "tileData.h"
 #include "tile/tile.h"
@@ -18,7 +19,8 @@ GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTe
     DataSource(_name, _urlTemplate) {
 }
 
-std::shared_ptr<TileData> GeoJsonSource::parse(const Tile& _tile, std::vector<char>& _rawData) const {
+std::shared_ptr<TileData> GeoJsonSource::parse(const TileID& _tileId, const MapProjection& _projection,
+                                               std::vector<char>& _rawData) const {
 
     std::shared_ptr<TileData> tileData = std::make_shared<TileData>();
 
@@ -34,15 +36,27 @@ std::shared_ptr<TileData> GeoJsonSource::parse(const Tile& _tile, std::vector<ch
 
         size_t offset = doc.GetErrorOffset();
         const char* error = rapidjson::GetParseError_En(doc.GetParseError());
-        LOGE("Json parsing failed on tile [%d, %d, %d]: %s (%u)", _tile.getID().z, _tile.getID().x, _tile.getID().y, error, offset);
+        LOGE("Json parsing failed on tile [%s]: %s (%u)", _tileId.toString().c_str(), error, offset);
         return tileData;
 
     }
 
+    BoundingBox tileBounds(_projection.TileBounds(_tileId));
+    glm::dvec2 tileOrigin = {tileBounds.min.x, tileBounds.max.y*-1.0};
+    double tileInverseScale = 1.0 / tileBounds.width();
+
+    const auto projFn = [&](glm::dvec2 _lonLat){
+        glm::dvec2 tmp = _projection.LonLatToMeters(_lonLat);
+        return Point {
+            (tmp.x - tileOrigin.x) * tileInverseScale,
+            (tmp.y - tileOrigin.y) * tileInverseScale,
+             0
+        };
+    };
     // transform JSON data into a TileData using GeoJson functions
     for (auto layer = doc.MemberBegin(); layer != doc.MemberEnd(); ++layer) {
         tileData->layers.emplace_back(std::string(layer->name.GetString()));
-        GeoJson::extractLayer(m_id, layer->value, tileData->layers.back(), _tile);
+        GeoJson::extractLayer(m_id, layer->value, tileData->layers.back(), projFn);
     }
 
 

--- a/core/src/data/geoJsonSource.h
+++ b/core/src/data/geoJsonSource.h
@@ -8,8 +8,8 @@ class GeoJsonSource: public DataSource {
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const TileID& _tileId, const MapProjection& _projection,
-                                            std::vector<char>& _rawData) const override;
+    virtual std::shared_ptr<TileData> parse(const TileTask& _task,
+                                            const MapProjection& _projection) const override;
 
 public:
 

--- a/core/src/data/geoJsonSource.h
+++ b/core/src/data/geoJsonSource.h
@@ -8,7 +8,8 @@ class GeoJsonSource: public DataSource {
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const Tile& _tile, std::vector<char>& _rawData) const override;
+    virtual std::shared_ptr<TileData> parse(const TileID& _tileId, const MapProjection& _projection,
+                                            std::vector<char>& _rawData) const override;
 
 public:
 

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -12,16 +12,18 @@
 
 namespace Tangram {
 
+
 MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate) :
     DataSource(_name, _urlTemplate) {
 }
 
-std::shared_ptr<TileData> MVTSource::parse(const TileID& _tileId, const MapProjection& _projection,
-                                           std::vector<char>& _rawData) const {
+std::shared_ptr<TileData> MVTSource::parse(const TileTask& _task, const MapProjection& _projection) const {
 
-    std::shared_ptr<TileData> tileData = std::make_shared<TileData>();
+    auto tileData = std::make_shared<TileData>();
 
-    protobuf::message item(_rawData.data(), _rawData.size());
+    auto& task = static_cast<const DownloadTileTask&>(_task);
+
+    protobuf::message item(task.rawTileData->data(), task.rawTileData->size());
     PbfParser::ParserContext ctx(m_id);
 
     while(item.next()) {

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -16,7 +16,8 @@ MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate) 
     DataSource(_name, _urlTemplate) {
 }
 
-std::shared_ptr<TileData> MVTSource::parse(const Tile& _tile, std::vector<char>& _rawData) const {
+std::shared_ptr<TileData> MVTSource::parse(const TileID& _tileId, const MapProjection& _projection,
+                                           std::vector<char>& _rawData) const {
 
     std::shared_ptr<TileData> tileData = std::make_shared<TileData>();
 

--- a/core/src/data/mvtSource.h
+++ b/core/src/data/mvtSource.h
@@ -8,8 +8,8 @@ class MVTSource : public DataSource {
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const TileID& _tileId, const MapProjection& _projection,
-                                            std::vector<char>& _rawData) const override;
+    virtual std::shared_ptr<TileData> parse(const TileTask& _task,
+                                            const MapProjection& _projection) const override;
 
 public:
 

--- a/core/src/data/mvtSource.h
+++ b/core/src/data/mvtSource.h
@@ -8,7 +8,8 @@ class MVTSource : public DataSource {
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const Tile& _tile, std::vector<char>& _rawData) const override;
+    virtual std::shared_ptr<TileData> parse(const TileID& _tileId, const MapProjection& _projection,
+                                            std::vector<char>& _rawData) const override;
 
 public:
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -59,7 +59,7 @@ void Labels::update(const View& _view, float _dt, const std::vector<std::unique_
         //     continue;
         // }
 
-        bool proxyTile = tile->getProxyCounter() > 0;
+        bool proxyTile = tile->isProxy();
 
         glm::mat4 mvp = _view.getViewProjectionMatrix() * tile->getModelMatrix();
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -21,8 +21,6 @@ namespace Tangram {
 Tile::Tile(TileID _id, const MapProjection& _projection, const DataSource* _source) :
     m_id(_id),
     m_projection(&_projection),
-    m_visible(false),
-    m_priority(0),
     m_sourceId(_source ? _source->id() : 0),
     m_sourceGeneration(_source ? _source->generation() : 0) {
 
@@ -116,7 +114,7 @@ void Tile::update(float _dt, const View& _view) {
 
 }
 
-void Tile::reset() {
+void Tile::resetState() {
     for (auto& entry : m_geometry) {
         if (!entry) { continue; }
         auto labelMesh = dynamic_cast<LabelMesh*>(entry.get());
@@ -132,7 +130,7 @@ void Tile::draw(const Style& _style, const View& _view) {
     if (styleMesh) {
         auto& shader = _style.getShaderProgram();
 
-        float zoomAndProxy = m_proxyCounter > 0 ? -m_id.z : m_id.z;
+        float zoomAndProxy = isProxy() ? -m_id.z : m_id.z;
 
         shader->setUniformMatrix4f("u_model", m_modelMatrix);
         shader->setUniformf("u_tile_origin", m_tileOrigin.x, m_tileOrigin.y, zoomAndProxy);

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -201,13 +201,18 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
                 }
 
             } else if (!entry.isLoading()) {
+                // Start loading when no task is set or the task stems from an
+                // older tile source generation
+                if (!entry.task ||
+                    (entry.task->sourceGeneration() < _tileSet.source->generation())) {
 
-                // Not yet available - enqueue for loading
-                enqueueTask(_tileSet, visTileId, viewCenter);
+                    // Not yet available - enqueue for loading
+                    enqueueTask(_tileSet, visTileId, viewCenter);
 
-                if (m_tileSetChanged) {
-                    // check again for proxies
-                    updateProxyTiles(_tileSet, visTileId, entry);
+                    if (m_tileSetChanged) {
+                        // check again for proxies
+                        updateProxyTiles(_tileSet, visTileId, entry);
+                    }
                 }
             }
 

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -148,7 +148,7 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
     // Tile load request above this zoom-level will be canceled in order to
     // not wait for tiles that are too small to contribute significantly to
     // the current view.
-    // int maxZoom = m_view->getZoom() + 2;
+    int maxZoom = m_view->getZoom() + 2;
 
     m_tileSetChanged |= m_workers->checkPendingTiles();
 
@@ -242,6 +242,9 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
                     }
                     if (entry.isReady()) {
                         m_tiles.push_back(entry.tile);
+
+                    } else if (curTileId.z < maxZoom){
+                        removeTiles.push_back(curTileId);
                     }
                 } else {
                     removeTiles.push_back(curTileId);
@@ -258,8 +261,8 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
 
         if ((it != tiles.end()) &&
             (!it->second.isVisible()) &&
-            (it->second.getProxyCounter() <= 0)) { // ||
-            //tileIt->first.z > maxZoom)) {
+            (it->second.getProxyCounter() <= 0  ||
+             it->first.z >= maxZoom)) {
 
             auto& entry = it->second;
 

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -338,7 +338,7 @@ void TileManager::loadTiles() {
             entry.task = task;
             m_dataCallback.func(std::move(task));
 
-        } else if (m_loadPending < int(MAX_DOWNLOADS)) {
+        } else if (m_loadPending < MAX_DOWNLOADS) {
             entry.task = task;
             if (tileSet.source->loadTileData(std::move(task), m_dataCallback)) {
                 m_loadPending++;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -158,6 +158,17 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
     auto& tiles = _tileSet.tiles;
     auto& visibleTiles = m_view->getVisibleTiles();
 
+    if (m_tileSetChanged) {
+        for (auto& it : tiles) {
+            auto& entry = it.second;
+            if (entry.newData()) {
+                clearProxyTiles(_tileSet, it.first, entry, removeTiles);
+                entry.tile = std::move(entry.task->tile());
+                entry.task.reset();
+            }
+        }
+    }
+
     // Loop over visibleTiles and add any needed tiles to tileSet
     auto curTilesIt = tiles.begin();
     auto visTilesIt = visibleTiles.begin();
@@ -178,12 +189,6 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
 
             auto& entry = curTilesIt->second;
             entry.setVisible(true);
-
-            if (entry.newData()) {
-                clearProxyTiles(_tileSet, curTileId, entry, removeTiles);
-                entry.tile = std::move(entry.task->tile());
-                entry.task.reset();
-            }
 
             if (entry.isReady()) {
                 m_tiles.push_back(entry.tile);
@@ -236,11 +241,6 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
             auto& entry = curTilesIt->second;
 
             if (entry.getProxyCounter() > 0) {
-                if (entry.newData()) {
-                    clearProxyTiles(_tileSet, curTileId, entry, removeTiles);
-                    entry.tile = std::move(entry.task->tile());
-                    entry.task.reset();
-                }
                 if (entry.isReady()) {
                     m_tiles.push_back(entry.tile);
 

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -282,11 +282,11 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
         }
     }
 
-    for (auto it = tiles.begin(); it != tiles.end();) {
-        auto& entry = it->second;
+    for (auto& it : tiles) {
+        auto& entry = it.second;
 
         LOG("> %s - ready:%d proxy:%d/%d loading:%d",
-            it->first.toString().c_str(),
+            it.first.toString().c_str(),
             entry.isReady(),
             entry.getProxyCounter(),
             entry.m_proxies,
@@ -294,7 +294,7 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
             );
 
         if (entry.isLoading()) {
-            auto& id = it->first;
+            auto& id = it.first;
             auto& task = entry.task;
 
             // Update tile distance to map center for load priority.
@@ -315,7 +315,6 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
             // Mark as proxy
             entry.tile->setProxyState(entry.getProxyCounter() > 0);
         }
-        ++it;
     }
 }
 

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -14,26 +14,20 @@
 
 namespace Tangram {
 
-TileManager::TileManager()
-    : m_loadPending(0) {
+TileManager::TileManager() {
 
     // Instantiate workers
     m_workers = std::unique_ptr<TileWorker>(new TileWorker(*this, MAX_WORKERS));
 
     m_tileCache = std::unique_ptr<TileCache>(new TileCache(DEFAULT_CACHE_SIZE));
 
-    m_dataCallback = TileTaskCb{[this](std::shared_ptr<TileTask>&& task){
-        if (!task->loaded) {
-            LOGD("No data for tile: %s", task->tile->getID().toString().c_str());
-
-            // Set 'canceled' state when no data was received, when state is
-            // already 'canceled' the state remains canceled.
-            setTileState(*task->tile, TileState::canceled);
-        }
-        else if (setTileState(*task->tile, TileState::processing)) {
-            // Enqueue tile for processing by TileWorker
-            m_workers->enqueue(std::move(task));
-        }
+    m_dataCallback = TileTaskCb{[this](std::shared_ptr<TileTask>&& task) {
+            if (task->loaded) {
+                m_workers->enqueue(std::move(task));
+            } else {
+                LOGD("No data for tile: %s", task->tile->getID().toString().c_str());
+                task->cancel();
+            }
     }};
 }
 
@@ -64,7 +58,8 @@ void TileManager::setScene(std::shared_ptr<Scene> _scene) {
 
             // Cancel pending  tiles
             for_each(tileSet.tiles.begin(), tileSet.tiles.end(), [&](auto& tile) {
-                    this->setTileState(*tile.second, TileState::canceled); });
+                    tile.second.cancelTask();
+                });
 
             // Clear cache
             tileSet.tiles.clear();
@@ -76,13 +71,11 @@ void TileManager::setScene(std::shared_ptr<Scene> _scene) {
     // add new sources
     for (const auto& source : sources) {
 
-        if(std::find_if(
-               m_tileSets.begin(), m_tileSets.end(),
-               [&](const TileSet& a) {
-                            return a.source->name() == source->name();
-                        }) == m_tileSets.end()) {
+        if (std::find_if(m_tileSets.begin(), m_tileSets.end(),
+                         [&](const TileSet& a) {
+                             return a.source->name() == source->name();
+                         }) == m_tileSets.end()) {
             LOG("add source %s", source->name().c_str());
-
             addDataSource(source);
         }
     }
@@ -99,63 +92,10 @@ void TileManager::tileProcessed(std::shared_ptr<TileTask>&& _task) {
     m_readyTiles.push_back(std::move(_task));
 }
 
-bool TileManager::setTileState(Tile& _tile, TileState _newState) {
-    std::lock_guard<std::mutex> lock(m_tileStateMutex);
-
-    switch (_tile.getState()) {
-    case TileState::none:
-        if (_newState == TileState::loading) {
-            _tile.setState(_newState);
-            m_loadPending++;
-            return true;
-        }
-        if (_newState == TileState::processing) {
-            _tile.setState(_newState);
-            return true;
-        }
-        if (_newState == TileState::none) {
-            return true;
-        }
-        break;
-
-    case TileState::loading:
-        if (_newState == TileState::processing ||
-            _newState == TileState::canceled) {
-            _tile.setState(_newState);
-            m_loadPending--;
-            return true;
-        }
-        break;
-
-    case TileState::processing:
-        if (_newState == TileState::ready) {
-            _tile.setState(_newState);
-            return true;
-        }
-        break;
-
-    case TileState::canceled:
-        // Ignore any state change when tile was canceled
-        return false;
-
-    default:
-        break;
-    }
-
-    if (_newState == TileState::canceled) {
-        _tile.setState(_newState);
-        return true;
-    }
-
-    LOGE("Wrong state change %d -> %d", _tile.getState(), _newState);
-    assert(false);
-    return false; // no warning
-}
-
 void TileManager::clearTileSets() {
     for (auto& tileSet : m_tileSets) {
         for (auto& tile : tileSet.tiles) {
-            setTileState(*tile.second, TileState::canceled);
+            tile.second.cancelTask();
         }
         tileSet.tiles.clear();
     }
@@ -168,7 +108,7 @@ void TileManager::clearTileSet(int32_t _sourceId) {
     for (auto& tileSet : m_tileSets) {
         if (tileSet.source->id() != _sourceId) { continue; }
         for (auto& tile : tileSet.tiles) {
-            setTileState(*tile.second, TileState::canceled);
+            tile.second.cancelTask();
         }
         tileSet.tiles.clear();
     }
@@ -182,6 +122,7 @@ void TileManager::updateTileSets() {
 
     m_tileSetChanged = false;
     m_tiles.clear();
+    m_loadPending = 0;
 
     for (auto& tileSet : m_tileSets) {
         updateTileSet(tileSet);
@@ -208,32 +149,57 @@ void TileManager::updateTileSet(TileSet& tileSet) {
         auto taskIt = m_readyTiles.begin();
 
         while (taskIt != m_readyTiles.end()) {
-            auto& task = *taskIt;
-            auto& tile = task->tile;
 
-            if (tileSet.source != task->source) {
+            if (tileSet.source != (*taskIt)->source) {
                 taskIt++;
                 continue;
             }
-            auto setTile = tileSet.tiles.find(tile->getID());
-
-            if (setTile != tileSet.tiles.end() &&
-                setTile->second->sourceGeneration() <= tile->sourceGeneration() &&
-                setTileState(*tile, TileState::ready)) {
-
-                // NB: proxies are added for the original
-                // tile in tileSet - not the one from tileTask.
-                // Dont use *tile here!
-                clearProxyTiles(tileSet, *setTile->second, removeTiles);
-
-                // Replace old tile with new tile from task
-                if (setTile->second != tile) {
-                    setTile->second = tile;
-                }
-
-                m_tileSetChanged = true;
-            }
+            auto task = *taskIt;
             taskIt = m_readyTiles.erase(taskIt);
+
+            auto setTile = tileSet.tiles.find(task->tileId);
+            if (setTile == tileSet.tiles.end()) { continue; }
+
+            auto& entry = setTile->second;
+
+            if (!task->tile) {
+                LOG("got empty tile task %d", task->isCanceled());
+                entry.task.reset();
+                continue;
+            }
+
+            if (!entry.isLoading()) {
+                // FIXME: just testing: this case should not happen
+                LOG("got orphaned tile task");
+                assert(entry.m_proxies == 0);
+                continue;
+            }
+
+            // NB: Unset implicit 'loading' state
+            entry.task.reset();
+
+            if (entry.isReady() &&
+                entry.tile->sourceGeneration() > task->tile->sourceGeneration()) {
+                // FIXME: just testing: this case should be avoided
+                LOG("got older tile task");
+                assert(entry.m_proxies == 0);
+                continue;
+            }
+
+            if (entry.isReady()) {
+                LOG("%s replace tile %d -> %d",
+                    task->tile->getID().toString().c_str(),
+                    entry.tile->sourceGeneration(),
+                    task->tile->sourceGeneration());
+            } else {
+                LOG("%s new tile %d",
+                    task->tile->getID().toString().c_str(),
+                    task->tile->sourceGeneration());
+            }
+
+            clearProxyTiles(tileSet, setTile->first, entry, removeTiles);
+            entry.tile = task->tile;
+            m_tileSetChanged = true;
         }
     }
 
@@ -244,7 +210,7 @@ void TileManager::updateTileSet(TileSet& tileSet) {
     // Tile load request above this zoom-level will be canceled in order to
     // not wait for tiles that are too small to contribute significantly to
     // the current view.
-    int maxZoom = m_view->getZoom() + 2;
+    //int maxZoom = m_view->getZoom() + 2;
 
     if (tileSet.sourceGeneration != tileSet.source->generation()) {
         tileSet.sourceGeneration = tileSet.source->generation();
@@ -268,34 +234,35 @@ void TileManager::updateTileSet(TileSet& tileSet) {
                 : curTilesIt->first;
 
             if (visTileId == curTileId) {
+                // tiles in both sets match
                 assert(!(visTileId == NOT_A_TILE));
 
-                // tiles in both sets match
-                auto& tile = curTilesIt->second;
-                tile->setVisible(true);
+                auto& entry = curTilesIt->second;
+                entry.setVisible(true);
 
-                // LOG("%s - %d %d %d", tile->getID().toString().c_str(),
-                //     tile->sourceGeneration(), tileSet.source->generation(), tile->reloading);
+                if (entry.isReady()) {
+                    m_tiles.push_back(entry.tile);
 
-                bool stale = (tile->sourceGeneration() < tileSet.source->generation() &&
-                              !tile->reloading);
+                    bool update = !entry.isLoading() &&
+                        (entry.tile->sourceGeneration() < tileSet.source->generation());
 
-                if (tile->isReady()) {
-                    m_tiles.push_back(tile);
+                    if (update) {
+                        LOG("reload tile %s - %d %d", visTileId.toString().c_str(),
+                            entry.tile->sourceGeneration(),
+                            tileSet.source->generation());
 
-                    if (stale) {
                         // Tile needs update - enqueue for loading
                         enqueueTask(tileSet, visTileId, viewCenter);
                     }
 
-                } else if (tile->hasState(TileState::none) || stale) {
+                } else if (!entry.isLoading()) {
 
                     // Not yet available - enqueue for loading
                     enqueueTask(tileSet, visTileId, viewCenter);
 
                     if (m_tileSetChanged) {
                         // check again for proxies
-                        updateProxyTiles(tileSet, *tile);
+                        updateProxyTiles(tileSet, visTileId, entry);
                     }
                 }
 
@@ -303,12 +270,12 @@ void TileManager::updateTileSet(TileSet& tileSet) {
                 ++visTilesIt;
 
             } else if (curTileId > visTileId) {
+                // tileSet is missing an element present in visibleTiles
                 // NB: if (curTileId == NOT_A_TILE) it is always > visTileId
                 //     and if curTileId > visTileId, then visTileId cannot be
                 //     NOT_A_TILE. (for the current implementation of > operator)
                 assert(!(visTileId == NOT_A_TILE));
 
-                // tileSet is missing an element present in visibleTiles
                 if (!addTile(tileSet, visTileId)) {
                     // Not in cache - enqueue for loading
                     enqueueTask(tileSet, visTileId, viewCenter);
@@ -317,25 +284,19 @@ void TileManager::updateTileSet(TileSet& tileSet) {
                 ++visTilesIt;
 
             } else {
-                assert(!(curTileId == NOT_A_TILE));
                 // tileSet has a tile not present in visibleTiles
-                auto& tile = curTilesIt->second;
+                assert(!(curTileId == NOT_A_TILE));
+                auto& entry = curTilesIt->second;
 
-                if (!tile) {
-                    curTilesIt = tiles.erase(curTilesIt);
-                    continue;
+                if (entry.getProxyCounter() > 0) {
+                    if (entry.isReady()) {
+                        m_tiles.push_back(entry.tile);
+                    }
+                } else {
+                    LOG("CLEANUP PROXY %s", curTileId.toString().c_str());
+                    removeTiles.push_back(curTileId);
                 }
-
-                if (tile->getProxyCounter() <= 0) {
-                    removeTiles.push_back(tile->getID());
-                } else if (tile->isReady()) {
-                    m_tiles.push_back(tile);
-                } else if (tile->getID().z > maxZoom) {
-                    // cancel requsts for tiles that
-                    // are too small on screen
-                    removeTiles.push_back(tile->getID());
-                }
-                tile->setVisible(false);
+                entry.setVisible(false);
 
                 ++curTilesIt;
             }
@@ -343,30 +304,66 @@ void TileManager::updateTileSet(TileSet& tileSet) {
     }
 
     while (!removeTiles.empty()) {
-        auto tileIt = tiles.find(removeTiles.back());
+        auto it = tiles.find(removeTiles.back());
         removeTiles.pop_back();
 
-        if ((tileIt != tiles.end()) &&
-            (!tileIt->second->isVisible()) &&
-            (tileIt->second->getProxyCounter() <= 0 ||
-             tileIt->second->getID().z > maxZoom)) {
+        if ((it != tiles.end()) &&
+            (!it->second.isVisible()) &&
+            (it->second.getProxyCounter() <= 0)) { // ||
+            //tileIt->first.z > maxZoom)) {
 
-            removeTile(tileSet, tileIt, removeTiles);
+            auto& entry = it->second;
+
+            LOG("REMOVE %s - ready:%d proxy:%d/%d",
+                it->first.toString().c_str(),
+                entry.isReady(),
+                entry.getProxyCounter(),
+                entry.m_proxies);
+
+            clearProxyTiles(tileSet, it->first, it->second, removeTiles);
+
+            removeTile(tileSet, it);
         }
     }
 
-    // Update tile distance to map center for load priority
-    for (auto& entry : tiles) {
-        auto& tile = entry.second;
-        auto tileCenter = m_view->getMapProjection().TileCenter(tile->getID());
-        double scaleDiv = exp2(tile->getID().z - m_view->getZoom());
-        // prefer parent tiles
-        if (scaleDiv < 1) { scaleDiv = 0.1/scaleDiv; }
-        tile->setPriority(glm::length2(tileCenter - viewCenter) * scaleDiv);
+    for (auto it = tiles.begin(); it != tiles.end();) {
+        auto& entry = it->second;
+
+        LOG("> %s - ready:%d proxy:%d/%d loading:%d",
+            it->first.toString().c_str(),
+            entry.isReady(),
+            entry.getProxyCounter(),
+            entry.m_proxies,
+            entry.task && !entry.task->loaded
+            );
+
+        if (entry.isLoading()) {
+            auto& id = it->first;
+            auto& task = entry.task;
+
+            // Update tile distance to map center for load priority.
+            auto tileCenter = m_view->getMapProjection().TileCenter(id);
+            double scaleDiv = exp2(id.z - m_view->getZoom());
+            if (scaleDiv < 1) { scaleDiv = 0.1/scaleDiv; } // prefer parent tiles
+            task->setPriority(glm::length2(tileCenter - viewCenter) * scaleDiv);
+
+            // Count tiles that are currently being downloaded to
+            // limit download requests.
+            if (!task->loaded) {
+
+                m_loadPending++;
+            }
+        }
+
+        if (entry.isReady()) {
+            // Mark as proxy
+            entry.tile->setProxyState(entry.getProxyCounter() > 0);
+        }
+        ++it;
     }
 }
 
-void TileManager::enqueueTask(const TileSet& tileSet, const TileID& tileID,
+void TileManager::enqueueTask(TileSet& tileSet, const TileID& tileID,
                               const glm::dvec2& viewCenter) {
 
     // Keep the items sorted by distance
@@ -383,42 +380,32 @@ void TileManager::enqueueTask(const TileSet& tileSet, const TileID& tileID,
 
 void TileManager::loadTiles() {
 
-    for (auto& item : m_loadTasks) {
+    for (auto& loadTask : m_loadTasks) {
 
-        auto id = *std::get<2>(item);
-        auto& tileSet = *std::get<1>(item);
-        auto tileIt = tileSet.tiles.find(id);
-        auto tile = tileIt->second;
-        auto task = std::make_shared<TileTask>(tile, tileSet.source);
+        auto tileId = *std::get<2>(loadTask);
+        auto& tileSet = *std::get<1>(loadTask);
+        auto tileIt = tileSet.tiles.find(tileId);
+        auto& entry = tileIt->second;
+        auto task = std::make_shared<TileTask>(tileId, tileSet.source);
 
         bool cached = tileSet.source->getTileData(task);
 
         if (cached || m_loadPending < int(MAX_DOWNLOADS)) {
-
-            if (tile->sourceGeneration() < tileSet.source->generation()) {
-                // use new tile for updating while the stale tile
-                // is kept in tileSet for rendering.
-                tile->reloading = true;
-                task->tile = std::make_shared<Tile>(id, m_view->getMapProjection(),
-                                                    tileSet.source.get());
-            }
-
-            setTileState(*task->tile, TileState::loading);
+            // NB: Set implicit 'loading' state
+            entry.task = task;
 
             if (cached) {
                 m_dataCallback.func(std::move(task));
 
-            } else if (!tileSet.source->loadTileData(std::move(task),
-                                                     m_dataCallback)) {
-                LOGE("Loading failed for tile [%d, %d, %d]", id.z, id.x, id.y);
-                m_loadPending--;
+            } else if (tileSet.source->loadTileData(std::move(task), m_dataCallback)) {
+                m_loadPending++;
             }
         }
     }
 
-    // LOGD("loading:%d pending:%d cache: %fMB",
-    //    m_loadTasks.size(), m_loadPending,
-    //    (double(m_tileCache->getMemoryUsage()) / (1024 * 1024)));
+    LOG("loading:%d pending:%d cache: %fMB",
+       m_loadTasks.size(), m_loadPending,
+       (double(m_tileCache->getMemoryUsage()) / (1024 * 1024)));
 
     m_loadTasks.clear();
 }
@@ -426,68 +413,78 @@ void TileManager::loadTiles() {
 bool TileManager::addTile(TileSet& tileSet, const TileID& _tileID) {
 
     auto tile = m_tileCache->get(tileSet.source->id(), _tileID);
-    bool cached = bool(tile);
 
-    if (cached) {
-        m_tiles.push_back(tile);
-        // Update tile origin based on wrap (set in the new tileID)
-        tile->updateTileOrigin(_tileID.wrap);
-        // Reset tile on potential internal dynamic data set
-        tile->reset();
+    if (tile) {
+        if (tile->sourceGeneration() == tileSet.source->generation()) {
+            m_tiles.push_back(tile);
 
-    } else {
-        tile = std::make_shared<Tile>(_tileID, m_view->getMapProjection(),
-                                      tileSet.source.get());
+            // Update tile origin based on wrap (set in the new tileID)
+            tile->updateTileOrigin(_tileID.wrap);
 
-        //Add Proxy if corresponding proxy MapTile ready
-        updateProxyTiles(tileSet, *tile);
+            // Reset tile on potential internal dynamic data set
+            // TODO rename to resetState() to avoid ambiguity
+            tile->resetState();
+        } else {
+            // Clear stale tile data
+            tile.reset();
+        }
     }
 
-    tile->setVisible(true);
-    tileSet.tiles.emplace(_tileID, tile);
+    // Add TileEntry to TileSet
+    auto entry = tileSet.tiles.emplace(_tileID, tile);
 
-    return cached;
+    if (!tile) {
+        // Add Proxy if corresponding proxy MapTile ready
+        updateProxyTiles(tileSet, _tileID, entry.first->second);
+    }
+    entry.first->second.setVisible(true);
+
+    return bool(tile);
 }
 
-void TileManager::removeTile(TileSet& tileSet, std::map<TileID,
-                             std::shared_ptr<Tile>>::iterator& _tileIt,
-                             std::vector<TileID>& _removes) {
+void TileManager::removeTile(TileSet& tileSet, std::map<TileID, TileEntry>::iterator& _tileIt) {
 
-    const TileID& id = _tileIt->first;
-    auto& tile = _tileIt->second;
+    auto& id = _tileIt->first;
+    auto& entry = _tileIt->second;
 
-    if (tile->hasState(TileState::loading) &&
-        setTileState(*tile, TileState::canceled)) {
-        // 1. Remove from Datasource. Make sure to cancel the network request
-        // associated with this tile.
+
+    if (entry.isLoading()) {
+        entry.cancelTask();
+
+        // 1. Remove from Datasource. Make sure to cancel
+        //  the network request associated with this tile.
         tileSet.source->cancelLoadingTile(id);
-    }
 
-    clearProxyTiles(tileSet, *tile, _removes);
-
-    if (tile->hasState(TileState::ready) && !tile->reloading) {
+    } else if (entry.isReady()) {
         // Add to cache
-        m_tileCache->put(tileSet.source->id(), tile);
+        m_tileCache->put(tileSet.source->id(), entry.tile);
     }
 
     // Remove tile from set
     _tileIt = tileSet.tiles.erase(_tileIt);
 }
 
-bool TileManager::updateProxyTile(TileSet& tileSet, Tile& _tile, const TileID& _proxy,
-                                  const Tile::ProxyID _proxyID) {
+bool TileManager::updateProxyTile(TileSet& tileSet, TileEntry& _tile, const TileID& _proxyTileId,
+                                  const ProxyID _proxyId) {
     auto& tiles = tileSet.tiles;
 
     // check if the proxy exists in the visible tile set
     {
-        const auto& it = tiles.find(_proxy);
+        const auto& it = tiles.find(_proxyTileId);
         if (it != tiles.end()) {
-            auto& proxyTile = it->second;
-            if (proxyTile && _tile.setProxy(_proxyID)) {
-                proxyTile->incProxyCounter();
-                if (proxyTile->isReady()) {
-                    m_tiles.push_back(proxyTile);
+            // FIXME: this uses indirect proxy tiles
+            // even if a cached tile for the direct proxy
+            // may be available
+            auto& entry = it->second;
+            if (_tile.setProxy(_proxyId)) {
+                entry.incProxyCounter();
+
+                if (entry.isReady()) {
+                    m_tiles.push_back(entry.tile);
                 }
+
+                // Note: No need to check the cache: When the tile is in
+                // tileSet it would have already been fetched from cache
                 return true;
             }
         }
@@ -495,13 +492,14 @@ bool TileManager::updateProxyTile(TileSet& tileSet, Tile& _tile, const TileID& _
 
     // check if the proxy exists in the cache
     {
-        auto proxyTile = m_tileCache->get(tileSet.source->id(), _proxy);
-        if (proxyTile) {
-            _tile.setProxy(_proxyID);
-            proxyTile->incProxyCounter();
-            m_tiles.push_back(proxyTile);
+        auto proxyTile = m_tileCache->get(tileSet.source->id(), _proxyTileId);
+        if (proxyTile && _tile.setProxy(_proxyId)) {
 
-            tiles.emplace(_proxy, std::move(proxyTile));
+            auto result = tiles.emplace(_proxyTileId, proxyTile);
+            auto& entry = result.first->second;
+            entry.incProxyCounter();
+
+            m_tiles.push_back(proxyTile);
             return true;
         }
     }
@@ -509,73 +507,60 @@ bool TileManager::updateProxyTile(TileSet& tileSet, Tile& _tile, const TileID& _
     return false;
 }
 
-void TileManager::updateProxyTiles(TileSet& tileSet, Tile& _tile) {
-    const TileID& _tileID = _tile.getID();
+void TileManager::updateProxyTiles(TileSet& tileSet, const TileID& _tileID, TileEntry& _tile) {
 
-    // Get current parent
+    // Try parent proxy
     auto parentID = _tileID.getParent();
-    // Get Grand Parent
-    auto gparentID = parentID.getParent();
-
-    if (!updateProxyTile(tileSet, _tile, gparentID, Tile::parent2)) {
-        if (!updateProxyTile(tileSet, _tile, parentID, Tile::parent)) {
-            if (m_view->s_maxZoom > _tileID.z) {
-                for (int i = 0; i < 4; i++) {
-                    updateProxyTile(tileSet, _tile, _tileID.getChild(i),
-                                    static_cast<Tile::ProxyID>(1 << i));
-                }
+    if (updateProxyTile(tileSet, _tile, parentID, ProxyID::parent)) {
+        LOG("use parent proxy");
+        return;
+    }
+    // Try grandparent
+    if (updateProxyTile(tileSet, _tile, parentID.getParent(), ProxyID::parent2)) {
+        LOG("use grand parent proxy");
+        return;
+    }
+    // Try children
+    if (m_view->s_maxZoom > _tileID.z) {
+        for (int i = 0; i < 4; i++) {
+            if (updateProxyTile(tileSet, _tile, _tileID.getChild(i), static_cast<ProxyID>(1 << i))) {
+                LOG("use child proxy");
             }
         }
     }
 }
 
-void TileManager::clearProxyTiles(TileSet& tileSet, Tile& _tile,
+void TileManager::clearProxyTiles(TileSet& tileSet, const TileID& _tileID, TileEntry& _tile,
                                   std::vector<TileID>& _removes) {
-    const TileID& _tileID = _tile.getID();
     auto& tiles = tileSet.tiles;
 
-    // Check if gparent proxy is present
-    if (_tile.unsetProxy(Tile::parent2)) {
-        TileID gparentID(_tileID.getParent().getParent());
-        auto it = tiles.find(gparentID);
+    auto removeProxy = [&tiles,&_removes](TileID id) {
+        auto it = tiles.find(id);
         if (it != tiles.end()) {
-            auto& gparent = it->second;
-            gparent->decProxyCounter();
-
-            if (gparent->getProxyCounter() == 0 && !gparent->isVisible()) {
-                _removes.push_back(gparentID);
+            auto& entry = it->second;
+            entry.decProxyCounter();
+            if (entry.getProxyCounter() <= 0 && !entry.isVisible()) {
+                _removes.push_back(id);
             }
         }
+    };
+    // Check if grand parent proxy is present
+    if (_tile.unsetProxy(ProxyID::parent2)) {
+        TileID gparentID(_tileID.getParent().getParent());
+        removeProxy(gparentID);
     }
 
     // Check if parent proxy is present
-    if (_tile.unsetProxy(Tile::parent)) {
+    if (_tile.unsetProxy(ProxyID::parent)) {
         TileID parentID(_tileID.getParent());
-        auto it = tiles.find(parentID);
-        if (it != tiles.end()) {
-            auto& parent = it->second;
-            parent->decProxyCounter();
-
-            if (parent->getProxyCounter() == 0 && !parent->isVisible()) {
-                _removes.push_back(parentID);
-            }
-        }
+        removeProxy(parentID);
     }
 
     // Check if child proxies are present
     for (int i = 0; i < 4; i++) {
-        if (_tile.unsetProxy(static_cast<Tile::ProxyID>(1 << i))) {
+        if (_tile.unsetProxy(static_cast<ProxyID>(1 << i))) {
             TileID childID(_tileID.getChild(i));
-            auto it = tiles.find(childID);
-
-            if (it != tiles.end()) {
-                auto& child = it->second;
-                child->decProxyCounter();
-
-                if (child->getProxyCounter() == 0 && !child->isVisible()) {
-                    _removes.push_back(childID);
-                }
-            }
+            removeProxy(childID);
         }
     }
 }

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -192,9 +192,6 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
                     (entry.tile->sourceGeneration() < _tileSet.source->generation());
 
                 if (update) {
-                    LOG("reload tile %s - %d %d", visTileId.toString().c_str(),
-                        entry.tile->sourceGeneration(),
-                        _tileSet.source->generation());
 
                     // Tile needs update - enqueue for loading
                     enqueueTask(_tileSet, visTileId, viewCenter);
@@ -268,14 +265,6 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
             (it->second.getProxyCounter() <= 0  ||
              it->first.z >= maxZoom)) {
 
-            auto& entry = it->second;
-
-            LOG("REMOVE %s - ready:%d proxy:%d/%d",
-                it->first.toString().c_str(),
-                entry.isReady(),
-                entry.getProxyCounter(),
-                entry.m_proxies);
-
             clearProxyTiles(_tileSet, it->first, it->second, removeTiles);
 
             removeTile(_tileSet, it);
@@ -285,13 +274,13 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
     for (auto& it : tiles) {
         auto& entry = it.second;
 
-        LOG("> %s - ready:%d proxy:%d/%d loading:%d",
-            it.first.toString().c_str(),
-            entry.isReady(),
-            entry.getProxyCounter(),
-            entry.m_proxies,
-            entry.task && !entry.task->hasData()
-            );
+        LOGD("> %s - ready:%d proxy:%d/%d loading:%d canceled:%d",
+             it.first.toString().c_str(),
+             entry.isReady(),
+             entry.getProxyCounter(),
+             entry.m_proxies,
+             entry.task && !entry.task->hasData(),
+             entry.task && entry.task->isCanceled());
 
         if (entry.isLoading()) {
             auto& id = it.first;
@@ -361,9 +350,9 @@ void TileManager::loadTiles() {
         }
     }
 
-    LOG("loading:%d pending:%d cache: %fMB",
-       m_loadTasks.size(), m_loadPending,
-       (double(m_tileCache->getMemoryUsage()) / (1024 * 1024)));
+    LOGD("loading:%d pending:%d cache: %fMB",
+         m_loadTasks.size(), m_loadPending,
+         (double(m_tileCache->getMemoryUsage()) / (1024 * 1024)));
 
     m_loadTasks.clear();
 }

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -22,10 +22,10 @@ TileManager::TileManager() {
     m_tileCache = std::unique_ptr<TileCache>(new TileCache(DEFAULT_CACHE_SIZE));
 
     m_dataCallback = TileTaskCb{[this](std::shared_ptr<TileTask>&& task) {
-            if (task->loaded) {
+            if (task->hasData()) {
                 m_workers->enqueue(std::move(task));
             } else {
-                LOGD("No data for tile: %s", task->tile->getID().toString().c_str());
+                LOGD("No data for tile: %s", task->tileId().toString().c_str());
                 task->cancel();
             }
     }};
@@ -182,7 +182,7 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
 
                 if (entry.newData()) {
                     clearProxyTiles(_tileSet, curTileId, entry, removeTiles);
-                    entry.tile = std::move(entry.task->tile);
+                    entry.tile = std::move(entry.task->tile());
                     entry.task.reset();
                 }
 
@@ -237,7 +237,7 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
                 if (entry.getProxyCounter() > 0) {
                     if (entry.newData()) {
                         clearProxyTiles(_tileSet, curTileId, entry, removeTiles);
-                        entry.tile = std::move(entry.task->tile);
+                        entry.tile = std::move(entry.task->tile());
                         entry.task.reset();
                     }
                     if (entry.isReady()) {
@@ -283,7 +283,7 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
             entry.isReady(),
             entry.getProxyCounter(),
             entry.m_proxies,
-            entry.task && !entry.task->loaded
+            entry.task && !entry.task->hasData()
             );
 
         if (entry.isLoading()) {
@@ -295,11 +295,11 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
             double scaleDiv = exp2(id.z - m_view->getZoom());
             if (scaleDiv < 1) { scaleDiv = 0.1/scaleDiv; } // prefer parent tiles
             task->setPriority(glm::length2(tileCenter - viewCenter) * scaleDiv);
+            task->setProxyState(entry.getProxyCounter() > 0);
 
             // Count tiles that are currently being downloaded to
             // limit download requests.
-            if (!task->loaded) {
-
+            if (!task->hasData()) {
                 m_loadPending++;
             }
         }
@@ -335,19 +335,22 @@ void TileManager::loadTiles() {
         auto& tileSet = *std::get<1>(loadTask);
         auto tileIt = tileSet.tiles.find(tileId);
         auto& entry = tileIt->second;
-        auto task = std::make_shared<TileTask>(tileId, tileSet.source);
 
-        bool cached = tileSet.source->getTileData(task);
+        auto task = tileSet.source->createTask(tileId);
 
-        if (cached || m_loadPending < int(MAX_DOWNLOADS)) {
+        if (task->hasData()) {
             // NB: Set implicit 'loading' state
             entry.task = task;
+            m_dataCallback.func(std::move(task));
 
-            if (cached) {
-                m_dataCallback.func(std::move(task));
-
-            } else if (tileSet.source->loadTileData(std::move(task), m_dataCallback)) {
+        } else if (m_loadPending < int(MAX_DOWNLOADS)) {
+            entry.task = task;
+            if (tileSet.source->loadTileData(std::move(task), m_dataCallback)) {
                 m_loadPending++;
+            } else {
+                // TODO: How to handle this case?
+                // This would constantly try to reload the failed tile:
+                // entry.task.reset()
             }
         }
     }

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -27,8 +27,8 @@ class TileCache;
 class TileManager {
 
     const static size_t MAX_WORKERS = 2;
-    const static size_t MAX_DOWNLOADS = 4;
     const static size_t DEFAULT_CACHE_SIZE = 32*1024*1024; // 32 MB
+    const static int MAX_DOWNLOADS = 4;
 
 public:
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -87,6 +87,8 @@ private:
         TileEntry(){}
         TileEntry(std::shared_ptr<Tile>& _tile) : tile(_tile) {}
 
+        ~TileEntry() { cancelTask(); }
+
         std::shared_ptr<Tile> tile;
         std::shared_ptr<TileTask> task;
 
@@ -97,7 +99,6 @@ private:
 
         bool isReady() { return bool(tile); }
         bool isLoading() {
-            // FIXME remove second condition (see m_dataCallback)
             return bool(task) && !task->isCanceled();
         }
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -102,7 +102,7 @@ private:
         }
 
         bool newData() {
-            return bool(task) && bool(task->tile);
+            return bool(task) && bool(task->tile());
         }
 
         void cancelTask() {

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -56,11 +56,6 @@ public:
 
     void clearTileSet(int32_t _sourceId);
 
-    /* For TileWorker: Pass TileTask with processed data back
-     * to TileManager.
-     */
-    void tileProcessed(std::shared_ptr<TileTask>&& task);
-
     /* Returns the set of currently visible tiles */
     const auto& getVisibleTiles() { return m_tiles; }
 
@@ -106,6 +101,10 @@ private:
         bool isLoading() {
             // FIXME remove second condition (see m_dataCallback)
             return bool(task) && !task->isCanceled();
+        }
+
+        bool newData() {
+            return bool(task) && bool(task->tile);
         }
 
         void cancelTask() {
@@ -215,9 +214,6 @@ private:
     /* Temporary list of tiles that need to be loaded */
     std::vector<std::tuple<double, TileSet*, const TileID*>> m_loadTasks;
 
-    /* List of tiles passed from <TileWorker> threads */
-    std::vector<std::shared_ptr<TileTask>> m_readyTiles;
-    std::mutex m_readyTileMutex;
 
 };
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -19,7 +19,7 @@ class Scene;
 class View;
 class TileCache;
 
-/* Singleton container of <Tile>s
+/* Singleton container of <TileSet>s
  *
  * TileManager is a singleton that maintains a set of Tiles based on the current
  * view into the map
@@ -42,8 +42,6 @@ public:
     /* Sets the scene which the TileManager will use to style tiles */
     void setScene(std::shared_ptr<Scene> _scene);
 
-    std::shared_ptr<Scene>& getScene() { return m_scene; }
-
     /* Updates visible tile set if necessary
      *
      * Contacts the <ViewModule> to determine whether the set of visible tiles
@@ -61,7 +59,7 @@ public:
 
     bool hasTileSetChanged() { return m_tileSetChanged; }
 
-    void addDataSource(std::shared_ptr<DataSource> dataSource);
+    void addDataSource(std::shared_ptr<DataSource> _dataSource);
 
     std::unique_ptr<TileCache>& getTileCache() { return m_tileCache; }
 
@@ -150,7 +148,6 @@ private:
         void setVisible(bool _visible) {
             m_visible = _visible;
         }
-
     };
 
     struct TileSet {
@@ -161,7 +158,7 @@ private:
 
     void updateTileSet(TileSet& tileSet);
 
-    void enqueueTask(TileSet& tileSet, const TileID& tileID, const glm::dvec2& viewCenter);
+    void enqueueTask(TileSet& _tileSet, const TileID& _tileID, const glm::dvec2& _viewCenter);
 
     void loadTiles();
 
@@ -170,25 +167,25 @@ private:
      *      also responsible for loading proxy tiles for the newly visible tiles
      * @_tileID: TileID for which new Tile needs to be constructed
      */
-    bool addTile(TileSet& tileSet, const TileID& _tileID);
+    bool addTile(TileSet& _tileSet, const TileID& _tileID);
 
     /*
      * Removes a tile from m_tileSet
      */
-    void removeTile(TileSet& tileSet, std::map<TileID, TileEntry>::iterator& _tileIter);
+    void removeTile(TileSet& _tileSet, std::map<TileID, TileEntry>::iterator& _tileIter);
 
     /*
      * Checks and updates m_tileSet with proxy tiles for every new visible tile
      *  @_tile: Tile, the new visible tile for which proxies needs to be added
      */
-    bool updateProxyTile(TileSet& tileSet, TileEntry& _tile, const TileID& _proxy, const ProxyID _proxyID);
-    void updateProxyTiles(TileSet& tileSet, const TileID& _tileID, TileEntry& _tile);
+    bool updateProxyTile(TileSet& _tileSet, TileEntry& _tile, const TileID& _proxy, const ProxyID _proxyID);
+    void updateProxyTiles(TileSet& _tileSet, const TileID& _tileID, TileEntry& _tile);
 
     /*
      * Once a visible tile finishes loading and is added to m_tileSet, all
      * its proxy(ies) Tiles are removed
      */
-    void clearProxyTiles(TileSet& tileSet, const TileID& _tileID, TileEntry& _tile, std::vector<TileID>& _removes);
+    void clearProxyTiles(TileSet& _tileSet, const TileID& _tileID, TileEntry& _tile, std::vector<TileID>& _removes);
 
     std::shared_ptr<View> m_view;
     std::shared_ptr<Scene> m_scene;

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -98,13 +98,9 @@ private:
         uint8_t m_proxies = 0;
 
         bool isReady() { return bool(tile); }
-        bool isLoading() {
-            return bool(task) && !task->isCanceled();
-        }
-
-        bool newData() {
-            return bool(task) && bool(task->tile());
-        }
+        bool isLoading() { return bool(task) && !task->isCanceled(); }
+        bool isCanceled() { return bool(task) && task->isCanceled(); }
+        bool newData() { return bool(task) && bool(task->tile()); }
 
         void cancelTask() {
             if (task) {

--- a/core/src/tile/tileTask.cpp
+++ b/core/src/tile/tileTask.cpp
@@ -3,8 +3,8 @@
 
 namespace Tangram {
 
-std::shared_ptr<TileData> TileTask::process() {
-    return source->parse(*tile, *rawTileData);
+std::shared_ptr<TileData> TileTask::process(MapProjection& _projection) {
+    return source->parse(tileId, _projection, *rawTileData);
 }
 
 }

--- a/core/src/tile/tileTask.cpp
+++ b/core/src/tile/tileTask.cpp
@@ -3,8 +3,9 @@
 
 namespace Tangram {
 
-std::shared_ptr<TileData> TileTask::process(MapProjection& _projection) {
-    return source->parse(tileId, _projection, *rawTileData);
-}
+TileTask::TileTask(TileID& _tileId, std::shared_ptr<DataSource> _source) :
+    m_tileId(_tileId),
+    m_source(_source),
+    m_sourceGeneration(_source->generation()) {}
 
 }

--- a/core/src/tile/tileTask.h
+++ b/core/src/tile/tileTask.h
@@ -18,15 +18,16 @@ struct TileData;
 class TileTask {
 
 public:
+    // Tile ID
     const TileID tileId;
 
-    // NB: Save shared reference to Datasource while building tile
+    // Save shared reference to Datasource while building tile
     std::shared_ptr<DataSource> source;
 
     // Raw tile data that will be processed by DataSource.
     std::shared_ptr<std::vector<char>> rawTileData;
 
-    //
+    // Tile result, set when tile was  sucessfully created
     std::shared_ptr<Tile> tile;
 
     bool loaded = false;
@@ -42,6 +43,8 @@ public:
 
     virtual std::shared_ptr<TileData> process(MapProjection& _projection);
 
+    virtual ~TileTask() {}
+
     TileTask& operator=(const TileTask& _other) = delete;
 
     double getPriority() const {
@@ -54,7 +57,12 @@ public:
 
     bool isCanceled() const { return canceled; }
 
-    void cancel() { canceled = true; }
+    bool isReady() const { return bool(tile); }
+
+    void cancel() {
+        canceled = true;
+        tile.reset();
+    }
 
     const int64_t sourceGeneration;
 

--- a/core/src/tile/tileTask.h
+++ b/core/src/tile/tileTask.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "data/dataSource.h"
 #include "tile/tileID.h"
 
 #include <memory>
@@ -13,59 +12,81 @@ namespace Tangram {
 class TileManager;
 class DataSource;
 class Tile;
+class MapProjection;
 struct TileData;
+
 
 class TileTask {
 
 public:
-    // Tile ID
-    const TileID tileId;
 
-    // Save shared reference to Datasource while building tile
-    std::shared_ptr<DataSource> source;
+    TileTask(TileID& _tileId, std::shared_ptr<DataSource> _source);
 
-    // Raw tile data that will be processed by DataSource.
-    std::shared_ptr<std::vector<char>> rawTileData;
-
-    // Tile result, set when tile was  sucessfully created
-    std::shared_ptr<Tile> tile;
-
-    bool loaded = false;
-    bool canceled = false;
-    bool visible = true;
-
-    std::atomic<double> priority;
-
-    TileTask(TileID& _tileId, std::shared_ptr<DataSource> _source) :
-        tileId(_tileId),
-        source(_source),
-        sourceGeneration(_source->generation()) {}
-
-    virtual std::shared_ptr<TileData> process(MapProjection& _projection);
+    // No copies
+    TileTask(const TileTask& _other) = delete;
+    TileTask& operator=(const TileTask& _other) = delete;
 
     virtual ~TileTask() {}
 
-    TileTask& operator=(const TileTask& _other) = delete;
+    virtual bool hasData() const { return true; }
+
+    void setTile(std::shared_ptr<Tile>&& _tile) {
+        m_tile = std::move(_tile);
+    }
+
+    std::shared_ptr<Tile>& tile() { return m_tile; }
+
+    bool isReady() const { return bool(m_tile); }
+
+    DataSource& source() { return *m_source; }
+    int64_t sourceGeneration() const { return m_sourceGeneration; }
+
+    TileID tileId() const { return m_tileId; }
+
+    void cancel() { m_canceled = true; }
+
+    bool isCanceled() const { return m_canceled; }
 
     double getPriority() const {
-        return priority.load();
+        return m_priority.load();
     }
 
     void setPriority(double _priority) {
-        priority.store(_priority);
+        m_priority.store(_priority);
     }
 
-    bool isCanceled() const { return canceled; }
+    bool isProxy() const { return m_proxyState; }
 
-    bool isReady() const { return bool(tile); }
+    void setProxyState(bool isProxy) { m_proxyState = isProxy; }
 
-    void cancel() {
-        canceled = true;
-        tile.reset();
+protected:
+
+    const TileID m_tileId;
+
+    // Save shared reference to Datasource while building tile
+    std::shared_ptr<DataSource> m_source;
+
+    const int64_t m_sourceGeneration;
+
+    // Tile result, set when tile was  sucessfully created
+    std::shared_ptr<Tile> m_tile;
+
+    bool m_canceled = false;
+
+    std::atomic<double> m_priority;
+    bool m_proxyState = false;
+};
+
+class DownloadTileTask : public TileTask {
+public:
+    DownloadTileTask(TileID& _tileId, std::shared_ptr<DataSource> _source)
+        : TileTask(_tileId, _source) {}
+
+    virtual bool hasData() const override {
+        return rawTileData && !rawTileData->empty();
     }
-
-    const int64_t sourceGeneration;
-
+    // Raw tile data that will be processed by DataSource.
+    std::shared_ptr<std::vector<char>> rawTileData;
 };
 
 struct TileTaskCb {

--- a/core/src/tile/tileTask.h
+++ b/core/src/tile/tileTask.h
@@ -31,8 +31,6 @@ public:
 
     bool loaded = false;
     bool canceled = false;
-
-    virtual std::shared_ptr<TileData> process();
     bool visible = true;
 
     std::atomic<double> priority;
@@ -41,6 +39,8 @@ public:
         tileId(_tileId),
         source(_source),
         sourceGeneration(_source->generation()) {}
+
+    virtual std::shared_ptr<TileData> process(MapProjection& _projection);
 
     TileTask& operator=(const TileTask& _other) = delete;
 

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -87,7 +87,7 @@ void TileWorker::run() {
 
         auto tileData = task->source().parse(*task, *scene->mapProjection());
 
-        const clock_t begin = clock();
+        // const clock_t begin = clock();
 
         context.initFunctions(*scene);
 
@@ -101,8 +101,8 @@ void TileWorker::run() {
             // Mark task as ready
             task->setTile(std::move(tile));
 
-            float loadTime = (float(clock() - begin) / CLOCKS_PER_SEC) * 1000;
-            LOG("loadTime %s - %f", task->tile()->getID().toString().c_str(), loadTime);
+            // float loadTime = (float(clock() - begin) / CLOCKS_PER_SEC) * 1000;
+            // LOG("loadTime %s - %f", task->tile()->getID().toString().c_str(), loadTime);
         } else {
             task->cancel();
         }

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -1,6 +1,7 @@
 #include "tileWorker.h"
 
 #include "platform.h"
+#include "data/dataSource.h"
 #include "tile/tile.h"
 #include "view/view.h"
 #include "scene/scene.h"
@@ -53,7 +54,7 @@ void TileWorker::run() {
 
             // Remove all canceled tasks
             auto removes = std::remove_if(m_queue.begin(), m_queue.end(),
-                [](const auto& a) { return a->tile->isCanceled(); });
+                                          [](const auto& a) { return a->isCanceled(); });
 
             m_queue.erase(removes, m_queue.end());
 
@@ -64,40 +65,44 @@ void TileWorker::run() {
             // Pop highest priority tile from queue
             auto it = std::min_element(m_queue.begin(), m_queue.end(),
                 [](const auto& a, const auto& b) {
-                    if (a->tile->isVisible() != b->tile->isVisible()) {
-                        return a->tile->isVisible();
+                    if (a->visible != b->visible) {
+                        return a->visible;
                     }
-                    if (a->tile->sourceID() == b->tile->sourceID() &&
-                        a->tile->sourceGeneration() != b->tile->sourceGeneration()) {
-                        return a->tile->sourceGeneration() < b->tile->sourceGeneration();
+                    if (a->source == b->source &&
+                        a->sourceGeneration != b->sourceGeneration) {
+                        return a->sourceGeneration < b->sourceGeneration;
                     }
-                    return a->tile->getPriority() < b->tile->getPriority();
+                    return a->getPriority() < b->getPriority();
                 });
 
             task = std::move(*it);
             m_queue.erase(it);
         }
 
-        if (task->tile->isCanceled()) {
-            continue;
-        }
-
-        auto tileData = task->process();
+        if (task->isCanceled()) { continue; }
 
         // NB: Save shared reference to Scene while building tile
         auto scene = m_tileManager.getScene();
 
         if (!scene) { continue; }
 
-        // const clock_t begin = clock();
+        // FIXME task->process() expects task->tile. Otherwise tile
+        // should be created when tileData is available.
+        task->tile = std::make_shared<Tile>(task->tileId, *scene->mapProjection(),
+                                            task->source.get());
+        auto tileData = task->process();
+
+        const clock_t begin = clock();
 
         context.initFunctions(*scene);
 
         if (tileData) {
             task->tile->build(context, *scene, *tileData, *task->source);
 
-            // float loadTime = (float(clock() - begin) / CLOCKS_PER_SEC) * 1000;
-            // LOG("loadTime %s - %f", task->tile->getID().toString().c_str(), loadTime);
+            float loadTime = (float(clock() - begin) / CLOCKS_PER_SEC) * 1000;
+            LOG("loadTime %s - %f", task->tile->getID().toString().c_str(), loadTime);
+        } else {
+            task->tile.reset();
         }
 
         m_tileManager.tileProcessed(std::move(task));

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -63,12 +63,12 @@ void TileWorker::run() {
             // Pop highest priority tile from queue
             auto it = std::min_element(m_queue.begin(), m_queue.end(),
                 [](const auto& a, const auto& b) {
-                    if (a->visible != b->visible) {
-                        return a->visible;
+                    if (a->isProxy() != b->isProxy()) {
+                        return !a->isProxy();
                     }
-                    if (a->source == b->source &&
-                        a->sourceGeneration != b->sourceGeneration) {
-                        return a->sourceGeneration < b->sourceGeneration;
+                    if (a->source().id() == b->source().id() &&
+                        a->sourceGeneration() != b->sourceGeneration()) {
+                        return a->sourceGeneration() < b->sourceGeneration();
                     }
                     return a->getPriority() < b->getPriority();
                 });
@@ -85,24 +85,24 @@ void TileWorker::run() {
         auto scene = m_scene;
         if (!scene) { continue; }
 
-        auto tileData = task->process(*scene->mapProjection());
+        auto tileData = task->source().parse(*task, *scene->mapProjection());
 
         const clock_t begin = clock();
 
         context.initFunctions(*scene);
 
         if (tileData) {
-            auto tile = std::make_shared<Tile>(task->tileId,
+            auto tile = std::make_shared<Tile>(task->tileId(),
                                                *scene->mapProjection(),
-                                               task->source.get());
+                                               &task->source());
 
-            tile->build(context, *scene, *tileData, *task->source);
+            tile->build(context, *scene, *tileData, task->source());
 
             // Mark task as ready
-            task->tile = std::move(tile);
+            task->setTile(std::move(tile));
 
             float loadTime = (float(clock() - begin) / CLOCKS_PER_SEC) * 1000;
-            LOG("loadTime %s - %f", task->tile->getID().toString().c_str(), loadTime);
+            LOG("loadTime %s - %f", task->tile()->getID().toString().c_str(), loadTime);
         } else {
             task->cancel();
         }

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -14,6 +14,7 @@ class Scene;
 class Tile;
 class TileTask;
 class View;
+
 class TileWorker {
 
 public:

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -5,42 +5,56 @@
 #include <condition_variable>
 #include <thread>
 #include <mutex>
+#include <atomic>
 
 namespace Tangram {
 
-class TileManager;
 class DataSource;
+class Scene;
 class Tile;
 class TileTask;
 class View;
-
 class TileWorker {
-    
+
 public:
-    
-    TileWorker(TileManager& _tileManager, int _num_worker);
+
+    TileWorker(int _num_worker);
 
     ~TileWorker();
-    
+
     void enqueue(std::shared_ptr<TileTask>&& task);
-    
+
     void stop();
-    
+
     bool isRunning() const { return m_running; }
-    
+
+    // Check pending-tiles flag. Resets flag on each call..
+    // TODO better name checkAndResetPendingTilesFlag?
+    bool checkPendingTiles() {
+        if (m_pendingTiles) {
+            m_pendingTiles = false;
+            return true;
+        }
+        return false;
+    }
+
+    void setScene(std::shared_ptr<Scene> _scene) { m_scene = _scene; }
+
 private:
 
     void run();
-    
-    TileManager& m_tileManager;
-    
+
     bool m_running;
-    
+
+    std::atomic<bool> m_pendingTiles;
+
     std::vector<std::thread> m_workers;
     std::condition_variable m_condition;
 
     std::mutex m_mutex;
     std::vector<std::shared_ptr<TileTask>> m_queue;
+
+    std::shared_ptr<Scene> m_scene;
 };
 
 }

--- a/core/src/util/geoJson.h
+++ b/core/src/util/geoJson.h
@@ -4,22 +4,23 @@
 #include "data/tileData.h"
 
 #include <vector>
+#include <functional>
 
 namespace Tangram {
 
-class Tile;
-
 namespace GeoJson {
 
-void extractPoint(const rapidjson::Value& _in, Point& _out, const Tile& _tile);
+typedef std::function<Point(glm::dvec2 _lonLat)> tileProjectionFn;
 
-void extractLine(const rapidjson::Value& _in, Line& _out, const Tile& _tile);
+void extractPoint(const rapidjson::Value& _in, Point& _out, const tileProjectionFn& _proj);
 
-void extractPoly(const rapidjson::Value& _in, Polygon& _out, const Tile& _tile);
+void extractLine(const rapidjson::Value& _in, Line& _out, const tileProjectionFn& _proj);
 
-void extractFeature(const rapidjson::Value& _in, Feature& _out, const Tile& _tile);
+void extractPoly(const rapidjson::Value& _in, Polygon& _out, const tileProjectionFn& _proj);
 
-void extractLayer(int32_t _sourceId, const rapidjson::Value& _in, Layer& _out, const Tile& _tile);
+void extractFeature(const rapidjson::Value& _in, Feature& _out, const tileProjectionFn& _proj);
+
+void extractLayer(int32_t _sourceId, const rapidjson::Value& _in, Layer& _out, const tileProjectionFn& _proj);
 
 }
 


### PR DESCRIPTION
Now based on master - continue #428

This branch removes the explicit use of TileState by directly working with the actual state of tiles. The Tile class now only holds the data that is used in rendering, state related to tile management is kept within the TileEntries of a TileSet. 

 