### PR TITLE
[WIP] Reuse style builder buffers

### DIFF
--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -89,7 +89,7 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
         view.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
 
         init(this, assetManager, scenePath);
-
+        setPixelScale(displayMetrics.density);
     }
 
     /**
@@ -399,6 +399,8 @@ public class MapController implements Renderer, OnTouchListener, OnScaleGestureL
 
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
         init(this, assetManager, scenePath);
+        setPixelScale(displayMetrics.density);
+
         // init() is safe to call twice, this invocation ensures that the jni
         // environment is attached to the rendering thread
         setupGL();

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -45,7 +45,7 @@ struct TestContext {
         }
         scene = std::make_unique<Scene>();
         SceneLoader::loadScene(sceneNode, *scene);
-        styleContext.initFunctions(*scene);
+        styleContext.setScene(*scene);
         styleContext.setGlobalZoom(0);
 
         source = scene->dataSources()[0];
@@ -101,7 +101,7 @@ public:
         }
         scene = std::make_unique<Scene>();
         SceneLoader::loadScene(sceneNode, *scene);
-        styleContext.initFunctions(*scene);
+        styleContext.setScene(*scene);
         styleContext.setGlobalZoom(10);
 
         const char* path = "tile.mvt";
@@ -139,7 +139,7 @@ BENCHMARK_DEFINE_F(TileLoadingFixture, BuildTest)(benchmark::State& st) {
 
     while (st.KeepRunning()) {
         Tile tile({0,0,0}, s_projection);
-        tile.build(styleContext, *scene, *tileData, *source);
+        tile.build(styleContext, *tileData, *source);
     }
 }
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -4,12 +4,14 @@ namespace Tangram {
 
 using namespace LabelProperty;
 
-TextLabel::TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim, TextBuffer& _mesh, Range _vertexRange,
-    Label::Options _options, FontContext::FontMetrics _metrics, int _nLines, Anchor _anchor, glm::vec2 _quadsLocalOrigin) :
-    Label(_transform, _dim, _type, static_cast<LabelMesh&>(_mesh), _vertexRange, _options),
-    m_metrics(_metrics),
-    m_nLines(_nLines),
-    m_quadLocalOrigin(_quadsLocalOrigin) {
+TextLabel::TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim,
+                     LabelMesh& _mesh, Range _vertexRange,
+                     Label::Options _options, FontContext::FontMetrics _metrics,
+                     int _nLines, Anchor _anchor, glm::vec2 _quadsLocalOrigin)
+    : Label(_transform, _dim, _type, _mesh, _vertexRange, _options),
+      m_metrics(_metrics),
+      m_nLines(_nLines),
+      m_quadLocalOrigin(_quadsLocalOrigin) {
 
     if (m_type == Type::point) {
         glm::vec2 halfDim = m_dim * 0.5f;

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "labels/label.h"
-#include "text/textBuffer.h"
+#include "labels/labelMesh.h"
 #include "text/fontContext.h"
 #include "style/labelProperty.h"
 
@@ -10,7 +10,7 @@ namespace Tangram {
 class TextLabel : public Label {
 
 public:
-    TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim, TextBuffer& _mesh, Range _vertexRange,
+    TextLabel(Label::Transform _transform, Type _type, glm::vec2 _dim, LabelMesh& _mesh, Range _vertexRange,
               Label::Options _options, FontContext::FontMetrics _metrics, int _nLines, LabelProperty::Anchor _anchor, 
               glm::vec2 _quadsLocalOrigin);
 

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -144,9 +144,13 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const Scene& _scene, const
     for (auto& rule : matchedRules) {
 
         auto* style = _scene.findStyle(rule.getStyleName());
-
         if (!style) {
             LOGE("Invalid style %s", rule.getStyleName().c_str());
+            continue;
+        }
+
+        bool visible;
+        if (rule.get(StyleParamKey::visible, visible) && !visible) {
             continue;
         }
 

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -133,8 +133,8 @@ bool DrawRuleMergeSet::match(const Feature& _feature, const SceneLayer& _layer, 
     return true;
 }
 
-void DrawRuleMergeSet::apply(const Feature& _feature, const Scene& _scene, const SceneLayer& _layer,
-                    StyleContext& _ctx, Tile& _tile) {
+void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
+                             StyleContext& _ctx, Tile& _tile) {
 
     // If no rules matched the feature, return immediately
     if (!match(_feature, _layer, _ctx)) { return; }
@@ -143,7 +143,7 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const Scene& _scene, const
     // build the feature with the rule's parameters
     for (auto& rule : matchedRules) {
 
-        auto* style = _scene.findStyle(rule.getStyleName());
+        StyleBuilder* style = _ctx.getStyleBuilder(rule.getStyleName());
         if (!style) {
             LOGE("Invalid style %s", rule.getStyleName().c_str());
             continue;
@@ -194,7 +194,7 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const Scene& _scene, const
         }
 
         if (valid) {
-            style->buildFeature(_tile, _feature, rule);
+            style->addFeature(_feature, rule);
         }
     }
 }

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -10,6 +10,7 @@
 #include "drawRuleWarnings.h"
 
 #include <algorithm>
+#include <chrono>
 
 namespace Tangram {
 
@@ -136,8 +137,16 @@ bool DrawRuleMergeSet::match(const Feature& _feature, const SceneLayer& _layer, 
 void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
                              StyleContext& _ctx, Tile& _tile) {
 
+    const clock_t t1 = clock();
+
+    if (m_tile.empty()) {
+        m_tile = _tile.getID().toString();
+    }
+
     // If no rules matched the feature, return immediately
     if (!match(_feature, _layer, _ctx)) { return; }
+
+    const clock_t t2 = clock();
 
     // For each matched rule, find the style to be used and
     // build the feature with the rule's parameters
@@ -197,6 +206,9 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
             style->addFeature(_feature, rule);
         }
     }
+
+    m_buildTime += (double(clock() - t2) / CLOCKS_PER_SEC) * 1000;
+    m_matchTime += (double(t2 - t1) / CLOCKS_PER_SEC) * 1000;
 }
 
 void DrawRuleMergeSet::mergeRules(const SceneLayer& _layer) {

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -89,8 +89,7 @@ struct DrawRuleMergeSet {
     /* Determine and apply DrawRules for a @_feature and add
      * the result to @_tile
      */
-    void apply(const Feature& _feature, const Scene& _scene,
-               const SceneLayer& _sceneLayer,
+    void apply(const Feature& _feature, const SceneLayer& _sceneLayer,
                StyleContext& _ctx, Tile& _tile);
 
     // internal

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -3,6 +3,7 @@
 #include "scene/styleParam.h"
 
 #include <vector>
+#include "platform.h"
 
 namespace Tangram {
 
@@ -104,6 +105,13 @@ struct DrawRuleMergeSet {
 
     // Container for dynamically-evaluated parameters
     StyleParam evaluated[StyleParamKeySize];
+
+    double m_buildTime = 0, m_matchTime = 0;
+    std::string m_tile;
+
+    ~DrawRuleMergeSet(){
+        LOG("    %s - match:%f\t style:%f", m_tile.c_str(), (float)m_matchTime, (float)m_buildTime);
+    }
 
 };
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -25,6 +25,7 @@ Scene::Scene() : id(s_serial++) {
     // For now we only have one projection..
     // TODO how to share projection with view?
     m_mapProjection.reset(new MercatorProjection());
+    m_layers = std::make_shared<std::vector<DataLayer>>();
 }
 
 Scene::~Scene() {}

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -68,7 +68,10 @@ private:
     std::unique_ptr<MapProjection> m_mapProjection;
     std::shared_ptr<View> m_view;
 
-    std::vector<DataLayer> m_layers;
+    // StyleContext/TileWoker instances need a shared reference
+    // to SceneLayers
+    std::shared_ptr<std::vector<DataLayer>> m_layers;
+
     std::vector<std::shared_ptr<DataSource>> m_dataSources;
     std::vector<std::unique_ptr<Style>> m_styles;
     std::vector<std::unique_ptr<Light>> m_lights;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1375,7 +1375,7 @@ void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
 
     auto sublayer = loadSublayer(layer.second, name, scene);
 
-    scene.layers().push_back({ sublayer, source, collections });
+    scene.layers()->push_back({ sublayer, source, collections });
 }
 
 void SceneLoader::loadBackground(Node background, Scene& scene) {

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -14,7 +14,7 @@ void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm
     m_spritesNodes[_name] = SpriteNode { uvBL, uvTR, _size };
 }
 
-bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) {
+bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) const {
     auto it = m_spritesNodes.find(_name);
     if (it == m_spritesNodes.end()) {
         return false;

--- a/core/src/scene/spriteAtlas.h
+++ b/core/src/scene/spriteAtlas.h
@@ -20,7 +20,7 @@ public:
 
     /* Creates a sprite node in the atlas located at _origin in the texture by a size in pixels _size */
     void addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size);
-    bool getSpriteNode(const std::string& _name, SpriteNode& _node);
+    bool getSpriteNode(const std::string& _name, SpriteNode& _node) const;
 
     /* Bind the atlas in the driver */
     void bind(GLuint _slot);

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -83,18 +83,19 @@ StyleBuilder* StyleContext::getStyleBuilder(const std::string& _name) {
     return it->second.get();
 }
 
-void StyleContext::initFunctions(const Scene& _scene) {
+void StyleContext::setScene(const Scene& _scene) {
 
-    if (_scene.id == m_sceneId) {
-        return;
-    }
+    if (_scene.id == m_sceneId) { return; }
     m_sceneId = _scene.id;
 
+    // Initialize StyleBuilders
     m_styleBuilder.clear();
-
     for (auto& style : _scene.styles()) {
         m_styleBuilder[style->getName()] = style->createBuilder();
     }
+
+    // Store reference to SceneLayers
+    m_sceneLayers = _scene.layers();
 
     auto arr_idx = duk_push_array(m_ctx);
     int id = 0;

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -5,6 +5,7 @@
 #include "data/tileData.h"
 #include "scene/filters.h"
 #include "scene/scene.h"
+#include "style/style.h"
 #include "util/builders.h"
 
 #include "duktape.h"
@@ -75,12 +76,25 @@ StyleContext::~StyleContext() {
     duk_destroy_heap(m_ctx);
 }
 
+StyleBuilder* StyleContext::getStyleBuilder(const std::string& _name) {
+    auto it = m_styleBuilder.find(_name);
+    if (it == m_styleBuilder.end()) { return nullptr; }
+
+    return it->second.get();
+}
+
 void StyleContext::initFunctions(const Scene& _scene) {
 
     if (_scene.id == m_sceneId) {
         return;
     }
     m_sceneId = _scene.id;
+
+    m_styleBuilder.clear();
+
+    for (auto& style : _scene.styles()) {
+        m_styleBuilder[style->getName()] = style->createBuilder();
+    }
 
     auto arr_idx = duk_push_array(m_ctx);
     int id = 0;

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <functional>
 #include <memory>
+#include <array>
 
 struct duk_hthread;
 typedef struct duk_hthread duk_context;
@@ -39,7 +40,7 @@ public:
     /*
      * Set global for currently processed Tile
      */
-    void setGlobalZoom(float _zoom);
+    void setGlobalZoom(int _zoom);
 
     /* Called from Filter::eval */
     float getGlobalZoom() const { return m_globalZoom; }
@@ -86,11 +87,12 @@ private:
 
     const Feature* m_feature = nullptr;
 
-    fastmap<FilterGlobal, Value> m_globals;
+    std::array<Value, 4> m_globals;
 
     int32_t m_sceneId = -1;
 
-    float m_globalZoom = -1;
+    double m_globalZoom = -1;
+    double m_globalGeom = -1;
 
     fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilder;
 

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -15,6 +15,7 @@ namespace Tangram {
 class Scene;
 struct Feature;
 struct StyleParam;
+class StyleBuilder;
 
 enum class StyleParamKey : uint8_t;
 enum class FilterGlobal : uint8_t;
@@ -68,6 +69,10 @@ public:
     void setGlobal(const std::string& _key, const Value& _value);
     const Value& getGlobal(const std::string& _key) const;
 
+    StyleBuilder* getStyleBuilder(const std::string& _name);
+
+    const auto& styleBuilders() { return m_styleBuilder; }
+
 private:
     static int jsGetProperty(duk_context *_ctx);
     static int jsHasProperty(duk_context *_ctx);
@@ -83,6 +88,8 @@ private:
     int32_t m_sceneId = -1;
 
     float m_globalZoom = -1;
+
+    fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilder;
 };
 
 }

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -12,6 +12,7 @@ typedef struct duk_hthread duk_context;
 
 namespace Tangram {
 
+class DataLayer;
 class Scene;
 struct Feature;
 struct StyleParam;
@@ -54,7 +55,7 @@ public:
     /*
      * Setup filter and style functions from @_scene
      */
-    void initFunctions(const Scene& _scene);
+    void setScene(const Scene& _scene);
 
     /*
      * Unset Feature handle
@@ -73,6 +74,8 @@ public:
 
     const auto& styleBuilders() { return m_styleBuilder; }
 
+    const auto& sceneLayers() const { return *m_sceneLayers; };
+
 private:
     static int jsGetProperty(duk_context *_ctx);
     static int jsHasProperty(duk_context *_ctx);
@@ -90,6 +93,8 @@ private:
     float m_globalZoom = -1;
 
     fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilder;
+
+    std::shared_ptr<std::vector<DataLayer>> m_sceneLayers;
 };
 
 }

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -44,6 +44,11 @@ void DebugStyle::constructShaderProgram() {
 
 }
 
+std::unique_ptr<StyleBuilder> DebugStyle::createBuilder() const {
+    return nullptr; /// std::make_unique<Builder>(m_fontContext, m_sdf);
+}
+
+#if 0
 void DebugStyle::onBeginBuildTile(Tile &_tile) const {
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::tile_bounds)) {
@@ -68,5 +73,6 @@ void DebugStyle::onBeginBuildTile(Tile &_tile) const {
 
     }
 }
+#endif
 
 }

--- a/core/src/style/debugStyle.h
+++ b/core/src/style/debugStyle.h
@@ -10,11 +10,13 @@ protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void onBeginBuildTile(Tile& _tile) const override;
 
-    virtual VboMesh* newMesh() const override {
-        return nullptr;
-    };
+    virtual std::unique_ptr<StyleBuilder> createBuilder() const override;
+
+    // virtual void onBeginBuildTile(Tile& _tile) const override;
+    // virtual VboMesh* newMesh() const override {
+    //     return nullptr;
+    // };
 
 public:
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -16,6 +16,11 @@ DebugTextStyle::DebugTextStyle(std::shared_ptr<FontContext> _fontContext, FontID
       m_font(_fontId), m_fontSize(_fontSize) {
 }
 
+std::unique_ptr<StyleBuilder> DebugTextStyle::createBuilder() const {
+    return nullptr; /// std::make_unique<Builder>(m_fontContext, m_sdf);
+}
+
+#if 0
 void DebugTextStyle::onBeginBuildTile(Tangram::Tile &_tile) const {
 
     Parameters params;
@@ -41,7 +46,7 @@ void DebugTextStyle::onBeginBuildTile(Tangram::Tile &_tile) const {
         onEndBuildTile(_tile);
 
     }
-
 }
+#endif
 
 }

--- a/core/src/style/debugTextStyle.h
+++ b/core/src/style/debugTextStyle.h
@@ -10,7 +10,8 @@ class DebugTextStyle : public TextStyle {
 
 protected:
 
-    virtual void onBeginBuildTile(Tile& _tile) const override;
+    // virtual void onBeginBuildTile(Tile& _tile) const override;
+    virtual std::unique_ptr<StyleBuilder> createBuilder() const override;
 
 public:
 

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -71,7 +71,9 @@ namespace {
 
 struct Builder : public StyleBuilder {
 
+    // FIXME - holds GL resources
     std::shared_ptr<SpriteAtlas> m_spriteAtlas;
+    float m_pixelScale;
 
     std::unique_ptr<LabelMesh> m_mesh;
 
@@ -92,8 +94,10 @@ struct Builder : public StyleBuilder {
     virtual std::unique_ptr<VboMesh> build() override { return std::move(m_mesh); };
 
     Builder(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode,
-            std::shared_ptr<SpriteAtlas> _spriteAtlas)
-        : StyleBuilder(_vertexLayout, _drawMode), m_spriteAtlas(_spriteAtlas) {}
+            std::shared_ptr<SpriteAtlas> _spriteAtlas, float _pixelScale)
+        : StyleBuilder(_vertexLayout, _drawMode),
+          m_spriteAtlas(_spriteAtlas),
+          m_pixelScale(_pixelScale) {}
 
 };
 
@@ -196,8 +200,7 @@ bool Builder::getUVQuad(PointStyle::Parameters& _params, glm::vec4& _quad) const
         }
     }
 
-    // FIXME
-    // _params.size *= m_pixelScale;
+    _params.size *= m_pixelScale;
 
     return true;
 }
@@ -297,7 +300,7 @@ void Builder::addPolygon(const Polygon& _polygon, const Properties& _props,
 }
 
 std::unique_ptr<StyleBuilder> PointStyle::createBuilder() const {
-    return std::make_unique<Builder>(m_vertexLayout, m_drawMode, m_spriteAtlas);
+    return std::make_unique<Builder>(m_vertexLayout, m_drawMode, m_spriteAtlas, m_pixelScale);
 }
 
 }

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -15,13 +15,6 @@ class PointStyle : public Style {
 
 public:
 
-    virtual void onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit = 0) override;
-
-    PointStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
-    void setSpriteAtlas(std::shared_ptr<SpriteAtlas> _spriteAtlas) { m_spriteAtlas = _spriteAtlas; }
-    void setTexture(std::shared_ptr<Texture> _texture) { m_texture = _texture; }
-
-    virtual ~PointStyle();
     struct Parameters {
         bool centroid = false;
         std::string sprite;
@@ -33,22 +26,21 @@ public:
         float extrudeScale = 1.f;
     };
 
+    PointStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
+
+    virtual void onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit = 0) override;
+
+    void setSpriteAtlas(std::shared_ptr<SpriteAtlas> _spriteAtlas) { m_spriteAtlas = _spriteAtlas; }
+    void setTexture(std::shared_ptr<Texture> _texture) { m_texture = _texture; }
+
+    virtual ~PointStyle();
+
 protected:
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual bool checkRule(const DrawRule& _rule) const override;
 
-    void pushQuad(std::vector<Label::Vertex>& _vertices, const glm::vec2& _size, const glm::vec2& _uvBL,
-            const glm::vec2& _uvTR, unsigned int _color, float _extrudeScale) const;
-    bool getUVQuad(Parameters& _params, glm::vec4& _quad) const;
-
-    Parameters applyRule(const DrawRule& _rule, const Properties& _props, float _zoom) const;
-
-    virtual VboMesh* newMesh() const override;
+    virtual std::unique_ptr<StyleBuilder> createBuilder() const override;
 
     std::shared_ptr<SpriteAtlas> m_spriteAtlas;
     std::shared_ptr<Texture> m_texture;
@@ -74,4 +66,3 @@ namespace std {
         }
     };
 }
-

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -43,13 +43,11 @@ struct Mesh : public VboMesh {
     Mesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
         : VboMesh(_vertexLayout, _drawMode) {}
 
-    void compile(std::vector<std::pair<uint32_t, uint32_t>> _offsets,
-                 std::vector<PolygonVertex> _vertices,
-                 std::vector<uint16_t> _indices) {
+    void compile(const std::vector<std::pair<uint32_t, uint32_t>>& _offsets,
+                 const std::vector<PolygonVertex>& _vertices,
+                 const std::vector<uint16_t>& _indices) {
 
-        m_vertexOffsets.insert(m_vertexOffsets.begin(),
-                               _offsets.begin(),
-                               _offsets.end());
+        m_vertexOffsets = _offsets;
 
         for (auto& p : m_vertexOffsets) {
             m_nVertices += p.second;
@@ -58,10 +56,14 @@ struct Mesh : public VboMesh {
 
         int stride = m_vertexLayout->getStride();
         m_glVertexData = new GLbyte[m_nVertices * stride];
-        std::memcpy(m_glVertexData, (GLbyte*)_vertices.data(), m_nVertices * stride);
+        std::memcpy(m_glVertexData,
+                    reinterpret_cast<const GLbyte*>(_vertices.data()),
+                    m_nVertices * stride);
 
         m_glIndexData = new GLushort[m_nIndices];
-        std::memcpy(m_glIndexData, (GLbyte*)_indices.data(), m_nIndices * sizeof(GLushort));
+        std::memcpy(m_glIndexData,
+                    reinterpret_cast<const GLbyte*>(_indices.data()),
+                    m_nIndices * sizeof(GLushort));
 
         m_isCompiled = true;
     }

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -42,8 +42,7 @@ using Mesh = TypedMesh<PolygonVertex>;
 
 
 PolygonStyle::PolygonStyle(std::string _name, Blending _blendMode, GLenum _drawMode)
-    : Style(_name, _blendMode, _drawMode) {
-}
+    : Style(_name, _blendMode, _drawMode) {}
 
 void PolygonStyle::constructVertexLayout() {
 
@@ -65,11 +64,31 @@ void PolygonStyle::constructShaderProgram() {
     m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
 }
 
-VboMesh* PolygonStyle::newMesh() const {
-    return new Mesh(m_vertexLayout, m_drawMode);
-}
+namespace {
 
-PolygonStyle::Parameters PolygonStyle::parseRule(const DrawRule& _rule) const {
+struct Builder : public StyleBuilder {
+
+    struct Parameters {
+        uint32_t order = 0;
+        uint32_t color = 0xff00ffff;
+        glm::vec2 extrude;
+    };
+
+    virtual void addPolygon(const Polygon& _polygon, const Properties& _props, const DrawRule& _rule) override;
+
+    Parameters parseRule(const DrawRule& _rule) const;
+
+    std::unique_ptr<Mesh> m_mesh;
+
+    virtual void initMesh() override { m_mesh = std::make_unique<Mesh>(m_vertexLayout, m_drawMode); }
+    virtual std::unique_ptr<VboMesh> build() override { return std::move(m_mesh); };
+
+    Builder(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
+        : StyleBuilder(_vertexLayout, _drawMode) {}
+
+};
+
+Builder::Parameters Builder::parseRule(const DrawRule& _rule) const {
     Parameters p;
     _rule.get(StyleParamKey::color, p.color);
     _rule.get(StyleParamKey::extrude, p.extrude);
@@ -78,8 +97,7 @@ PolygonStyle::Parameters PolygonStyle::parseRule(const DrawRule& _rule) const {
     return p;
 }
 
-void PolygonStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule,
-                                const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
+void Builder::addPolygon(const Polygon& _polygon, const Properties& _props, const DrawRule& _rule) {
 
     std::vector<PolygonVertex> vertices;
 
@@ -89,7 +107,7 @@ void PolygonStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule,
     auto& extrude = params.extrude;
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::proxy_colors)) {
-        abgr = abgr << (_tile.getID().z % 6);
+        abgr = abgr << (m_tile->getID().z % 6);
     }
 
     PolygonBuilder builder = {
@@ -99,23 +117,27 @@ void PolygonStyle::buildPolygon(const Polygon& _polygon, const DrawRule& _rule,
         [&](size_t sizeHint){ vertices.reserve(sizeHint); }
     };
 
-    auto& mesh = static_cast<Mesh&>(_mesh);
-
-    float tileUnitsPerMeter = _tile.getInverseScale();
+    float tileUnitsPerMeter = m_tile->getInverseScale();
     float minHeight = getLowerExtrudeMeters(extrude, _props) * tileUnitsPerMeter;
     float height = getUpperExtrudeMeters(extrude, _props) * tileUnitsPerMeter;
 
     if (minHeight != height) {
 
         Builders::buildPolygonExtrusion(_polygon, minHeight, height, builder);
-        mesh.addVertices(std::move(vertices), std::move(builder.indices));
+        m_mesh->addVertices(std::move(vertices), std::move(builder.indices));
 
         // TODO add builder.clear() ?;
         builder.numVertices = 0;
     }
 
     Builders::buildPolygon(_polygon, height, builder);
-    mesh.addVertices(std::move(vertices), std::move(builder.indices));
+    m_mesh->addVertices(std::move(vertices), std::move(builder.indices));
+}
+
+}
+
+std::unique_ptr<StyleBuilder> PolygonStyle::createBuilder() const {
+    return std::make_unique<Builder>(m_vertexLayout, m_drawMode);
 }
 
 }

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -11,19 +11,10 @@ class PolygonStyle : public Style {
 
 protected:
 
-    struct Parameters {
-        uint32_t order = 0;
-        uint32_t color = 0xff00ffff;
-        glm::vec2 extrude;
-    };
-
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
 
-    Parameters parseRule(const DrawRule& _rule) const;
-
-    virtual VboMesh* newMesh() const override;
+    virtual std::unique_ptr<StyleBuilder> createBuilder() const override;
 
 public:
 

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -43,7 +43,39 @@ struct PolylineVertex {
     GLuint abgr;
 };
 
-using Mesh = TypedMesh<PolylineVertex>;
+
+struct Mesh : public VboMesh {
+
+    Mesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
+        : VboMesh(_vertexLayout, _drawMode) {}
+
+    void compile(std::vector<std::pair<uint32_t, uint32_t>> _offsets,
+                 std::vector<PolylineVertex> _vertices,
+                 std::vector<uint16_t> _indices) {
+
+        m_vertexOffsets.insert(m_vertexOffsets.begin(),
+                               _offsets.begin(),
+                               _offsets.end());
+
+        for (auto& p : m_vertexOffsets) {
+            m_nVertices += p.second;
+            m_nIndices += p.first;
+        }
+
+        int stride = m_vertexLayout->getStride();
+        m_glVertexData = new GLbyte[m_nVertices * stride];
+        std::memcpy(m_glVertexData, (GLbyte*)_vertices.data(), m_nVertices * stride);
+
+        m_glIndexData = new GLushort[m_nIndices];
+        std::memcpy(m_glIndexData, (GLbyte*)_indices.data(), m_nIndices * sizeof(GLushort));
+
+        m_isCompiled = true;
+    }
+
+    void compileVertexBuffer() override {}
+
+};
+
 
 PolylineStyle::PolylineStyle(std::string _name, Blending _blendMode, GLenum _drawMode)
     : Style(_name, _blendMode, _drawMode) {
@@ -85,20 +117,42 @@ struct Builder : public StyleBuilder {
         glm::vec2 extrude;
     };
 
-    std::unique_ptr<Mesh> m_mesh;
-
     virtual void addPolygon(const Polygon& _polygon, const Properties& _props, const DrawRule& _rule) override;
     virtual void addLine(const Line& _line, const Properties& _props, const DrawRule& _rule) override;
 
     static Parameters parseRule(const DrawRule& _rule);
 
-    virtual void initMesh() override { m_mesh = std::make_unique<Mesh>(m_vertexLayout, m_drawMode); }
-    virtual std::unique_ptr<VboMesh> build() override { return std::move(m_mesh); };
+    virtual void initMesh() override {
+        m_vertexOffsets.clear();
+        m_vertexOffsets.emplace_back(0,0);
+        m_indices.clear();
+        m_vertices.clear();
+    }
+    virtual std::unique_ptr<VboMesh> build() override;
 
     Builder(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
         : StyleBuilder(_vertexLayout, _drawMode) {}
 
+    PolyLineBuilder m_builder {
+        [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {},
+        [&](size_t sizeHint){
+            //LOGE("RESERVE %d %d", m_vertices.size(), sizeHint);
+            //m_vertices.reserve(m_vertices.size() + sizeHint);
+        }
+    };
+
+    // Used in draw for legth and offsets: sumIndices, sumVertices
+    std::vector<std::pair<uint32_t, uint32_t>> m_vertexOffsets;
+    std::vector<PolylineVertex> m_vertices;
+    std::vector<uint16_t> m_indices;
 };
+
+
+std::unique_ptr<VboMesh> Builder::build() {
+    auto mesh = std::make_unique<Mesh>(m_vertexLayout, m_drawMode);
+    mesh->compile(m_vertexOffsets, m_vertices, m_indices);
+    return std::move(mesh);
+}
 
 auto Builder::parseRule(const DrawRule& _rule) -> Parameters {
     Parameters p;
@@ -204,8 +258,6 @@ bool evalStyleParamWidth(StyleParamKey _key, const DrawRule& _rule, const Tile& 
 
 void Builder::addLine(const Line& _line, const Properties& _props, const DrawRule& _rule) {
 
-    std::vector<PolylineVertex> vertices;
-
     Parameters params = parseRule(_rule);
     GLuint abgr = params.color;
 
@@ -228,57 +280,75 @@ void Builder::addLine(const Line& _line, const Properties& _props, const DrawRul
     float height = getUpperExtrudeMeters(extrude, _props) * tileUnitsPerMeter;
     float order = params.order;
 
-    PolyLineBuilder builder {
-        [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& texCoord) {
-            glm::vec3 position = glm::vec3{coord.x, coord.y, height};
-            vertices.push_back({position, order, texCoord, normal, { width, dWdZ }, abgr});
-        },
-        [&](size_t sizeHint){ vertices.reserve(sizeHint); },
-        params.cap,
-        params.join
+    m_builder.cap = params.cap;
+    m_builder.join = params.join;
+
+    m_builder.addVertex = [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {
+        m_vertices.push_back({ {coord.x, coord.y, height}, order, uv, normal, {width, dWdZ}, abgr });
     };
 
-    Builders::buildPolyLine(_line, builder);
-
-    if (params.outlineOn) {
-
-        GLuint abgrOutline = params.outlineColor;
-        float outlineOrder = std::min(params.outlineOrder, params.order) - 0.5f;
-
-        float widthOutline = 0.f;
-        float dWdZOutline = 0.f;
-
-        if (evalStyleParamWidth(StyleParamKey::outline_width, _rule,
-                                *m_tile, widthOutline, dWdZOutline) &&
-            ((widthOutline > 0.0f || dWdZOutline > 0.0f)) ) {
-
-            // Note: this must update <width> and <dWdZ> as they are captured
-            // (and used) by <builder>
-            width += widthOutline;
-            dWdZ += dWdZOutline;
-
-            if (params.outlineCap != params.cap || params.outlineJoin != params.join) {
-                // need to re-triangulate with different cap and/or join
-                builder.cap = params.outlineCap;
-                builder.join = params.outlineJoin;
-                Builders::buildPolyLine(_line, builder);
-            } else {
-                // re-use indices from original line
-                size_t oldSize = builder.indices.size();
-                size_t offset = vertices.size();
-                builder.indices.reserve(2 * oldSize);
-
-                for(size_t i = 0; i < oldSize; i++) {
-                    builder.indices.push_back(offset + builder.indices[i]);
-                }
-                for (size_t i = 0; i < offset; i++) {
-                    vertices.push_back({ vertices[i], outlineOrder, { width, dWdZ }, abgrOutline });
-                }
-            }
+    auto addVertices = [&](){
+        auto sumVertices = m_vertexOffsets.back().second;
+        if (sumVertices + m_builder.numVertices > MAX_INDEX_VALUE) {
+            m_vertexOffsets.emplace_back(0, 0);
+            sumVertices = 0;
+            LOGE("LARGE BUFFER");
         }
+        for (uint16_t idx : m_builder.indices) {
+            m_indices.push_back(idx + sumVertices);
+        }
+        auto& vertexOffset = m_vertexOffsets.back();
+        vertexOffset.first += m_builder.indices.size();
+        vertexOffset.second += m_builder.numVertices;
+        //LOGE("add %d %d", m_builder.indices.size(), m_builder.numVertices);
+
+        m_builder.clear();
+    };
+
+    Builders::buildPolyLine(_line, m_builder);
+    addVertices();
+
+    if (!params.outlineOn) { return; }
+
+    float widthOutline = 0.f;
+    float dWdZOutline = 0.f;
+    if (!evalStyleParamWidth(StyleParamKey::outline_width, _rule, *m_tile,
+                             widthOutline, dWdZOutline)) {
+        return;
     }
 
-    m_mesh->addVertices(std::move(vertices), std::move(builder.indices));
+    if (!(widthOutline > 0.0f || dWdZOutline > 0.0f)) {
+        return;
+    }
+
+    // Note: this must update values captured (and used) by builder!
+    width += widthOutline;
+    dWdZ += dWdZOutline;
+    abgr = params.outlineColor;
+    order = std::min(params.outlineOrder, params.order) - .5f;
+
+    //if (params.outlineCap != params.cap || params.outlineJoin != params.join) {
+        // need to re-triangulate with different cap and/or join
+        m_builder.cap = params.outlineCap;
+        m_builder.join = params.outlineJoin;
+        Builders::buildPolyLine(_line, m_builder);
+        addVertices();
+
+    // } else {
+    //     return;
+
+    //     // re-use indices from original line
+    //     size_t oldSize = m_builder.indices.size();
+    //     size_t offset = m_vertices.size();
+    //     m_builder.indices.reserve(2 * oldSize);
+
+    //     for(size_t i = 0; i < oldSize; i++) {
+    //         m_builder.indices.push_back(offset + m_builder.indices[i]);
+    //     }
+    //     for (size_t i = 0; i < offset; i++) {
+    //         vertices.push_back({ vertices[i], outlineOrder, { width, dWdZ }, abgrOutline });
+    //     }
+    // }
 }
 
 }

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -49,13 +49,11 @@ struct Mesh : public VboMesh {
     Mesh(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
         : VboMesh(_vertexLayout, _drawMode) {}
 
-    void compile(std::vector<std::pair<uint32_t, uint32_t>> _offsets,
-                 std::vector<PolylineVertex> _vertices,
-                 std::vector<uint16_t> _indices) {
+    void compile(const std::vector<std::pair<uint32_t, uint32_t>>& _offsets,
+                 const std::vector<PolylineVertex>& _vertices,
+                 const std::vector<uint16_t>& _indices) {
 
-        m_vertexOffsets.insert(m_vertexOffsets.begin(),
-                               _offsets.begin(),
-                               _offsets.end());
+        m_vertexOffsets = _offsets;
 
         for (auto& p : m_vertexOffsets) {
             m_nVertices += p.second;
@@ -64,16 +62,19 @@ struct Mesh : public VboMesh {
 
         int stride = m_vertexLayout->getStride();
         m_glVertexData = new GLbyte[m_nVertices * stride];
-        std::memcpy(m_glVertexData, (GLbyte*)_vertices.data(), m_nVertices * stride);
+        std::memcpy(m_glVertexData,
+                    reinterpret_cast<const GLbyte*>(_vertices.data()),
+                    m_nVertices * stride);
 
         m_glIndexData = new GLushort[m_nIndices];
-        std::memcpy(m_glIndexData, (GLbyte*)_indices.data(), m_nIndices * sizeof(GLushort));
+        std::memcpy(m_glIndexData,
+                    reinterpret_cast<const GLbyte*>(_indices.data()),
+                    m_nIndices * sizeof(GLushort));
 
         m_isCompiled = true;
     }
 
     void compileVertexBuffer() override {}
-
 };
 
 

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -1,9 +1,6 @@
 #pragma once
 
 #include "style.h"
-#include "glm/vec2.hpp"
-// TODO move cap/join types to types.h
-#include "util/builders.h"
 
 namespace Tangram {
 
@@ -11,27 +8,10 @@ class PolylineStyle : public Style {
 
 protected:
 
-    struct Parameters {
-        uint32_t order = 0;
-        uint32_t outlineOrder = 0;
-        uint32_t color = 0xff00ffff;
-        uint32_t outlineColor = 0xff00ffff;
-        CapTypes cap = CapTypes::butt;
-        CapTypes outlineCap = CapTypes::butt;
-        JoinTypes join = JoinTypes::miter;
-        JoinTypes outlineJoin = JoinTypes::miter;
-        bool outlineOn = false;
-        glm::vec2 extrude;
-    };
-
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
-    virtual void buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildPolygon(const Polygon& _poly, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
 
-    Parameters parseRule(const DrawRule& _rule) const;
-
-    virtual VboMesh* newMesh() const override;
+    virtual std::unique_ptr<StyleBuilder> createBuilder() const override;
 
 public:
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -45,70 +45,14 @@ void Style::build(const std::vector<std::unique_ptr<Light>>& _lights) {
     for (auto& light : _lights) {
         light->injectOnProgram(*m_shaderProgram);
     }
-
 }
 
 void Style::setMaterial(const std::shared_ptr<Material>& _material) {
-
     m_material = _material;
-
 }
 
 void Style::setLightingType(LightingType _type){
-
     m_lightingType = _type;
-
-}
-
-bool Style::checkRule(const DrawRule& _rule) const {
-
-    uint32_t checkColor;
-    uint32_t checkOrder;
-
-    if (!_rule.get(StyleParamKey::color, checkColor)) {
-        const auto& blocks = m_shaderProgram->getSourceBlocks();
-        if (blocks.find("color") == blocks.end() && blocks.find("filter") == blocks.end()) {
-            return false; // No color parameter or color block? NO SOUP FOR YOU
-        }
-    }
-
-    if (!_rule.get(StyleParamKey::order, checkOrder)) {
-        return false;
-    }
-
-    return true;
-}
-
-void Style::buildFeature(Tile& _tile, const Feature& _feat, const DrawRule& _rule) const {
-
-    if (!checkRule(_rule)) { return; }
-
-    auto& mesh = _tile.getMesh(*this);
-
-    if (!mesh) {
-        mesh.reset(newMesh());
-    }
-
-    switch (_feat.geometryType) {
-        case GeometryType::points:
-            for (auto& point : _feat.points) {
-                buildPoint(point, _rule, _feat.props, *mesh, _tile);
-            }
-            break;
-        case GeometryType::lines:
-            for (auto& line : _feat.lines) {
-                buildLine(line, _rule, _feat.props, *mesh, _tile);
-            }
-            break;
-        case GeometryType::polygons:
-            for (auto& polygon : _feat.polygons) {
-                buildPolygon(polygon, _rule, _feat.props, *mesh, _tile);
-            }
-            break;
-        default:
-            break;
-    }
-
 }
 
 void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
@@ -211,23 +155,63 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit)
     }
 }
 
-void Style::onBeginBuildTile(Tile& _tile) const {
+
+bool StyleBuilder::checkRule(const DrawRule& _rule) const {
+
+    uint32_t checkColor;
+    uint32_t checkOrder;
+
+    if (!_rule.get(StyleParamKey::color, checkColor)) {
+        // const auto& blocks = m_shaderProgram->getSourceBlocks();
+        // if (blocks.find("color") == blocks.end() &&
+        //     blocks.find("filter") == blocks.end()) {
+        //     return false; // No color parameter or color block? NO SOUP FOR YOU
+        // }
+        return false;
+    }
+
+    if (!_rule.get(StyleParamKey::order, checkOrder)) {
+        return false;
+    }
+
+    return true;
+}
+
+void StyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) {
+
+    if (!checkRule(_rule)) { return; }
+
+    switch (_feat.geometryType) {
+        case GeometryType::points:
+            for (auto& point : _feat.points) {
+                addPoint(point, _feat.props, _rule);
+            }
+            break;
+        case GeometryType::lines:
+            for (auto& line : _feat.lines) {
+                addLine(line, _feat.props, _rule);
+            }
+            break;
+        case GeometryType::polygons:
+            for (auto& polygon : _feat.polygons) {
+                addPolygon(polygon, _feat.props, _rule);
+            }
+            break;
+        default:
+            break;
+    }
+
+}
+
+void StyleBuilder::addPoint(const Point& _point, const Properties& _props, const DrawRule& _rule) {
     // No-op by default
 }
 
-void Style::onEndBuildTile(Tile& _tile) const {
+void StyleBuilder::addLine(const Line& _line, const Properties& _props, const DrawRule& _rule) {
     // No-op by default
 }
 
-void Style::buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
-    // No-op by default
-}
-
-void Style::buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
-    // No-op by default
-}
-
-void Style::buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const {
+void StyleBuilder::addPolygon(const Polygon& _polygon, const Properties& _props, const DrawRule& _rule) {
     // No-op by default
 }
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -83,11 +83,6 @@ void Style::buildFeature(Tile& _tile, const Feature& _feat, const DrawRule& _rul
 
     if (!checkRule(_rule)) { return; }
 
-    bool visible;
-    if (_rule.get(StyleParamKey::visible, visible) && !visible) {
-        return;
-    }
-
     auto& mesh = _tile.getMesh(*this);
 
     if (!mesh) {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -35,6 +35,43 @@ enum class Blending : int8_t {
     overlay,
 };
 
+class StyleBuilder {
+public:
+
+    StyleBuilder(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode)
+        : m_vertexLayout(_vertexLayout), m_drawMode(_drawMode) {}
+
+    /* <VertexLayout> shared between meshes using this style */
+    std::shared_ptr<VertexLayout> m_vertexLayout;
+
+    /* Draw mode to pass into <VboMesh>es created with this style */
+    GLenum m_drawMode;
+
+    const Tile* m_tile;
+
+    void beginTile(const Tile& _tile) {
+        m_tile = &_tile;
+        initMesh();
+    }
+
+    void addFeature(const Feature& _feat, const DrawRule& _rule);
+
+    /* Build styled vertex data for point geometry */
+    virtual void addPoint(const Point& _point, const Properties& _props, const DrawRule& _rule);
+
+    /* Build styled vertex data for line geometry */
+    virtual void addLine(const Line& _line, const Properties& _props, const DrawRule& _rule);
+
+    /* Build styled vertex data for polygon geometry */
+    virtual void addPolygon(const Polygon& _polygon, const Properties& _props, const DrawRule& _rule);
+
+    virtual void initMesh() = 0;
+
+    /* Create a new mesh object using the vertex layout corresponding to this style */
+    virtual std::unique_ptr<VboMesh> build() = 0;
+
+    virtual bool checkRule(const DrawRule& _rule) const;
+};
 
 /* Means of constructing and rendering map geometry
  *
@@ -86,18 +123,6 @@ protected:
     /* Create <ShaderProgram> for this style; subclasses must implement this and call it on construction */
     virtual void constructShaderProgram() = 0;
 
-    /* Build styled vertex data for point geometry and add it to the given <VboMesh> */
-    virtual void buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const;
-
-    /* Build styled vertex data for line geometry and add it to the given <VboMesh> */
-    virtual void buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const;
-
-    /* Build styled vertex data for polygon geometry and add it to the given <VboMesh> */
-    virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const;
-
-    /* Create a new mesh object using the vertex layout corresponding to this style */
-    virtual VboMesh* newMesh() const = 0;
-
     /* Set uniform values when @_updateUniforms is true,
        and bind textures starting at @_textureUnit */
     void setupShaderUniforms(int _textureUnit, Scene& _scene);
@@ -142,15 +167,13 @@ public:
     /* Make this style ready to be used (call after all needed properties are set) */
     virtual void build(const std::vector<std::unique_ptr<Light>>& _lights);
 
-    virtual bool checkRule(const DrawRule& _rule) const;
+    // virtual bool checkRule(const DrawRule& _rule) const;
 
-    void buildFeature(Tile& _tile, const Feature& _feat, const DrawRule& _rule) const;
+    // /* Perform any needed setup to process the data for a tile */
+    // virtual void onBeginBuildTile(Tile& _tile) const;
 
-    /* Perform any needed setup to process the data for a tile */
-    virtual void onBeginBuildTile(Tile& _tile) const;
-
-    /* Perform any needed teardown after processing data for a tile */
-    virtual void onEndBuildTile(Tile& _tile) const;
+    // /* Perform any needed teardown after processing data for a tile */
+    // virtual void onEndBuildTile(Tile& _tile) const;
 
     /* Perform any setup needed before drawing each frame
      * _textUnit is the next available texture unit
@@ -178,6 +201,8 @@ public:
     const uint32_t& getID() const { return m_id; }
 
     std::vector<StyleUniform>& styleUniforms() { return m_styleUniforms; }
+
+    virtual std::unique_ptr<StyleBuilder> createBuilder() const = 0;
 
 };
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -54,7 +54,7 @@ public:
         initMesh();
     }
 
-    void addFeature(const Feature& _feat, const DrawRule& _rule);
+    virtual void addFeature(const Feature& _feat, const DrawRule& _rule);
 
     /* Build styled vertex data for point geometry */
     virtual void addPoint(const Point& _point, const Properties& _props, const DrawRule& _rule);

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -70,11 +70,11 @@ namespace {
 
 struct Builder : public StyleBuilder {
 
+    // FIXME - holds GL resources
     std::shared_ptr<FontContext> m_fontContext;
 
     bool m_sdf;
-    // FIXME
-    float m_pixelScale = 1;
+    float m_pixelScale;
 
     std::unique_ptr<TextBuffer> m_mesh;
 
@@ -90,9 +90,11 @@ struct Builder : public StyleBuilder {
     virtual std::unique_ptr<VboMesh> build() override { return std::move(m_mesh); };
 
     Builder(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode,
-            std::shared_ptr<FontContext> _fontContext, bool _sdf)
+            std::shared_ptr<FontContext> _fontContext, bool _sdf, float _pixelScale)
         : StyleBuilder(_vertexLayout, _drawMode),
-          m_fontContext(_fontContext), m_sdf(_sdf) {}
+          m_fontContext(_fontContext),
+          m_sdf(_sdf),
+          m_pixelScale(_pixelScale) {}
 
 };
 
@@ -225,7 +227,7 @@ void Builder::addPolygon(const Polygon& _polygon, const Properties& _props, cons
 }
 
 std::unique_ptr<StyleBuilder> TextStyle::createBuilder() const {
-    return std::make_unique<Builder>(m_vertexLayout, m_drawMode, m_fontContext, m_sdf);
+    return std::make_unique<Builder>(m_vertexLayout, m_drawMode, m_fontContext, m_sdf, m_pixelScale);
 }
 
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -68,6 +68,46 @@ void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureU
 
 namespace {
 
+struct Mesh : public LabelMesh {
+    const size_t maxVertices = 16384;
+
+    Mesh(std::shared_ptr<VertexLayout> _vertexLayout)
+        : LabelMesh(_vertexLayout, GL_TRIANGLES) {}
+
+    void setLabels(std::vector<std::unique_ptr<Label>>& _labels,
+                   std::vector<Label::Vertex>& _vertices) {
+
+        typedef std::vector<std::unique_ptr<Label>>::iterator iter_t;
+
+        m_labels.reserve(_labels.size());
+        m_labels.insert(m_labels.begin(),
+                      std::move_iterator<iter_t>(_labels.begin()),
+                      std::move_iterator<iter_t>(_labels.end()));
+
+        // Compile vertex buffer directly instead of making a temporary copy
+        m_nVertices = _vertices.size();
+
+        int stride = m_vertexLayout->getStride();
+        m_glVertexData = new GLbyte[stride * m_nVertices];
+        std::memcpy(m_glVertexData,
+                    reinterpret_cast<const GLbyte*>(_vertices.data()),
+                    m_nVertices * stride);
+
+        for (size_t offset = 0; offset < m_nVertices; offset += maxVertices) {
+            size_t nVertices = maxVertices;
+            if (offset + maxVertices > m_nVertices) {
+                nVertices = m_nVertices - offset;
+            }
+            m_vertexOffsets.emplace_back(nVertices / 4 * 6, nVertices);
+        }
+        m_isCompiled = true;
+    }
+
+    virtual void compileVertexBuffer() override {
+        // already compiled above
+    }
+};
+
 struct Builder : public StyleBuilder {
 
     // FIXME - holds GL resources
@@ -76,18 +116,22 @@ struct Builder : public StyleBuilder {
     bool m_sdf;
     float m_pixelScale;
 
-    std::unique_ptr<TextBuffer> m_mesh;
-
     virtual void addPolygon(const Polygon& _polygon, const Properties& _props, const DrawRule& _rule) override;
     virtual void addLine(const Line& _line, const Properties& _props, const DrawRule& _rule) override;
     virtual void addPoint(const Point& _line, const Properties& _props, const DrawRule& _rule) override;
-
     virtual bool checkRule(const DrawRule& _rule) const override;
 
-    TextStyle::Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;
-
-    virtual void initMesh() override { m_mesh = std::make_unique<TextBuffer>(m_vertexLayout); }
-    virtual std::unique_ptr<VboMesh> build() override { return std::move(m_mesh); };
+    virtual void initMesh() override {
+        m_vertices.clear();
+        m_labels.clear();
+        m_mesh = std::make_unique<Mesh>(m_vertexLayout);
+    }
+    virtual std::unique_ptr<VboMesh> build() override {
+        if (!m_labels.empty()) {
+            m_mesh->setLabels(m_labels, m_vertices);
+        }
+        return std::move(m_mesh);
+    };
 
     Builder(std::shared_ptr<VertexLayout> _vertexLayout, GLenum _drawMode,
             std::shared_ptr<FontContext> _fontContext, bool _sdf, float _pixelScale)
@@ -96,6 +140,24 @@ struct Builder : public StyleBuilder {
           m_sdf(_sdf),
           m_pixelScale(_pixelScale) {}
 
+    TextStyle::Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;
+
+    struct {
+        std::vector<Label::Vertex> vertices;
+        glm::vec2 bbox;
+        glm::vec2 quadsLocalOrigin;
+        int numLines;
+        FontContext::FontMetrics metrics;
+
+    } m_scratch;
+
+    std::unique_ptr<Mesh> m_mesh;
+
+    std::vector<Label::Vertex> m_vertices;
+    std::vector<std::unique_ptr<Label>> m_labels;
+
+    bool prepareLabel(const TextStyle::Parameters& _params, Label::Type _type);
+    void addLabel(const TextStyle::Parameters& _params, Label::Type _type, Label::Transform _transform);
 };
 
 bool Builder::checkRule(const DrawRule& _rule) const {
@@ -195,14 +257,11 @@ void Builder::addPoint(const Point& _point, const Properties& _props, const Draw
 
     TextStyle::Parameters params = applyRule(_rule, _props);
 
-   // std::hash<Parameters> hash;
-   // auto h = hash(params);
-   // LOG("Hash %d", h);
-
     if (!params.isValid()) { return; }
 
-    m_mesh->addLabel(params, { glm::vec2(_point), glm::vec2(_point) },
-                    Label::Type::point, *m_fontContext);
+    if (!prepareLabel(params, Label::Type::point)) { return; }
+
+    addLabel(params, Label::Type::point, { glm::vec2(_point), glm::vec2(_point) });
 }
 
 void Builder::addLine(const Line& _line, const Properties& _props, const DrawRule& _rule) {
@@ -211,17 +270,128 @@ void Builder::addLine(const Line& _line, const Properties& _props, const DrawRul
 
     if (!params.isValid()) { return; }
 
+    if (!prepareLabel(params, Label::Type::line)) { return; }
+
+    //LOGE("label lenght %f - %f", m_scratch.bbox.x, m_tile->getProjection()->TileSize());
+
+    float pixel = 2.0 / m_tile->getProjection()->TileSize();
+    float minLength = m_scratch.bbox.x * pixel * 0.2;
+
     for (size_t i = 0; i < _line.size() - 1; i++) {
         glm::vec2 p1 = glm::vec2(_line[i]);
         glm::vec2 p2 = glm::vec2(_line[i + 1]);
-
-        m_mesh->addLabel(params, { p1, p2 }, Label::Type::line, *m_fontContext);
+        if (glm::length(p1-p2) > minLength) {
+            addLabel(params, Label::Type::line, { p1, p2 });
+        }
     }
 }
 
 void Builder::addPolygon(const Polygon& _polygon, const Properties& _props, const DrawRule& _rule) {
     Point p = glm::vec3(centroid(_polygon), 0.0);
     addPoint(p, _props, _rule);
+}
+
+bool Builder::prepareLabel(const TextStyle::Parameters& _params, Label::Type _type) {
+
+    if (_params.fontId < 0 || _params.fontSize <= 0.f || _params.text.size() == 0) {
+        return false;
+    }
+
+    /// Apply text transforms
+    const std::string* renderText;
+    std::string text;
+
+    if (_params.transform == TextLabelProperty::Transform::none) {
+        renderText = &_params.text;
+    } else {
+        text = TextBuffer::applyTextTransform(_params, _params.text);
+        renderText = &text;
+    }
+
+    if (!m_fontContext->lock()) {
+        return false;
+    }
+
+    /// Rasterize the glyphs
+    auto& quads = m_fontContext->rasterize(*renderText, _params.fontId,
+                                           _params.fontSize, _params.blurSpread);
+
+    size_t numGlyphs = quads.size();
+
+    if (numGlyphs == 0) {
+        m_fontContext->unlock();
+        return false;
+    }
+
+    // Stroke width is normalized by the distance of the SDF spread, then scaled
+    // to a char, then packed into the "alpha" channel of stroke. The .25 scaling
+    // probably has to do with how the SDF is generated, but honestly I'm not sure
+    // what it represents.
+    uint32_t strokeWidth = _params.strokeWidth / _params.blurSpread * 255. * .25;
+    uint32_t stroke = (_params.strokeColor & 0x00ffffff) + (strokeWidth << 24);
+
+    m_scratch.metrics = m_fontContext->getMetrics();
+    m_scratch.bbox = glm::vec2(0);
+
+    /// Apply word wrapping
+    std::vector<TextBuffer::WordBreak> wordBreaks;
+    int nLine = TextBuffer::applyWordWrapping(quads, _params, m_scratch.metrics, _type, wordBreaks);
+
+    /// Generate the quads
+    float yMin = std::numeric_limits<float>::max();
+    float xMin = std::numeric_limits<float>::max();
+
+    m_scratch.vertices.clear();
+
+    for (int i = 0; i < int(quads.size()); ++i) {
+        if (wordBreaks.size() > 0) {
+            bool skip = false;
+            // Skip spaces/CR quads
+            for (int j = 0; j < int(wordBreaks.size()) - 1; ++j) {
+                const auto& b1 = wordBreaks[j];
+                const auto& b2 = wordBreaks[j + 1];
+                if (i >= b1.end + 1 && i <= b2.start - 1) {
+                    skip = true;
+                    break;
+                }
+            }
+            if (skip) { continue; }
+        }
+
+        const auto& q = quads[i];
+        m_scratch.vertices.push_back({{q.x0, q.y0}, {q.s0, q.t0}, _params.fill, stroke});
+        m_scratch.vertices.push_back({{q.x0, q.y1}, {q.s0, q.t1}, _params.fill, stroke});
+        m_scratch.vertices.push_back({{q.x1, q.y0}, {q.s1, q.t0}, _params.fill, stroke});
+        m_scratch.vertices.push_back({{q.x1, q.y1}, {q.s1, q.t1}, _params.fill, stroke});
+
+        yMin = std::min(yMin, q.y0);
+        xMin = std::min(xMin, q.x0);
+
+        m_scratch.bbox.x = std::max(m_scratch.bbox.x, q.x1);
+        m_scratch.bbox.y = std::max(m_scratch.bbox.y, std::abs(yMin - q.y1));
+    }
+
+    m_scratch.bbox.x -= xMin;
+    m_scratch.quadsLocalOrigin = { xMin, quads[0].y0 };
+    m_scratch.numLines = nLine;
+
+    m_fontContext->unlock();
+
+    return true;
+}
+
+void Builder::addLabel(const TextStyle::Parameters& _params, Label::Type _type, Label::Transform _transform) {
+    int vertexOffset = m_vertices.size();
+    int numVertices = m_scratch.vertices.size();
+
+    m_labels.emplace_back(new TextLabel(_transform, _type, m_scratch.bbox, *m_mesh,
+                                        { vertexOffset, numVertices },
+                                        _params.labelOptions, m_scratch.metrics, m_scratch.numLines,
+                                        _params.anchor, m_scratch.quadsLocalOrigin));
+
+    m_vertices.insert(m_vertices.end(),
+                      m_scratch.vertices.begin(),
+                      m_scratch.vertices.end());
 }
 
 }

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -9,7 +9,6 @@
 
 namespace Tangram {
 
-class TextBuffer;
 class FontContext;
 struct Properties;
 typedef int FontID;
@@ -47,16 +46,6 @@ protected:
     virtual void constructShaderProgram() override;
 
     virtual std::unique_ptr<StyleBuilder> createBuilder() const override;
-
-    // virtual void buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    // virtual void buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    // virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    // virtual bool checkRule(const DrawRule& _rule) const override;
-
-    // virtual VboMesh* newMesh() const override;
-
-    /* Creates a text label and add it to the processed <TextBuffer>. */
-    // void addTextLabel(TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const;
 
     bool m_sdf;
     bool m_sdfMultisampling;

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -28,7 +28,6 @@ public:
         float strokeWidth = 0.0f;
         float fontSize = 16.0f;
         float blurSpread = 0.0f;
-        bool visible = true;
         Label::Options labelOptions;
         bool wordWrap = true;
         unsigned int maxLineWidth = 15;
@@ -47,17 +46,17 @@ protected:
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
 
-    virtual void buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
-    virtual bool checkRule(const DrawRule& _rule) const override;
+    virtual std::unique_ptr<StyleBuilder> createBuilder() const override;
 
-    virtual VboMesh* newMesh() const override;
+    // virtual void buildPoint(const Point& _point, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
+    // virtual void buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
+    // virtual void buildPolygon(const Polygon& _polygon, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
+    // virtual bool checkRule(const DrawRule& _rule) const override;
 
-    Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;
+    // virtual VboMesh* newMesh() const override;
 
     /* Creates a text label and add it to the processed <TextBuffer>. */
-    void addTextLabel(TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const;
+    // void addTextLabel(TextBuffer& _buffer, Label::Transform _transform, std::string _text, Label::Type _type) const;
 
     bool m_sdf;
     bool m_sdfMultisampling;
@@ -95,7 +94,6 @@ namespace std {
             hash_combine(seed, p.strokeColor);
             hash_combine(seed, p.strokeWidth);
             hash_combine(seed, p.fontSize);
-            hash_combine(seed, p.visible);
             hash_combine(seed, p.wordWrap);
             hash_combine(seed, p.maxLineWidth);
             hash_combine(seed, (int)p.transform);

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -1,32 +1,16 @@
 #pragma once
 
-#include "gl.h"
 #include "labels/labelMesh.h"
 #include "style/textStyle.h"
 #include "text/fontContext.h"
 
-#include <memory>
-#include <locale>
-#include <limits>
-
 namespace Tangram {
 
-class FontContext;
-
-/*
- * This class holds TextLabels together with their VboMesh
- */
-class TextBuffer : public LabelMesh {
+class TextBuffer {
 
 public:
 
-    TextBuffer(std::shared_ptr<VertexLayout> _vertexLayout);
-    ~TextBuffer();
-
-    /* Create and add TextLabel */
-    bool addLabel(const TextStyle::Parameters& _params, Label::Transform _transform,
-                  Label::Type _type, FontContext& _fontContext);
-
+    // TODO move static Utility functions to some other place
     struct WordBreak {
         int start;
         int end;
@@ -34,12 +18,13 @@ public:
 
     static std::vector<WordBreak> findWords(const std::string& _text);
 
-private:
     static int applyWordWrapping(std::vector<FONSquad>& _quads, const TextStyle::Parameters& _params,
                                  const FontContext::FontMetrics& _metrics, Label::Type _type,
-                                 std::vector<TextBuffer::WordBreak>& words);
+                                 std::vector<WordBreak>& words);
 
     static std::string applyTextTransform(const TextStyle::Parameters& _params, const std::string& _string);
+
+    TextBuffer() = delete;
 
 };
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -47,7 +47,8 @@ void Tile::updateTileOrigin(const int _wrap) {
     BoundingBox bounds(m_projection->TileBounds(m_id));
 
     m_tileOrigin = { bounds.min.x, bounds.max.y }; // South-West corner
-    // negative y coordinate: to change from y down to y up (tile system has y down and gl context we use has y up).
+    // negative y coordinate: to change from y down to y up
+    // (tile system has y down and gl context we use has y up).
     m_tileOrigin.y *= -1.0;
 
     auto mapBound = m_projection->MapBounds();
@@ -57,21 +58,19 @@ void Tile::updateTileOrigin(const int _wrap) {
 }
 
 void Tile::initGeometry(uint32_t _size) {
-    m_geometry.resize(_size);
+    //m_geometry.resize(_size);
 }
 
 void Tile::build(StyleContext& _ctx, const Scene& _scene, const TileData& _data,
                  const DataSource& _source) {
 
-    // Initialize m_geometry
-    initGeometry(_scene.styles().size());
-
     const auto& layers = _scene.layers();
 
     _ctx.setGlobalZoom(m_id.z);
 
-    for (auto& style : _scene.styles()) {
-        style->onBeginBuildTile(*this);
+    for (auto& builder : _ctx.styleBuilders()) {
+        if (builder.second)
+            builder.second->beginTile(*this);
     }
 
     DrawRuleMergeSet ruleSet;
@@ -91,19 +90,20 @@ void Tile::build(StyleContext& _ctx, const Scene& _scene, const TileData& _data,
             }
 
             for (const auto& feat : collection.features) {
-                ruleSet.apply(feat, _scene, datalayer, _ctx, *this);
+                ruleSet.apply(feat, datalayer, _ctx, *this);
             }
         }
     }
 
-    for (auto& style : _scene.styles()) {
-        style->onEndBuildTile(*this);
-    }
-
-    for (auto& geometry : m_geometry) {
-        if (geometry) {
-            geometry->compileVertexBuffer();
+    for (auto& builder : _ctx.styleBuilders()) {
+        std::unique_ptr<VboMesh> geometry;
+        if (builder.second) {
+            geometry = builder.second->build();
+            if (geometry) {
+                geometry->compileVertexBuffer();
+            }
         }
+        m_geometry[builder.first.k] = std::move(geometry);
     }
 }
 
@@ -118,8 +118,8 @@ void Tile::update(float _dt, const View& _view) {
 
 void Tile::reset() {
     for (auto& entry : m_geometry) {
-        if (!entry) { continue; }
-        auto labelMesh = dynamic_cast<LabelMesh*>(entry.get());
+        if (!entry.second) { continue; }
+        auto labelMesh = dynamic_cast<LabelMesh*>(entry.second.get());
         if (!labelMesh) { continue; }
         labelMesh->reset();
     }
@@ -142,18 +142,17 @@ void Tile::draw(const Style& _style, const View& _view) {
 }
 
 std::unique_ptr<VboMesh>& Tile::getMesh(const Style& _style) {
-    static std::unique_ptr<VboMesh> NONE = nullptr;
-
-    if (_style.getID() >= m_geometry.size()) { return NONE; }
-
-    return m_geometry[_style.getID()];
+    // static std::unique_ptr<VboMesh> NONE = nullptr;
+    // if (_style.getID() >= m_geometry.size()) { return NONE; }
+    // return m_geometry[_style.getID()];
+    return m_geometry[_style.getName()];
 }
 
 size_t Tile::getMemoryUsage() const {
     if (m_memoryUsage == 0) {
         for (auto& entry : m_geometry) {
-            if (entry) {
-                m_memoryUsage += entry->bufferSize();
+            if (entry.second) {
+                m_memoryUsage += entry.second->bufferSize();
             }
         }
     }

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -61,10 +61,8 @@ void Tile::initGeometry(uint32_t _size) {
     //m_geometry.resize(_size);
 }
 
-void Tile::build(StyleContext& _ctx, const Scene& _scene, const TileData& _data,
+void Tile::build(StyleContext& _ctx, const TileData& _tileData,
                  const DataSource& _source) {
-
-    const auto& layers = _scene.layers();
 
     _ctx.setGlobalZoom(m_id.z);
 
@@ -75,11 +73,11 @@ void Tile::build(StyleContext& _ctx, const Scene& _scene, const TileData& _data,
 
     DrawRuleMergeSet ruleSet;
 
-    for (const auto& datalayer : layers) {
+    for (const auto& datalayer : _ctx.sceneLayers()) {
 
         if (datalayer.source() != _source.name()) { continue; }
 
-        for (const auto& collection : _data.layers) {
+        for (const auto& collection : _tileData.layers) {
 
             if (!collection.name.empty()) {
                 const auto& dlc = datalayer.collections();

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -3,6 +3,7 @@
 #include "glm/mat4x4.hpp"
 #include "glm/vec2.hpp"
 #include "tileID.h"
+#include "util/fastmap.h"
 
 #include <map>
 #include <memory>
@@ -193,7 +194,9 @@ private:
     // Distances from the global origin are too large to represent precisely in 32-bit floats, so we only apply the
     // relative translation from the view origin to the model origin immediately before drawing the tile.
 
-    std::vector<std::unique_ptr<VboMesh>> m_geometry; // Map of <Style>s and their associated <VboMesh>es
+    // Map of <Style>s and their associated <VboMesh>es
+    fastmap<std::string, std::unique_ptr<VboMesh>> m_geometry;
+    //std::vector<std::unique_ptr<VboMesh>> m_geometry;
 
     mutable size_t m_memoryUsage = 0;
 };

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -17,7 +17,6 @@ class DataSource;
 class MapProjection;
 class Scene;
 class Style;
-class TextBuffer;
 class VboMesh;
 class View;
 class StyleContext;

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -70,7 +70,7 @@ public:
     /* Draws the geometry associated with the provided <Style> and view-projection matrix */
     void draw(const Style& _style, const View& _view);
 
-    void build(StyleContext& _ctx, const Scene& _scene, const TileData& _data, const DataSource& _source);
+    void build(StyleContext& _ctx, const TileData& _data, const DataSource& _source);
 
     void reset();
 

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -87,6 +87,7 @@ void TileManager::setScene(std::shared_ptr<Scene> _scene) {
         }
     }
 
+    m_workers->setScene(*_scene);
     m_scene = _scene;
 }
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -42,8 +42,6 @@ public:
     /* Sets the scene which the TileManager will use to style tiles */
     void setScene(std::shared_ptr<Scene> _scene);
 
-    std::shared_ptr<Scene>& getScene() { return m_scene; }
-
     /* Updates visible tile set if necessary
      *
      * Contacts the <ViewModule> to determine whether the set of visible tiles

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -10,33 +10,42 @@ namespace Tangram {
 
 class TileManager;
 class DataSource;
+class StyleContext;
+class Scene;
 class Tile;
 class TileTask;
 class View;
 
 class TileWorker {
-    
+
 public:
-    
+
     TileWorker(TileManager& _tileManager, int _num_worker);
 
     ~TileWorker();
-    
+
     void enqueue(std::shared_ptr<TileTask>&& task);
-    
+
     void stop();
-    
+
     bool isRunning() const { return m_running; }
-    
+
+    void setScene(const Scene& _scene);
+
 private:
 
-    void run();
-    
+    struct Worker {
+        std::thread thread;
+        std::unique_ptr<StyleContext> styleContext;
+    };
+
+    void run(Worker* instance);
+
     TileManager& m_tileManager;
-    
+
     bool m_running;
-    
-    std::vector<std::thread> m_workers;
+
+    std::vector<std::unique_ptr<Worker>> m_workers;
     std::condition_variable m_condition;
 
     std::mutex m_mutex;

--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -5,8 +5,6 @@
 #include "platform.h"
 #include <memory>
 
-#include "earcut.hpp/include/earcut.hpp"
-
 namespace mapbox { namespace util {
 template <>
 struct nth<0, Tangram::Point> {
@@ -34,17 +32,15 @@ JoinTypes JoinTypeFromString(const std::string& str) {
 
 void Builders::buildPolygon(const Polygon& _polygon, float _height, PolygonBuilder& _ctx) {
 
-    mapbox::Earcut<float, uint16_t> earcut;
-
-    earcut(_polygon);
+    _ctx.earcut(_polygon);
 
     uint16_t vertexDataOffset = _ctx.numVertices;
 
     if (vertexDataOffset == 0) {
-        _ctx.indices = std::move(earcut.indices);
+        _ctx.indices = std::move(_ctx.earcut.indices);
     } else {
-        _ctx.indices.reserve(_ctx.indices.size() +  earcut.indices.size());
-        for (auto i : earcut.indices) {
+        _ctx.indices.reserve(_ctx.indices.size() +  _ctx.earcut.indices.size());
+        for (auto i : _ctx.earcut.indices) {
             _ctx.indices.push_back(vertexDataOffset + i);
         }
     }
@@ -66,10 +62,10 @@ void Builders::buildPolygon(const Polygon& _polygon, float _height, PolygonBuild
     // call the tesselator
     glm::vec3 normal(0.0, 0.0, 1.0);
 
-    _ctx.numVertices += earcut.vertices.size();
+    _ctx.numVertices += _ctx.earcut.vertices.size();
     _ctx.sizeHint(_ctx.numVertices);
 
-    for (auto& p : earcut.vertices) {
+    for (auto& p : _ctx.earcut.vertices) {
         glm::vec3 coord(p[0], p[1], _height);
 
         if (_ctx.useTexCoords) {
@@ -97,6 +93,8 @@ void Builders::buildPolygonExtrusion(const Polygon& _polygon, float _minHeight, 
         size_t lineSize = line.size();
         sumIndices += lineSize * 6;
         sumVertices += (lineSize - 1) * 4;
+
+        _ctx.numVertices = sumVertices;
     }
 
     _ctx.indices.reserve(sumIndices);

--- a/core/src/util/builders.h
+++ b/core/src/util/builders.h
@@ -5,6 +5,8 @@
 #include <functional>
 #include <vector>
 
+#include "earcut.hpp/include/earcut.hpp"
+
 namespace Tangram {
 
 enum class CapTypes {
@@ -43,8 +45,15 @@ struct PolygonBuilder {
     size_t numVertices = 0;
     bool useTexCoords;
 
+    mapbox::Earcut<float, uint16_t> earcut;
+
     PolygonBuilder(PolygonVertexFn _addVertex, SizeHintFn _sizeHint, bool _useTexCoords = true)
         : addVertex(_addVertex), sizeHint(_sizeHint), useTexCoords(_useTexCoords){}
+
+    void clear() {
+        numVertices = 0;
+        indices.clear();
+    }
 };
 
 
@@ -69,6 +78,11 @@ struct PolyLineBuilder {
 
     PolyLineBuilder(PolyLineVertexFn _addVertex, SizeHintFn _sizeHint, CapTypes _cap = CapTypes::butt, JoinTypes _join = JoinTypes::bevel)
         : addVertex(_addVertex), sizeHint(_sizeHint), cap(_cap), join(_join) {}
+
+    void clear() {
+        numVertices = 0;
+        indices.clear();
+    }
 };
 
 /* Callback function for SpriteBuilder

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -232,7 +232,7 @@ TEST_CASE( "Test evalFilter - Init filter function from yaml", "[Duktape][evalFi
     REQUIRE(filter1.data.is<Filter::Function>());
 
     StyleContext ctx;
-    ctx.initFunctions(scene);
+    ctx.setScene(scene);
 
     Feature feat1;
     feat1.props.add("sort_key", 2);
@@ -280,7 +280,7 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
     // }
 
     StyleContext ctx;
-    ctx.initFunctions(scene);
+    ctx.setScene(scene);
 
     for (auto& style : styles) {
         //logMsg("S: %d - '%s' %d\n", style.key, style.toString().c_str(), style.function);

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -10,7 +10,7 @@
 using namespace Tangram;
 
 glm::vec2 screenSize(500.f, 500.f);
-TextBuffer dummy(nullptr);
+LabelMesh dummy(nullptr, 0);
 
 TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
     Label::Options options;

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -13,7 +13,7 @@
 namespace Tangram {
 
 glm::vec2 screenSize(256.f, 256.f);
-TextBuffer dummy(nullptr);
+LabelMesh dummy(nullptr, 0);
 
 std::unique_ptr<TextLabel> makeLabel(Label::Transform _transform, Label::Type _type, std::string id) {
     Label::Options options;


### PR DESCRIPTION
- Reuse the temporary vertex buffers used by StyleBuilders
- Instead of allocating small temp buffer for each feature reuse two large temp buffers for all vertices and indices  
- Directly create compiled vbo arrays from StyleBuilder buffers

TextBuffer:
- Create only one styled instance per feature and then copy this instance for each line label position (TextBuffer::addLabel moved to TextStyle::Builder::prepareLabel/addLabel)

   