### PR TITLE
Fix evaluated draw parameters containing extra function/stops values

### DIFF
--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -174,19 +174,20 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const Scene& _scene, const
 
             if (param->function >= 0) {
 
+                evaluated[i] = *param;
+
                 if (!_ctx.evalStyle(param->function, param->key, evaluated[i].value) &&
                     StyleParam::isRequired(param->key)) {
                     valid = false;
                     break;
                 }
 
-                evaluated[i].function = param->function;
                 rule.params[i] = &evaluated[i];
 
             }
             if (param->stops) {
 
-                evaluated[i].stops = param->stops;
+                evaluated[i] = *param;
 
                 if (StyleParam::isColor(param->key)) {
                     evaluated[i].value = param->stops->evalColor(_ctx.getGlobalZoom());


### PR DESCRIPTION
Dynamically-evaluated draw parameters are stored in temporary arrays that are re-used for each feature in a tile and then disposed. In the current draw rule evaluation code, values are overridden as needed by each subsequent draw rule as features are built - but they are *incompletely* overridden: A parameter that is evaluated as a function for one feature and as stops for the next feature will end up placing both a `Stops*` and a function index in the same parameter. The result is that a style may incorrectly interpret the rule, possibly causing a bad access violation and killing the program. 

This change fixes the potential error by *completely* overriding the evaluated parameter with the assignment operator. 