### PR TITLE
Data sources can set maximum zoom for tile requests

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -64,6 +64,7 @@ sources:
     osm:
         type: MVT
         url:  https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt
+        max_zoom: 16
 
 layers:
     touch:

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -16,8 +16,6 @@ using namespace mapbox::util;
 namespace Tangram {
 
 const double extent = 4096;
-const uint8_t maxZoom = (uint8_t)View::s_maxZoom;
-const uint8_t indexMaxZoom = maxZoom;
 const uint32_t indexMaxPoints = 100000;
 double tolerance = 1E-8;
 
@@ -30,8 +28,8 @@ Point transformPoint(geojsonvt::TilePoint pt) {
     return { pt.x / extent, 1. - pt.y / extent, 0 };
 }
 
-ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url)
-    : DataSource(_name, _url) {
+ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom)
+    : DataSource(_name, _url, _maxZoom) {
 
     if (!_url.empty()) {
         // Load from file
@@ -47,7 +45,7 @@ void ClientGeoJsonSource::addData(const std::string& _data) {
     m_features = geojsonvt::GeoJSONVT::convertFeatures(_data);
 
     std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store = std::make_unique<GeoJSONVT>(m_features, maxZoom, indexMaxZoom, indexMaxPoints, tolerance);
+    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
 
 }
 
@@ -80,7 +78,7 @@ void ClientGeoJsonSource::addPoint(const Properties& _tags, LngLat _point) {
     m_features.push_back(std::move(feature));
 
     std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store = std::make_unique<GeoJSONVT>(m_features, maxZoom, indexMaxZoom, indexMaxPoints, tolerance);
+    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
     m_generation++;
 }
 
@@ -96,7 +94,7 @@ void ClientGeoJsonSource::addLine(const Properties& _tags, const Coordinates& _l
     m_features.push_back(std::move(feature));
 
     std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store = std::make_unique<GeoJSONVT>(m_features, maxZoom, indexMaxZoom, indexMaxPoints, tolerance);
+    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
     m_generation++;
 }
 
@@ -115,7 +113,7 @@ void ClientGeoJsonSource::addPoly(const Properties& _tags, const std::vector<Coo
     m_features.push_back(std::move(feature));
 
     std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store = std::make_unique<GeoJSONVT>(m_features, maxZoom, indexMaxZoom, indexMaxPoints, tolerance);
+    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
     m_generation++;
 }
 

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -23,7 +23,7 @@ class ClientGeoJsonSource : public DataSource {
 
 public:
 
-    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom = 20);
+    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -23,7 +23,7 @@ class ClientGeoJsonSource : public DataSource {
 
 public:
 
-    ClientGeoJsonSource(const std::string& _name, const std::string& _url);
+    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom = 20);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -86,8 +86,8 @@ struct RawCache {
 
 static std::atomic<int32_t> s_serial;
 
-DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate) :
-    m_name(_name), m_urlTemplate(_urlTemplate),
+DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom) :
+    m_name(_name), m_maxZoom(_maxZoom), m_urlTemplate(_urlTemplate),
     m_cache(std::make_unique<RawCache>()){
 
     m_id = s_serial++;

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -114,6 +114,20 @@ void DataSource::clearData() {
     m_generation++;
 }
 
+TileID DataSource::remapTileID(TileID _id) const {
+
+    if (_id.z <= m_maxZoom) {
+        return _id;
+    }
+
+    int32_t over = _id.z - m_maxZoom;
+    int32_t x = _id.x >> over;
+    int32_t y = _id.y >> over;
+
+    return TileID(x, y, m_maxZoom, _id.z, _id.wrap);
+
+}
+
 void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const {
     _url.assign(m_urlTemplate);
     try {

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -114,20 +114,6 @@ void DataSource::clearData() {
     m_generation++;
 }
 
-TileID DataSource::remapTileID(TileID _id) const {
-
-    if (_id.z <= m_maxZoom) {
-        return _id;
-    }
-
-    int32_t over = _id.z - m_maxZoom;
-    int32_t x = _id.x >> over;
-    int32_t y = _id.y >> over;
-
-    return TileID(x, y, m_maxZoom, _id.z, _id.wrap);
-
-}
-
 void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const {
     _url.assign(m_urlTemplate);
     try {

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -25,7 +25,7 @@ public:
      * each of '{x}', '{y}', and '{z}' which will be replaced by the x index, y index,
      * and zoom level of tiles to produce their URL.
      */
-    DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom = 20);
+    DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom = 18);
 
     virtual ~DataSource();
 

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -25,7 +25,7 @@ public:
      * each of '{x}', '{y}', and '{z}' which will be replaced by the x index, y index,
      * and zoom level of tiles to produce their URL.
      */
-    DataSource(const std::string& _name, const std::string& _urlTemplate);
+    DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom = 20);
 
     virtual ~DataSource();
 
@@ -82,6 +82,9 @@ protected:
 
     // Name used to identify this source in the style sheet
     std::string m_name;
+
+    // Maximum zoom for which tiles will be requested
+    int32_t m_maxZoom;
 
     // Unique id for DataSource
     int32_t m_id;

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -69,8 +69,6 @@ public:
 
     int32_t maxZoom() const { return m_maxZoom; }
 
-    TileID remapTileID(TileID _id) const;
-
 protected:
 
     void onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<TileTask>& _task, TileTaskCb _cb);

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -67,6 +67,10 @@ public:
     /* Generation ID of DataSource state (incremented for each update, e.g. on clearData()) */
     int64_t generation() const { return m_generation; }
 
+    int32_t maxZoom() const { return m_maxZoom; }
+
+    TileID remapTileID(TileID _id) const;
+
 protected:
 
     void onTileLoaded(std::vector<char>&& _rawData, std::shared_ptr<TileTask>& _task, TileTaskCb _cb);

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -15,8 +15,8 @@
 
 namespace Tangram {
 
-GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate) :
-    DataSource(_name, _urlTemplate) {
+GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _maxZoom) {
 }
 
 std::shared_ptr<TileData> GeoJsonSource::parse(const TileTask& _task,

--- a/core/src/data/geoJsonSource.h
+++ b/core/src/data/geoJsonSource.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate);
+    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom);
 
 };
 

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -13,8 +13,8 @@
 namespace Tangram {
 
 
-MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate) :
-    DataSource(_name, _urlTemplate) {
+MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _maxZoom) {
 }
 
 std::shared_ptr<TileData> MVTSource::parse(const TileTask& _task, const MapProjection& _projection) const {

--- a/core/src/data/mvtSource.h
+++ b/core/src/data/mvtSource.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    MVTSource(const std::string& _name, const std::string& _urlTemplate);
+    MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom);
 
 };
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -806,7 +806,7 @@ void SceneLoader::loadSource(const std::pair<Node, Node>& src, Scene& _scene) {
     std::string name = src.first.as<std::string>();
     std::string type = source["type"].as<std::string>();
     std::string url = source["url"].as<std::string>();
-    int32_t maxZoom = std::numeric_limits<int32_t>::max();
+    int32_t maxZoom = 18;
 
     if (auto maxZoomNode = source["max_zoom"]) {
         maxZoom = maxZoomNode.as<int32_t>(maxZoom);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -806,6 +806,11 @@ void SceneLoader::loadSource(const std::pair<Node, Node>& src, Scene& _scene) {
     std::string name = src.first.as<std::string>();
     std::string type = source["type"].as<std::string>();
     std::string url = source["url"].as<std::string>();
+    int32_t maxZoom = std::numeric_limits<int32_t>::max();
+
+    if (auto maxZoomNode = source["max_zoom"]) {
+        maxZoom = maxZoomNode.as<int32_t>(maxZoom);
+    }
 
     // distinguish tiled and non-tiled sources by url
     bool tiled = url.find("{x}") != std::string::npos &&
@@ -816,14 +821,14 @@ void SceneLoader::loadSource(const std::pair<Node, Node>& src, Scene& _scene) {
 
     if (type == "GeoJSON") {
         if (tiled) {
-            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url));
+            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url, maxZoom));
         } else {
-            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url));
+            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, maxZoom));
         }
     } else if (type == "TopoJSON") {
         LOGW("TopoJSON data sources not yet implemented"); // TODO
     } else if (type == "MVT") {
-        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url));
+        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url, maxZoom));
     } else {
         LOGW("Unrecognized data source type '%s', skipping", type.c_str());
     }

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -66,7 +66,7 @@ void Tile::build(StyleContext& _ctx, const Scene& _scene, const TileData& _data,
 
     const auto& layers = _scene.layers();
 
-    _ctx.setGlobalZoom(m_id.z);
+    _ctx.setGlobalZoom(m_id.s);
 
     for (auto& style : _scene.styles()) {
         style->onBeginBuildTile(*this);

--- a/core/src/tile/tileID.h
+++ b/core/src/tile/tileID.h
@@ -21,7 +21,9 @@ struct TileID {
     int32_t s; // Styling zoom
     int32_t wrap;
 
-    TileID(int32_t _x, int32_t _y, int32_t _z, int32_t _s, int32_t _wrap = 0) : x(_x), y(_y), z(_z), s(_s), wrap(_wrap) {}
+    TileID(int32_t _x, int32_t _y, int32_t _z, int32_t _s, int32_t _wrap) : x(_x), y(_y), z(_z), s(_s), wrap(_wrap) {}
+
+    TileID(int32_t _x, int32_t _y, int32_t _z) : TileID(_x, _y, _z, _z, 0) {}
 
     TileID(const TileID& _rhs) = default;
 

--- a/core/src/tile/tileID.h
+++ b/core/src/tile/tileID.h
@@ -17,9 +17,9 @@ struct TileID {
 
     int32_t x; // Index from left edge of projection space
     int32_t y; // Index from top edge of projection space
-    int32_t z; // Data zoom
-    int32_t s; // Styling zoom
-    int32_t wrap;
+    int8_t  z; // Data zoom
+    int8_t  s; // Styling zoom
+    int16_t wrap;
 
     TileID(int32_t _x, int32_t _y, int32_t _z, int32_t _s, int32_t _wrap) : x(_x), y(_y), z(_z), s(_s), wrap(_wrap) {}
 

--- a/core/src/tile/tileID.h
+++ b/core/src/tile/tileID.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 /* An immutable identifier for a map tile
@@ -14,23 +15,23 @@ namespace Tangram {
 
 struct TileID {
 
-    const int x;
-    const int y;
-    const int z;
-    const int wrap;
+    int32_t x; // Index from left edge of projection space
+    int32_t y; // Index from top edge of projection space
+    int32_t z; // Data zoom
+    int32_t s; // Styling zoom
+    int32_t wrap;
 
-    TileID(int _x, int _y, int _z, int _wrap = 0) : x(_x), y(_y), z(_z), wrap(_wrap) {};
-    TileID(const TileID& _rhs): x(_rhs.x), y(_rhs.y), z(_rhs.z), wrap(_rhs.wrap) {};
+    TileID(int32_t _x, int32_t _y, int32_t _z, int32_t _s, int32_t _wrap = 0) : x(_x), y(_y), z(_z), s(_s), wrap(_wrap) {}
+
+    TileID(const TileID& _rhs) = default;
 
     bool operator< (const TileID& _rhs) const {
-        return z > _rhs.z || (z == _rhs.z && (x < _rhs.x || (x == _rhs.x && (y < _rhs.y || (y == _rhs.y && wrap < _rhs.wrap)))));
+        return s > _rhs.s || (s == _rhs.s && (z > _rhs.z || (z == _rhs.z && (x < _rhs.x || (x == _rhs.x && (y < _rhs.y || (y == _rhs.y && wrap < _rhs.wrap)))))));
     }
     bool operator> (const TileID& _rhs) const { return _rhs < const_cast<TileID&>(*this); }
     bool operator<=(const TileID& _rhs) const { return !(*this > _rhs); }
     bool operator>=(const TileID& _rhs) const { return !(*this < _rhs); }
-    bool operator==(const TileID& _rhs) const { return x == _rhs.x && y == _rhs.y && z == _rhs.z && wrap == _rhs.wrap; }
-
-    TileID& operator=(const TileID& _rhs) = delete;
+    bool operator==(const TileID& _rhs) const { return x == _rhs.x && y == _rhs.y && z == _rhs.z && s == _rhs.s && wrap == _rhs.wrap; }
 
     bool isValid() const {
         int max = 1 << z;
@@ -42,13 +43,13 @@ struct TileID {
     }
 
     TileID getParent() const {
-        return TileID(x >> 1, y >> 1, z-1, wrap);
+        return TileID(x >> 1, y >> 1, z-1, z-1, wrap);
     }
 
     TileID getChild(int _index) const {
 
         if (_index > 3 || _index < 0) {
-            return TileID(-1, -1, -1, -1);
+            return TileID(-1, -1, -1, -1, -1);
         }
 
         int i = _index / 2;
@@ -58,7 +59,7 @@ struct TileID {
         // i:      0, 0, 1, 1
         // j:      0, 1, 0, 1
 
-        return TileID((x<<1)+i, (y<<1)+j, z+1, wrap);
+        return TileID((x<<1)+i, (y<<1)+j, z+1, z+1, wrap);
     }
 
     std::string toString() const {
@@ -67,6 +68,6 @@ struct TileID {
 
 };
 
-static TileID NOT_A_TILE(-1, -1, -1, -1);
+static const TileID NOT_A_TILE(-1, -1, -1, -1, -1);
 
 }

--- a/core/src/tile/tileID.h
+++ b/core/src/tile/tileID.h
@@ -44,11 +44,27 @@ struct TileID {
         return isValid() && z <= _maxZoom;
     }
 
+    TileID withMaxSourceZoom(int32_t _max) const {
+
+        if (z <= _max) {
+            return *this;
+        }
+
+        int32_t over = z - _max;
+
+        return TileID(x >> over, y >> over, _max, z, wrap);
+    }
+
     TileID getParent() const {
+
+        if (s > z) {
+            // Over-zoomed, keep the same data coordinates
+            return TileID(x, y, z, s - 1, wrap);
+        }
         return TileID(x >> 1, y >> 1, z-1, z-1, wrap);
     }
 
-    TileID getChild(int _index) const {
+    TileID getChild(int32_t _index) const {
 
         if (_index > 3 || _index < 0) {
             return TileID(-1, -1, -1, -1, -1);
@@ -62,6 +78,10 @@ struct TileID {
         // j:      0, 1, 0, 1
 
         return TileID((x<<1)+i, (y<<1)+j, z+1, z+1, wrap);
+    }
+
+    TileID getChild(int32_t _index, int32_t _maxSourceZoom) const {
+        return getChild(_index).withMaxSourceZoom(_maxSourceZoom);
     }
 
     std::string toString() const {

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -472,7 +472,7 @@ void TileManager::updateProxyTiles(TileSet& _tileSet, const TileID& _tileID, Til
         return;
     }
     // Try children
-    if (m_view->s_maxZoom > _tileID.z) {
+    if (_tileSet.source->maxZoom() > _tileID.z) {
         for (int i = 0; i < 4; i++) {
             auto childID = _tileID.getChild(i, _tileSet.source->maxZoom());
             updateProxyTile(_tileSet, _tile, childID, static_cast<ProxyID>(1 << i));

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -157,9 +157,14 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
 
     auto& tiles = _tileSet.tiles;
 
-    std::set<TileID> visibleTiles;
-    for (auto& t : m_view->getVisibleTiles()) {
-        visibleTiles.insert(t.withMaxSourceZoom(_tileSet.source->maxZoom()));
+    const auto* visibleTiles = &m_view->getVisibleTiles();
+
+    std::set<TileID> mappedTiles;
+    if (m_view->getZoom() > _tileSet.source->maxZoom()) {
+        for (const auto& id : *visibleTiles) {
+            mappedTiles.insert(id.withMaxSourceZoom(_tileSet.source->maxZoom()));
+        }
+        visibleTiles = &mappedTiles;
     }
 
     if (m_tileSetChanged) {
@@ -175,11 +180,11 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
 
     // Loop over visibleTiles and add any needed tiles to tileSet
     auto curTilesIt = tiles.begin();
-    auto visTilesIt = visibleTiles.begin();
+    auto visTilesIt = visibleTiles->begin();
 
-    while (visTilesIt != visibleTiles.end() || curTilesIt != tiles.end()) {
+    while (visTilesIt != visibleTiles->end() || curTilesIt != tiles.end()) {
 
-        auto& visTileId = visTilesIt == visibleTiles.end()
+        auto& visTileId = visTilesIt == visibleTiles->end()
             ? NOT_A_TILE
             : *visTilesIt;
 

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -156,7 +156,11 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
     int maxZoom = m_view->getZoom() + 2;
 
     auto& tiles = _tileSet.tiles;
-    auto& visibleTiles = m_view->getVisibleTiles();
+
+    std::set<TileID> visibleTiles;
+    for (auto& t : m_view->getVisibleTiles()) {
+        visibleTiles.emplace(_tileSet.source->remapTileID(t));
+    }
 
     if (m_tileSetChanged) {
         for (auto& it : tiles) {
@@ -319,14 +323,14 @@ void TileManager::enqueueTask(TileSet& _tileSet, const TileID& _tileID,
                                    return distance < std::get<0>(other);
                                });
 
-    m_loadTasks.insert(it, std::make_tuple(distance, &_tileSet, &_tileID));
+    m_loadTasks.insert(it, std::make_tuple(distance, &_tileSet, _tileID));
 }
 
 void TileManager::loadTiles() {
 
     for (auto& loadTask : m_loadTasks) {
 
-        auto tileId = *std::get<2>(loadTask);
+        auto tileId = std::get<2>(loadTask);
         auto& tileSet = *std::get<1>(loadTask);
         auto tileIt = tileSet.tiles.find(tileId);
         auto& entry = tileIt->second;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -159,7 +159,7 @@ void TileManager::updateTileSet(TileSet& _tileSet) {
 
     std::set<TileID> visibleTiles;
     for (auto& t : m_view->getVisibleTiles()) {
-        visibleTiles.emplace(_tileSet.source->remapTileID(t));
+        visibleTiles.insert(t.withMaxSourceZoom(_tileSet.source->maxZoom()));
     }
 
     if (m_tileSetChanged) {
@@ -474,7 +474,8 @@ void TileManager::updateProxyTiles(TileSet& _tileSet, const TileID& _tileID, Til
     // Try children
     if (m_view->s_maxZoom > _tileID.z) {
         for (int i = 0; i < 4; i++) {
-            updateProxyTile(_tileSet, _tile, _tileID.getChild(i), static_cast<ProxyID>(1 << i));
+            auto childID = _tileID.getChild(i, _tileSet.source->maxZoom());
+            updateProxyTile(_tileSet, _tile, childID, static_cast<ProxyID>(1 << i));
         }
     }
 }

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -206,7 +206,7 @@ private:
     TileTaskCb m_dataCallback;
 
     /* Temporary list of tiles that need to be loaded */
-    std::vector<std::tuple<double, TileSet*, const TileID*>> m_loadTasks;
+    std::vector<std::tuple<double, TileSet*, TileID>> m_loadTasks;
 
 
 };

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -501,7 +501,7 @@ void View::updateTiles() {
         int wx = x & ((1 << z) - 1);
         int wrap = (x - wx) >> zoom;
 
-        m_visibleTiles.emplace(wx, y, z, wrap);
+        m_visibleTiles.emplace(wx, y, z, z, wrap);
 
     };
 

--- a/tests/unit/tileIDTests.cpp
+++ b/tests/unit/tileIDTests.cpp
@@ -76,3 +76,20 @@ TEST_CASE( "Ensure TileIDs correctly evaluate their validity", "[Core][TileID]")
     REQUIRE(!NOT_A_TILE.isValid());
 
 }
+
+TEST_CASE("TileID correctly applies source zoom limits", "[Core][TileID]") {
+
+    auto a = TileID(1, 2, 4);
+    REQUIRE(a.withMaxSourceZoom(4) == a);
+    REQUIRE(a.withMaxSourceZoom(3) == TileID(0, 1, 3, 4, 0));
+    REQUIRE(a.withMaxSourceZoom(2) == TileID(0, 0, 2, 4, 0));
+
+    auto b = TileID(2, 1, 4, 6, 0); // Over-zoomed to zoom 6 with a limit of 4
+    auto c = b.getParent();
+    auto d = c.getParent();
+    auto e = d.getParent();
+    REQUIRE(c == TileID(2, 1, 4, 5, 0));
+    REQUIRE(d == TileID(2, 1, 4, 4, 0));
+    REQUIRE(e == TileID(1, 0, 3, 3, 0));
+
+}


### PR DESCRIPTION
Beyond `max_zoom`, data from the highest available zoom is scaled up and re-styled for the current zoom level.