### PR TITLE
add TileBuilder

### DIFF
--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -8,6 +8,7 @@
 #include "scene/styleContext.h"
 #include "util/mapProjection.h"
 #include "tile/tile.h"
+#include "tile/tileBuilder.h"
 #include "tile/tileTask.h"
 
 #include <vector>
@@ -24,7 +25,7 @@ struct TestContext {
     MercatorProjection s_projection;
     const char* sceneFile = "scene.yaml";
 
-    std::unique_ptr<Scene> scene;
+    std::shared_ptr<Scene> scene;
     StyleContext styleContext;
 
     std::shared_ptr<DataSource> source;
@@ -32,6 +33,8 @@ struct TestContext {
     std::vector<char> rawTileData;
 
     std::shared_ptr<TileData> tileData;
+
+    TileBuilder tileBuilder;
 
     void loadScene(const char* sceneFile) {
         auto sceneRelPath = setResourceRoot(sceneFile);
@@ -44,12 +47,13 @@ struct TestContext {
             LOGE("Parsing scene config '%s'", e.what());
             return;
         }
-        scene = std::make_unique<Scene>();
+        scene = std::make_shared<Scene>();
         SceneLoader::loadScene(sceneNode, *scene);
         styleContext.initFunctions(*scene);
         styleContext.setGlobalZoom(0);
 
         source = scene->dataSources()[0];
+        tileBuilder.setScene(scene);
     }
 
     void loadTile(const char* path){
@@ -82,68 +86,21 @@ struct TestContext {
 
 class TileLoadingFixture : public benchmark::Fixture {
 public:
+    TestContext ctx;
     MercatorProjection s_projection;
     const char* sceneFile = "scene.yaml";
 
-    std::unique_ptr<Scene> scene;
-    StyleContext styleContext;
-
-    std::shared_ptr<DataSource> source;
-    std::shared_ptr<TileData> tileData;
-    std::vector<char> rawTileData;
+    std::shared_ptr<Tile> result;
 
     void SetUp() override {
         LOG("SETUP");
-        if (scene) {  return; }
-
-        auto sceneRelPath = setResourceRoot(sceneFile);
-        auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource);
-
-        YAML::Node sceneNode;
-
-        try { sceneNode = YAML::Load(sceneString); }
-        catch (YAML::ParserException e) {
-            LOGE("Parsing scene config '%s'", e.what());
-            return;
-        }
-        scene = std::make_unique<Scene>();
-        SceneLoader::loadScene(sceneNode, *scene);
-        styleContext.initFunctions(*scene);
-        styleContext.setGlobalZoom(10);
-
-        const char* path = "tile.mvt";
-
-        std::ifstream resource(path, std::ifstream::ate | std::ifstream::binary);
-        if(!resource.is_open()) {
-            LOGE("Failed to read file at path: %s", path.c_str());
-            return;
-        }
-
-        size_t _size = resource.tellg();
-        resource.seekg(std::ifstream::beg);
-
-        rawTileData.resize(_size);
-
-        resource.read(&rawTileData[0], _size);
-        resource.close();
-
-        LOG("Initialized TileData");
-
-        Tile tile({0,0,0}, s_projection);
-
-        if (!scene->dataSources().empty()) {
-            source = scene->dataSources()[0];
-            auto task = source->createTask(tile.getID());
-            auto& t = dynamic_cast<DownloadTileTask&>(*task);
-            t.rawTileData = std::make_shared<std::vector<char>>();
-            std::swap(*t.rawTileData, rawTileData);
-
-            tileData = source->parse(*task, s_projection);
-        }
-
+        ctx.loadScene(sceneFile);
+        ctx.loadTile("tile.mvt");
+        ctx.parseTile();
         LOG("Ready");
     }
     void TearDown() override {
+        result.reset();
         LOG("TEARDOWN");
     }
 };
@@ -151,8 +108,7 @@ public:
 BENCHMARK_DEFINE_F(TileLoadingFixture, BuildTest)(benchmark::State& st) {
 
     while (st.KeepRunning()) {
-        Tile tile({0,0,0}, s_projection);
-        tile.build(styleContext, *scene, *tileData, *source);
+        result = ctx.tileBuilder.build({0,0,0}, *ctx.tileData, *ctx.source);
     }
 }
 

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -1,6 +1,6 @@
 #include "drawRule.h"
 
-#include "tile/tile.h"
+#include "tile/tileBuilder.h"
 #include "scene/scene.h"
 #include "scene/sceneLayer.h"
 #include "scene/stops.h"
@@ -148,8 +148,8 @@ bool DrawRuleMergeSet::match(const Feature& _feature, const SceneLayer& _layer, 
     return true;
 }
 
-void DrawRuleMergeSet::apply(const Feature& _feature, const Scene& _scene, const SceneLayer& _layer,
-                    StyleContext& _ctx, Tile& _tile) {
+void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
+                             StyleContext& _ctx, TileBuilder& _builder) {
 
     // If no rules matched the feature, return immediately
     if (!match(_feature, _layer, _ctx)) { return; }
@@ -158,8 +158,7 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const Scene& _scene, const
     // build the feature with the rule's parameters
     for (auto& rule : matchedRules) {
 
-        auto* style = _scene.findStyle(rule.getStyleName());
-
+        const Style* style = _builder.scene().findStyle(rule.getStyleName());
         if (!style) {
             LOGE("Invalid style %s", rule.getStyleName().c_str());
             continue;
@@ -206,7 +205,7 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const Scene& _scene, const
         }
 
         if (valid) {
-            style->buildFeature(_tile, _feature, rule);
+            style->buildFeature(_builder.tile(), _feature, rule);
         }
     }
 }

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -8,7 +8,7 @@
 namespace Tangram {
 
 struct Feature;
-class Tile;
+class TileBuilder;
 class Scene;
 class SceneLayer;
 class StyleContext;
@@ -94,9 +94,8 @@ struct DrawRuleMergeSet {
     /* Determine and apply DrawRules for a @_feature and add
      * the result to @_tile
      */
-    void apply(const Feature& _feature, const Scene& _scene,
-               const SceneLayer& _sceneLayer,
-               StyleContext& _ctx, Tile& _tile);
+    void apply(const Feature& _feature, const SceneLayer& _sceneLayer,
+               StyleContext& _ctx, TileBuilder& _builder);
 
     // internal
     bool match(const Feature& _feature, const SceneLayer& _layer, StyleContext& _ctx);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -126,6 +126,8 @@ void toggleDebugFlag(DebugFlags _flag);
 
 void loadScene(const char* _scenePath, bool _setPositionFromScene = false);
 
+void runOnMainLoop(std::function<void()> _task);
+
 struct TouchItem {
     std::shared_ptr<Properties> properties;
     float position[2];

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -19,7 +19,6 @@ class TextBuffer;
 class VboMesh;
 class View;
 class StyleContext;
-struct TileData;
 
 /* Tile of vector map data
  *
@@ -67,8 +66,6 @@ public:
     /* Draws the geometry associated with the provided <Style> and view-projection matrix */
     void draw(const Style& _style, const View& _view);
 
-    void build(StyleContext& _ctx, const Scene& _scene, const TileData& _data, const DataSource& _source);
-
     void resetState();
 
     /* Get the sum in bytes of all <VboMesh>es */
@@ -107,7 +104,8 @@ private:
     // Distances from the global origin are too large to represent precisely in 32-bit floats, so we only apply the
     // relative translation from the view origin to the model origin immediately before drawing the tile.
 
-    std::vector<std::unique_ptr<VboMesh>> m_geometry; // Map of <Style>s and their associated <VboMesh>es
+    // Map of <Style>s and their associated <VboMesh>es
+    std::vector<std::unique_ptr<VboMesh>> m_geometry;
 
     mutable size_t m_memoryUsage = 0;
 };

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -1,0 +1,69 @@
+#include "tile/tileBuilder.h"
+
+#include "gl/vboMesh.h"
+
+#include "data/dataSource.h"
+
+#include "scene/dataLayer.h"
+#include "scene/scene.h"
+#include "style/style.h"
+#include "tile/tile.h"
+
+
+namespace Tangram {
+
+TileBuilder::TileBuilder() {}
+
+TileBuilder::~TileBuilder() {}
+
+void TileBuilder::setScene(std::shared_ptr<Scene> _scene) {
+
+    m_scene = _scene;
+
+    m_styleContext.initFunctions(*_scene);
+}
+
+std::shared_ptr<Tile> TileBuilder::build(TileID _tileID, const TileData& _tileData,
+                                         const DataSource& _source) {
+
+    m_tile = std::make_shared<Tile>(_tileID, *m_scene->mapProjection(), &_source);
+    m_tile->initGeometry(m_scene->styles().size());
+
+    m_styleContext.setGlobalZoom(_tileID.s);
+
+    for (auto& style : m_scene->styles()) {
+        style->onBeginBuildTile(*m_tile);
+    }
+
+    for (const auto& datalayer : m_scene->layers()) {
+
+        if (datalayer.source() != _source.name()) { continue; }
+
+        for (const auto& collection : _tileData.layers) {
+
+            if (!collection.name.empty()) {
+                const auto& dlc = datalayer.collections();
+                bool layerContainsCollection =
+                    std::find(dlc.begin(), dlc.end(), collection.name) != dlc.end();
+
+                if (!layerContainsCollection) { continue; }
+            }
+
+            for (const auto& feat : collection.features) {
+                m_ruleSet.apply(feat, datalayer, m_styleContext, *this);
+            }
+        }
+    }
+
+    for (auto& style : m_scene->styles()) {
+        style->onEndBuildTile(*m_tile);
+        auto& mesh = m_tile->getMesh(*style);
+        if (mesh) {
+            mesh->compileVertexBuffer();
+        }
+    }
+
+    return std::move(m_tile);
+}
+
+}

--- a/core/src/tile/tileBuilder.h
+++ b/core/src/tile/tileBuilder.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "data/dataSource.h"
+#include "scene/styleContext.h"
+#include "scene/drawRule.h"
+
+namespace Tangram {
+
+class DataLayer;
+class DataSource;
+class Tile;
+struct TileData;
+
+class TileBuilder {
+
+public:
+
+    TileBuilder();
+
+    ~TileBuilder();
+
+    void setScene(std::shared_ptr<Scene> _scene);
+
+    std::shared_ptr<Tile> build(TileID _tileID, const TileData& _data, const DataSource& _source);
+
+    const Scene& scene() const { return *m_scene; }
+
+    Tile& tile() const { return *m_tile; }
+
+private:
+    std::shared_ptr<Scene> m_scene;
+
+    StyleContext m_styleContext;
+    DrawRuleMergeSet m_ruleSet;
+
+    std::shared_ptr<Tile> m_tile;
+};
+
+}

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -5,9 +5,9 @@
 #include "tile/tile.h"
 #include "view/view.h"
 #include "scene/scene.h"
-#include "scene/styleContext.h"
 #include "tile/tileID.h"
 #include "tile/tileTask.h"
+#include "tile/tileBuilder.h"
 
 #include <algorithm>
 
@@ -20,7 +20,9 @@ TileWorker::TileWorker(int _num_worker) {
     m_pendingTiles = false;
 
     for (int i = 0; i < _num_worker; i++) {
-        m_workers.emplace_back(&TileWorker::run, this);
+        auto worker = std::make_unique<Worker>();
+        worker->thread = std::thread(&TileWorker::run, this, worker.get());
+        m_workers.push_back(std::move(worker));
     }
 }
 
@@ -30,11 +32,11 @@ TileWorker::~TileWorker(){
     }
 }
 
-void TileWorker::run() {
+void TileWorker::run(Worker* instance) {
 
     setCurrentThreadPriority(WORKER_NICENESS);
 
-    StyleContext context;
+    std::unique_ptr<TileBuilder> builder;
 
     while (true) {
 
@@ -78,26 +80,27 @@ void TileWorker::run() {
             m_queue.erase(it);
         }
 
-        if (task->isCanceled()) { continue; }
+        if (task->isCanceled()) {
+            continue;
+        }
 
-        // Save shared reference to Scene while building tile
-        // FIXME: Scene could be released on Worker-Thread and
-        // therefore call unsafe glDelete* functions...
-        auto scene = m_scene;
-        if (!scene) { continue; }
+        if (instance->tileBuilder) {
+            builder = std::move(instance->tileBuilder);
+            LOG("Passed new StyleContext to TileWorker");
+        }
 
-        auto tileData = task->source().parse(*task, *scene->mapProjection());
+        if (!builder) {
+            LOGE("Missing Scene/StyleContext in TileWorker!");
+            continue;
+        }
+
+        auto tileData = task->source().parse(*task, *builder->scene().mapProjection());
 
         // const clock_t begin = clock();
 
-        context.initFunctions(*scene);
-
         if (tileData) {
-            auto tile = std::make_shared<Tile>(task->tileId(),
-                                               *scene->mapProjection(),
-                                               &task->source());
 
-            tile->build(context, *scene, *tileData, task->source());
+            auto&& tile = builder->build(task->tileId(), *tileData, task->source());
 
             // Mark task as ready
             task->setTile(std::move(tile));
@@ -111,6 +114,15 @@ void TileWorker::run() {
         m_pendingTiles = true;
 
         requestRender();
+    }
+}
+
+void TileWorker::setScene(std::shared_ptr<Scene>& _scene) {
+    for (auto& worker : m_workers) {
+        auto tileBuilder = std::make_unique<TileBuilder>();
+        tileBuilder->setScene(_scene);
+
+        worker->tileBuilder = std::move(tileBuilder);
     }
 }
 
@@ -133,8 +145,8 @@ void TileWorker::stop() {
 
     m_condition.notify_all();
 
-    for (std::thread &worker: m_workers) {
-        worker.join();
+    for (auto& worker : m_workers) {
+        worker->thread.join();
     }
 }
 

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -11,8 +11,8 @@
 
 namespace Tangram {
 
-class DataSource;
 class Scene;
+class TileBuilder;
 
 class TileWorker : public TileTaskQueue {
 
@@ -36,17 +36,23 @@ public:
         return false;
     }
 
-    void setScene(std::shared_ptr<Scene> _scene) { m_scene = _scene; }
+    void setScene(std::shared_ptr<Scene>& _scene);
 
 private:
 
-    void run();
+    struct Worker {
+        std::thread thread;
+        std::unique_ptr<TileBuilder> tileBuilder;
+    };
+
+    void run(Worker* instance);
 
     bool m_running;
 
     std::atomic<bool> m_pendingTiles;
 
-    std::vector<std::thread> m_workers;
+    std::vector<std::unique_ptr<Worker>> m_workers;
+
     std::condition_variable m_condition;
 
     std::mutex m_mutex;

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -58,7 +58,6 @@ private:
     std::mutex m_mutex;
     std::vector<std::shared_ptr<TileTask>> m_queue;
 
-    std::shared_ptr<Scene> m_scene;
 };
 
 }


### PR DESCRIPTION
This PR adds a TileBuilder to each TileWorker thread. 
So far the TileBuilder itself is only a refactoring of existing parts to have one place to hold all structures used for tile building. This is the groundwork for StyleBuilder and TileDataSink branches.

- Tile::build() moved to TileBuilder
- TileBuilder holds a Scene reference, and embeds a StyleContext and DrawRuleMergeSet.
- Finally save scene reloading is possible. Old TileBuilder instances are disposed on the main-loop.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/tangrams/tangram-es/498)
<!-- Reviewable:end -->
