### PR TITLE
MVT source speedup

### DIFF
--- a/core/src/data/properties.cpp
+++ b/core/src/data/properties.cpp
@@ -20,8 +20,12 @@ Properties::Properties(std::vector<Item>&& _items) {
 }
 
 Properties& Properties::operator=(Properties&& _other) {
-     props = std::move(_other.props);
-     return *this;
+    props = std::move(_other.props);
+    return *this;
+}
+
+void Properties::setSorted(std::vector<Item>&& _items) {
+    props = std::move(_items);
 }
 
 const Value& Properties::get(const std::string& key) const {
@@ -29,11 +33,7 @@ const Value& Properties::get(const std::string& key) const {
 
     const auto it = std::lower_bound(props.begin(), props.end(), key,
                                      [](const auto& item, const auto& key) {
-                                         if (item.key.size() == key.size()) {
-                                             return item.key < key;
-                                         } else {
-                                             return item.key.size() < key.size();
-                                         }
+                                         return keyComparator(item.key, key);
                                      });
 
     if (it == props.end() || it->key != key) {

--- a/core/src/data/properties.h
+++ b/core/src/data/properties.h
@@ -45,6 +45,8 @@ struct Properties {
     void add(std::string key, std::string value);
     void add(std::string key, double value);
 
+    void setSorted(std::vector<Item>&& _items);
+
     // template <typename... Args> void add(std::string key, Args&&... args) {
     //     props.emplace_back(std::move(key), Value{std::forward<Args>(args)...});
     //     sort();
@@ -54,6 +56,13 @@ struct Properties {
 
     int32_t sourceId;
 
+    static bool keyComparator(const std::string& a, const std::string& b) {
+        if (a.size() == b.size()) {
+            return a < b;
+        } else {
+            return a.size() < b.size();
+        }
+    }
 private:
     std::vector<Item> props;
 };

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -1,9 +1,8 @@
 #pragma once
 
 #include "data/tileData.h"
-#include "data/propertyItem.h"
-
 #include "pbf/pbf.hpp"
+#include "util/variant.h"
 
 #include <vector>
 #include <string>
@@ -20,10 +19,13 @@ namespace PbfParser {
         int32_t sourceId;
         std::vector<std::string> keys;
         std::vector<Value> values;
-        std::vector<Properties::Item> properties;
         std::vector<protobuf::message> featureMsgs;
         std::vector<Point> coordinates;
         std::vector<int> numCoordinates;
+        // Map Key ID -> Tag values
+        std::vector<int> featureTags;
+        // Key IDs sorted by Property key ordering
+        std::vector<int> orderedKeys;
 
         int tileExtent = 0;
     };


### PR DESCRIPTION
Sort feature tag-key IDs once per layer instead of sorting Properties for each feature
