### PR TITLE
fix: do not remove visible tiles

### DIFF
--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -347,6 +347,7 @@ void TileManager::updateTileSet(TileSet& tileSet) {
         removeTiles.pop_back();
 
         if ((tileIt != tiles.end()) &&
+            (!tileIt->second->isVisible()) &&
             (tileIt->second->getProxyCounter() <= 0 ||
              tileIt->second->getID().z > maxZoom)) {
 


### PR DESCRIPTION
This is a hard to hit case where:
1. tile A was used as proxy in the previous iteration and
2. tile B (the last tile) referencing A as proxy has been loaded in the current
   iteration, so A will be added to removeTiles (line 227)
3. tile A became 'visible' in the current iteration.
4. when tile A is not has not been loaded (and is therefore added to loadTasks)
   this will lead to a SEGV in loadTiles() line 390.
   So this should be the proper fix for  ba6d3f9515e33f8a5164516f7b00011ef92bf5d5

This problem could also be solved by updating the tile isVisible state at the beginning of 
updateTileSet when new readyTiles are available.  