### PR TITLE
Omit all tile edges for polylines

### DIFF
--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -243,15 +243,17 @@ float valuesWithinTolerance(float _a, float _b, float _tolerance = 0.001) {
 // Tests if a line segment (from point A to B) is nearly coincident with the edge of a tile
 bool isOnTileEdge(const glm::vec3& _pa, const glm::vec3& _pb) {
 
-    float tolerance = 0.0002; // tweak this adjust if catching too few/many line segments near tile edges
+    float tolerance = 0.0005; // tweak this adjust if catching too few/many line segments near tile edges
     // TODO: make tolerance configurable by source if necessary
     glm::vec2 tile_min(0.0, 0.0);
     glm::vec2 tile_max(1.0, 1.0);
+    glm::vec2 a(fmod(_pa.x, tile_max.x), fmod(_pa.y, tile_max.y));
+    glm::vec2 b(fmod(_pb.x, tile_max.x), fmod(_pb.y, tile_max.y));
 
-    return (valuesWithinTolerance(_pa.x, tile_min.x, tolerance) && valuesWithinTolerance(_pb.x, tile_min.x, tolerance)) ||
-           (valuesWithinTolerance(_pa.x, tile_max.x, tolerance) && valuesWithinTolerance(_pb.x, tile_max.x, tolerance)) ||
-           (valuesWithinTolerance(_pa.y, tile_min.y, tolerance) && valuesWithinTolerance(_pb.y, tile_min.y, tolerance)) ||
-           (valuesWithinTolerance(_pa.y, tile_max.y, tolerance) && valuesWithinTolerance(_pb.y, tile_max.y, tolerance));
+    return (valuesWithinTolerance(a.x, tile_min.x, tolerance) && valuesWithinTolerance(b.x, tile_min.x, tolerance)) ||
+           (valuesWithinTolerance(a.x, tile_max.x, tolerance) && valuesWithinTolerance(b.x, tile_max.x, tolerance)) ||
+           (valuesWithinTolerance(a.y, tile_min.y, tolerance) && valuesWithinTolerance(b.y, tile_min.y, tolerance)) ||
+           (valuesWithinTolerance(a.y, tile_max.y, tolerance) && valuesWithinTolerance(b.y, tile_max.y, tolerance));
 }
 
 void Builders::buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx) {

--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -254,7 +254,7 @@ bool isOnTileEdge(const glm::vec3& _pa, const glm::vec3& _pb) {
            (valuesWithinTolerance(_pa.y, tile_max.y, tolerance) && valuesWithinTolerance(_pb.y, tile_max.y, tolerance));
 }
 
-void Builders::buildPolyLine(const Line& _line, PolyLineBuilder& _ctx) {
+void Builders::buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx) {
 
     int lineSize = (int)_line.size();
     if (lineSize < 2) { return; }
@@ -363,7 +363,7 @@ void Builders::buildPolyLine(const Line& _line, PolyLineBuilder& _ctx) {
 #endif
 }
 
-void Builders::buildOutline(const Line& _line, PolyLineBuilder& _ctx) {
+void Builders::buildPolyLine(const Line& _line, PolyLineBuilder& _ctx) {
 
     int cut = 0;
 
@@ -372,13 +372,13 @@ void Builders::buildOutline(const Line& _line, PolyLineBuilder& _ctx) {
         const glm::vec3& coordNext = _line[i+1];
         if (isOnTileEdge(coordCurr, coordNext)) {
             Line line = Line(&_line[cut], &_line[i+1]);
-            buildPolyLine(line, _ctx);
+            buildPolyLineSegment(line, _ctx);
             cut = i + 1;
         }
     }
 
     Line line = Line(&_line[cut], &_line[_line.size()]);
-    buildPolyLine(line, _ctx);
+    buildPolyLineSegment(line, _ctx);
 
 }
 

--- a/core/src/util/builders.h
+++ b/core/src/util/builders.h
@@ -110,10 +110,10 @@ public:
      * @_options parameters for polyline construction
      * @_ctx output vectors, see <PolyLineBuilder>
      */
-    static void buildPolyLine(const Line& _line, PolyLineBuilder& _ctx);
+    static void buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx);
 
-    /* Build a tesselated outline that follows the given line while skipping tile boundaries */
-    static void buildOutline(const Line& _line, PolyLineBuilder& _ctx);
+    /* Build a tesselated polygon line that skips tile boundaries */
+    static void buildPolyLine(const Line& _line, PolyLineBuilder& _ctx);
 
     /* Build a tesselated quad centered on _screenOrigin
      * @_screenOrigin the sprite origin in screen space


### PR DESCRIPTION
 - Fixes polyline builder never checking line segments for coincidence with tile edges (not sure when this was broken)
 - Modifies tile edge check to match edges of any tile, not just the current tile