### PR TITLE
Filter optimization

### DIFF
--- a/core/src/data/properties.cpp
+++ b/core/src/data/properties.cpp
@@ -31,14 +31,22 @@ void Properties::setSorted(std::vector<Item>&& _items) {
 const Value& Properties::get(const std::string& key) const {
     const static Value NOT_FOUND(none_type{});
 
-    const auto it = std::lower_bound(props.begin(), props.end(), key,
-                                     [](const auto& item, const auto& key) {
-                                         return keyComparator(item.key, key);
-                                     });
-
-    if (it == props.end() || it->key != key) {
+    const auto it = std::find_if(props.begin(), props.end(),
+                                 [&](const auto& item) {
+                                     return item.key == key;
+                                 });
+    if (it == props.end()) {
         return NOT_FOUND;
     }
+
+    // auto it = std::lower_bound(props.begin(), props.end(), key,
+    //                            [](auto& item, auto& key) {
+    //                                return keyComparator(item.key, key);
+    //                            });
+    // if (it == props.end() || it->key != key) {
+    //     return NOT_FOUND;
+    // }
+
     return it->value;
 }
 

--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -1,10 +1,211 @@
 #include "filters.h"
 #include "scene/styleContext.h"
 #include "data/tileData.h"
+#include "platform.h"
 
 #include <cmath>
 
 namespace Tangram {
+
+void countTypes(const std::vector<Filter>& filters, int& global, int& function, int& property) {
+
+}
+
+void Filter::print(int _indent) const {
+
+    switch (data.get_type_index()) {
+
+    case Data::type<OperatorAny>::value: {
+        logMsg("%*s any\n", _indent, "");
+        for (const auto& filt : data.get<OperatorAny>().operands) {
+            filt.print(_indent + 2);
+        }
+        break;
+    }
+    case Data::type<OperatorAll>::value: {
+        logMsg("%*s all\n", _indent, "");
+        for (const auto& filt : data.get<OperatorAll>().operands) {
+            filt.print(_indent + 2);
+        }
+        break;
+    }
+    case Data::type<OperatorNone>::value: {
+        logMsg("%*s none\n", _indent, "");
+        for (const auto& filt : data.get<OperatorNone>().operands) {
+            filt.print(_indent + 2);
+        }
+        break;
+    }
+    case Data::type<Existence>::value: {
+        auto& f = data.get<Existence>();
+        logMsg("%*s existence - key:%s\n", _indent, "", f.key.c_str());
+        break;
+    }
+    case Data::type<Equality>::value: {
+        auto& f = data.get<Equality>();
+        if (f.values[0].is<std::string>()) {
+            logMsg("%*s equality - global:%d key:%s val:%s\n", _indent, "",
+                   f.global != FilterGlobal::undefined,
+                   f.key.c_str(),
+                   f.values[0].get<std::string>().c_str());
+        }
+        if (f.values[0].is<double>()) {
+            logMsg("%*s equality - global:%d key:%s val:%f\n", _indent, "",
+                   f.global != FilterGlobal::undefined,
+                   f.key.c_str(),
+                   f.values[0].get<double>());
+        }
+        break;
+    }
+    case Data::type<Range>::value: {
+        auto& f = data.get<Range>();
+        logMsg("%*s range - global:%d key:%s min:%f max:%f\n", _indent, "",
+               f.global != FilterGlobal::undefined,
+               f.key.c_str(), f.min, f.max);
+        return;
+    }
+    case Data::type<Function>::value: {
+        logMsg("%*s function\n", _indent, "");
+        break;
+    }
+    default:
+        break;
+    }
+
+}
+
+
+int Filter::matchCost() const {
+    // Add some extra penalty for set vs simple filters
+    int sum = -100;
+
+    switch (data.get_type_index()) {
+    case Data::type<OperatorAny>::value:
+        for (auto& f : operands()) { sum -= f.matchCost(); }
+        return sum;
+
+    case Data::type<OperatorAll>::value:
+        for (auto& f : operands()) { sum -= f.matchCost(); }
+        return sum;
+
+    case Data::type<OperatorNone>::value:
+        for (auto& f : operands()) { sum -= f.matchCost(); }
+        return sum;
+
+    case Data::type<Existence>::value:
+        // Equality and Range are more specific for increasing
+        // the chance to fail early check them before Existence
+        return 20;
+
+    case Data::type<Equality>::value:
+        return data.get<Equality>().global == FilterGlobal::undefined ? 10 : 1;
+
+    case Data::type<Filter::Range>::value:
+        return data.get<Range>().global == FilterGlobal::undefined ? 10 : 1;
+
+    case Data::type<Function>::value:
+        // Most expensive filter should be checked last
+        return 1000;
+    }
+    assert(false);
+    return 0;
+}
+
+const std::string& Filter::key() const {
+    static const std::string empty = "";
+
+    switch (data.get_type_index()) {
+
+    case Data::type<Existence>::value:
+        return data.get<Existence>().key;
+
+    case Data::type<Equality>::value:
+        return data.get<Equality>().key;
+
+    case Data::type<Filter::Range>::value:
+        return data.get<Range>().key;
+
+    default:
+        break;
+    }
+    return empty;
+}
+
+const std::vector<Filter>& Filter::operands() const {
+    static const std::vector<Filter> empty;
+
+    switch (data.get_type_index()) {
+    case Data::type<OperatorAny>::value:
+        return data.get<OperatorAny>().operands;
+
+    case Data::type<OperatorAll>::value:
+        return data.get<OperatorAll>().operands;
+
+    case Data::type<OperatorNone>::value:
+        return data.get<OperatorNone>().operands;
+
+    default:
+        break;
+    }
+    return empty;
+}
+
+int compareSetFilter(const Filter& a, const Filter& b) {
+    auto& oa = a.operands();
+    auto& ob = b.operands();
+
+    if (oa.size() != ob.size()) { return oa.size() < ob.size(); }
+
+    if (oa[0].data.is<Filter::Range>() &&
+        ob[0].data.is<Filter::Range>() &&
+        oa[0].key() == ob[0].key()) {
+        // take the one with more restrictive range
+        auto ra = oa[0].data.get<Filter::Range>();
+        auto rb = ob[0].data.get<Filter::Range>();
+
+        if (ra.max == std::numeric_limits<double>::infinity() &&
+            rb.max == std::numeric_limits<double>::infinity()) {
+
+            return rb.min - ra.min;
+        }
+    }
+
+    return 0;
+}
+
+std::vector<Filter> Filter::sort(const std::vector<Filter>& _filters) {
+    std::vector<Filter> filters = _filters;
+    std::sort(filters.begin(), filters.end(),
+              [](auto& a, auto& b) {
+
+                  // Sort simple filters by eval cost
+                  int ma = a.matchCost();
+                  int mb = b.matchCost();
+                  if (ma > 0 && mb > 0) {
+                      int diff = ma - mb;
+                      if (diff != 0) {
+                          return diff < 0;
+                      }
+
+                      // just for consistent ordering
+                      // (and using > to prefer $zoom over $geom)
+                      return a.key() > b.key();
+                  }
+
+                  // When one is a simple Filter and the other is a set
+                  // or both are sets prefer the one with the cheaper
+                  // filter(s).
+                  if (ma != mb) {
+                      // No abs(int) in our android libstdc..
+                      //return std::abs(ma) < std::abs(mb);
+                      return std::fabs(ma) < std::fabs(mb);
+                  }
+
+                  return compareSetFilter(a, b) < 0;
+              });
+
+    return filters;
+}
 
 bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
 
@@ -64,7 +265,7 @@ bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
         if (f.global == FilterGlobal::undefined) {
             auto& value = feat.props.get(f.key);
             if (value.is<double>()) {
-                auto num =  value.get<double>();
+                double num =  value.get<double>();
                 return num >= f.min && num < f.max;
             }
         } else {
@@ -72,7 +273,7 @@ bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
             if (!global.is<none_type>()) {
                 // only check range for numbers
                 if (global.is<double>()) {
-                    auto num = global.get<double>();
+                    double num = global.get<double>();
                     return num >= f.min && num < f.max;
                 }
             }
@@ -88,7 +289,7 @@ bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
     }
 
     // Cannot be reached
-    assert(false);
+    //assert(false);
     return false;
 }
 

--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -7,10 +7,6 @@
 
 namespace Tangram {
 
-void countTypes(const std::vector<Filter>& filters, int& global, int& function, int& property) {
-
-}
-
 void Filter::print(int _indent) const {
 
     switch (data.get_type_index()) {
@@ -244,95 +240,6 @@ std::vector<Filter> Filter::sort(const std::vector<Filter>& _filters) {
     return filters;
 }
 
-#if 0
-
-bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
-
-    switch (data.get_type_index()) {
-
-    case Data::type<OperatorAny>::value: {
-        for (const auto& filt : data.get<OperatorAny>().operands) {
-            if (filt.eval(feat, ctx)) { return true; }
-        }
-        return false;
-    }
-    case Data::type<OperatorAll>::value: {
-        for (const auto& filt : data.get<OperatorAll>().operands) {
-            if (!filt.eval(feat, ctx)) { return false; }
-        }
-        return true;
-    }
-    case Data::type<OperatorNone>::value: {
-        for (const auto& filt : data.get<OperatorNone>().operands) {
-            if (filt.eval(feat, ctx)) { return false; }
-        }
-        return true;
-    }
-    case Data::type<Existence>::value: {
-        auto& f = data.get<Existence>();
-        return f.exists == feat.props.contains(f.key);
-    }
-    case Data::type<Equality>::value: {
-        auto& f = data.get<Equality>();
-
-        if (f.global == FilterGlobal::undefined) {
-            auto& value = feat.props.get(f.key);
-            for (const auto& v : f.values) {
-                if (v == value) {
-                    return true;
-                } else if (value.is<double>() && v.is<double>()) {
-                    auto& a = v.get<double>();
-                    auto& b = value.get<double>();
-                    if (std::fabs(a - b) <= std::numeric_limits<double>::epsilon()) { return true; }
-                }
-            }
-        } else {
-            auto& global = ctx.getGlobal(f.global);
-            if (!global.is<none_type>()) {
-                for (const auto& v : f.values) {
-                    if (v == global) { return true; }
-                }
-                return false;
-            }
-        }
-
-        return false;
-    }
-    case Data::type<Range>::value: {
-        auto& f = data.get<Range>();
-
-        if (f.global == FilterGlobal::undefined) {
-            auto& value = feat.props.get(f.key);
-            if (value.is<double>()) {
-                double num =  value.get<double>();
-                return num >= f.min && num < f.max;
-            }
-        } else {
-            auto& global = ctx.getGlobal(f.global);
-            if (!global.is<none_type>()) {
-                // only check range for numbers
-                if (global.is<double>()) {
-                    double num = global.get<double>();
-                    return num >= f.min && num < f.max;
-                }
-            }
-        }
-        return false;
-    }
-    case Data::type<Function>::value: {
-        auto& f = data.get<Function>();
-        return ctx.evalFilter(f.id);
-    }
-    default:
-        return true;
-    }
-
-    // Cannot be reached
-    //assert(false);
-    return false;
-}
-
-#else
 
 struct string_matcher {
     using result_type = bool;
@@ -476,7 +383,5 @@ struct matcher {
 bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
     return Data::visit(data, matcher(feat, ctx));
 }
-
-#endif
 
 }

--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -203,9 +203,7 @@ int compareSetFilter(const Filter& a, const Filter& b) {
         auto ra = oa[0].data.get<Filter::Range>();
         auto rb = ob[0].data.get<Filter::Range>();
 
-        if (ra.max == std::numeric_limits<double>::infinity() &&
-            rb.max == std::numeric_limits<double>::infinity()) {
-
+        if (std::isinf(ra.max) && std::isinf(rb.max)) {
             return rb.min - ra.min;
         }
     }

--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -207,6 +207,8 @@ std::vector<Filter> Filter::sort(const std::vector<Filter>& _filters) {
     return filters;
 }
 
+#if 0
+
 bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
 
     switch (data.get_type_index()) {
@@ -292,5 +294,131 @@ bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
     //assert(false);
     return false;
 }
+
+#else
+
+struct string_matcher {
+    using result_type = bool;
+    const std::string& str;
+
+    template <typename T>
+    bool operator()(T v) const { return false; }
+    bool operator()(const std::string& v) const {
+        return str == v;
+    }
+};
+
+struct number_matcher {
+    using result_type = bool;
+    double num;
+
+    template <typename T>
+    bool operator()(T v) const { return false; }
+    bool operator()(const double& v) const {
+        if (num == v) { return true; }
+        return std::fabs(num - v) <= std::numeric_limits<double>::epsilon();
+    }
+};
+
+struct match_equal {
+    using result_type = bool;
+
+    const std::vector<Value>& values;
+
+    template <typename T>
+    bool operator()(T) const { return false; }
+
+    bool operator()(const double& num) const {
+        number_matcher m{num};
+        for (const auto& v : values) {
+            if (Value::visit(v, m)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    bool operator()(const std::string& str) const {
+        string_matcher m{str};
+
+        for (const auto& v : values) {
+            if (Value::visit(v, m)) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+struct match_range {
+    const Filter::Range& f;
+
+    bool operator() (const double& num) const {
+        return num >= f.min && num < f.max;
+    }
+    bool operator() (const std::string&) const { return false; }
+    bool operator() (const none_type&) const { return false; }
+};
+
+struct matcher {
+    using result_type = bool;
+
+    matcher(const Feature& feat, StyleContext& ctx) :
+        props(feat.props), ctx(ctx) {}
+
+    const Properties& props;
+    StyleContext& ctx;
+
+    bool eval(const Filter::Data& data) const {
+        return Filter::Data::visit(data, *this);
+    }
+
+    bool operator() (const Filter::OperatorAny& f) const {
+        for (const auto& filt : f.operands) {
+            if (eval(filt.data)) { return true; }
+        }
+        return false;
+    }
+    bool operator() (const Filter::OperatorAll& f) const {
+        for (const auto& filt : f.operands) {
+            if (!eval(filt.data)) { return false; }
+        }
+        return true;
+    }
+    bool operator() (const Filter::OperatorNone& f) const {
+        for (const auto& filt : f.operands) {
+            if (eval(filt.data)) { return false; }
+        }
+        return true;
+    }
+    bool operator() (const Filter::Existence& f) const {
+        return f.exists == props.contains(f.key);
+    }
+    bool operator() (const Filter::Equality& f) const {
+        auto& value = (f.global == FilterGlobal::undefined)
+            ? props.get(f.key)
+            : ctx.getGlobal(f.global);
+
+        return Value::visit(value, match_equal{f.values});
+    }
+    bool operator() (const Filter::Range& f) const {
+        auto& value = (f.global == FilterGlobal::undefined)
+            ? props.get(f.key)
+            : ctx.getGlobal(f.global);
+
+        return Value::visit(value, match_range{f});
+    }
+    bool operator() (const Filter::Function& f) const {
+        return ctx.evalFilter(f.id);
+    }
+    bool operator() (const none_type& f) const {
+        return true;
+    }
+};
+
+bool Filter::eval(const Feature& feat, StyleContext& ctx) const {
+    return Data::visit(data, matcher(feat, ctx));
+}
+
+#endif
 
 }

--- a/core/src/scene/filters.h
+++ b/core/src/scene/filters.h
@@ -31,6 +31,11 @@ struct Filter {
         std::vector<Value> values;
         FilterGlobal global;
     };
+    struct EqualityOne {
+        std::string key;
+        Value value;
+        FilterGlobal global;
+    };
     struct Range {
         std::string key;
         float min;
@@ -57,19 +62,29 @@ struct Filter {
     Filter() : data(none_type{}) {}
     Filter(Data _data) : data(std::move(_data)) {}
 
+    static std::vector<Filter> sort(const std::vector<Filter>& filters);
+    void print(int _indent = 0) const;
+    int matchCost() const;
+    const std::string& key() const;
+    const std::vector<Filter>& operands() const;
+
     // Create an 'any', 'all', or 'none' filter
     inline static Filter MatchAny(const std::vector<Filter>& filters) {
-        return { OperatorAny{ filters }};
+        return { OperatorAny{ sort(filters) }};
     }
     inline static Filter MatchAll(const std::vector<Filter>& filters) {
-        return { OperatorAll{ filters }};
+        return { OperatorAll{ sort(filters) }};
     }
     inline static Filter MatchNone(const std::vector<Filter>& filters) {
-        return { OperatorNone{ filters }};
+        return { OperatorNone{ sort(filters) }};
     }
     // Create an 'equality' filter
     inline static Filter MatchEquality(const std::string& k, const std::vector<Value>& vals) {
+        // if (vals.size() == 1) {
+        //     return { EqualityOne{ k, vals[0], globalType(k) }};
+        // } else {
         return { Equality{ k, vals, globalType(k) }};
+        // }
     }
     // Create a 'range' filter
     inline static Filter MatchRange(const std::string& k, float min, float max) {

--- a/core/src/scene/filters.h
+++ b/core/src/scene/filters.h
@@ -63,11 +63,7 @@ struct Filter {
     Filter() : data(none_type{}) {}
     Filter(Data _data) : data(std::move(_data)) {}
 
-    static std::vector<Filter> sort(const std::vector<Filter>& filters);
-    void print(int _indent = 0) const;
-    int matchCost() const;
-    const std::string& key() const;
-    const std::vector<Filter>& operands() const;
+    bool eval(const Feature& feat, StyleContext& ctx) const;
 
     // Create an 'any', 'all', or 'none' filter
     inline static Filter MatchAny(const std::vector<Filter>& filters) {
@@ -100,8 +96,6 @@ struct Filter {
         return { Function{ id }};
     }
 
-    bool eval(const Feature& feat, StyleContext& ctx) const;
-
     static FilterGlobal globalType(const std::string& _key) {
         if (_key == "$geometry") {
             return FilterGlobal::geometry;
@@ -110,5 +104,14 @@ struct Filter {
         }
         return  FilterGlobal::undefined;
     }
+
+    /* Public for testing */
+    static std::vector<Filter> sort(const std::vector<Filter>& filters);
+    void print(int _indent = 0) const;
+    int filterCost() const;
+    const bool isOperator() const;
+    const std::string& key() const;
+    const std::vector<Filter>& operands() const;
+
 };
 }

--- a/core/src/scene/filters.h
+++ b/core/src/scene/filters.h
@@ -26,12 +26,12 @@ struct Filter {
         std::vector<Filter> operands;
     };
 
-    struct Equality {
+    struct EqualitySet {
         std::string key;
         std::vector<Value> values;
         FilterGlobal global;
     };
-    struct EqualityOne {
+    struct Equality {
         std::string key;
         Value value;
         FilterGlobal global;
@@ -53,6 +53,7 @@ struct Filter {
                          OperatorAll,
                          OperatorNone,
                          OperatorAny,
+                         EqualitySet,
                          Equality,
                          Range,
                          Existence,
@@ -80,11 +81,11 @@ struct Filter {
     }
     // Create an 'equality' filter
     inline static Filter MatchEquality(const std::string& k, const std::vector<Value>& vals) {
-        // if (vals.size() == 1) {
-        //     return { EqualityOne{ k, vals[0], globalType(k) }};
-        // } else {
-        return { Equality{ k, vals, globalType(k) }};
-        // }
+        if (vals.size() == 1) {
+            return { Equality{ k, vals[0], globalType(k) }};
+        } else {
+            return { EqualitySet{ k, vals, globalType(k) }};
+        }
     }
     // Create a 'range' filter
     inline static Filter MatchRange(const std::string& k, float min, float max) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -52,6 +52,15 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
     return loadScene(config, _scene);
 }
 
+void printFilters(const SceneLayer& layer, int indent){
+    logMsg("%*s >>> %s\n", indent, "", layer.name().c_str());
+    layer.filter().print(indent + 2);
+
+    for (auto& l : layer.sublayers()) {
+        printFilters(l, indent + 2);
+    }
+};
+
 bool SceneLoader::loadScene(Node& config, Scene& _scene) {
 
     // Instantiate built-in styles
@@ -143,6 +152,9 @@ bool SceneLoader::loadScene(Node& config, Scene& _scene) {
         style->build(_scene.lights());
     }
 
+    for (auto& l : _scene.layers()) {
+        printFilters(l, 0);
+    }
     return true;
 }
 

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -154,10 +154,6 @@ void StyleContext::setGlobal(const std::string& _key, const Value& _val) {
     }
 }
 
-const Value& StyleContext::getGlobal(FilterGlobal _key) const {
-    return m_globals[static_cast<uint8_t>(_key)];
-}
-
 const Value& StyleContext::getGlobal(const std::string& _key) const {
     return getGlobal(Filter::globalType(_key));
 }

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -18,7 +18,7 @@ namespace Tangram {
 const static char INSTANCE_ID[] = "\xff""\xff""obj";
 const static char FUNC_ID[] = "\xff""\xff""fns";
 
-static const std::string key_geometry = "$geometry";
+static const std::string key_geom("$geometry");
 static const std::string key_zoom("$zoom");
 
 static const std::vector<std::string> s_geometryStrings = {
@@ -117,10 +117,13 @@ void StyleContext::setFeature(const Feature& _feature) {
 
     m_feature = &_feature;
 
-    setGlobal(key_geometry, s_geometryStrings[m_feature->geometryType]);
+    if (m_feature->geometryType != m_globalGeom) {
+        //setGlobal(key_geom, m_feature->geometryType);
+        setGlobal(key_geom, s_geometryStrings[m_feature->geometryType]);
+    }
 }
 
-void StyleContext::setGlobalZoom(float _zoom) {
+void StyleContext::setGlobalZoom(int _zoom) {
     if (_zoom != m_globalZoom) {
         setGlobal(key_zoom, _zoom);
     }
@@ -133,7 +136,7 @@ void StyleContext::setGlobal(const std::string& _key, const Value& _val) {
         return;
     }
 
-    Value& entry = m_globals[globalKey];
+    Value& entry = m_globals[static_cast<uint8_t>(globalKey)];
     if (entry == _val) { return; }
 
     entry = _val;
@@ -142,24 +145,17 @@ void StyleContext::setGlobal(const std::string& _key, const Value& _val) {
         duk_push_number(m_ctx, _val.get<double>());
         duk_put_global_string(m_ctx, _key.c_str());
 
-        if (_key == "$zoom") { m_globalZoom = _val.get<double>(); }
+        if (_key == key_zoom) { m_globalZoom = _val.get<double>(); }
+        if (_key == key_geom) { m_globalGeom = _val.get<double>(); }
 
     } else if (_val.is<std::string>()) {
         duk_push_string(m_ctx, _val.get<std::string>().c_str());
         duk_put_global_string(m_ctx, _key.c_str());
-
     }
 }
 
 const Value& StyleContext::getGlobal(FilterGlobal _key) const {
-    const static Value NOT_FOUND(none_type{});
-
-    auto it = m_globals.find(_key);
-    if (it != m_globals.end()) {
-        return it->second;
-    }
-    return NOT_FOUND;
-
+    return m_globals[static_cast<uint8_t>(_key)];
 }
 
 const Value& StyleContext::getGlobal(const std::string& _key) const {
@@ -218,34 +214,6 @@ bool StyleContext::evalFilter(FunctionID _id) {
     // pop result
     duk_pop(m_ctx);
     // pop fns obj
-    duk_pop(m_ctx);
-
-    DUMP("evalFilterFn\n");
-    return result;
-}
-
-bool StyleContext::evalFilterFn(const std::string& _name) {
-
-    if (!duk_get_global_string(m_ctx, _name.c_str())) {
-        LOGE("EvalFilter %s", _name.c_str());
-        return false;
-    }
-
-    if (duk_pcall(m_ctx, 0) != 0) {
-        LOGE("EvalFilterFn: %s", duk_safe_to_string(m_ctx, -1));
-        duk_pop(m_ctx);
-        return false;
-    }
-
-    bool result = false;
-
-    if (duk_is_boolean(m_ctx, -1)) {
-        result = duk_get_boolean(m_ctx, -1);
-    } else {
-        LOGE("EvalFilterFn: invalid return type");
-    }
-
-    // pop result
     duk_pop(m_ctx);
 
     DUMP("evalFilterFn\n");
@@ -404,23 +372,6 @@ bool StyleContext::evalStyle(FunctionID _id, StyleParamKey _key, StyleParam::Val
     return parseStyleResult(_key, _val);
 }
 
-
-bool StyleContext::evalStyleFn(const std::string& name, StyleParamKey _key, StyleParam::Value& _val) {
-
-    if (!duk_get_global_string(m_ctx, name.c_str())) {
-        LOGE("EvalFilter %s", name.c_str());
-        return false;
-    }
-
-    if (duk_pcall(m_ctx, 0) != 0) {
-        LOGE("EvalStyleFn: %s", duk_safe_to_string(m_ctx, -1));
-        duk_pop(m_ctx);
-        return false;
-    }
-
-    return parseStyleResult(_key, _val);
-}
-
 // Implements Proxy handler.has(target_object, key)
 duk_ret_t StyleContext::jsHasProperty(duk_context *_ctx) {
 
@@ -463,6 +414,52 @@ duk_ret_t StyleContext::jsGetProperty(duk_context *_ctx) {
     }
 
     return 1;
+}
+
+/* This function is only used by tests - Remove? */
+bool StyleContext::evalFilterFn(const std::string& _name) {
+
+    if (!duk_get_global_string(m_ctx, _name.c_str())) {
+        LOGE("EvalFilter %s", _name.c_str());
+        return false;
+    }
+
+    if (duk_pcall(m_ctx, 0) != 0) {
+        LOGE("EvalFilterFn: %s", duk_safe_to_string(m_ctx, -1));
+        duk_pop(m_ctx);
+        return false;
+    }
+
+    bool result = false;
+
+    if (duk_is_boolean(m_ctx, -1)) {
+        result = duk_get_boolean(m_ctx, -1);
+    } else {
+        LOGE("EvalFilterFn: invalid return type");
+    }
+
+    // pop result
+    duk_pop(m_ctx);
+
+    DUMP("evalFilterFn\n");
+    return result;
+}
+
+/* This function is only used by tests - Remove? */
+bool StyleContext::evalStyleFn(const std::string& name, StyleParamKey _key, StyleParam::Value& _val) {
+
+    if (!duk_get_global_string(m_ctx, name.c_str())) {
+        LOGE("EvalFilter %s", name.c_str());
+        return false;
+    }
+
+    if (duk_pcall(m_ctx, 0) != 0) {
+        LOGE("EvalStyleFn: %s", duk_safe_to_string(m_ctx, -1));
+        duk_pop(m_ctx);
+        return false;
+    }
+
+    return parseStyleResult(_key, _val);
 }
 
 }

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -63,11 +63,8 @@ public:
      */
     void clear();
 
-    // Public for testing
-    bool addFunction(const std::string& _name, const std::string& _func);
-    bool evalFilterFn(const std::string& _name);
-    bool evalStyleFn(const std::string& _name, StyleParamKey _key, StyleParam::Value& _val);
-    void addAccessor(const std::string& _name);
+    bool setFunctions(const std::vector<std::string>& _functions);
+
     void setGlobal(const std::string& _key, const Value& _value);
     const Value& getGlobal(const std::string& _key) const;
 

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <functional>
 #include <memory>
+#include <array>
 
 struct duk_hthread;
 typedef struct duk_hthread duk_context;
@@ -37,7 +38,7 @@ public:
     /*
      * Set global for currently processed Tile
      */
-    void setGlobalZoom(float _zoom);
+    void setGlobalZoom(int _zoom);
 
     /* Called from Filter::eval */
     float getGlobalZoom() const { return m_globalZoom; }
@@ -78,11 +79,12 @@ private:
 
     const Feature* m_feature = nullptr;
 
-    fastmap<FilterGlobal, Value> m_globals;
+    std::array<Value, 4> m_globals;
 
     int32_t m_sceneId = -1;
 
-    float m_globalZoom = -1;
+    double m_globalGeom = -1;
+    double m_globalZoom = -1;
 };
 
 }

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -43,7 +43,9 @@ public:
     /* Called from Filter::eval */
     float getGlobalZoom() const { return m_globalZoom; }
 
-    const Value& getGlobal(FilterGlobal _key) const;
+    const Value& getGlobal(FilterGlobal _key) const {
+        return m_globals[static_cast<uint8_t>(_key)];
+    }
 
     /* Called from Filter::eval */
     bool evalFilter(FunctionID id);
@@ -75,16 +77,15 @@ private:
 
     bool parseStyleResult(StyleParamKey _key, StyleParam::Value& _val) const;
 
-    mutable duk_context *m_ctx;
-
-    const Feature* m_feature = nullptr;
-
     std::array<Value, 4> m_globals;
+    double m_globalGeom = -1;
+    double m_globalZoom = -1;
 
     int32_t m_sceneId = -1;
 
-    double m_globalGeom = -1;
-    double m_globalZoom = -1;
+    const Feature* m_feature = nullptr;
+
+    mutable duk_context *m_ctx;
 };
 
 }

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -18,12 +18,17 @@
 
 namespace Tangram {
 struct none_type {
+    template<typename T>
+    bool operator==(T const& rhs) const {
+        return false;
+    }
     bool operator==(none_type const& rhs) const {
         return true;
     }
     bool operator<(none_type const& rhs) const {
         return false;
     }
+
 };
 
 template<typename... Types>


### PR DESCRIPTION
The main addition here is to sort filters so that cheaper tests are performed first:

- check globals (zoom, geom) before properties
- check functions last
- for list of zoom+area pairs and the zoom ranges overlap (have min zoom but no max) start to check the highest zoom-level first, the other way round one would fail more often on the area property:
```
-> original
- { $zoom: { min: 14 }, area: { min: 50000 } }
- { $zoom: { min: 15 }, area: { min: 2000 } }
- { $zoom: { min: 16 } }
-> use shorter group when both have the same number of global tests
- { $zoom: { min: 16 } }
- { $zoom: { min: 14 }, area: { min: 50000 } }
- { $zoom: { min: 15 }, area: { min: 2000 } }
-> when both match on the same range property use the one with smaller range first
- { $zoom: { min: 16 } }
- { $zoom: { min: 15 }, area: { min: 2000 } }
- { $zoom: { min: 14 }, area: { min: 50000 } }
```

TODO
- determine possible zoom-range for layers, to be able to skip whole layers directly (needs TileDataSink)
- comparison of filter groups can be further extended
- one could e.g. also analyze sublayer groups further for things like switch case matching on one property. Or propagate required properties up by inserting Existence filters on the lowest common layer
