### PR TITLE
Use rounding when encoding position attributes as integers

### DIFF
--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -52,12 +52,12 @@ public:
     struct Vertex {
         // Constructor for TextStyle vertices
         Vertex(glm::vec2 pos, glm::vec2 uv, uint32_t color, uint32_t stroke)
-            : pos(pos * position_scale), uv(uv),
+            : pos(glm::round(pos * position_scale)), uv(uv),
               color(color), stroke(stroke) {}
 
         // Constructor for PointStyle vertices
         Vertex(glm::vec2 pos, glm::vec2 uv, glm::vec2 extrude, uint32_t color)
-            : pos(pos * position_scale), uv(uv),
+            : pos(glm::round(pos * position_scale)), uv(uv),
               color(color),
               extrude(extrude * extrusion_scale) {}
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -26,7 +26,7 @@ struct PolygonVertex {
 
     PolygonVertex(glm::vec3 position, uint32_t order,
                   glm::vec3 normal, glm::vec2 uv, GLuint abgr)
-        : pos(glm::i16vec4{ position * position_scale, order }),
+        : pos(glm::i16vec4{ glm::round(position * position_scale), order }),
           norm(normal * normal_scale),
           texcoord(uv * texture_scale),
           abgr(abgr) {}

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -25,13 +25,13 @@ struct PolylineVertex {
 
     PolylineVertex(glm::vec3 position, float order, glm::vec2 uv,
                    glm::vec2 extrude, glm::vec2 width, GLuint abgr)
-        : pos(glm::i16vec4{ position * position_scale, order * order_scale }),
+        : pos(glm::i16vec4{ glm::round(position * position_scale), order * order_scale }),
           texcoord(uv * texture_scale),
           extrude(extrude * extrusion_scale, width * extrusion_scale),
           abgr(abgr) {}
 
     PolylineVertex(PolylineVertex v, float order, glm::vec2 width, GLuint abgr)
-        : pos(glm::i16vec4{ v.pos.x, v.pos.y, v.pos.z, order * order_scale}),
+        : pos(glm::i16vec4{ glm::round(glm::vec3(v.pos)), order * order_scale}),
           texcoord(v.texcoord),
           extrude(glm::i16vec4{ v.extrude.x, v.extrude.y, width * extrusion_scale }),
           abgr(abgr) {}


### PR DESCRIPTION
Fixes some small (but visible) discrepancies in vertex positions at the edges of tiles. 