### PR TITLE
Refactor label state machine

### DIFF
--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -175,7 +175,6 @@ glm::vec2 Label::center() const {
 }
 
 void Label::enterState(const State& _state, float _alpha) {
-    m_prevState = m_state;
     m_state = _state;
     setAlpha(_alpha);
 }
@@ -237,7 +236,7 @@ bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _z
 
     // one of the label rules has not been satisfied
     if (!ruleSatisfied) {
-        if ((m_state & State::wait_occ) != 0) {
+        if (m_state == State::wait_occ) {
             // go to dead state, this breaks determinism, but reduce potential
             // label set since a lot of discarded labels are discared for line
             // exceed (lots of tiny small lines on a curve for example), which
@@ -266,7 +265,6 @@ bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _z
 bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
 
     bool animate = false;
-    m_prevState = m_state;
 
     switch (m_state) {
         case State::visible:
@@ -279,21 +277,21 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
             break;
         case State::fading_in:
             if (m_occluded) {
-                // enterState(State::sleep, 0.0);
-                enterState(State::fading_out, m_transform.state.alpha);
-                animate = true;
+                enterState(State::sleep, 0.0);
+                // enterState(State::fading_out, m_transform.state.alpha);
+                // animate = true;
                 break;
             }
             setAlpha(m_fade.update(_dt));
             animate = true;
-            if (m_fade.isFinished() || (m_transform.state.alpha > 0.9f)) {
+            if (m_fade.isFinished()) {
                 enterState(State::visible, 1.0);
             }
             break;
         case State::fading_out:
             setAlpha(m_fade.update(_dt));
             animate = true;
-            if (m_fade.isFinished() || (m_transform.state.alpha < 0.1f )) {
+            if (m_fade.isFinished()) {
                 enterState(State::sleep, 0.0);
             }
             break;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -46,7 +46,8 @@ public:
         sleep           = 1 << 3,
         out_of_screen   = 1 << 4,
         wait_occ        = 1 << 5, // state waiting for first occlusion result
-        dead            = 1 << 6,
+        skip_transition = 1 << 6,
+        dead            = 1 << 7,
     };
 
     struct Vertex {
@@ -118,24 +119,17 @@ public:
         size_t paramHash = 0;
     };
 
-    enum OcclusionType {
-        none,
-        collision,
-        repeat_group
-    };
-
     Label(Transform _transform, glm::vec2 _size, Type _type, LabelMesh& _mesh, Range _vertexRange,
             Options _options);
 
     virtual ~Label();
 
-    /* Update the transform of the label in world space, and project it to screen space */
-    void updateTransform(const Transform& _transform, const glm::mat4& _mvp, const glm::vec2& _screenSize);
-
-    bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt, float _zoomFract);
+    bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract);
 
     /* Push the pending transforms to the vbo by updating the vertices */
     void pushTransform();
+
+    bool evalState(const glm::vec2& _screenSize, float _dt);
 
     /* Update the screen position of the label */
     bool updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize,
@@ -144,13 +138,10 @@ public:
     virtual void updateBBoxes(float _zoomFract) = 0;
 
     /* Occlude the label */
-    void occlude(OcclusionType _type, bool _occlusion = true);
+    void occlude(bool _occlusion = true);
 
     /* Checks whether the label is in a state where it can occlusion */
     bool canOcclude();
-
-    /* Mark the label as resolved */
-    void occlusionSolved();
 
     void skipTransitions();
 
@@ -172,11 +163,12 @@ public:
     /* Gets the oriented bounding box of the label */
     const OBB& obb() const { return m_obb; }
     const Transform& transform() const { return m_transform; }
-    const State& state() const { return m_currentState; }
+    State state() const { return m_state; }
+    State prevState() const { return m_prevState; }
+    bool isOccluded() const { return m_occluded; }
     bool occludedLastFrame() const { return m_occludedLastFrame; }
-    virtual glm::vec2 center() const;
 
-    OcclusionType occlusionType() const { return m_occlusionType; }
+    virtual glm::vec2 center() const;
 
 private:
 
@@ -184,25 +176,19 @@ private:
 
     inline void enterState(const State& _state, float _alpha = 1.0f);
 
-    bool updateState(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _dt, float _zoomFract);
-
     void setAlpha(float _alpha);
 
     bool m_proxy;
     // the current label state
-    State m_currentState;
+    State m_state;
+    State m_prevState;
     // the label fade effect
     FadeEffect m_fade;
     // whether the label was occluded on the previous frame
     bool m_occludedLastFrame;
-    // whether or not the occlusion has been solved by the occlusion manager
-    bool m_occlusionSolved;
+    bool m_occluded;
     // whether or not we need to update the mesh visibilit (alpha channel)
     bool m_updateMeshVisibility;
-    // whether this label should skip transitions to move to first visible state
-    bool m_skipTransitions;
-    // How occlusion have been triggered
-    OcclusionType m_occlusionType;
 
 protected:
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -164,7 +164,6 @@ public:
     const OBB& obb() const { return m_obb; }
     const Transform& transform() const { return m_transform; }
     State state() const { return m_state; }
-    State prevState() const { return m_prevState; }
     bool isOccluded() const { return m_occluded; }
     bool occludedLastFrame() const { return m_occludedLastFrame; }
 
@@ -181,7 +180,6 @@ private:
     bool m_proxy;
     // the current label state
     State m_state;
-    State m_prevState;
     // the label fade effect
     FadeEffect m_fade;
     // whether the label was occluded on the previous frame

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -6,6 +6,8 @@
 #include "gl/primitives.h"
 #include "view/view.h"
 #include "style/style.h"
+#include "style/pointStyle.h"
+#include "style/textStyle.h"
 #include "tile/tile.h"
 #include "tile/tileCache.h"
 
@@ -27,12 +29,10 @@ int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
     return (int) MIN(floor(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5)), MAX_LOD);
 }
 
-bool Labels::updateLabels(const std::vector<std::unique_ptr<Style>>& _styles,
+void Labels::updateLabels(const std::vector<std::unique_ptr<Style>>& _styles,
                           const std::vector<std::shared_ptr<Tile>>& _tiles,
                           float _dt, float _dz, const View& _view)
 {
-    bool animate = false;
-
     glm::vec2 screenSize = glm::vec2(_view.getWidth(), _view.getHeight());
 
     // int lodDiscard = LODDiscardFunc(View::s_maxZoom, _view.getZoom());
@@ -56,54 +56,53 @@ bool Labels::updateLabels(const std::vector<std::unique_ptr<Style>>& _styles,
             if (!labelMesh) { continue; }
 
             for (auto& label : labelMesh->getLabels()) {
-                animate |= label->update(mvp, screenSize, _dt, _dz);
+                if (!label->update(mvp, screenSize, _dz)) {
+                    // skip dead labels
+                    continue;
+                }
 
                 label->setProxy(proxyTile);
-
-                if (label->canOcclude()) {
-                    m_aabbs.push_back(label->aabb());
-                    m_aabbs.back().m_userData = (void*)label.get();
-                }
                 m_labels.push_back(label.get());
             }
         }
     }
-
-    return animate;
 }
 
-std::set<std::pair<Label*, Label*>> Labels::narrowPhase(const CollisionPairs& _pairs) const {
-    std::set<std::pair<Label*, Label*>> occlusions;
+void skip(const std::vector<const Style*>& _styles, Tile& _tile, Tile& _proxy) {
 
-    for (auto pair : _pairs) {
-        const auto& aabb1 = m_aabbs[pair.first];
-        const auto& aabb2 = m_aabbs[pair.second];
+    for (const auto& style : _styles) {
 
-        auto l1 = static_cast<Label*>(aabb1.m_userData);
-        auto l2 = static_cast<Label*>(aabb2.m_userData);
+        auto* mesh0 = static_cast<const LabelMesh*>(_tile.getMesh(*style).get());
+        if (!mesh0) { continue; }
 
-        if (intersect(l1->obb(), l2->obb())) {
-            occlusions.insert({l1, l2});
-        }
-    }
+        auto* mesh1 = static_cast<const LabelMesh*>(_proxy.getMesh(*style).get());
+        if (!mesh1) { continue; }
 
-    return occlusions;
-}
+        for (auto& l0 : mesh0->getLabels()) {
+            if (!l0->canOcclude()) { continue; }
+            if ((l0->state() & Label::State::wait_occ) == 0) { continue; }
 
-void Labels::applyPriorities(const std::set<std::pair<Label*, Label*>> _occlusions) const {
-    for (auto& pair : _occlusions) {
-        if (!pair.first->occludedLastFrame() || !pair.second->occludedLastFrame()) {
-            // check first is the label belongs to a proxy tile
-            if (pair.first->isProxy() && !pair.second->isProxy()) {
-                pair.first->occlude(Label::OcclusionType::collision);
-            } else if (!pair.first->isProxy() && pair.second->isProxy()) {
-                pair.second->occlude(Label::OcclusionType::collision);
-            } else {
-                // lower numeric priority means higher priority
-                if (pair.first->options().priority < pair.second->options().priority) {
-                    pair.second->occlude(Label::OcclusionType::collision);
-                } else {
-                    pair.first->occlude(Label::OcclusionType::collision);
+            for (auto& l1 : mesh1->getLabels()) {
+                //if (!l1->canOcclude() || l0->hash() != l1->hash()) { continue; }
+                if (!l1->canOcclude() || l0->options().repeatGroup != l1->options().repeatGroup) {
+                    continue;
+                }
+
+                float d2 = glm::distance2(l0->transform().state.screenPos,
+                                          l1->transform().state.screenPos);
+
+                // The new label lies within the circle defined by the bbox of l0
+                if (sqrt(d2) < std::max(l0->dimension().x, l0->dimension().y)) {
+
+                    auto* t = dynamic_cast<const TextLabel*>(l0.get());
+                    if (t && t->options().properties) {
+                        auto v = t->options().properties->get("name");
+                        if (v.is<std::string>())
+                            LOG("skip transition: %s", v.get<std::string>().c_str());
+                    }
+                    // LOG("skip transition... ");
+
+                    l0->skipTransitions();
                 }
             }
         }
@@ -114,54 +113,42 @@ void Labels::skipTransitions(const std::vector<std::unique_ptr<Style>>& _styles,
                              const std::vector<std::shared_ptr<Tile>>& _tiles,
                              std::unique_ptr<TileCache>& _cache, float _currentZoom) const
 {
-    for (const auto& t0 : _tiles) {
-        TileID tileID = t0->getID();
-        std::vector<std::shared_ptr<Tile>> tiles;
+    std::vector<const Style*> styles;
+
+    for (const auto& style : _styles) {
+        if (dynamic_cast<const TextStyle*>(style.get()) ||
+            dynamic_cast<const PointStyle*>(style.get())) {
+            styles.push_back(style.get());
+        }
+    }
+
+    for (const auto& tile : _tiles) {
+        TileID tileID = tile->getID();
+        std::shared_ptr<Tile> proxy;
 
         if (m_lastZoom < _currentZoom) {
             // zooming in, add the one cached parent tile
-            tiles.push_back(_cache->contains(t0->sourceID(), tileID.getParent()));
+            proxy = _cache->contains(tile->sourceID(), tileID.getParent());
+            if (proxy) { skip(styles, *tile, *proxy); }
         } else {
             // zooming out, add the 4 cached children tiles
-            tiles.push_back(_cache->contains(t0->sourceID(), tileID.getChild(0)));
-            tiles.push_back(_cache->contains(t0->sourceID(), tileID.getChild(1)));
-            tiles.push_back(_cache->contains(t0->sourceID(), tileID.getChild(2)));
-            tiles.push_back(_cache->contains(t0->sourceID(), tileID.getChild(3)));
-        }
+            proxy = _cache->contains(tile->sourceID(), tileID.getChild(0));
+            if (proxy) { skip(styles, *tile, *proxy); }
 
-        for (const auto& t1 : tiles) {
-            if (!t1) { continue; }
-            for (const auto& style : _styles) {
-                const auto& m0 = t0->getMesh(*style);
-                if (!m0) { continue; }
-                const LabelMesh* mesh0 = dynamic_cast<const LabelMesh*>(m0.get());
-                if (!mesh0) { continue; }
-                const auto& m1 = t1->getMesh(*style);
-                if (!m1) { continue; }
-                const LabelMesh* mesh1 = static_cast<const LabelMesh*>(m1.get());
+            proxy = _cache->contains(tile->sourceID(), tileID.getChild(1));
+            if (proxy) { skip(styles, *tile, *proxy); }
 
-                for (auto& l0 : mesh0->getLabels()) {
-                    if (!l0->canOcclude()) { continue; }
+            proxy = _cache->contains(tile->sourceID(), tileID.getChild(2));
+            if (proxy) { skip(styles, *tile, *proxy); }
 
-                    for (auto& l1 : mesh1->getLabels()) {
-                        if (!l1 || !l1->canOcclude() || l0->hash() != l1->hash()) {
-                            continue;
-                        }
-                        float d2 = glm::distance2(l0->transform().state.screenPos,
-                                l1->transform().state.screenPos);
-
-                        // The new label lies within the circle defined by the bbox of l0
-                        if (sqrt(d2) < std::max(l0->dimension().x, l0->dimension().y)) {
-                            l0->skipTransitions();
-                        }
-                    }
-                }
-            }
+            proxy = _cache->contains(tile->sourceID(), tileID.getChild(3));
+            if (proxy) { skip(styles, *tile, *proxy); }
         }
     }
 }
 
 void Labels::checkRepeatGroups(std::vector<TextLabel*>& _visibleSet) const {
+
     struct GroupElement {
         glm::vec2 position;
 
@@ -194,7 +181,7 @@ void Labels::checkRepeatGroups(std::vector<TextLabel*>& _visibleSet) const {
 
             float d2 = distance2(ge.position, element.position);
             if (d2 < threshold2) {
-                textLabel->occlude(Label::OcclusionType::repeat_group);
+                textLabel->occlude();
                 add = false;
                 break;
             }
@@ -221,59 +208,120 @@ void Labels::update(const View& _view, float _dt,
 
     /// Collect and update labels from visible tiles
 
-    m_needUpdate = updateLabels(_styles, _tiles, _dt, dz, _view);
+    updateLabels(_styles, _tiles, _dt, dz, _view);
+
+
+    /// Mark labels to skip transitions
+
+    if (int(m_lastZoom) != int(_view.getZoom())) {
+        skipTransitions(_styles, _tiles, _cache, currentZoom);
+    }
 
     /// Manage occlusions
 
     // Update collision context size
-
     m_isect2d.resize({_view.getWidth() / 256, _view.getHeight() / 256},
                      {_view.getWidth(), _view.getHeight()});
 
     // Broad phase collision detection
+    for (auto* label : m_labels) {
+        if (!label->isOccluded() && label->canOcclude()) {
+            m_aabbs.push_back(label->aabb());
+            m_aabbs.back().m_userData = (void*)label;
+        }
+    }
     m_isect2d.intersect(m_aabbs);
 
-    // Narrow Phase
-    auto occlusions = narrowPhase(m_isect2d.pairs);
+    // Narrow Phase, resolve conflicts
+    for (auto& pair : m_isect2d.pairs) {
+        const auto& aabb1 = m_aabbs[pair.first];
+        const auto& aabb2 = m_aabbs[pair.second];
 
-    applyPriorities(occlusions);
+        auto l1 = static_cast<Label*>(aabb1.m_userData);
+        auto l2 = static_cast<Label*>(aabb2.m_userData);
 
-    /// Mark labels to skip transitions
+        if (l1->isOccluded() || l2->isOccluded()) {
+            // One of this pair is already occluded.
+            // => conflict solved
+            continue;
+        }
 
-    if ((int) m_lastZoom != (int) _view.getZoom()) {
-        skipTransitions(_styles, _tiles, _cache, currentZoom);
-    }
+        if (!intersect(l1->obb(), l2->obb())) { continue; }
 
-    /// Update label meshes
-
-    std::vector<TextLabel*> repeatGroupSet;
-
-    for (auto label : m_labels) {
-        label->occlusionSolved();
-        label->pushTransform();
-
-        if (label->canOcclude()) {
-            if (!label->visibleState() && label->occlusionType() == Label::OcclusionType::collision) {
-                continue;
+        if (l1->isProxy() != l2->isProxy()) {
+            // check first is the label belongs to a proxy tile
+            if (l1->isProxy()) {
+                l1->occlude();
+            } else {
+                l2->occlude();
             }
-            if (label->options().repeatDistance == 0.f) {
-                continue;
+        } else if (l1->options().priority != l2->options().priority) {
+            // lower numeric priority means higher priority
+            if(l1->options().priority > l2->options().priority) {
+                l1->occlude();
+            } else {
+                l2->occlude();
             }
-
-            TextLabel* textLabel = dynamic_cast<TextLabel*>(label);
-            if (!textLabel) { continue; }
-            repeatGroupSet.push_back(textLabel);
+        } else if (l1->occludedLastFrame() != l2->occludedLastFrame()) {
+            // keep the one that way active previously
+            if (l1->occludedLastFrame()) {
+                l1->occlude();
+            } else {
+                l2->occlude();
+            }
+        } else if (l1->visibleState() != l2->visibleState()) {
+            // keep the visible one, different from occludedLastframe
+            // when one lets labels fade out
+            if (!l1->visibleState()) {
+                l1->occlude();
+            } else {
+                l2->occlude();
+            }
+        } else {
+            // just so it is consistent between two instances
+            if (l1 < l2) {
+                l1->occlude();
+            } else {
+                l2->occlude();
+            }
         }
     }
 
-    // Ensure the labels are always treated in the same order in the visible set
-    std::sort(repeatGroupSet.begin(), repeatGroupSet.end(), [](TextLabel* _a, TextLabel* _b) {
-        return glm::length2(_a->transform().modelPosition1) < glm::length2(_b->transform().modelPosition1);
-    });
-
     /// Apply repeat groups
 
+    std::vector<TextLabel*> repeatGroupSet;
+    for (auto* label : m_labels) {
+        if (!label->canOcclude() || label->isOccluded()) {
+            continue;
+        }
+
+        if (label->options().repeatDistance == 0.f) {
+            continue;
+        }
+        TextLabel* textLabel = dynamic_cast<TextLabel*>(label);
+        if (!textLabel) { continue; }
+        repeatGroupSet.push_back(textLabel);
+    }
+
+    // Ensure the labels are always treated in the same order in the visible set
+    std::sort(repeatGroupSet.begin(), repeatGroupSet.end(),
+              [](TextLabel* _a, TextLabel* _b) {
+        return glm::length2(_a->transform().modelPosition1) <
+               glm::length2(_b->transform().modelPosition1);
+    });
+
     checkRepeatGroups(repeatGroupSet);
+
+
+    /// Update label meshes
+
+    glm::vec2 screenSize = glm::vec2(_view.getWidth(), _view.getHeight());
+
+    m_needUpdate = false;
+    for (auto* label : m_labels) {
+        m_needUpdate |= label->evalState(screenSize, _dt);
+        label->pushTransform();
+    }
 
     // Request for render if labels are in fading in/out states
     if (m_needUpdate) {

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -102,10 +102,25 @@ void Labels::skipTransitions(const std::vector<const Style*>& _styles, Tile& _ti
     }
 }
 
+std::shared_ptr<Tile> findProxy(int32_t _sourceID, const TileID& _proxyID,
+                                const std::vector<std::shared_ptr<Tile>>& _tiles,
+                                std::unique_ptr<TileCache>& _cache) {
+
+    auto proxy = _cache->contains(_sourceID, _proxyID);
+    if (proxy) { return proxy; }
+
+    for (auto& tile : _tiles) {
+        if (tile->getID() == _proxyID && tile->sourceID() == _sourceID) {
+            return tile;
+        }
+    }
+    return nullptr;
+}
+
 void Labels::skipTransitions(const std::vector<std::unique_ptr<Style>>& _styles,
                              const std::vector<std::shared_ptr<Tile>>& _tiles,
-                             std::unique_ptr<TileCache>& _cache, float _currentZoom) const
-{
+                             std::unique_ptr<TileCache>& _cache, float _currentZoom) const {
+
     std::vector<const Style*> styles;
 
     for (const auto& style : _styles) {
@@ -121,20 +136,20 @@ void Labels::skipTransitions(const std::vector<std::unique_ptr<Style>>& _styles,
 
         if (m_lastZoom < _currentZoom) {
             // zooming in, add the one cached parent tile
-            proxy = _cache->contains(tile->sourceID(), tileID.getParent());
+            proxy = findProxy(tile->sourceID(), tileID.getParent(), _tiles, _cache);
             if (proxy) { skipTransitions(styles, *tile, *proxy); }
         } else {
             // zooming out, add the 4 cached children tiles
-            proxy = _cache->contains(tile->sourceID(), tileID.getChild(0));
+            proxy = findProxy(tile->sourceID(), tileID.getChild(0), _tiles, _cache);
             if (proxy) { skipTransitions(styles, *tile, *proxy); }
 
-            proxy = _cache->contains(tile->sourceID(), tileID.getChild(1));
+            proxy = findProxy(tile->sourceID(), tileID.getChild(1), _tiles, _cache);
             if (proxy) { skipTransitions(styles, *tile, *proxy); }
 
-            proxy = _cache->contains(tile->sourceID(), tileID.getChild(2));
+            proxy = findProxy(tile->sourceID(), tileID.getChild(2), _tiles, _cache);
             if (proxy) { skipTransitions(styles, *tile, *proxy); }
 
-            proxy = _cache->contains(tile->sourceID(), tileID.getChild(3));
+            proxy = findProxy(tile->sourceID(), tileID.getChild(3), _tiles, _cache);
             if (proxy) { skipTransitions(styles, *tile, *proxy); }
         }
     }

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -48,13 +48,9 @@ private:
     using OBB = isect2d::OBB<glm::vec2>;
     using CollisionPairs = std::vector<isect2d::ISect2D<glm::vec2>::Pair>;
 
-    bool updateLabels(const std::vector<std::unique_ptr<Style>>& _styles,
+    void updateLabels(const std::vector<std::unique_ptr<Style>>& _styles,
                       const std::vector<std::shared_ptr<Tile>>& _tiles,
                       float _dt, float _dz, const View& _view);
-
-    std::set<std::pair<Label*, Label*>> narrowPhase(const CollisionPairs& _pairs) const;
-
-    void applyPriorities(const std::set<std::pair<Label*, Label*>> _occlusions) const;
 
     void skipTransitions(const std::vector<std::unique_ptr<Style>>& _styles,
                          const std::vector<std::shared_ptr<Tile>>& _tiles,

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -56,6 +56,8 @@ private:
                          const std::vector<std::shared_ptr<Tile>>& _tiles,
                          std::unique_ptr<TileCache>& _cache, float _currentZoom) const;
 
+    void skipTransitions(const std::vector<const Style*>& _styles, Tile& _tile, Tile& _proxy) const;
+
     void checkRepeatGroups(std::vector<TextLabel*>& _visibleSet) const;
 
     int LODDiscardFunc(float _maxZoom, float _zoom);

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -22,16 +22,17 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
     REQUIRE(l.state() == Label::State::wait_occ);
-    l.occlude(Label::OcclusionType::collision, true);
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    // l.occlude(true);
+    // l.evalState(screenSize, 0);
 
     REQUIRE(l.state() != Label::State::sleep);
     REQUIRE(l.state() == Label::State::wait_occ);
     REQUIRE(l.canOcclude());
 
-    l.occlude(Label::OcclusionType::collision, true);
-    l.occlusionSolved();
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    l.occlude(true);
+    l.evalState(screenSize, 0);
 
     REQUIRE(l.state() == Label::State::dead);
     REQUIRE(!l.canOcclude());
@@ -42,20 +43,23 @@ TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens
 
     REQUIRE(l.state() == Label::State::wait_occ);
 
-    l.occlude(Label::OcclusionType::collision, false);
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0, 0);
+    // l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    // l.occlude(false);
+    // l.evalState(screenSize, 0);
 
-    REQUIRE(l.state() != Label::State::sleep);
-    REQUIRE(l.state() == Label::State::wait_occ);
+    // REQUIRE(l.state() != Label::State::sleep);
+    // REQUIRE(l.state() == Label::State::wait_occ);
 
-    l.occlude(Label::OcclusionType::collision, false);
-    l.occlusionSolved();
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    l.occlude(false);
+    l.evalState(screenSize, 0);
 
     REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 1.f, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    l.evalState(screenSize, 1.f);
+
     REQUIRE(l.state() == Label::State::visible);
     REQUIRE(l.canOcclude());
 }
@@ -63,16 +67,22 @@ TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens
 TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
-    l.occlude(Label::OcclusionType::collision, false);
-    l.occlusionSolved();
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    l.occlude(false);
+    l.evalState(screenSize, 0);
 
     REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
-    l.occlude(Label::OcclusionType::collision, true);
-    l.occlusionSolved();
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    l.occlude(true);
+    l.evalState(screenSize, 1.f);
+
+    REQUIRE(l.state() == Label::State::fading_out);
+
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    l.occlude(true);
+    l.evalState(screenSize, 1.f);
 
     REQUIRE(l.state() == Label::State::sleep);
     REQUIRE(l.canOcclude());
@@ -83,25 +93,28 @@ TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
 
     REQUIRE(l.state() == Label::State::wait_occ);
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
 
     REQUIRE(l.state() == Label::State::out_of_screen);
     REQUIRE(l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
+    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0);
+    l.evalState(screenSize, 0);
     REQUIRE(l.state() == Label::State::wait_occ);
     REQUIRE(l.canOcclude());
 
-    l.occlude(Label::OcclusionType::collision, false);
+    l.occlude(false);
     l.resetState();
-    l.occlusionSolved();
-    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0.f, 0);
+    //l.occlusionSolved();
+    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0);
+    l.evalState(screenSize, 0);
     REQUIRE(l.state() != Label::State::wait_occ);
 
     REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 1.f, 0);
+    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0);
+    l.evalState(screenSize, 1.f);
 
     REQUIRE(l.state() == Label::State::visible);
     REQUIRE(l.canOcclude());
@@ -113,7 +126,8 @@ TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][
     REQUIRE(l.state() == Label::State::visible);
     REQUIRE(!l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 1.f, 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    l.evalState(screenSize, 1.f);
 
     REQUIRE(l.state() == Label::State::visible);
     REQUIRE(!l.canOcclude());

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -78,11 +78,11 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
     l.occlude(true);
     l.evalState(screenSize, 1.f);
 
-    REQUIRE(l.state() == Label::State::fading_out);
-
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
-    l.occlude(true);
-    l.evalState(screenSize, 1.f);
+    // Depends whether fading-in labels fade out or set to sleep in evalState
+    // REQUIRE(l.state() == Label::State::fading_out);
+    // l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+    // l.occlude(true);
+    // l.evalState(screenSize, 1.f);
 
     REQUIRE(l.state() == Label::State::sleep);
     REQUIRE(l.canOcclude());


### PR DESCRIPTION
https://github.com/tangrams/tangram-es/issues/478

- label occlusion *should* have stopped running into loops
- separate updateState() and evalState().
  Before the state was applied for the previous frame (m_occludedLastFrame)
- this also fixes first frame flickering (non-drawn labels) when
  switching zoom-level
- refactor: skipTransitions (move nested loop into separate function)
- remove temporary 'occlusions' set. The result of broadphase is already a unique set

