### PR TITLE
Stencil proxy

### DIFF
--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -26,7 +26,7 @@ public class MapView extends GLSurfaceView {
 
         setEGLContextClientVersion(2);
         setPreserveEGLContextOnPause(true);
-        setEGLConfigChooser(new ConfigChooser(8, 8, 8, 0, 16, 0));
+        setEGLConfigChooser(new ConfigChooser(8, 8, 8, 0, 16, 8));
 
     }
 

--- a/core/src/gl.h
+++ b/core/src/gl.h
@@ -216,6 +216,9 @@ typedef char            GLchar;
 #define GL_DEPTH_WRITEMASK              0x0B72
 #define GL_DEPTH_COMPONENT              0x1902
 
+/* Polygon Offset */
+#define GL_POLYGON_OFFSET_FILL          0x8037
+
 /* Stencil */
 #define GL_STENCIL_BITS                 0x0D57
 #define GL_STENCIL_TEST                 0x0B90
@@ -232,6 +235,7 @@ typedef char            GLchar;
 #define GL_REPLACE                      0x1E01
 #define GL_INCR                         0x1E02
 #define GL_DECR                         0x1E03
+#define GL_INVERT                       0x150A
 
 /* Texture mapping */
 #define GL_NEAREST_MIPMAP_NEAREST       0x2700
@@ -289,6 +293,8 @@ extern "C" {
     GL_APICALL void GL_APIENTRY glDisable(GLenum);
     GL_APICALL void GL_APIENTRY glDepthFunc(GLenum func);
     GL_APICALL void GL_APIENTRY glDepthMask(GLboolean flag);
+    
+    GL_APICALL void GL_APIENTRY glPolygonOffset (GLfloat factor, GLfloat units);
 #ifdef PLATFORM_OSX
     GL_APICALL void GL_APIENTRY glDepthRange(GLclampd n, GLclampd f);
     GL_APICALL void GL_APIENTRY glClearDepth(GLclampd d);

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -52,7 +52,7 @@ namespace RenderState {
         depthWrite.init(GL_TRUE);
 
         glDisable(GL_STENCIL_TEST);
-        glDepthFunc(GL_LEQUAL);
+        glDepthFunc(GL_LESS);
         glClearDepthf(1.0);
         glDepthRangef(0.0, 1.0);
 

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -18,6 +18,8 @@ namespace RenderState {
     ColorWrite colorWrite;
     FrontFace frontFace;
     CullFace cullFace;
+    PolygonOffsetFill polygonOffsetFill;
+    PolygonOffset polygonOffset;
 
     VertexBuffer vertexBuffer;
     IndexBuffer indexBuffer;

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -99,6 +99,7 @@ namespace RenderState {
     using StencilTest = State<BoolSwitch<GL_STENCIL_TEST>>;
     using Blending = State<BoolSwitch<GL_BLEND>>;
     using Culling = State<BoolSwitch<GL_CULL_FACE>>;
+    using PolygonOffsetFill = State<BoolSwitch<GL_POLYGON_OFFSET_FILL>>;
 
 #define FUN(X) decltype((X)), X
 
@@ -147,6 +148,9 @@ namespace RenderState {
                                  GLclampf,  // green
                                  GLclampf,  // blue
                                  GLclampf>; // alpha
+    using PolygonOffset = StateWrap<FUN(glPolygonOffset),
+                                    GLfloat,  // factor
+                                    GLfloat>; // units
 
 #undef FUN
 
@@ -163,6 +167,8 @@ namespace RenderState {
     extern CullFace cullFace;
     extern Culling culling;
     extern ShaderProgram shaderProgram;
+    extern PolygonOffsetFill polygonOffsetFill;
+    extern PolygonOffset polygonOffset;
 
     extern VertexBuffer vertexBuffer;
     extern IndexBuffer indexBuffer;

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -24,6 +24,7 @@ using Mesh = TypedMesh<PosColVertex>;
 
 
 DebugStyle::DebugStyle(std::string _name, Blending _blendMode, GLenum _drawMode) : Style(_name, _blendMode, _drawMode) {
+    m_drawProxy = false;
 }
 
 void DebugStyle::constructVertexLayout() {

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -14,6 +14,7 @@ DebugTextStyle::DebugTextStyle(std::shared_ptr<FontContext> _fontContext, FontID
                                bool _sdfMultisampling, Blending _blendMode, GLenum _drawMode)
     : TextStyle(_name, _fontContext, _sdf, _sdfMultisampling, _blendMode, _drawMode),
       m_font(_fontId), m_fontSize(_fontSize) {
+          m_drawProxy = false;
 }
 
 void DebugTextStyle::onBeginBuildTile(Tangram::Tile &_tile) const {

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -20,7 +20,9 @@ constexpr float texture_scale = 65535.f;
 namespace Tangram {
 
 PointStyle::PointStyle(std::string _name, Blending _blendMode, GLenum _drawMode)
-    : Style(_name, _blendMode, _drawMode) {}
+    : Style(_name, _blendMode, _drawMode) {
+	m_drawProxy = false;
+}
 
 PointStyle::~PointStyle() {}
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -102,6 +102,8 @@ protected:
        and bind textures starting at @_textureUnit */
     void setupShaderUniforms(int _textureUnit, Scene& _scene);
 
+    bool m_drawProxy = true;
+
 private:
 
     std::vector<StyleUniform> m_styleUniforms;
@@ -111,6 +113,8 @@ public:
     Style(std::string _name, Blending _blendMode, GLenum _drawMode);
 
     virtual ~Style();
+
+    bool drawProxy() { return m_drawProxy; }
 
     static bool compare(std::unique_ptr<Style>& a, std::unique_ptr<Style>& b) {
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -21,6 +21,7 @@ TextStyle::TextStyle(std::string _name, std::shared_ptr<FontContext> _fontContex
                      bool _sdfMultisampling, Blending _blendMode, GLenum _drawMode) :
     Style(_name, _blendMode, _drawMode), m_sdf(_sdf), m_sdfMultisampling(_sdfMultisampling),
     m_fontContext(_fontContext) {
+        m_drawProxy = false;
 }
 
 TextStyle::~TextStyle() {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -213,7 +213,7 @@ void render() {
         RenderState::stencilOp(GL_KEEP, GL_KEEP, GL_INVERT);
 
         glEnable(GL_POLYGON_OFFSET_FILL);
-        glPolygonOffset(1.0, 1.0);
+        glPolygonOffset(1.0, 1024.0);
 
         for (const auto& style : m_scene->styles()) {
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -217,6 +217,8 @@ void render() {
 
         for (const auto& style : m_scene->styles()) {
 
+            if (!style->drawProxy()) { continue; }
+
             // Set time uniforms style's shader programs
             style->getShaderProgram()->setUniformf("u_time", g_time);
             style->onBeginDrawFrame(*m_view, *m_scene);
@@ -238,6 +240,8 @@ void render() {
         glDisable(GL_POLYGON_OFFSET_FILL);
 
         for (const auto& style : m_scene->styles()) {
+
+            if (!style->drawProxy()) { continue; }
 
             // Set time uniforms style's shader programs
             style->getShaderProgram()->setUniformf("u_time", g_time);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -211,9 +211,8 @@ void render() {
         RenderState::stencilTest(GL_TRUE);
         RenderState::stencilWrite(0xFF);
         RenderState::stencilOp(GL_KEEP, GL_KEEP, GL_INVERT);
-
-        glEnable(GL_POLYGON_OFFSET_FILL);
-        glPolygonOffset(1.0, 1024.0);
+        RenderState::polygonOffsetFill(GL_TRUE);
+        RenderState::polygonOffset(1.0, 1024.0);
 
         for (const auto& style : m_scene->styles()) {
 
@@ -237,7 +236,7 @@ void render() {
         RenderState::colorWrite(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
         RenderState::stencilTest(GL_TRUE);
         RenderState::stencilWrite(0x00);
-        glDisable(GL_POLYGON_OFFSET_FILL);
+        RenderState::polygonOffsetFill(GL_FALSE);
 
         for (const auto& style : m_scene->styles()) {
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -135,7 +135,7 @@ void Tile::draw(const Style& _style, const View& _view) {
         float zoomAndProxy = m_proxyCounter > 0 ? -m_id.z : m_id.z;
 
         shader->setUniformMatrix4f("u_model", m_modelMatrix);
-        shader->setUniformf("u_tile_origin", m_tileOrigin.x, m_tileOrigin.y, zoomAndProxy);
+        shader->setUniformf("u_tile_origin", m_tileOrigin.x, m_tileOrigin.y, m_id.z);
 
         styleMesh->draw(*shader);
     }

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -3,6 +3,7 @@
 #include "glm/mat4x4.hpp"
 #include "glm/vec2.hpp"
 #include "tileID.h"
+#include "gl.h"
 
 #include <map>
 #include <memory>

--- a/tests/src/gl_mock.cpp
+++ b/tests/src/gl_mock.cpp
@@ -65,6 +65,7 @@ extern "C" {
     void glGetDoublev( GLenum pname, GLdouble *params ){}
     void glGetFloatv( GLenum pname, GLfloat *params ){}
     void glGetIntegerv( GLenum pname, GLint *params ){}
+    void glPolygonOffset( GLfloat factor, GLfloat units) {};
     void glBindTexture( GLenum target, GLuint texture ){}
     void glActiveTexture (GLenum texture){}
     void glGenTextures( GLsizei n, GLuint *textures ){}


### PR DESCRIPTION
Stencil Buffer usage to draw proxy tiles:

Approach:

1. Draw Non-Proxy Tiles
 - Enable stencil writing and draw all non-proxy tiles marking stencil fragments to 1

2. Draw Proxy Tiles
 - Pass 1:
   - Disable color buffer writing
    - enable stencil writes and depth tests
    - set stencil to invert when depth and stencil test pass.
    - enable GL_POLYGON_OFFSET_FILL
    - set glPolygonOffset (this is required to avoid z fighting between same depth proxy and non-proxy fragments)
 - Pass 2: Enable color buffer writing, disable stencil writes and draw proxy tiles with stencil tests enabled

Issues to work on:
- [x] Text and Point/Icon style drawing for proxy tiles. (Because these have their own z depth).
- [x] Update RenderStates with new gl functions.
- [ ] Possible better values for `glPolygonOffset` for 16bit depth buffer or another approach?