### PR TITLE
Clean Android build files without invoking Gradle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ else
 	ANDROID_TOOLCHAIN = arm-linux-androideabi-clang3.6
 endif
 
-#$(info ANDROID_ARCH is ${ANDROID_ARCH}) 
-#$(info ANDROID_TOOLCHAIN is ${ANDROID_TOOLCHAIN}) 
-#$(info ANDROID_BUILD_DIR is ${ANDROID_BUILD_DIR}) 
+#$(info ANDROID_ARCH is ${ANDROID_ARCH})
+#$(info ANDROID_TOOLCHAIN is ${ANDROID_TOOLCHAIN})
+#$(info ANDROID_BUILD_DIR is ${ANDROID_BUILD_DIR})
 
 ifndef ANDROID_API_LEVEL
 	ANDROID_API_LEVEL = android-15
@@ -152,10 +152,12 @@ LINUX_CMAKE_PARAMS = \
 clean: clean-android clean-osx clean-ios clean-rpi clean-tests clean-xcode clean-linux
 
 clean-android:
-	@cd android/ && \
-	./gradlew clean
 	rm -rf ${ANDROID_BUILD_DIR}
+	rm -rf android/build
+	rm -rf android/tangram/build
 	rm -rf android/tangram/libs
+	rm -rf android/demo/build
+	rm -rf android/demo/libs
 
 clean-osx:
 	rm -rf ${OSX_BUILD_DIR}


### PR DESCRIPTION
2nd attempt to address https://github.com/tangrams/tangram-es/issues/447

With this change, `make clean` will still remove build files for all target platforms, but the sub-task `clean-android` now has no Gradle invocation; instead the Makefile manually removes the same directories that `gradle clean` would remove. Consequently, running `make clean` will no longer require a Gradle installation. 