### PR TITLE
two-pass label shader

### DIFF
--- a/core/resources/shaders/point.vs
+++ b/core/resources/shaders/point.vs
@@ -86,7 +86,7 @@ void main() {
 
         #ifdef TANGRAM_TEXT
 
-        if (u_pass == 1) {
+        if (u_pass == 0) {
           // fill
           v_sdf_threshold = 0.5;
         } else {

--- a/core/resources/shaders/point.vs
+++ b/core/resources/shaders/point.vs
@@ -18,6 +18,7 @@ uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
 #ifdef TANGRAM_TEXT
 uniform vec2 u_uv_scale_factor;
+uniform int u_pass;
 #endif
 
 #pragma tangram: uniforms
@@ -37,8 +38,7 @@ attribute vec3 a_extrude;
 varying vec4 v_color;
 varying vec2 v_texcoords;
 #ifdef TANGRAM_TEXT
-varying vec4 v_strokeColor;
-varying float v_strokeWidth;
+varying float v_sdf_threshold;
 #endif
 varying float v_alpha;
 const vec4 clipped = vec4(2.0, 0.0, 2.0, 1.0);
@@ -85,11 +85,17 @@ void main() {
         gl_Position = u_ortho * position;
 
         #ifdef TANGRAM_TEXT
-        v_strokeWidth = a_stroke.a;
 
-        // If width of stroke is zero, set the stroke color to the fill color -
-        // the border pixel of the fill is always slightly mixed with the stroke color
-        v_strokeColor.rgb = (v_strokeWidth > TANGRAM_EPSILON) ? a_stroke.rgb : a_color.rgb;
+        if (u_pass == 1) {
+          // fill
+          v_sdf_threshold = 0.5;
+        } else {
+          // stroke
+          float stroke_width = a_stroke.a;
+          v_sdf_threshold = 0.5 - stroke_width * u_device_pixel_ratio;
+          v_color.rgb = a_stroke.rgb;
+        }
+
         #endif
     } else {
         gl_Position = clipped;

--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -26,6 +26,7 @@ uniform vec2 u_resolution;
 uniform float u_time;
 uniform float u_meters_per_pixel;
 uniform float u_device_pixel_ratio;
+uniform int u_pass;
 
 #pragma tangram: uniforms
 
@@ -68,16 +69,20 @@ float sampleAlpha(in vec2 uv, float distance, float threshold) {
 
 void main(void) {
 
-    float threshold_fill = 0.5;
-    float threshold_stroke = threshold_fill - v_strokeWidth * u_device_pixel_ratio;
-
     float distance = texture2D(u_tex, v_texcoords).a;
+    vec4 color;
 
-    float alpha_fill = pow(sampleAlpha(v_texcoords, distance, threshold_fill), 0.4545);
-    float alpha_stroke = pow(sampleAlpha(v_texcoords, distance, threshold_stroke), 0.4545);
-
-    vec4 color = mix(v_strokeColor, v_color, alpha_fill);
-    color.a = max(alpha_fill, alpha_stroke) * v_alpha * v_color.a;
+    if (u_pass == 1) {
+        float threshold_fill = 0.5;
+        float alpha_fill = pow(sampleAlpha(v_texcoords, distance, threshold_fill), 0.4545);
+        color = v_color;
+        color.a *= alpha_fill * v_alpha;
+    } else {
+        float threshold_stroke = 0.5 - v_strokeWidth * u_device_pixel_ratio;
+        float alpha_stroke = pow(sampleAlpha(v_texcoords, distance, threshold_stroke), 0.4545);
+        color = v_strokeColor;
+        color.a = alpha_stroke * v_alpha * v_color.a;
+    }
 
     #pragma tangram: color
     #pragma tangram: filter

--- a/core/resources/shaders/sdf.fs
+++ b/core/resources/shaders/sdf.fs
@@ -31,9 +31,8 @@ uniform int u_pass;
 #pragma tangram: uniforms
 
 varying vec4 v_color;
-varying vec4 v_strokeColor;
 varying vec2 v_texcoords;
-varying float v_strokeWidth;
+varying float v_sdf_threshold;
 varying float v_alpha;
 
 #pragma tangram: global
@@ -69,20 +68,11 @@ float sampleAlpha(in vec2 uv, float distance, float threshold) {
 
 void main(void) {
 
-    float distance = texture2D(u_tex, v_texcoords).a;
-    vec4 color;
+    vec4 color = v_color;
 
-    if (u_pass == 1) {
-        float threshold_fill = 0.5;
-        float alpha_fill = pow(sampleAlpha(v_texcoords, distance, threshold_fill), 0.4545);
-        color = v_color;
-        color.a *= alpha_fill * v_alpha;
-    } else {
-        float threshold_stroke = 0.5 - v_strokeWidth * u_device_pixel_ratio;
-        float alpha_stroke = pow(sampleAlpha(v_texcoords, distance, threshold_stroke), 0.4545);
-        color = v_strokeColor;
-        color.a = alpha_stroke * v_alpha * v_color.a;
-    }
+    float distance = texture2D(u_tex, v_texcoords).a;
+
+    color.a *= v_alpha * pow(sampleAlpha(v_texcoords, distance, v_sdf_threshold), 0.4545);
 
     #pragma tangram: color
     #pragma tangram: filter

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -3,6 +3,7 @@
 #include "labels/textLabel.h"
 #include "gl/texture.h"
 #include "gl/vboMesh.h"
+#include "gl/shaderProgram.h"
 
 #include <limits>
 
@@ -262,6 +263,15 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
     m_nVertices = vertices.size();
 
     return true;
+}
+
+void TextBuffer::draw(ShaderProgram& _shader) {
+
+    _shader.setUniformi("u_pass", 0);
+    LabelMesh::draw(_shader);
+
+    _shader.setUniformi("u_pass", 1);
+    LabelMesh::draw(_shader);
 }
 
 }

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -270,11 +270,11 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
 void TextBuffer::draw(ShaderProgram& _shader) {
 
     if (m_strokePass) {
-        _shader.setUniformi("u_pass", 0);
+        _shader.setUniformi("u_pass", 1);
         LabelMesh::draw(_shader);
+        _shader.setUniformi("u_pass", 0);
     }
 
-    _shader.setUniformi("u_pass", 1);
     LabelMesh::draw(_shader);
 }
 

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -174,6 +174,8 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
         return false;
     }
 
+    if (_params.strokeWidth > 0.f) { m_strokePass = true; }
+
     /// Apply text transforms
     const std::string* renderText;
     std::string text;
@@ -267,8 +269,10 @@ bool TextBuffer::addLabel(const TextStyle::Parameters& _params, Label::Transform
 
 void TextBuffer::draw(ShaderProgram& _shader) {
 
-    _shader.setUniformi("u_pass", 0);
-    LabelMesh::draw(_shader);
+    if (m_strokePass) {
+        _shader.setUniformi("u_pass", 0);
+        LabelMesh::draw(_shader);
+    }
 
     _shader.setUniformi("u_pass", 1);
     LabelMesh::draw(_shader);

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -34,6 +34,8 @@ public:
 
     static std::vector<WordBreak> findWords(const std::string& _text);
 
+    virtual void draw(ShaderProgram& _shader) override;
+
 private:
     static int applyWordWrapping(std::vector<FONSquad>& _quads, const TextStyle::Parameters& _params,
                                  const FontContext::FontMetrics& _metrics, Label::Type _type,

--- a/core/src/text/textBuffer.h
+++ b/core/src/text/textBuffer.h
@@ -43,6 +43,7 @@ private:
 
     static std::string applyTextTransform(const TextStyle::Parameters& _params, const std::string& _string);
 
+    bool m_strokePass = false;
 };
 
 }


### PR DESCRIPTION
Draw fill and stroke in separate passes to prevent drawing strokes over other glyphs fill.

Should resolve issue https://github.com/tangrams/tangram-es/issues/460