### PR TITLE
Shutdown GLFW properly

### DIFF
--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -8,7 +8,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <cstdlib>
-
 #include <signal.h>
 
 
@@ -267,7 +266,16 @@ int main(int argc, char* argv[]) {
 
     static bool keepRunning = true;
 
-    signal(SIGINT, [](int) { keepRunning = false; });
+    // Give it a chance to shutdown cleanly on CTRL-C
+    signal(SIGINT, [](int) {
+            if (keepRunning) {
+                logMsg("shutdown\n");
+                keepRunning = false;
+                glfwPostEmptyEvent();
+            } else {
+                logMsg("killed!\n");
+                exit(1);
+            }});
 
     int argi = 0;
     while (++argi < argc) {

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -332,6 +332,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    finishUrlRequests();
+
     curl_global_cleanup();
     glfwTerminate();
     return 0;

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -21,6 +21,7 @@ std::string sceneFile = "scene.yaml";
 GLFWwindow* main_window = nullptr;
 int width = 800;
 int height = 600;
+bool recreate_context;
 
 // Input handling
 // ==============
@@ -192,7 +193,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 Tangram::loadScene(sceneFile.c_str());
                 break;
             case GLFW_KEY_BACKSPACE:
-                init_main_window(); // Simulate GL context loss
+                recreate_context = true;
                 break;
             case GLFW_KEY_N:
                 Tangram::setRotation(0.f, 1.f);
@@ -308,6 +309,8 @@ int main(int argc, char* argv[]) {
     setContinuousRendering(false);
     glfwSwapInterval(0);
 
+    recreate_context = false;
+
     // Loop until the user closes the window
     while (keepRunning && !glfwWindowShouldClose(main_window)) {
 
@@ -330,6 +333,14 @@ int main(int argc, char* argv[]) {
         } else {
             glfwWaitEvents();
         }
+
+        if (recreate_context) {
+            logMsg("recreate context\n");
+             // Simulate GL context loss
+            init_main_window();
+            recreate_context = false;
+        }
+
         if (scene_editing_mode) {
             if (stat(sceneFile.c_str(), &sb) == 0) {
                 if (last_mod != sb.st_mtime) {

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -157,6 +157,12 @@ void cancelUrlRequest(const std::string& _url) {
     }
 }
 
+void finishUrlRequests() {
+    for(auto& worker : s_Workers) {
+        worker.join();
+    }
+}
+
 void setCurrentThreadPriority(int priority){
     int tid = syscall(SYS_gettid);
     //int  p1 = getpriority(PRIO_PROCESS, tid);

--- a/linux/src/platform_linux.h
+++ b/linux/src/platform_linux.h
@@ -7,3 +7,5 @@
 
 void processNetworkQueue();
 
+void finishUrlRequests();
+

--- a/linux/src/urlWorker.cpp
+++ b/linux/src/urlWorker.cpp
@@ -71,6 +71,10 @@ void UrlWorker::reset() {
     m_task.reset();
 }
 
+void UrlWorker::join() {
+    m_future.get();
+}
+
 bool UrlWorker::hasTask(const std::string& _url) {
     return (m_task && m_task->url == _url);
 }

--- a/linux/src/urlWorker.cpp
+++ b/linux/src/urlWorker.cpp
@@ -72,7 +72,9 @@ void UrlWorker::reset() {
 }
 
 void UrlWorker::join() {
-    m_future.get();
+    if (m_future.valid()) {
+        m_future.get();
+    }
 }
 
 bool UrlWorker::hasTask(const std::string& _url) {

--- a/linux/src/urlWorker.h
+++ b/linux/src/urlWorker.h
@@ -32,6 +32,7 @@ class UrlWorker {
         void reset();
         bool isAvailable() { return !bool(m_task); }
         bool hasTask(const std::string& _url);
+        void join();
 
         UrlWorker();
         ~UrlWorker();

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -4,7 +4,8 @@
 #include <cmath>
 #include <memory>
 #include <signal.h>
-
+#include <stdlib.h>
+ 
 // Forward declaration
 void init_main_window();
 

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -3,6 +3,7 @@
 #include "data/clientGeoJsonSource.h"
 #include <cmath>
 #include <memory>
+#include <signal.h>
 
 // Forward declaration
 void init_main_window();
@@ -258,6 +259,19 @@ void init_main_window() {
 
 int main(int argc, char* argv[]) {
 
+    static bool keepRunning = true;
+
+    // Give it a chance to shutdown cleanly on CTRL-C
+    signal(SIGINT, [](int) {
+            if (keepRunning) {
+                logMsg("shutdown\n");
+                keepRunning = false;
+                glfwPostEmptyEvent();
+            } else {
+                logMsg("killed!\n");
+                exit(1);
+            }});
+
     int argi = 0;
     while (++argi < argc) {
         if (strcmp(argv[argi - 1], "-f") == 0) {
@@ -280,7 +294,7 @@ int main(int argc, char* argv[]) {
     double lastTime = glfwGetTime();
 
     // Loop until the user closes the window
-    while (!glfwWindowShouldClose(main_window)) {
+    while (keepRunning && !glfwWindowShouldClose(main_window)) {
 
         double currentTime = glfwGetTime();
         double delta = currentTime - lastTime;

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -13,6 +13,7 @@ std::string sceneFile = "scene.yaml";
 GLFWwindow* main_window = nullptr;
 int width = 800;
 int height = 600;
+bool recreate_context;
 
 // Input handling
 // ==============
@@ -172,7 +173,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 Tangram::toggleDebugFlag(Tangram::DebugFlags::tangram_infos);
                 break;
             case GLFW_KEY_BACKSPACE:
-                init_main_window(); // Simulate GL context loss
+                recreate_context = true;
                 break;
             case GLFW_KEY_R:
                 Tangram::loadScene(sceneFile.c_str());
@@ -293,6 +294,8 @@ int main(int argc, char* argv[]) {
 
     double lastTime = glfwGetTime();
 
+    recreate_context = false;
+
     // Loop until the user closes the window
     while (keepRunning && !glfwWindowShouldClose(main_window)) {
 
@@ -313,6 +316,14 @@ int main(int argc, char* argv[]) {
         } else {
             glfwWaitEvents();
         }
+
+        if (recreate_context) {
+            logMsg("recreate context\n");
+             // Simulate GL context loss
+            init_main_window();
+            recreate_context = false;
+        }
+
     }
 
     glfwTerminate();


### PR DESCRIPTION
Explicity stop UrlWorkers before other static globals may be destructed. This seems to fix occasional crashes on shutdown for linux. 

While at it I've added a shutdown method that ensures that TileWorker is stopped before TileManager gets destructed. It may be sufficient though to change the implicit order of destruction by switching the lines 

```
std::unique_ptr<TileManager> m_tileManager;
std::unique_ptr<TileWorker> m_tileWorker;
```

... no it was the global m_tasks queue introduced in TileBuilder branch which was destructed to early.
Still having an explicit order might be good. In case someone shuffles global declarations in tangram.cpp 
