### PR TITLE
Check for known-unsupported compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
           env: PLATFORM=linux CXX=g++-4.9 CC=gcc-4.9
           addons:
             apt:
-              sources: [ 'kubuntu-backports', 'ubuntu-toolchain-r-test' ]
+              sources: [ 'kubuntu-backports', 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
               packages: [ 'cmake', 'gcc-4.9', 'g++-4.9', 'xorg-dev', 'libglu1-mesa-dev' ]
         - os: osx
           env: PLATFORM=ios
@@ -18,7 +18,7 @@ matrix:
           env: PLATFORM=android
           addons:
             apt:
-              sources: [ 'kubuntu-backports' ]
+              sources: [ 'kubuntu-backports', 'george-edison55-precise-backports' ]
               packages: [ 'cmake', 'lib32z1-dev', 'lib32stdc++6', 's3cmd' ]
           android:
             components: [ 'build-tools-21.1.2', 'android-22' ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0)
 
 project(tangram)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ tangram-es
 
 tangram-es is a C++ library for rendering 2D and 3D maps from vector data using OpenGL ES, it is a counterpart to [tangram](https://github.com/tangrams/tangram) focused on mobile and embedded devices.
 
-This repository contains both the core rendering library and sample applications that use the library on Android, iOS, Mac OS X, Ubuntu, and Raspberry Pi. 
+This repository contains both the core rendering library and sample applications that use the library on Android, iOS, Mac OS X, Ubuntu, and Raspberry Pi.
 
 *tangram-es is in active development and is not yet feature-complete*
 
@@ -25,7 +25,7 @@ Make sure to update git submodules before you build:
 git submodule init && git submodule update
 ```
 
-Currently we are targeting five platforms: OS X, Ubuntu Linux, iOS, Android, and Raspberry Pi. 
+Currently we are targeting five platforms: OS X, Ubuntu Linux, iOS, Android, and Raspberry Pi.
 
 ## platforms ##
 
@@ -42,13 +42,13 @@ open build/osx/bin/tangram.app
 ```
 
 ### OS X (Xcode) ###
-For running on OS X from Xcode, generate and compile an Xcode project:
+For running on OS X from Xcode you will need Xcode version **6.0** or higher. Generate and compile an Xcode project:
 
 ```bash
 make xcode
 ```
 
-Then just open the Xcode project and run/debug from there: 
+Then just open the Xcode project and run/debug from there:
 
 ```bash
 open build/xcode/tangram.xcodeproj
@@ -57,7 +57,9 @@ open build/xcode/tangram.xcodeproj
 Note that any Xcode configuration change you make to the project won't be preserved when CMake runs again. Build configuration is defined only in the CMakeLists file(s).
 
 ### Ubuntu Linux ###
-To build on Ubuntu you will need to install development packages for libcurl, x11, and opengl:
+To build on Ubuntu you will need a C++ toolchain with support for C++14. GCC 4.9 (or higher) and Clang 3.4 (or higher) are known to work.
+
+You will also need to install development packages for libcurl, x11, and opengl:
 
 ```bash
 sudo apt-get install libcurl4-openssl-dev xorg-dev libgl1-mesa-dev
@@ -82,7 +84,7 @@ For running on the iOS simulator, generate and compile an Xcode project:
 make ios-sim
 ```
 
-Then just open the Xcode project and run/debug from there: 
+Then just open the Xcode project and run/debug from there:
 
 ```bash
 open build/ios-sim/tangram.xcodeproj
@@ -91,7 +93,7 @@ open build/ios-sim/tangram.xcodeproj
 Note that any Xcode configuration change you make to the project won't be preserved when CMake runs again. Build configuration is defined only in the CMakeLists file(s).
 
 ### iOS Devices ###
-For running on iOS devices you will need an iOS developer account, a valid code signing certificate, and a valid provisioning profile. Help on these topics can be found at [Apple's developer website](http://developer.apple.com). 
+For running on iOS devices you will need an iOS developer account, a valid code signing certificate, and a valid provisioning profile. Help on these topics can be found at [Apple's developer website](http://developer.apple.com).
 
 First generate an Xcode project without compiling:
 
@@ -108,7 +110,7 @@ open build/ios/tangram.xcodeproj
 If you run into problems deploying to an iOS device, see [this note](https://github.com/tangrams/tangram-es/wiki/iOS-Notes).
 
 ### Android ###
-To build for Android you'll need to have installed both the [Android SDK](http://developer.android.com/sdk/installing/index.html?pkg=tools) and the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html). Set an `ANDROID_HOME` environment variable with the root directory of your SDK and an `ANDROID_NDK` environment variable with the root directory of your NDK. 
+To build for Android you'll need to have installed both the [Android SDK](http://developer.android.com/sdk/installing/index.html?pkg=tools) and the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html). Set an `ANDROID_HOME` environment variable with the root directory of your SDK and an `ANDROID_NDK` environment variable with the root directory of your NDK.
 
 Build an APK of the demo application and optionally specify an architecture (default is armeabi-v7a):
 
@@ -123,14 +125,13 @@ Then install to a connected device or emulator. You can (re)install and run the 
 ```
 
 ### Raspberry Pi ###
+To build on Rasberry Pi you will need a C++ toolchain with support for C++14. GCC 4.9 (or higher) is known to work (refer [here](https://solarianprogrammer.com/2015/01/13/raspberry-pi-raspbian-install-gcc-compile-cpp-14-programs/) for instructions on getting GCC 4.9).
 
 First, install CMake and libcurl:
 
 ```
 sudo apt-get install cmake libcurl4-openssl-dev
 ```
-
-To build the project, you will need to have C++11 compatible compiler installed, for example GNU g++-4.9 or greater (refer [here](https://solarianprogrammer.com/2015/01/13/raspberry-pi-raspbian-install-gcc-compile-cpp-14-programs/) for instructions on getting g++-4.9)
 
 Before compiling, choose which compiler to use:
 ```
@@ -154,22 +155,22 @@ cd build/rpi/bin
 
 You can also move the map with `w`, `a`, `s`, and `z`, zoom in and out with `-` and `=`, and quit with `q`.
 
-code-styling
+Code Style
 =====
-Tangram is using clang-format to style the code. 
-When submitting a PR, make sure the code conforms to the styling rules defined in the clang style file.
+In general, code changes should follow the style of the surrounding code.
 
-Install clang-format (available through brew or apt-get)
+When in doubt, you can use the provided clang-format style file for automatic styling.
+
+Install clang-format (available through brew or apt-get):
 ```
 brew install clang-format
-```  
+```
 or
 ```
 sudo apt-get install clang-format
 ```
 
-Running clang-format with specified style (use -i to modify the contents of the specified file):
+Run clang-format with specified style (use -i to modify the contents of the specified file):
 ```
-clang-format -i -style=file [file] 
+clang-format -i -style=file [file]
 ```
-

--- a/toolchains/android.cmake
+++ b/toolchains/android.cmake
@@ -8,6 +8,9 @@ else()
     message(STATUS "Will use make prebuilt tool located at : ${CMAKE_BUILD_TOOL}")
 endif()
 
+# check for unsupported compilers
+check_unsupported_compiler_version()
+
 # configurations
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -pedantic")
 

--- a/toolchains/darwin.cmake
+++ b/toolchains/darwin.cmake
@@ -1,6 +1,8 @@
 # set for test in other cmake files
 set(PLATFORM_OSX ON)
 
+check_unsupported_compiler_version()
+
 # options
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -stdlib=libc++ -std=c++1y")
 set(CXX_FLAGS_DEBUG "-g -O0")

--- a/toolchains/linux.cmake
+++ b/toolchains/linux.cmake
@@ -12,7 +12,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)
-  execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
     OUTPUT_VARIABLE GCC_VERSION)
   string(REGEX MATCHALL "[0-9]+" GCC_VERSION_COMPONENTS ${GCC_VERSION})
   list(GET GCC_VERSION_COMPONENTS 0 GCC_MAJOR)
@@ -24,6 +24,8 @@ if (CMAKE_COMPILER_IS_GNUCC)
     add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
   endif()
 endif()
+
+check_unsupported_compiler_version()
 
 # compile definitions (adds -DPLATFORM_LINUX)
 set(CORE_COMPILE_DEFS PLATFORM_LINUX)

--- a/toolchains/raspberrypi.cmake
+++ b/toolchains/raspberrypi.cmake
@@ -6,18 +6,9 @@ set(EXECUTABLE_NAME "tangram")
 
 add_definitions(-DPLATFORM_RPI)
 
-# check for c++11 compiler
-execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+check_unsupported_compiler_version()
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  if(NOT (GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9))
-    message(FATAL_ERROR "Please install g++ version 4.9 or greater")
-  else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  endif()
-else()
-  message(FATAL_ERROR "Please install a C++14 compatible compiler")
-endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 # add sources and include headers
 find_sources_and_include_directories(

--- a/toolchains/utils.cmake
+++ b/toolchains/utils.cmake
@@ -1,3 +1,27 @@
+function(check_unsupported_compiler_version)
+
+    set(MIN_GCC 4.9)
+    set(MIN_CLANG 3.4)
+    set(MIN_APPLECLANG 6.0)
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MIN_GCC})
+            message(FATAL_ERROR "Your GCC version does not support C++14, please install version ${MIN_GCC} or higher")
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MIN_CLANG})
+            message(FATAL_ERROR "Your Clang version does not support C++14, please install version ${MIN_CLANG} or higher")
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MIN_APPLECLANG})
+            message(FATAL_ERROR "Your Xcode version does not support C++14, please install version ${MIN_APPLECLANG} or higher")
+        endif()
+    else()
+        message(WARNING "Compilation has only been tested with Clang, AppleClang, and GCC")
+    endif()
+
+endfunction(check_unsupported_compiler_version)
+
 function(find_sources_and_include_directories HEADERS_PATH SOURCES_PATH)
     include_recursive_dirs(${HEADERS_PATH})
     file(GLOB_RECURSE FOUND_SOURCES ${SOURCES_PATH})


### PR DESCRIPTION
The CMake toolchain won't know everything about every compiler, so we'll only make checks for compiler versions that we *know* to be unsupported; any compilers that we don't have checks for will just receive a warning that compilation is untested in their configuration. Known-unsupported compilers are currently:

 - GCC 4.8 or lower
 - Clang 3.3 or lower
 - AppleClang (i.e. Xcode) 5.1 or lower

The README has also been update to reflect this.
 
This also *formally* raises our minimum CMake version to 3.0 (required to correctly identify compilers). To install this version on Ubuntu 12.04 another PPA was needed in the Travis config. 