### PR TITLE
Transfer view parameters to new view when new scene is loaded

### DIFF
--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -102,7 +102,12 @@ void loadScene(const char* _scenePath, bool _setPositionFromScene) {
             m_scene->view()->setPosition(m_view->getPosition());
             m_scene->view()->setZoom(m_view->getZoom());
         }
+        auto w = m_view->getWidth();
+        auto h = m_view->getHeight();
+        auto s = m_view->pixelScale();
         m_view = m_scene->view();
+        setPixelScale(s);
+        resize(w, h);
         m_inputHandler->setView(m_view);
         m_tileManager->setView(m_view);
         m_tileManager->setScene(scene);


### PR DESCRIPTION
Loading a new scene file creates a new `View` object, but parameters like width, height, and pixel scale that have been set in the previous `View` are not correctly applied to the new `View` in the current implementation. This can result in a distorted or re-scaled view when the new scene file is loaded. 
