### PR TITLE
Drawrule optimizations

### DIFF
--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -10,6 +10,7 @@
 #include "tile/tile.h"
 #include "tile/tileBuilder.h"
 #include "tile/tileTask.h"
+#include "text/fontContext.h"
 
 #include <vector>
 #include <iostream>
@@ -49,6 +50,8 @@ struct TestContext {
         }
         scene = std::make_shared<Scene>();
         SceneLoader::loadScene(sceneNode, *scene);
+        scene->fontContext()->addFont("firasans", "medium", "");
+
         styleContext.initFunctions(*scene);
         styleContext.setGlobalZoom(0);
 
@@ -73,12 +76,11 @@ struct TestContext {
     }
 
     void parseTile() {
-        Tile tile({0,0,0}, s_projection);
+        Tile tile({0,0,10,10,0}, s_projection);
         source = scene->dataSources()[0];
         auto task = source->createTask(tile.getID());
         auto& t = dynamic_cast<DownloadTileTask&>(*task);
-        t.rawTileData = std::make_shared<std::vector<char>>();
-        std::swap(*t.rawTileData, rawTileData);
+        t.rawTileData = std::make_shared<std::vector<char>>(rawTileData);
 
         tileData = source->parse(*task, s_projection);
     }
@@ -108,7 +110,10 @@ public:
 BENCHMARK_DEFINE_F(TileLoadingFixture, BuildTest)(benchmark::State& st) {
 
     while (st.KeepRunning()) {
-        result = ctx.tileBuilder.build({0,0,0}, *ctx.tileData, *ctx.source);
+        ctx.parseTile();
+        result = ctx.tileBuilder.build({0,0,10,10,0}, *ctx.tileData, *ctx.source);
+
+        LOG("ok %d / bytes - %d", bool(result), result->getMemoryUsage());
     }
 }
 

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -103,15 +103,12 @@ const char* DrawRule::getLayerName(StyleParamKey _key) const {
     return params[static_cast<uint8_t>(_key)].name;
 }
 
-std::set<const char*> DrawRule::getLayerNames() const {
-    std::set<const char*> layerNames;
-
+size_t DrawRule::getParamSetHash() const {
+    size_t seed = 0;
     for (size_t i = 0; i < StyleParamKeySize; i++) {
-        if (params[i].name) {
-            layerNames.insert(params[i].name);
-        }
+        if (active[i]) { hash_combine(seed, params[i].name); }
     }
-    return layerNames;
+    return seed;
 }
 
 void DrawRule::logGetError(StyleParamKey _expectedKey, const StyleParam& _param) const {

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -14,7 +14,7 @@
 namespace Tangram {
 
 DrawRuleData::DrawRuleData(std::string _name, int _id,
-                               const std::vector<StyleParam>& _parameters) :
+                           const std::vector<StyleParam>& _parameters) :
     parameters(_parameters),
     name(std::move(_name)),
     id(_id) {}
@@ -39,6 +39,7 @@ DrawRule::DrawRule(const DrawRuleData& _ruleData) :
 }
 
 void DrawRule::merge(const DrawRuleData& _ruleData, const SceneLayer& _layer) {
+    // TODO Optimize - string copying going on here
 
     evalConflict(*this, _ruleData, _layer);
 
@@ -115,28 +116,28 @@ void DrawRule::logGetError(StyleParamKey _expectedKey, const StyleParam& _param)
 bool DrawRuleMergeSet::match(const Feature& _feature, const SceneLayer& _layer, StyleContext& _ctx) {
 
     _ctx.setFeature(_feature);
-    matchedRules.clear();
-    queuedLayers.clear();
+    m_matchedRules.clear();
+    m_queuedLayers.clear();
 
     // If the first filter doesn't match, return immediately
     if (!_layer.filter().eval(_feature, _ctx)) { return false; }
 
     // Add the first layer to the stack
-    queuedLayers.push_back(&_layer);
+    m_queuedLayers.push_back(&_layer);
 
     // Iterate depth-first over the layer hierarchy
-    while (!queuedLayers.empty()) {
+    while (!m_queuedLayers.empty()) {
 
         // Pop a layer off the top of the stack
-        const auto& layer = *queuedLayers.back();
-        queuedLayers.pop_back();
+        const auto& layer = *m_queuedLayers.back();
+        m_queuedLayers.pop_back();
 
         // If the filter doesn't pass, move on to the next one
         if (!layer.filter().eval(_feature, _ctx)) { continue; }
 
         // Push each of the layer's sublayers onto the stack
         for (const auto& sublayer : layer.sublayers()) {
-            queuedLayers.push_back(&sublayer);
+            m_queuedLayers.push_back(&sublayer);
         }
 
         // Merge rules from current layer into accumulated set
@@ -153,7 +154,7 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
 
     // For each matched rule, find the style to be used and
     // build the feature with the rule's parameters
-    for (auto& rule : matchedRules) {
+    for (auto& rule : m_matchedRules) {
 
         StyleBuilder* style = _builder.getStyleBuilder(rule.getStyleName());
         if (!style) {
@@ -175,33 +176,32 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
 
             if (param->function >= 0) {
 
-                evaluated[i] = *param;
+                m_evaluated[i] = *param;
 
-                if (!_ctx.evalStyle(param->function, param->key, evaluated[i].value) &&
+                if (!_ctx.evalStyle(param->function, param->key, m_evaluated[i].value) &&
                     StyleParam::isRequired(param->key)) {
                     valid = false;
                     break;
                 }
 
-                rule.params[i] = &evaluated[i];
-
+                rule.params[i] = &m_evaluated[i];
             }
             if (param->stops) {
 
-                evaluated[i] = *param;
+                m_evaluated[i] = *param;
 
                 if (StyleParam::isColor(param->key)) {
-                    evaluated[i].value = param->stops->evalColor(_ctx.getGlobalZoom());
+                    m_evaluated[i].value = param->stops->evalColor(_ctx.getGlobalZoom());
                 } else if (StyleParam::isWidth(param->key)) {
                     // FIXME width result is ignored from here
-                    evaluated[i].value = param->stops->evalWidth(_ctx.getGlobalZoom());
+                    m_evaluated[i].value = param->stops->evalWidth(_ctx.getGlobalZoom());
                 } else if (StyleParam::isOffsets(param->key)) {
-                    evaluated[i].value = param->stops->evalVec2(_ctx.getGlobalZoom());
+                    m_evaluated[i].value = param->stops->evalVec2(_ctx.getGlobalZoom());
                 } else {
-                    evaluated[i].value = param->stops->evalFloat(_ctx.getGlobalZoom());
+                    m_evaluated[i].value = param->stops->evalFloat(_ctx.getGlobalZoom());
                 }
 
-                rule.params[i] = &evaluated[i];
+                rule.params[i] = &m_evaluated[i];
 
             }
         }
@@ -216,11 +216,11 @@ void DrawRuleMergeSet::mergeRules(const SceneLayer& _layer) {
 
     for (const auto& rule : _layer.rules()) {
 
-        auto it = std::find_if(matchedRules.begin(), matchedRules.end(),
+        auto it = std::find_if(m_matchedRules.begin(), m_matchedRules.end(),
                                [&](auto& m) { return rule.id == m.id; });
 
-        if (it == matchedRules.end()) {
-            it = matchedRules.emplace(it, rule);
+        if (it == m_matchedRules.end()) {
+            it = m_matchedRules.emplace(it, rule);
         }
 
         it->merge(rule, _layer);

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -36,28 +36,25 @@ std::string DrawRuleData::toString() const {
 DrawRule::DrawRule(const DrawRuleData& _ruleData) :
     name(&_ruleData.name),
     id(_ruleData.id) {
-
-    const static char* empty = "";
-    std::fill_n(layers, StyleParamKeySize, empty);
 }
 
 void DrawRule::merge(const DrawRuleData& _ruleData, const SceneLayer& _layer) {
 
     evalConflict(*this, _ruleData, _layer);
 
+    const auto depthNew = _layer.depth();
+    const char* layerNew = _layer.name().c_str();
+
     for (const auto& param : _ruleData.parameters) {
 
         auto key = static_cast<uint8_t>(param.key);
+        auto& layer = layers[key];
 
-        const auto depthOld = depths[key];
-        const auto depthNew = _layer.depth();
-        const char* layerOld = layers[key];
-        const char* layerNew = _layer.name().c_str();
-
-        if (depthNew > depthOld || (depthNew == depthOld && strcmp(layerNew, layerOld) > 0)) {
+        if (depthNew > layer.depth || layer.name == nullptr ||
+            (depthNew == layer.depth && strcmp(layerNew, layer.name) > 0)) {
             params[key] = &param;
-            depths[key] = depthNew;
-            layers[key] = layerNew;
+            layer.name = layerNew;
+            layer.depth = depthNew;
         }
     }
 }
@@ -97,15 +94,15 @@ const std::string& DrawRule::getStyleName() const {
 }
 
 const char* DrawRule::getLayerName(StyleParamKey _key) const {
-    return layers[static_cast<uint8_t>(_key)];
+    return layers[static_cast<uint8_t>(_key)].name;
 }
 
 std::set<const char*> DrawRule::getLayerNames() const {
     std::set<const char*> layerNames;
 
     for (size_t i = 0; i < StyleParamKeySize; i++) {
-        if (layers[i][0] != '\0') {
-            layerNames.insert(layers[i]);
+        if (layers[i].name) {
+            layerNames.insert(layers[i].name);
         }
     }
     return layerNames;
@@ -223,7 +220,7 @@ void DrawRuleMergeSet::mergeRules(const SceneLayer& _layer) {
                                [&](auto& m) { return rule.id == m.id; });
 
         if (it == matchedRules.end()) {
-            it = matchedRules.insert(it, DrawRule(rule));
+            it = matchedRules.emplace(it, rule);
         }
 
         it->merge(rule, _layer);

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -44,8 +44,7 @@ DrawRule::DrawRule(const DrawRuleData& _ruleData, const SceneLayer& _layer) :
     for (const auto& param : _ruleData.parameters) {
         auto key = static_cast<uint8_t>(param.key);
         active[key] = true;
-        params[key] = &param;
-        layers[key] = { layerName, layerDepth };
+        params[key] = { &param, layerName, layerDepth };
     }
 }
 
@@ -60,13 +59,10 @@ void DrawRule::merge(const DrawRuleData& _ruleData, const SceneLayer& _layer) {
 
         auto key = static_cast<uint8_t>(paramNew.key);
         auto& param = params[key];
-        auto& layer = layers[key];
 
-        if (!active[key] || depthNew > layer.depth ||
-            (depthNew == layer.depth && strcmp(layerNew, layer.name) > 0)) {
-            param = &paramNew;
-            layer.name = layerNew;
-            layer.depth = depthNew;
+        if (!active[key] || depthNew > param.depth ||
+            (depthNew == param.depth && strcmp(layerNew, param.name) > 0)) {
+            param = { &paramNew, layerNew, depthNew };
             active[key] = true;
         }
     }
@@ -89,7 +85,7 @@ const StyleParam& DrawRule::findParameter(StyleParamKey _key) const {
 
     uint8_t key = static_cast<uint8_t>(_key);
     if (!active[key]) { return NONE; }
-    return *params[key];
+    return *params[key].param;
 }
 
 const std::string& DrawRule::getStyleName() const {
@@ -104,15 +100,15 @@ const std::string& DrawRule::getStyleName() const {
 }
 
 const char* DrawRule::getLayerName(StyleParamKey _key) const {
-    return layers[static_cast<uint8_t>(_key)].name;
+    return params[static_cast<uint8_t>(_key)].name;
 }
 
 std::set<const char*> DrawRule::getLayerNames() const {
     std::set<const char*> layerNames;
 
     for (size_t i = 0; i < StyleParamKeySize; i++) {
-        if (layers[i].name) {
-            layerNames.insert(layers[i].name);
+        if (params[i].name) {
+            layerNames.insert(params[i].name);
         }
     }
     return layerNames;
@@ -182,21 +178,24 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
 
             if (!rule.active[i]) { continue; }
 
-            auto*& param = rule.params[i];
+            auto*& param = rule.params[i].param;
             if (param->function >= 0) {
 
+                // Copy param into 'evaluated' and point param to the evaluated StyleParam.
                 m_evaluated[i] = *param;
-
-                if (!_ctx.evalStyle(param->function, param->key, m_evaluated[i].value) &&
-                    StyleParam::isRequired(param->key)) {
-                    valid = false;
-                    break;
-                }
                 param = &m_evaluated[i];
-            }
-            if (param->stops) {
 
+                if (!_ctx.evalStyle(param->function, param->key, m_evaluated[i].value)) {
+                    if (StyleParam::isRequired(param->key)) {
+                        valid = false;
+                        break;
+                    } else {
+                        rule.active[i] = false;
+                    }
+                }
+            } else if (param->stops) {
                 m_evaluated[i] = *param;
+                param = &m_evaluated[i];
 
                 if (StyleParam::isColor(param->key)) {
                     m_evaluated[i].value = param->stops->evalColor(_ctx.getGlobalZoom());
@@ -207,7 +206,6 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
                 } else {
                     m_evaluated[i].value = param->stops->evalFloat(_ctx.getGlobalZoom());
                 }
-                param = &m_evaluated[i];
             }
         }
 

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -198,15 +198,8 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
                 m_evaluated[i] = *param;
                 param = &m_evaluated[i];
 
-                if (StyleParam::isColor(param->key)) {
-                    m_evaluated[i].value = param->stops->evalColor(_ctx.getGlobalZoom());
-                } else if (StyleParam::isWidth(param->key)) {
-                    m_evaluated[i].value = param->stops->evalWidth(_ctx.getGlobalZoom());
-                } else if (StyleParam::isOffsets(param->key)) {
-                    m_evaluated[i].value = param->stops->evalVec2(_ctx.getGlobalZoom());
-                } else {
-                    m_evaluated[i].value = param->stops->evalFloat(_ctx.getGlobalZoom());
-                }
+                Stops::eval(*param->stops, param->key, _ctx.getGlobalZoom(),
+                            m_evaluated[i].value);
             }
         }
 

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -169,13 +169,17 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
             continue;
         }
 
-        // Evaluate JS functions and Stops
         bool valid = true;
         for (size_t i = 0; i < StyleParamKeySize; ++i) {
 
-            if (!rule.active[i]) { continue; }
+            if (!rule.active[i]) {
+                rule.params[i].param = nullptr;
+                continue;
+            }
 
             auto*& param = rule.params[i].param;
+
+            // Evaluate JS functions and Stops
             if (param->function >= 0) {
 
                 // Copy param into 'evaluated' and point param to the evaluated StyleParam.

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -15,10 +15,10 @@
 namespace Tangram {
 
 DrawRuleData::DrawRuleData(std::string _name, int _id,
-                           const std::vector<StyleParam>& _parameters) :
-    parameters(_parameters),
-    name(std::move(_name)),
-    id(_id) {}
+                           std::vector<StyleParam> _parameters)
+    : parameters(std::move(_parameters)),
+      name(std::move(_name)),
+      id(_id) {}
 
 std::string DrawRuleData::toString() const {
     std::string str = "{\n";

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -50,8 +50,13 @@ struct DrawRuleData {
 struct DrawRule {
 
     const StyleParam* params[StyleParamKeySize] = { nullptr };
-    const char*       layers[StyleParamKeySize] = { nullptr };
-    size_t            depths[StyleParamKeySize] = { 0 };
+
+    struct Layer {
+        const char* name = nullptr;
+        size_t depth = 0;
+    };
+
+    Layer layers[StyleParamKeySize];
 
     const std::string* name = nullptr;
 

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -37,12 +37,15 @@ class StyleContext;
 
 struct DrawRuleData {
 
+    // https://github.com/tangrams/tangram-docs/blob/gh-pages/pages/draw.md#style-parameters
     std::vector<StyleParam> parameters;
+
+    // draw-rule name (and assigned id)
+    // https://github.com/tangrams/tangram-docs/blob/gh-pages/pages/draw.md#draw-rule
     std::string name;
     int id;
 
-    DrawRuleData(std::string _name, int _id,
-                 const std::vector<StyleParam>& _parameters);
+    DrawRuleData(std::string _name, int _id, std::vector<StyleParam> _parameters);
 
     std::string toString() const;
 

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -94,8 +94,9 @@ private:
 
 };
 
-struct DrawRuleMergeSet {
+class DrawRuleMergeSet {
 
+public:
     /* Determine and apply DrawRules for a @_feature and add
      * the result to @_tile
      */
@@ -108,12 +109,15 @@ struct DrawRuleMergeSet {
     // internal
     void mergeRules(const SceneLayer& _layer);
 
+    auto& matchedRules() { return m_matchedRules; }
+
+private:
     // Reusable containers 'matchedRules' and 'queuedLayers'
-    std::vector<DrawRule> matchedRules;
-    std::vector<const SceneLayer*> queuedLayers;
+    std::vector<DrawRule> m_matchedRules;
+    std::vector<const SceneLayer*> m_queuedLayers;
 
     // Container for dynamically-evaluated parameters
-    StyleParam evaluated[StyleParamKeySize];
+    StyleParam m_evaluated[StyleParamKeySize];
 
 };
 

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -50,17 +50,22 @@ struct DrawRuleData {
 
 struct DrawRule {
 
-    std::bitset<StyleParamKeySize> active = { 0 };
-
-    struct Param {
+    // Map of StypeParamKey => StyleParam pointer
+    // of the matched SceneLayer or the evaluated
+    // Function/Stops in DrawRuleMergeset.
+    struct {
         const StyleParam* param;
-        // Layer name
+        // SceneLayer name and depth
         const char* name;
-        // Layer depth
         size_t depth;
-    };
 
-    Param params[StyleParamKeySize];
+    } params[StyleParamKeySize];
+
+    // A mask to indicate which parameters are set.
+    // 'active' MUST be checked before accessing 'params'
+    // This is cheaper to zero out 4 byte than
+    // 480 (on 32bit arch) or 980 byte for params array.
+    std::bitset<StyleParamKeySize> active = { 0 };
 
     // draw-style name and id
     const std::string* name = nullptr;

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -78,7 +78,7 @@ struct DrawRule {
 
     const char* getLayerName(StyleParamKey _key) const;
 
-    std::set<const char*> getLayerNames() const;
+    size_t getParamSetHash() const;
 
     const StyleParam& findParameter(StyleParamKey _key) const;
 

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -84,17 +84,50 @@ struct DrawRule {
 
     template<typename T>
     bool get(StyleParamKey _key, T& _value) const {
-        auto& param = findParameter(_key);
-        if (!param) { return false; }
-        if (!param.value.is<T>()) {
-            return false;
+        if (auto& param = findParameter(_key)) {
+            return StyleParam::Value::visit(param.value,
+                                            prop_visitor<T>{ _value });
         }
-        _value = param.value.get<T>();
-        return true;
+        return false;
+    }
+
+    template<typename T>
+    const T* get(StyleParamKey _key) const {
+        if (auto& param = findParameter(_key)) {
+            return StyleParam::Value::visit(param.value,
+                                            prop_visitor_ptr<T>{});
+        }
+        return nullptr;
     }
 
 private:
     void logGetError(StyleParamKey _expectedKey, const StyleParam& _param) const;
+
+    template<typename T>
+    struct prop_visitor {
+        using result_type = bool;
+        T& out;
+        bool operator()(const T& v) const {
+            out = v;
+            return true;
+        }
+        template<typename O>
+        bool operator()(const O v) const {
+            return false;
+        }
+    };
+    template<typename T>
+    struct prop_visitor_ptr {
+        using result_type = const T*;
+        const T* operator()(const T& v) const {
+            return &v;
+        }
+        template<typename O>
+        const T* operator()(const O v) const {
+            return nullptr;
+        }
+    };
+
 
 };
 

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -52,14 +52,15 @@ struct DrawRule {
 
     std::bitset<StyleParamKeySize> active = { 0 };
 
-    const StyleParam* params[StyleParamKeySize]; // = { nullptr };
-
-    struct Layer {
+    struct Param {
+        const StyleParam* param;
+        // Layer name
         const char* name;
+        // Layer depth
         size_t depth;
     };
 
-    Layer layers[StyleParamKeySize];
+    Param params[StyleParamKeySize];
 
     // draw-style name and id
     const std::string* name = nullptr;

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <set>
+#include <bitset>
 
 namespace Tangram {
 
@@ -49,20 +50,22 @@ struct DrawRuleData {
 
 struct DrawRule {
 
-    const StyleParam* params[StyleParamKeySize] = { nullptr };
+    std::bitset<StyleParamKeySize> active = { 0 };
+
+    const StyleParam* params[StyleParamKeySize]; // = { nullptr };
 
     struct Layer {
-        const char* name = nullptr;
-        size_t depth = 0;
+        const char* name;
+        size_t depth;
     };
 
     Layer layers[StyleParamKeySize];
 
+    // draw-style name and id
     const std::string* name = nullptr;
-
     int id;
 
-    DrawRule(const DrawRuleData& _ruleData);
+    DrawRule(const DrawRuleData& _ruleData, const SceneLayer& _layer);
 
     void merge(const DrawRuleData& _ruleData, const SceneLayer& _layer);
 

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -85,8 +85,7 @@ struct DrawRule {
     template<typename T>
     bool get(StyleParamKey _key, T& _value) const {
         if (auto& param = findParameter(_key)) {
-            return StyleParam::Value::visit(param.value,
-                                            prop_visitor<T>{ _value });
+            return StyleParam::Value::visit(param.value, StyleParam::visitor<T>{ _value });
         }
         return false;
     }
@@ -94,40 +93,13 @@ struct DrawRule {
     template<typename T>
     const T* get(StyleParamKey _key) const {
         if (auto& param = findParameter(_key)) {
-            return StyleParam::Value::visit(param.value,
-                                            prop_visitor_ptr<T>{});
+            return StyleParam::Value::visit(param.value, StyleParam::visitor_ptr<T>{});
         }
         return nullptr;
     }
 
 private:
     void logGetError(StyleParamKey _expectedKey, const StyleParam& _param) const;
-
-    template<typename T>
-    struct prop_visitor {
-        using result_type = bool;
-        T& out;
-        bool operator()(const T& v) const {
-            out = v;
-            return true;
-        }
-        template<typename O>
-        bool operator()(const O v) const {
-            return false;
-        }
-    };
-    template<typename T>
-    struct prop_visitor_ptr {
-        using result_type = const T*;
-        const T* operator()(const T& v) const {
-            return &v;
-        }
-        template<typename O>
-        const T* operator()(const O v) const {
-            return nullptr;
-        }
-    };
-
 
 };
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1322,7 +1322,7 @@ void SceneLoader::parseTransition(Node params, Scene& scene, std::vector<StylePa
     }
 }
 
-SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& name, Scene& scene) {
+SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& layerName, Scene& scene) {
 
     std::vector<SceneLayer> sublayers;
     std::vector<DrawRuleData> rules;
@@ -1341,10 +1341,10 @@ SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& name, Scene&
                 std::vector<StyleParam> params;
                 parseStyleParams(ruleNode.second, scene, "", params);
 
-                auto name = ruleNode.first.as<std::string>();
-                int nameId = scene.addIdForName(name);
+                auto ruleName = ruleNode.first.as<std::string>();
+                int ruleId = scene.addIdForName(ruleName);
 
-                rules.push_back({ name, nameId, std::move(params) });
+                rules.push_back({ ruleName, ruleId, std::move(params) });
             }
         } else if (key == "filter") {
             filter = generateFilter(member.second, scene);
@@ -1354,11 +1354,11 @@ SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& name, Scene&
             // TODO: ignored for now
         } else {
             // Member is a sublayer
-            sublayers.push_back(loadSublayer(member.second, (name + ":" + key), scene));
+            sublayers.push_back(loadSublayer(member.second, (layerName + ":" + key), scene));
         }
     }
 
-    return { name, filter, rules, sublayers };
+    return { layerName, filter, rules, sublayers };
 }
 
 void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -273,4 +273,16 @@ auto Stops::nearestHigherFrame(float _key) const -> std::vector<Frame>::const_it
                             [](const Frame& f, float z) { return f.key < z; });
 }
 
+void Stops::eval(const Stops& _stops, StyleParamKey _key, float _zoom, StyleParam::Value& _result) {
+    if (StyleParam::isColor(_key)) {
+        _result = _stops.evalColor(_zoom);
+    } else if (StyleParam::isWidth(_key)) {
+        _result = _stops.evalWidth(_zoom);
+    } else if (StyleParam::isOffsets(_key)) {
+        _result = _stops.evalVec2(_zoom);
+    } else {
+        _result = _stops.evalFloat(_zoom);
+    }
+}
+
 }

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -40,6 +40,8 @@ struct Stops {
     auto evalColor(float _key) const -> uint32_t;
     auto evalVec2(float _key) const -> glm::vec2;
     auto nearestHigherFrame(float _key) const -> std::vector<Frame>::const_iterator;
+
+    static void eval(const Stops& _stops, StyleParamKey _key, float _zoom, StyleParam::Value& _result);
 };
 
 }

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -146,6 +146,31 @@ struct StyleParam {
     static StyleParamKey getKey(const std::string& _key);
 
     static const std::string& keyName(StyleParamKey _key);
+
+    template<typename T>
+    struct visitor {
+        using result_type = bool;
+        T& out;
+        bool operator()(const T& v) const {
+            out = v;
+            return true;
+        }
+        template<typename O>
+        bool operator()(const O v) const {
+            return false;
+        }
+    };
+    template<typename T>
+    struct visitor_ptr {
+        using result_type = const T*;
+        const T* operator()(const T& v) const {
+            return &v;
+        }
+        template<typename O>
+        const T* operator()(const O v) const {
+            return nullptr;
+        }
+    };
 };
 
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -109,20 +109,26 @@ auto TextStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _props
 
     TextStyle::Parameters p;
 
-    std::string fontFamily, fontWeight, fontStyle, transform, align, anchor;
+    const std::string *fontFamily = nullptr, *fontWeight = nullptr, *fontStyle = nullptr;
     glm::vec2 offset;
 
-    _rule.get(StyleParamKey::font_family, fontFamily);
-    _rule.get(StyleParamKey::font_weight, fontWeight);
-    _rule.get(StyleParamKey::font_style, fontStyle);
+    fontFamily = _rule.get<std::string>(StyleParamKey::font_family);
+    fontWeight = _rule.get<std::string>(StyleParamKey::font_weight);
+    fontStyle = _rule.get<std::string>(StyleParamKey::font_style);
 
-    fontWeight = (fontWeight.size() == 0) ? "400" : fontWeight;
-    fontStyle = (fontStyle.size() == 0) ? "normal" : fontStyle;
+    static const std::string defaultWeight = "400";
+    static const std::string defaultStyle = "normal";
+    static const std::string defaultFamily = "";
+
+    fontWeight = (!fontWeight) ? &defaultWeight : fontWeight;
+    fontStyle = (!fontStyle) ? &defaultStyle : fontStyle;
+    fontFamily = (!fontFamily) ? &defaultFamily : fontFamily;
+
     {
         auto& fontContext = m_style.fontContext();
         if (!fontContext.lock()) { return p; }
 
-        p.fontId = fontContext.addFont(fontFamily, fontWeight, fontStyle);
+        p.fontId = fontContext.addFont(*fontFamily, *fontWeight, *fontStyle);
 
         fontContext.unlock();
         if (p.fontId < 0) { return p; }
@@ -133,9 +139,6 @@ auto TextStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _props
     _rule.get(StyleParamKey::offset, p.labelOptions.offset);
     _rule.get(StyleParamKey::font_stroke_color, p.strokeColor);
     _rule.get(StyleParamKey::font_stroke_width, p.strokeWidth);
-    _rule.get(StyleParamKey::transform, transform);
-    _rule.get(StyleParamKey::align, align);
-    _rule.get(StyleParamKey::anchor, anchor);
     _rule.get(StyleParamKey::priority, p.labelOptions.priority);
     _rule.get(StyleParamKey::collide, p.labelOptions.collide);
     _rule.get(StyleParamKey::transition_hide_time, p.labelOptions.hideTransition.time);
@@ -184,12 +187,18 @@ auto TextStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _props
         p.labelOptions.properties = std::make_shared<Properties>(_props);
     }
 
-    LabelProperty::anchor(anchor, p.anchor);
+    if (auto* anchor = _rule.get<std::string>(StyleParamKey::anchor)) {
+        LabelProperty::anchor(*anchor, p.anchor);
+    }
 
-    TextLabelProperty::transform(transform, p.transform);
-    bool res = TextLabelProperty::align(align, p.align);
-    if (!res) {
-        switch(p.anchor) {
+    if (auto* transform = _rule.get<std::string>(StyleParamKey::transform)) {
+        TextLabelProperty::transform(*transform, p.transform);
+    }
+
+    if (auto* align = _rule.get<std::string>(StyleParamKey::align)) {
+        bool res = TextLabelProperty::align(*align, p.align);
+        if (!res) {
+            switch(p.anchor) {
             case LabelProperty::Anchor::top_left:
             case LabelProperty::Anchor::left:
             case LabelProperty::Anchor::bottom_left:
@@ -204,6 +213,7 @@ auto TextStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _props
             case LabelProperty::Anchor::bottom:
             case LabelProperty::Anchor::center:
                 break;
+            }
         }
     }
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -158,11 +158,13 @@ auto TextStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _props
         hash_combine(repeatGroupHash, repeatGroup);
     } else {
         // Default to hash on all used layer names ('draw.key' in JS version)
-        for (auto* name : _rule.getLayerNames()) {
-            hash_combine(repeatGroupHash, name);
-            // repeatGroup += name;
-            // repeatGroup += "/";
-        }
+        repeatGroup = _rule.getParamSetHash();
+
+        // for (auto* name : _rule.getLayerNames()) {
+        //     hash_combine(repeatGroupHash, name);
+        //     // repeatGroup += name;
+        //     // repeatGroup += "/";
+        // }
         //LOG("rg: %s", p.labelOptions.repeatGroup.c_str());
     }
 

--- a/tests/unit/drawRuleTests.cpp
+++ b/tests/unit/drawRuleTests.cpp
@@ -60,8 +60,8 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
         DrawRuleMergeSet ruleSet;
         ruleSet.mergeRules(layer_a);
 
-        REQUIRE(ruleSet.matchedRules.size() == 1);
-        auto& merged_ab = ruleSet.matchedRules[0];
+        REQUIRE(ruleSet.matchedRules().size() == 1);
+        auto& merged_ab = ruleSet.matchedRules()[0];
 
         for (size_t i = 0; i < StyleParamKeySize; i++) {
             auto* param = merged_ab.params[i];
@@ -74,7 +74,7 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
 
         ruleSet.mergeRules(layer_b);
 
-        REQUIRE(ruleSet.matchedRules.size() == 1);
+        REQUIRE(ruleSet.matchedRules().size() == 1);
 
         // printf("rule_a:\n %s", rule_a.toString().c_str());
         // printf("rule_c:\n %s", rule_c.toString().c_str());
@@ -109,9 +109,9 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
         ruleSet.mergeRules(layer_b);
         ruleSet.mergeRules(layer_a);
 
-        REQUIRE(ruleSet.matchedRules.size() == 1);
+        REQUIRE(ruleSet.matchedRules().size() == 1);
 
-        auto& merged_ba = ruleSet.matchedRules[0];
+        auto& merged_ba = ruleSet.matchedRules()[0];
 
         REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::cap)]->key == StyleParamKey::cap);
         REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::cap)]->value.get<std::string>() == "value_3b");
@@ -135,9 +135,9 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
         ruleSet.mergeRules(layer_c);
         ruleSet.mergeRules(layer_b);
 
-        REQUIRE(ruleSet.matchedRules.size() == 1);
+        REQUIRE(ruleSet.matchedRules().size() == 1);
 
-        auto& merged_bc = ruleSet.matchedRules[0];
+        auto& merged_bc = ruleSet.matchedRules()[0];
 
         // for (size_t i = 0; i < StyleParamKeySize; i++) {
         //     auto* param = merged_bc.params[i];
@@ -162,7 +162,7 @@ TEST_CASE("DrawRule locates and outputs a parameter that it contains", "[DrawRul
 
     DrawRuleMergeSet a;
     a.mergeRules(layer_a);
-    auto& rule_a = a.matchedRules[0];
+    auto& rule_a = a.matchedRules()[0];
 
     REQUIRE(rule_a.get(StyleParamKey::order, str)); REQUIRE(str == "value_0a");
     REQUIRE(rule_a.get(StyleParamKey::color, str)); REQUIRE(str == "value_1a");
@@ -170,7 +170,7 @@ TEST_CASE("DrawRule locates and outputs a parameter that it contains", "[DrawRul
 
     DrawRuleMergeSet b;
     b.mergeRules(layer_b);
-    auto& rule_b = b.matchedRules[0];
+    auto& rule_b = b.matchedRules()[0];
 
     REQUIRE(rule_b.get(StyleParamKey::color, str)); REQUIRE(str == "value_1b");
     REQUIRE(rule_b.get(StyleParamKey::width, str)); REQUIRE(str == "value_2b");
@@ -184,18 +184,18 @@ TEST_CASE("DrawRule correctly reports that it doesn't contain a parameter", "[Dr
     const SceneLayer layer_a = { "a", Filter(), { instance_a() }, {} };
     DrawRuleMergeSet a;
     a.mergeRules(layer_a);
-    REQUIRE(!a.matchedRules[0].get(StyleParamKey::width, str)); REQUIRE(str == "");
+    REQUIRE(!a.matchedRules()[0].get(StyleParamKey::width, str)); REQUIRE(str == "");
 
 
     const SceneLayer layer_b = { "b", Filter(), { instance_b() }, {} };
     DrawRuleMergeSet b;
     b.mergeRules(layer_b);
-    REQUIRE(!b.matchedRules[0].get(StyleParamKey::join, str)); REQUIRE(str == "");
+    REQUIRE(!b.matchedRules()[0].get(StyleParamKey::join, str)); REQUIRE(str == "");
 
     const SceneLayer layer_c = { "c", Filter(), { instance_c() }, {} };
     DrawRuleMergeSet c;
     c.mergeRules(layer_c);
-    REQUIRE(!c.matchedRules[0].get(StyleParamKey::order, str)); REQUIRE(str == "");
+    REQUIRE(!c.matchedRules()[0].get(StyleParamKey::order, str)); REQUIRE(str == "");
 
 
 }

--- a/tests/unit/drawRuleTests.cpp
+++ b/tests/unit/drawRuleTests.cpp
@@ -64,7 +64,7 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
         auto& merged_ab = ruleSet.matchedRules()[0];
 
         for (size_t i = 0; i < StyleParamKeySize; i++) {
-            auto* param = merged_ab.params[i];
+            auto* param = merged_ab.params[i].param;
             if (!param) {
                 logMsg("param : none %d\n", i);
                 continue;
@@ -80,25 +80,25 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
         // printf("rule_c:\n %s", rule_c.toString().c_str());
         // printf("merged_ac:\n %s", merged_ac.toString().c_str());
         for (size_t i = 0; i < StyleParamKeySize; i++) {
-            auto* param = merged_ab.params[i];
+            auto* param = merged_ab.params[i].param;
             if (!param) {
                 logMsg("param : none %d\n", i);
                 continue;
             }
             logMsg("param : %s\n", param->toString().c_str());
         }
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::cap)]->key == StyleParamKey::cap);
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::cap)]->value.get<std::string>() == "value_3b");
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::color)]->key == StyleParamKey::color);
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::color)]->value.get<std::string>() == "value_1b");
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::join)]->key == StyleParamKey::join);
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::join)]->value.get<std::string>() == "value_4a");
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::order)]->key == StyleParamKey::order);
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::order)]->value.get<std::string>() == "value_0b");
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::style)]->key == StyleParamKey::style);
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::style)]->value.get<std::string>() == "value_4b");
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::width)]->key == StyleParamKey::width);
-        REQUIRE(merged_ab.params[static_cast<uint8_t>(StyleParamKey::width)]->value.get<std::string>() == "value_2b");
+        REQUIRE(merged_ab.findParameter(StyleParamKey::cap).key == StyleParamKey::cap);
+        REQUIRE(merged_ab.findParameter(StyleParamKey::cap).value.get<std::string>() == "value_3b");
+        REQUIRE(merged_ab.findParameter(StyleParamKey::color).key == StyleParamKey::color);
+        REQUIRE(merged_ab.findParameter(StyleParamKey::color).value.get<std::string>() == "value_1b");
+        REQUIRE(merged_ab.findParameter(StyleParamKey::join).key == StyleParamKey::join);
+        REQUIRE(merged_ab.findParameter(StyleParamKey::join).value.get<std::string>() == "value_4a");
+        REQUIRE(merged_ab.findParameter(StyleParamKey::order).key == StyleParamKey::order);
+        REQUIRE(merged_ab.findParameter(StyleParamKey::order).value.get<std::string>() == "value_0b");
+        REQUIRE(merged_ab.findParameter(StyleParamKey::style).key == StyleParamKey::style);
+        REQUIRE(merged_ab.findParameter(StyleParamKey::style).value.get<std::string>() == "value_4b");
+        REQUIRE(merged_ab.findParameter(StyleParamKey::width).key == StyleParamKey::width);
+        REQUIRE(merged_ab.findParameter(StyleParamKey::width).value.get<std::string>() == "value_2b");
 
         // explicit style wins
         REQUIRE(merged_ab.getStyleName() == "value_4b");
@@ -113,18 +113,18 @@ TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
 
         auto& merged_ba = ruleSet.matchedRules()[0];
 
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::cap)]->key == StyleParamKey::cap);
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::cap)]->value.get<std::string>() == "value_3b");
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::color)]->key == StyleParamKey::color);
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::color)]->value.get<std::string>() == "value_1b");
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::join)]->key == StyleParamKey::join);
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::join)]->value.get<std::string>() == "value_4a");
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::order)]->key == StyleParamKey::order);
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::order)]->value.get<std::string>() == "value_0b");
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::style)]->key == StyleParamKey::style);
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::style)]->value.get<std::string>() == "value_4b");
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::width)]->key == StyleParamKey::width);
-        REQUIRE(merged_ba.params[static_cast<uint8_t>(StyleParamKey::width)]->value.get<std::string>() == "value_2b");
+        REQUIRE(merged_ba.findParameter(StyleParamKey::cap).key == StyleParamKey::cap);
+        REQUIRE(merged_ba.findParameter(StyleParamKey::cap).value.get<std::string>() == "value_3b");
+        REQUIRE(merged_ba.findParameter(StyleParamKey::color).key == StyleParamKey::color);
+        REQUIRE(merged_ba.findParameter(StyleParamKey::color).value.get<std::string>() == "value_1b");
+        REQUIRE(merged_ba.findParameter(StyleParamKey::join).key == StyleParamKey::join);
+        REQUIRE(merged_ba.findParameter(StyleParamKey::join).value.get<std::string>() == "value_4a");
+        REQUIRE(merged_ba.findParameter(StyleParamKey::order).key == StyleParamKey::order);
+        REQUIRE(merged_ba.findParameter(StyleParamKey::order).value.get<std::string>() == "value_0b");
+        REQUIRE(merged_ba.findParameter(StyleParamKey::style).key == StyleParamKey::style);
+        REQUIRE(merged_ba.findParameter(StyleParamKey::style).value.get<std::string>() == "value_4b");
+        REQUIRE(merged_ba.findParameter(StyleParamKey::width).key == StyleParamKey::width);
+        REQUIRE(merged_ba.findParameter(StyleParamKey::width).value.get<std::string>() == "value_2b");
 
         // explicit style wins
         REQUIRE(merged_ba.getStyleName() == "value_4b");

--- a/tests/unit/layerTests.cpp
+++ b/tests/unit/layerTests.cpp
@@ -117,8 +117,8 @@ TEST_CASE("SceneLayer", "[SceneLayer][Filter][DrawRule][Match][Merge]") {
 
         REQUIRE(matches.size() == 1);
         REQUIRE(matches[0].getStyleName() == "group1");
-        REQUIRE(matches[0].params[static_cast<uint8_t>(StyleParamKey::order)]->key == StyleParamKey::order);
-        REQUIRE(matches[0].params[static_cast<uint8_t>(StyleParamKey::order)]->value.get<std::string>() == "a");
+        REQUIRE(matches[0].findParameter(StyleParamKey::order).key == StyleParamKey::order);
+        REQUIRE(matches[0].findParameter(StyleParamKey::order).value.get<std::string>() == "a");
     }
 
     {
@@ -139,8 +139,8 @@ TEST_CASE("SceneLayer", "[SceneLayer][Filter][DrawRule][Match][Merge]") {
 
         REQUIRE(matches.size() == 2);
         REQUIRE(matches[0].getStyleName() == "group1");
-        REQUIRE(matches[0].params[static_cast<uint8_t>(StyleParamKey::order)]->key == StyleParamKey::order);
-        REQUIRE(matches[0].params[static_cast<uint8_t>(StyleParamKey::order)]->value.get<std::string>() == "a");
+        REQUIRE(matches[0].findParameter(StyleParamKey::order).key == StyleParamKey::order);
+        REQUIRE(matches[0].findParameter(StyleParamKey::order).value.get<std::string>() == "a");
         REQUIRE(matches[1].getStyleName() == "group2");
     }
 
@@ -207,12 +207,12 @@ TEST_CASE("SceneLayer correctly merges rules matched from sublayer", "[SceneLaye
 
     // deeper match from layer_a should override parameters in same style from layer_d
     REQUIRE(matches[1].getStyleName() == "dg0");
-    REQUIRE(matches[1].params[static_cast<uint8_t>(StyleParamKey::order)]->key == StyleParamKey::order);
-    REQUIRE(matches[1].params[static_cast<uint8_t>(StyleParamKey::order)]->value.get<std::string>() == "value_a");
+    REQUIRE(matches[1].findParameter(StyleParamKey::order).key == StyleParamKey::order);
+    REQUIRE(matches[1].findParameter(StyleParamKey::order).value.get<std::string>() == "value_a");
 
     // deeper match from layer_c should override parameters in same style from layer_e
     REQUIRE(matches[0].getStyleName() == "dg2");
-    REQUIRE(matches[0].params[static_cast<uint8_t>(StyleParamKey::order)]->key == StyleParamKey::order);
-    REQUIRE(matches[0].params[static_cast<uint8_t>(StyleParamKey::order)]->value.get<std::string>() == "value_c");
+    REQUIRE(matches[0].findParameter(StyleParamKey::order).key == StyleParamKey::order);
+    REQUIRE(matches[0].findParameter(StyleParamKey::order).value.get<std::string>() == "value_c");
 
 }

--- a/tests/unit/layerTests.cpp
+++ b/tests/unit/layerTests.cpp
@@ -102,7 +102,7 @@ TEST_CASE("SceneLayer", "[SceneLayer][Filter][DrawRule][Match][Merge]") {
         DrawRuleMergeSet ruleSet;
         f1.props.set("base", "blah"); // Should match Base Layer
         ruleSet.match(f1, layer, ctx);
-        auto& matches = ruleSet.matchedRules;
+        auto& matches = ruleSet.matchedRules();
 
         REQUIRE(matches.size() == 1);
         REQUIRE(matches[0].getStyleName() == "group1");
@@ -113,7 +113,7 @@ TEST_CASE("SceneLayer", "[SceneLayer][Filter][DrawRule][Match][Merge]") {
         f2.props.set("one", "blah"); // Should match Base and subLayer1
         f2.props.set("base", "blah");
         ruleSet.match(f2, layer, ctx);
-        auto& matches = ruleSet.matchedRules;
+        auto& matches = ruleSet.matchedRules();
 
         REQUIRE(matches.size() == 1);
         REQUIRE(matches[0].getStyleName() == "group1");
@@ -125,7 +125,7 @@ TEST_CASE("SceneLayer", "[SceneLayer][Filter][DrawRule][Match][Merge]") {
         DrawRuleMergeSet ruleSet;
         f3.props.set("two", "blah"); // Should not match anything as uber layer will not be satisfied
         ruleSet.match(f3, layer, ctx);
-        auto& matches = ruleSet.matchedRules;
+        auto& matches = ruleSet.matchedRules();
 
         REQUIRE(matches.size() == 0);
     }
@@ -135,7 +135,7 @@ TEST_CASE("SceneLayer", "[SceneLayer][Filter][DrawRule][Match][Merge]") {
         f4.props.set("two", "blah");
         f4.props.set("base", "blah"); // Should match Base and subLayer2
         ruleSet.match(f4, layer, ctx);
-        auto& matches = ruleSet.matchedRules;
+        auto& matches = ruleSet.matchedRules();
 
         REQUIRE(matches.size() == 2);
         REQUIRE(matches[0].getStyleName() == "group1");
@@ -156,7 +156,7 @@ TEST_CASE("SceneLayer matches correct rules for a feature and context", "[SceneL
         auto layer_a = instance_a();
 
         ruleSet.match(feat, layer_a, ctx);
-        auto& matches_a = ruleSet.matchedRules;
+        auto& matches_a = ruleSet.matchedRules();
 
         REQUIRE(matches_a.size() == 1);
         REQUIRE(matches_a[0].getStyleName() == "dg0");
@@ -167,7 +167,7 @@ TEST_CASE("SceneLayer matches correct rules for a feature and context", "[SceneL
         auto layer_b = instance_b();
 
         ruleSet.match(feat, layer_b, ctx);
-        auto& matches_b = ruleSet.matchedRules;
+        auto& matches_b = ruleSet.matchedRules();
 
         REQUIRE(matches_b.size() == 0);
     }
@@ -183,7 +183,7 @@ TEST_CASE("SceneLayer matches correct sublayer rules for a feature and context",
     auto layer_c = instance_c();
 
     ruleSet.match(feat, layer_c, ctx);
-    auto& matches = ruleSet.matchedRules;
+    auto& matches = ruleSet.matchedRules();
 
     REQUIRE(matches.size() == 2);
 
@@ -201,7 +201,7 @@ TEST_CASE("SceneLayer correctly merges rules matched from sublayer", "[SceneLaye
     auto layer_e = instance_e();
 
     ruleSet.match(feat, layer_e, ctx);
-    auto& matches = ruleSet.matchedRules;
+    auto& matches = ruleSet.matchedRules();
 
     REQUIRE(matches.size() == 2);
 


### PR DESCRIPTION
- The most expensive part in merging was to zero out the params-,layer- and depth arrays on DrawRule initialization. Using a bitset reduces this to 4 bytes vs previously 480 or 960 bytes (on 64bit arch)

- Instead of creating a set a all matched layer strings to calculate the label repeatGroup hash, drawRule got a new helper functions to calculate the hash without allocations.