### PR TITLE
Use JS Proxy object for feature

### DIFF
--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -69,24 +69,15 @@ public:
     const Value& getGlobal(const std::string& _key) const;
 
 private:
-    static int jsPropertyGetter(duk_context *_ctx);
-    static int jsPropertySetter(duk_context *_ctx);
+    static int jsGetProperty(duk_context *_ctx);
+    static int jsHasProperty(duk_context *_ctx);
 
     bool parseStyleResult(StyleParamKey _key, StyleParam::Value& _val) const;
-
-    void setAccessors();
 
     mutable duk_context *m_ctx;
 
     const Feature* m_feature = nullptr;
-    bool m_featureIsReady;
 
-    struct Accessor {
-        std::string key;
-        StyleContext* ctx;
-    };
-
-    fastmap<std::string, std::unique_ptr<Accessor>> m_accessors;
     fastmap<FilterGlobal, Value> m_globals;
 
     int32_t m_sceneId = -1;

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -14,16 +14,6 @@ TEST_CASE( "", "[Duktape][init]") {
     StyleContext();
 }
 
-TEST_CASE( "Test filter without feature being set", "[Duktape][evalFilterFn]") {
-    StyleContext ctx;
-    ctx.addFunction("fn", R"(function() { return feature.name === undefined; })");
-    ctx.addAccessor("name");
-    REQUIRE(ctx.evalFilterFn("fn") == true);
-
-    ctx.addFunction("fn2", R"(function() { return feature.name === ''; })");
-    REQUIRE(ctx.evalFilterFn("fn2") == false);
-}
-
 TEST_CASE( "Test evalFilterFn with feature", "[Duktape][evalFilterFn]") {
     Feature feature;
     feature.props.add("a", "A");


### PR DESCRIPTION
Duktape supports ES6 Proxy objects which enables use of generic handler functions for all property access.
This avoids creating (and checking the existence of) explicit property accessors for each feature.

Found this option by looking through duk_hobject_props.c - Writing the proxy code oneself would have rather been a full month project I guess :)  