### PR TITLE
Fix accidental gl call during initialization

### DIFF
--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -95,6 +95,9 @@ void loadScene(const char* _scenePath, bool _setPositionFromScene) {
     bool setPositionFromCurrentView = bool(m_scene);
 
     auto scene = std::make_shared<Scene>();
+    if (m_view) {
+        scene->view() = std::make_shared<View>(*m_view);
+    }
     if (SceneLoader::loadScene(sceneString, *scene)) {
         m_scene = scene;
         m_scene->fontContext()->addFont("firasans", "medium", "");
@@ -102,15 +105,11 @@ void loadScene(const char* _scenePath, bool _setPositionFromScene) {
             m_scene->view()->setPosition(m_view->getPosition());
             m_scene->view()->setZoom(m_view->getZoom());
         }
-        auto w = m_view->getWidth();
-        auto h = m_view->getHeight();
-        auto s = m_view->pixelScale();
         m_view = m_scene->view();
-        setPixelScale(s);
-        resize(w, h);
         m_inputHandler->setView(m_view);
         m_tileManager->setView(m_view);
         m_tileManager->setScene(scene);
+        setPixelScale(m_view->pixelScale());
 
     }
 }

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -32,6 +32,8 @@ public:
 
     View(int _width = 800, int _height = 600, ProjectionType _projType = ProjectionType::mercator);
 
+    View(const View& _view) = default;
+
     /* Sets a new map projection with default tileSize */
     void setMapProjection(ProjectionType _projType);
 
@@ -151,7 +153,7 @@ protected:
      */
     bool checkMapBound();
 
-    std::unique_ptr<MapProjection> m_projection;
+    std::shared_ptr<MapProjection> m_projection;
     std::set<TileID> m_visibleTiles;
 
     glm::dvec3 m_pos;


### PR DESCRIPTION
Frankly I'm not sure how the desktop client continued to work for a full day after I introduced this bug. 

¯\\(ツ)/¯