### PR TITLE
Line parameter refactor

### DIFF
--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -48,6 +48,7 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"style", StyleParamKey::style},
     {"text_source", StyleParamKey::text_source},
     {"text_wrap", StyleParamKey::text_wrap},
+    {"tile_edges", StyleParamKey::tile_edges},
     {"transition:hide:time", StyleParamKey::transition_hide_time},
     {"transition:selected:time", StyleParamKey::transition_selected_time},
     {"transition:show:time", StyleParamKey::transition_show_time},
@@ -178,6 +179,7 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     }
     case StyleParamKey::centroid:
     case StyleParamKey::interactive:
+    case StyleParamKey::tile_edges:
     case StyleParamKey::visible:
     case StyleParamKey::collide:
         if (_value == "true") { return true; }
@@ -293,6 +295,7 @@ std::string StyleParam::toString() const {
         if (!value.is<std::string>()) break;
         return k + value.get<std::string>();
     case StyleParamKey::interactive:
+    case StyleParamKey::tile_edges:
     case StyleParamKey::visible:
     case StyleParamKey::centroid:
     case StyleParamKey::collide:

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -43,6 +43,7 @@ enum class StyleParamKey : uint8_t {
     style,
     text_source,
     text_wrap,
+    tile_edges,
     transform,
     transition_hide_time,
     transition_selected_time,

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -84,6 +84,7 @@ void PolylineStyle::buildLine(const Line& _line, const DrawRule& _rule, const Pr
                               VboMesh& _mesh, Tile& _tile) const {
 
     auto params = parseRule(_rule, _props, _tile);
+    params.keepTileEdges = true; // Line geometries are never clipped to tiles, so keep all segments
     buildMesh(_line, params, _mesh);
 
 }
@@ -191,6 +192,8 @@ PolylineStyle::Parameters PolylineStyle::parseRule(const DrawRule& _rule, const 
         p.outline.color = p.outline.color << (_tile.getID().z % 6);
     }
 
+    _rule.get(StyleParamKey::tile_edges, p.keepTileEdges);
+
     return p;
 }
 
@@ -212,7 +215,8 @@ void PolylineStyle::buildMesh(const Line& _line, Parameters& _params, VboMesh& _
         },
         [&](size_t sizeHint){ vertices.reserve(sizeHint); },
         _params.fill.cap,
-        _params.fill.join
+        _params.fill.join,
+        _params.keepTileEdges
     };
 
     Builders::buildPolyLine(_line, builder);

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -71,41 +71,21 @@ VboMesh* PolylineStyle::newMesh() const {
     return new Mesh(m_vertexLayout, m_drawMode);
 }
 
-PolylineStyle::Parameters PolylineStyle::parseRule(const DrawRule& _rule) const {
-    Parameters p;
-
-    uint32_t cap = 0, join = 0;
-
-    _rule.get(StyleParamKey::extrude, p.extrude);
-    _rule.get(StyleParamKey::color, p.color);
-    _rule.get(StyleParamKey::cap, cap);
-    _rule.get(StyleParamKey::join, join);
-    _rule.get(StyleParamKey::order, p.order);
-
-    p.cap = static_cast<CapTypes>(cap);
-    p.join = static_cast<JoinTypes>(join);
-
-    p.outlineOrder = p.order; // will offset from fill later
-
-    if (_rule.get(StyleParamKey::outline_color, p.outlineColor) |
-        _rule.get(StyleParamKey::outline_order, p.outlineOrder) |
-        _rule.contains(StyleParamKey::outline_width) |
-        _rule.get(StyleParamKey::outline_cap, cap) |
-        _rule.get(StyleParamKey::outline_join, join)) {
-        p.outlineOn = true;
-        p.outlineCap = static_cast<CapTypes>(cap);
-        p.outlineJoin = static_cast<JoinTypes>(join);
-    }
-
-    return p;
-}
-
 void PolylineStyle::buildPolygon(const Polygon& _poly, const DrawRule& _rule, const Properties& _props,
                                  VboMesh& _mesh, Tile& _tile) const {
 
+    auto params = parseRule(_rule, _props, _tile);
     for (const auto& line : _poly) {
-        buildLine(line, _rule, _props, _mesh, _tile);
+        buildMesh(line, params, _mesh);
     }
+}
+
+void PolylineStyle::buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props,
+                              VboMesh& _mesh, Tile& _tile) const {
+
+    auto params = parseRule(_rule, _props, _tile);
+    buildMesh(_line, params, _mesh);
+
 }
 
 double widthMeterToPixel(int _zoom, double _tileSize, double _width) {
@@ -174,79 +154,93 @@ bool evalStyleParamWidth(StyleParamKey _key, const DrawRule& _rule, const Tile& 
     return false;
 }
 
-void PolylineStyle::buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props,
-                              VboMesh& _mesh, Tile& _tile) const {
+PolylineStyle::Parameters PolylineStyle::parseRule(const DrawRule& _rule, const Properties& _props, const Tile& _tile) const {
+    Parameters p;
+
+    uint32_t cap = 0, join = 0;
+
+    _rule.get(StyleParamKey::color, p.fill.color);
+    _rule.get(StyleParamKey::cap, cap);
+    _rule.get(StyleParamKey::join, join);
+    _rule.get(StyleParamKey::order, p.fill.order);
+
+    p.fill.cap = static_cast<CapTypes>(cap);
+    p.fill.join = static_cast<JoinTypes>(join);
+
+    evalStyleParamWidth(StyleParamKey::width, _rule, _tile, p.fill.width, p.fill.slope);
+
+    p.outline.order = p.fill.order; // will offset from fill later
+
+    if (_rule.get(StyleParamKey::outline_color, p.outline.color) |
+        _rule.get(StyleParamKey::outline_order, p.outline.order) |
+        _rule.contains(StyleParamKey::outline_width) |
+        _rule.get(StyleParamKey::outline_cap, cap) |
+        _rule.get(StyleParamKey::outline_join, join)) {
+        p.outlineOn = true;
+        p.outline.cap = static_cast<CapTypes>(cap);
+        p.outline.join = static_cast<JoinTypes>(join);
+        evalStyleParamWidth(StyleParamKey::outline_width, _rule, _tile, p.outline.width, p.outline.slope);
+    }
+
+    Extrude extrude;
+    _rule.get(StyleParamKey::extrude, extrude);
+    p.height = getUpperExtrudeMeters(extrude, _props) * _tile.getInverseScale();
+
+    if (Tangram::getDebugFlag(Tangram::DebugFlags::proxy_colors)) {
+        p.fill.color = p.fill.color << (_tile.getID().z % 6);
+        p.outline.color = p.outline.color << (_tile.getID().z % 6);
+    }
+
+    return p;
+}
+
+void PolylineStyle::buildMesh(const Line& _line, Parameters& _params, VboMesh& _mesh) const {
 
     std::vector<PolylineVertex> vertices;
 
-    Parameters params = parseRule(_rule);
-    GLuint abgr = params.color;
+    GLuint color = _params.fill.color;
+    float width = _params.fill.width;
+    float slope = _params.fill.slope;
+    float order = _params.fill.order;
 
-    float dWdZ = 0.f;
-    float width = 0.f;
-
-    if (!evalStyleParamWidth(StyleParamKey::width, _rule, _tile, width, dWdZ)) {
-        return;
-    }
-
-    if (width <= 0.0f && dWdZ <= 0.0f ) { return; }
-
-    if (Tangram::getDebugFlag(Tangram::DebugFlags::proxy_colors)) {
-        abgr = abgr << (_tile.getID().z % 6);
-    }
-
-    auto& extrude = params.extrude;
-
-    float tileUnitsPerMeter = _tile.getInverseScale();
-    float height = getUpperExtrudeMeters(extrude, _props) * tileUnitsPerMeter;
-    float order = params.order;
+    if (width <= 0.f && slope <= 0.f ) { return; }
 
     PolyLineBuilder builder {
         [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& texCoord) {
-            glm::vec3 position = glm::vec3{coord.x, coord.y, height};
-            vertices.push_back({position, order, texCoord, normal, { width, dWdZ }, abgr});
+            glm::vec3 position = glm::vec3{coord.x, coord.y, _params.height};
+            vertices.push_back({position, order, texCoord, normal, { width, slope }, color});
         },
         [&](size_t sizeHint){ vertices.reserve(sizeHint); },
-        params.cap,
-        params.join
+        _params.fill.cap,
+        _params.fill.join
     };
 
     Builders::buildPolyLine(_line, builder);
 
-    if (params.outlineOn) {
+    if (_params.outlineOn && (_params.outline.width > 0.f || _params.outline.slope > 0.f)) {
 
-        GLuint abgrOutline = params.outlineColor;
-        float outlineOrder = std::min(params.outlineOrder, params.order) - 0.5f;
+        // Must update existing variables, they are captured (and used) by the builder
+        color = _params.outline.color;
+        width += _params.outline.width;
+        slope += _params.outline.slope;
+        order = std::min(_params.outline.order, _params.fill.order) - 0.5f;
 
-        float widthOutline = 0.f;
-        float dWdZOutline = 0.f;
+        if (_params.outline.cap != _params.fill.cap || _params.outline.join != _params.fill.join) {
+            // need to re-triangulate with different cap and/or join
+            builder.cap = _params.outline.cap;
+            builder.join = _params.outline.join;
+            Builders::buildPolyLine(_line, builder);
+        } else {
+            // re-use indices and positions from original line
+            size_t oldSize = builder.indices.size();
+            size_t offset = vertices.size();
+            builder.indices.reserve(2 * oldSize);
 
-        if (evalStyleParamWidth(StyleParamKey::outline_width, _rule, _tile,
-                                widthOutline, dWdZOutline) &&
-            ((widthOutline > 0.0f || dWdZOutline > 0.0f))) {
-
-            // Note: this must update <width> and <dWdZ> as they are captured
-            // (and used) by <builder>
-            width += widthOutline;
-            dWdZ += dWdZOutline;
-
-            if (params.outlineCap != params.cap || params.outlineJoin != params.join) {
-                // need to re-triangulate with different cap and/or join
-                builder.cap = params.outlineCap;
-                builder.join = params.outlineJoin;
-                Builders::buildPolyLine(_line, builder);
-            } else {
-                // re-use indices from original line
-                size_t oldSize = builder.indices.size();
-                size_t offset = vertices.size();
-                builder.indices.reserve(2 * oldSize);
-
-                for(size_t i = 0; i < oldSize; i++) {
-                    builder.indices.push_back(offset + builder.indices[i]);
-                }
-                for (size_t i = 0; i < offset; i++) {
-                    vertices.push_back({ vertices[i], outlineOrder, { width, dWdZ }, abgrOutline });
-                }
+            for(size_t i = 0; i < oldSize; i++) {
+                builder.indices.push_back(offset + builder.indices[i]);
+            }
+            for (size_t i = 0; i < offset; i++) {
+                vertices.push_back({ vertices[i], order, { width, slope }, color });
             }
         }
     }

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -21,6 +21,7 @@ protected:
         } fill, outline;
         float height = 0.f;
         bool outlineOn = false;
+        bool keepTileEdges = false;
     };
 
     virtual void constructVertexLayout() override;

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "style.h"
-#include "glm/vec2.hpp"
 // TODO move cap/join types to types.h
 #include "util/builders.h"
 
@@ -12,16 +11,16 @@ class PolylineStyle : public Style {
 protected:
 
     struct Parameters {
-        uint32_t order = 0;
-        uint32_t outlineOrder = 0;
-        uint32_t color = 0xff00ffff;
-        uint32_t outlineColor = 0xff00ffff;
-        CapTypes cap = CapTypes::butt;
-        CapTypes outlineCap = CapTypes::butt;
-        JoinTypes join = JoinTypes::miter;
-        JoinTypes outlineJoin = JoinTypes::miter;
+        struct {
+            uint32_t order = 0;
+            uint32_t color = 0xff00ffff;
+            float width = 0.f;
+            float slope = 0.f;
+            CapTypes cap = CapTypes::butt;
+            JoinTypes join = JoinTypes::miter;
+        } fill, outline;
+        float height = 0.f;
         bool outlineOn = false;
-        glm::vec2 extrude;
     };
 
     virtual void constructVertexLayout() override;
@@ -29,7 +28,8 @@ protected:
     virtual void buildLine(const Line& _line, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
     virtual void buildPolygon(const Polygon& _poly, const DrawRule& _rule, const Properties& _props, VboMesh& _mesh, Tile& _tile) const override;
 
-    Parameters parseRule(const DrawRule& _rule) const;
+    Parameters parseRule(const DrawRule& _rule, const Properties& _props, const Tile& _tile) const;
+    void buildMesh(const Line& _line, Parameters& _parameters, VboMesh& _mesh) const;
 
     virtual VboMesh* newMesh() const override;
 
@@ -37,8 +37,8 @@ public:
 
     PolylineStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
 
-    virtual ~PolylineStyle() {
-    }
+    virtual ~PolylineStyle() {}
+
 };
 
 }

--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -236,24 +236,31 @@ void addCap(const glm::vec3& _coord, const glm::vec2& _normal, int _numCorners, 
     addFan(_coord, nA, nB, nC, uA, uB, uC, _numCorners, _ctx);
 }
 
-float valuesWithinTolerance(float _a, float _b, float _tolerance = 0.001) {
+bool nearlyEqual(float _a, float _b, float _tolerance = 0.001) {
     return fabsf(_a - _b) < _tolerance;
 }
 
 // Tests if a line segment (from point A to B) is nearly coincident with the edge of a tile
-bool isOnTileEdge(const glm::vec3& _pa, const glm::vec3& _pb) {
+bool isOnTileEdge(const glm::vec3& _a, const glm::vec3& _b) {
 
     float tolerance = 0.0005; // tweak this adjust if catching too few/many line segments near tile edges
     // TODO: make tolerance configurable by source if necessary
     glm::vec2 tile_min(0.0, 0.0);
     glm::vec2 tile_max(1.0, 1.0);
-    glm::vec2 a(fmod(_pa.x, tile_max.x), fmod(_pa.y, tile_max.y));
-    glm::vec2 b(fmod(_pb.x, tile_max.x), fmod(_pb.y, tile_max.y));
 
-    return (valuesWithinTolerance(a.x, tile_min.x, tolerance) && valuesWithinTolerance(b.x, tile_min.x, tolerance)) ||
-           (valuesWithinTolerance(a.x, tile_max.x, tolerance) && valuesWithinTolerance(b.x, tile_max.x, tolerance)) ||
-           (valuesWithinTolerance(a.y, tile_min.y, tolerance) && valuesWithinTolerance(b.y, tile_min.y, tolerance)) ||
-           (valuesWithinTolerance(a.y, tile_max.y, tolerance) && valuesWithinTolerance(b.y, tile_max.y, tolerance));
+    if (nearlyEqual(_a.x, _b.x, tolerance)) {
+        auto x = fmod(_a.x, tile_max.x);
+        if (nearlyEqual(x, tile_min.x, tolerance) || nearlyEqual(x, tile_max.x, tolerance)) {
+            return true;
+        }
+    }
+    if (nearlyEqual(_a.y, _b.y, tolerance)) {
+        auto y = fmod(_a.y, tile_max.y);
+        if (nearlyEqual(y, tile_min.y, tolerance) || nearlyEqual(y, tile_min.y, tolerance)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx) {

--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -256,7 +256,7 @@ bool isOnTileEdge(const glm::vec3& _pa, const glm::vec3& _pb) {
            (valuesWithinTolerance(a.y, tile_max.y, tolerance) && valuesWithinTolerance(b.y, tile_max.y, tolerance));
 }
 
-void Builders::buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx) {
+void buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx) {
 
     int lineSize = (int)_line.size();
     if (lineSize < 2) { return; }
@@ -367,20 +367,28 @@ void Builders::buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx) {
 
 void Builders::buildPolyLine(const Line& _line, PolyLineBuilder& _ctx) {
 
-    int cut = 0;
+    if (_ctx.keepTileEdges) {
 
-    for (size_t i = 0; i < _line.size() - 1; i++) {
-        const glm::vec3& coordCurr = _line[i];
-        const glm::vec3& coordNext = _line[i+1];
-        if (isOnTileEdge(coordCurr, coordNext)) {
-            Line line = Line(&_line[cut], &_line[i+1]);
-            buildPolyLineSegment(line, _ctx);
-            cut = i + 1;
+        buildPolyLineSegment(_line, _ctx);
+
+    } else {
+
+        int cut = 0;
+
+        for (size_t i = 0; i < _line.size() - 1; i++) {
+            const glm::vec3& coordCurr = _line[i];
+            const glm::vec3& coordNext = _line[i+1];
+            if (isOnTileEdge(coordCurr, coordNext)) {
+                Line line = Line(&_line[cut], &_line[i+1]);
+                buildPolyLineSegment(line, _ctx);
+                cut = i + 1;
+            }
         }
-    }
 
-    Line line = Line(&_line[cut], &_line[_line.size()]);
-    buildPolyLineSegment(line, _ctx);
+        Line line = Line(&_line[cut], &_line[_line.size()]);
+        buildPolyLineSegment(line, _ctx);
+
+    }
 
 }
 

--- a/core/src/util/builders.h
+++ b/core/src/util/builders.h
@@ -66,9 +66,10 @@ struct PolyLineBuilder {
     size_t numVertices = 0;
     CapTypes cap;
     JoinTypes join;
+    bool keepTileEdges;
 
-    PolyLineBuilder(PolyLineVertexFn _addVertex, SizeHintFn _sizeHint, CapTypes _cap = CapTypes::butt, JoinTypes _join = JoinTypes::bevel)
-        : addVertex(_addVertex), sizeHint(_sizeHint), cap(_cap), join(_join) {}
+    PolyLineBuilder(PolyLineVertexFn _addVertex, SizeHintFn _sizeHint, CapTypes _cap = CapTypes::butt, JoinTypes _join = JoinTypes::bevel, bool _kte = true)
+        : addVertex(_addVertex), sizeHint(_sizeHint), cap(_cap), join(_join), keepTileEdges(_kte) {}
 };
 
 /* Callback function for SpriteBuilder
@@ -110,9 +111,6 @@ public:
      * @_options parameters for polyline construction
      * @_ctx output vectors, see <PolyLineBuilder>
      */
-    static void buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx);
-
-    /* Build a tesselated polygon line that skips tile boundaries */
     static void buildPolyLine(const Line& _line, PolyLineBuilder& _ctx);
 
     /* Build a tesselated quad centered on _screenOrigin


### PR DESCRIPTION
 - Cleanly separates polyline rule interpretation from mesh building process
 - Handles `tile_edges` parameter and provides correct default behavior when absent

Fixes https://github.com/mapzen/eraser-map/issues/265