### PR TITLE
Enable posting Runnables to the render thread

### DIFF
--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -282,6 +282,14 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
         featureTouchListener = listener;
     }
 
+    /**
+     * Enqueue a Runnable to be executed synchronously on the rendering thread
+     * @param r Runnable to run
+     */
+    public void queueEvent(Runnable r) {
+        mapView.queueEvent(r);
+    }
+
     // Native methods
     // ==============
 

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -22,7 +22,6 @@ import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 
-import java.io.File;
 import java.io.IOException;
 
 import javax.microedition.khronos.egl.EGLConfig;


### PR DESCRIPTION
This is pretty useful for any render-loop-based application, but in particular this will help with instances where a client application needs to make multiple synchronous changes to the map view. For example, this code might cause stuttering in the view:
```java
mapController.setMapPosition(a.longitude, a.latitude);
// Render might start here...
mapController.setMapRotation(a.bearing);
// ... then render again after producing one frame with the wrong rotation!
```
But this code has no such risk:
```java
mapController.queueEvent(new Runnable() {
    public void run() {
        // This runs on the render thread!
        mapController.setMapPosition(a.longitude, a.latitude);
        mapController.setMapRotation(a.bearing);
    }
});
```