### PR TITLE
Android font fallbacks

### DIFF
--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -40,6 +40,7 @@ static jmethodID setRenderModeMethodID;
 static jmethodID startUrlRequestMID;
 static jmethodID cancelUrlRequestMID;
 static jmethodID getFontFilePath;
+static jmethodID getFontFallbackFilePath;
 static jmethodID featureSelectionCbMID;
 
 static jmethodID propertiesConstructorMID;
@@ -64,6 +65,7 @@ void setupJniEnv(JNIEnv* _jniEnv, jobject _tangramInstance, jobject _assetManage
     startUrlRequestMID = jniEnv->GetMethodID(tangramClass, "startUrlRequest", "(Ljava/lang/String;J)Z");
     cancelUrlRequestMID = jniEnv->GetMethodID(tangramClass, "cancelUrlRequest", "(Ljava/lang/String;)V");
     getFontFilePath = jniEnv->GetMethodID(tangramClass, "getFontFilePath", "(Ljava/lang/String;)Ljava/lang/String;");
+    getFontFallbackFilePath = jniEnv->GetMethodID(tangramClass, "getFontFallbackFilePath", "(II)V");
     requestRenderMethodID = _jniEnv->GetMethodID(tangramClass, "requestRender", "()V");
     setRenderModeMethodID = _jniEnv->GetMethodID(tangramClass, "setRenderMode", "(I)V");
     featureSelectionCbMID = _jniEnv->GetMethodID(tangramClass, "featureSelectionCb", "(Lcom/mapzen/tangram/Properties;FF)V");
@@ -115,6 +117,19 @@ void requestRender() {
     jniEnv->CallVoidMethod(tangramInstance, requestRenderMethodID);
 }
 
+std::string systemFontFallbackPath(int _order, int _weightHint) {
+
+    JniThreadBinding jniEnv(jvm);
+
+    jstring returnStr = (jstring) jniEnv->CallObjectMethod(tangramInstance, getFontFallbackFilePath, _order, _weightHint);
+
+    size_t length = jniEnv->GetStringUTFLength(returnStr);
+    std::string fontFallbackPath(length, 0);
+    jniEnv->GetStringUTFRegion(returnStr, 0, length, &fontFallbackPath[0]);
+
+    return fontFallbackPath;
+}
+
 std::string systemFontPath(const std::string& _family, const std::string& _weight, const std::string& _style) {
 
     JniThreadBinding jniEnv(jvm);
@@ -125,7 +140,7 @@ std::string systemFontPath(const std::string& _family, const std::string& _weigh
     jstring returnStr = (jstring) jniEnv->CallObjectMethod(tangramInstance, getFontFilePath, jkey);
 
     size_t length = jniEnv->GetStringUTFLength(returnStr);
-    std::string fontPath = std::string(length, 0);
+    std::string fontPath(length, 0);
     jniEnv->GetStringUTFRegion(returnStr, 0, length, &fontPath[0]);
 
     return fontPath;

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -65,7 +65,7 @@ void setupJniEnv(JNIEnv* _jniEnv, jobject _tangramInstance, jobject _assetManage
     startUrlRequestMID = jniEnv->GetMethodID(tangramClass, "startUrlRequest", "(Ljava/lang/String;J)Z");
     cancelUrlRequestMID = jniEnv->GetMethodID(tangramClass, "cancelUrlRequest", "(Ljava/lang/String;)V");
     getFontFilePath = jniEnv->GetMethodID(tangramClass, "getFontFilePath", "(Ljava/lang/String;)Ljava/lang/String;");
-    getFontFallbackFilePath = jniEnv->GetMethodID(tangramClass, "getFontFallbackFilePath", "(II)V");
+    getFontFallbackFilePath = jniEnv->GetMethodID(tangramClass, "getFontFallbackFilePath", "(II)Ljava/lang/String;");
     requestRenderMethodID = _jniEnv->GetMethodID(tangramClass, "requestRender", "()V");
     setRenderModeMethodID = _jniEnv->GetMethodID(tangramClass, "setRenderMode", "(I)V");
     featureSelectionCbMID = _jniEnv->GetMethodID(tangramClass, "featureSelectionCb", "(Lcom/mapzen/tangram/Properties;FF)V");

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -117,11 +117,11 @@ void requestRender() {
     jniEnv->CallVoidMethod(tangramInstance, requestRenderMethodID);
 }
 
-std::string systemFontFallbackPath(int _order, int _weightHint) {
+std::string systemFontFallbackPath(int _importance, int _weightHint) {
 
     JniThreadBinding jniEnv(jvm);
 
-    jstring returnStr = (jstring) jniEnv->CallObjectMethod(tangramInstance, getFontFallbackFilePath, _order, _weightHint);
+    jstring returnStr = (jstring) jniEnv->CallObjectMethod(tangramInstance, getFontFallbackFilePath, _importance, _weightHint);
 
     size_t length = jniEnv->GetStringUTFLength(returnStr);
     std::string fontFallbackPath(length, 0);

--- a/android/tangram/src/com/mapzen/tangram/FontFileParser.java
+++ b/android/tangram/src/com/mapzen/tangram/FontFileParser.java
@@ -131,10 +131,9 @@ class FontFileParser {
         }
     }
 
-    public FontFileParser() {
-
+    public void parse(String fontXMLPath) {
         InputStream in = null;
-        final File fontFile = new File("/system/etc/fonts.xml");
+        final File fontFile = new File(fontXMLPath);
 
         // TODO: Handle system_fonts parsing which has a different xml layout as compared to fonts.xml
         //       system_fonts.xml also does not seem to have a good css style font parameter mapping as is the case with

--- a/android/tangram/src/com/mapzen/tangram/FontFileParser.java
+++ b/android/tangram/src/com/mapzen/tangram/FontFileParser.java
@@ -6,18 +6,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.ArrayList;
+import java.util.Vector;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import android.util.Xml;
-import android.util.Log;
 
 class FontFileParser {
 
     private Map<String, String> fontDict = new HashMap<String, String>();
+    private Map<Integer, Vector<String>> fallbackFontDict = new HashMap<Integer, Vector<String>>();
 
     private void processDocument(XmlPullParser parser) throws XmlPullParserException, IOException {
 
@@ -34,7 +36,36 @@ class FontFileParser {
                 familyWeights.clear();
                 // Parse this family:
                 String name = parser.getAttributeValue(null, "name");
-                if (name == null) { continue; }
+
+                // fallback fonts
+                if (name == null) {
+                    while (parser.next() != XmlPullParser.END_TAG) {
+                        if (parser.getEventType() != XmlPullParser.START_TAG) {
+                            continue;
+                        }
+                        String tag = parser.getName();
+                        if ("font".equals(tag)) {
+                            String weightStr = parser.getAttributeValue(null, "weight");
+                            if (weightStr != null) { familyWeights.add(weightStr); }
+                            weightStr = (weightStr == null) ? "400" : weightStr;
+
+                            String styleStr = parser.getAttributeValue(null, "style");
+                            styleStr = (styleStr == null) ? "normal" : styleStr;
+
+                            String filename = parser.nextText();
+
+                            Integer weight = new Integer(weightStr);
+                            if (!fallbackFontDict.containsKey(weight)) {
+                                fallbackFontDict.put(weight, new Vector<String>());
+                            }
+
+                            fallbackFontDict.get(weight).add(filename);
+                        } else {
+                            skip(parser);
+                        }
+                    }
+                    continue;
+                }
                 while (parser.next() != XmlPullParser.END_TAG) {
                     if (parser.getEventType() != XmlPullParser.START_TAG) {
                         continue;
@@ -90,12 +121,12 @@ class FontFileParser {
         int depth = 1;
         while (depth > 0) {
             switch (parser.next()) {
-            case XmlPullParser.START_TAG:
-                depth++;
-                break;
-            case XmlPullParser.END_TAG:
-                depth--;
-                break;
+                case XmlPullParser.START_TAG:
+                    depth++;
+                    break;
+                case XmlPullParser.END_TAG:
+                    depth--;
+                    break;
             }
         }
     }
@@ -150,6 +181,34 @@ class FontFileParser {
         } else {
             return "";
         }
+    }
+
+    /*
+     * Returns the next available font fallback, or empty string if not found
+     * The integer value determines the fallback priority (lower is higher)
+     * The weightHint value determines the closest fallback hint for boldness
+     * See /etc/fonts/font_fallback for documentation
+     */
+    public String getFontFallback(int id, int weightHint) {
+        Iterator it = fallbackFontDict.entrySet().iterator();
+        Integer diffWeight = Integer.MAX_VALUE;
+        String fallback = "";
+
+        while (it.hasNext()) {
+            Map.Entry pair = (Map.Entry)it.next();
+            Integer diff = Math.abs((Integer) pair.getKey() - weightHint);
+
+            if (diff < diffWeight) {
+                Vector<String> fallbacks = (Vector<String>) pair.getValue();
+
+                if (id < fallbacks.size()) {
+                    fallback = fallbacks.elementAt(id);
+                    diffWeight = diff;
+                }
+            }
+        }
+
+        return fallback;
     }
 
 }

--- a/android/tangram/src/com/mapzen/tangram/FontFileParser.java
+++ b/android/tangram/src/com/mapzen/tangram/FontFileParser.java
@@ -189,7 +189,7 @@ class FontFileParser {
      * The weightHint value determines the closest fallback hint for boldness
      * See /etc/fonts/font_fallback for documentation
      */
-    public String getFontFallback(int id, int weightHint) {
+    public String getFontFallback(int importance, int weightHint) {
         Iterator it = fallbackFontDict.entrySet().iterator();
         Integer diffWeight = Integer.MAX_VALUE;
         String fallback = "";
@@ -201,8 +201,8 @@ class FontFileParser {
             if (diff < diffWeight) {
                 Vector<String> fallbacks = (Vector<String>) pair.getValue();
 
-                if (id < fallbacks.size()) {
-                    fallback = fallbacks.elementAt(id);
+                if (importance < fallbacks.size()) {
+                    fallback = fallbacks.elementAt(importance);
                     diffWeight = diff;
                 }
             }

--- a/android/tangram/src/com/mapzen/tangram/FontFileParser.java
+++ b/android/tangram/src/com/mapzen/tangram/FontFileParser.java
@@ -59,7 +59,8 @@ class FontFileParser {
                                 fallbackFontDict.put(weight, new Vector<String>());
                             }
 
-                            fallbackFontDict.get(weight).add(filename);
+                            String fullFileName = "/system/fonts/" + filename;
+                            fallbackFontDict.get(weight).add(fullFileName);
                         } else {
                             skip(parser);
                         }

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -541,9 +541,9 @@ public class MapController implements Renderer {
 
     }
 
-    public String getFontFallbackFilePath(int id, int weightHint) {
+    public String getFontFallbackFilePath(int importance, int weightHint) {
 
-        return fontFileParser.getFontFallback(id, weightHint);
+        return fontFileParser.getFontFallback(importance, weightHint);
     }
 
     // Feature selection

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -541,6 +541,11 @@ public class MapController implements Renderer {
 
     }
 
+    public String getFontFallbackFilePath(int id, int weightHint) {
+
+        return fontFileParser.getFontFallback(id, weightHint);
+    }
+
     // Feature selection
     // =================
     public void featureSelectionCb(Properties properties, float positionX, float positionY) {

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -89,6 +89,10 @@ public class MapController implements Renderer {
         view.setRenderer(this);
         view.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
 
+        // Load the fonts
+        fontFileParser = new FontFileParser();
+        fontFileParser.parse("/system/etc/fonts.xml");
+
         init(this, assetManager, scenePath);
 
     }
@@ -466,7 +470,7 @@ public class MapController implements Renderer {
     private AssetManager assetManager;
     private TouchInput touchInput;
 
-    private final FontFileParser fontFileParser = new FontFileParser();
+    private FontFileParser fontFileParser;
 
     private DisplayMetrics displayMetrics = new DisplayMetrics();
 

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -70,6 +70,11 @@ void cancelUrlRequest(const std::string& _url);
  */
 void setCurrentThreadPriority(int priority);
 
+/* Get the font fallback ordered by importance, 0 being the first fallback
+ * (e.g. the fallback more willing resolve the glyph codepoint)
+ */
+std::string systemFontFallbackPath(int _order, int _weightHint);
+
 void initGLExtensions();
 
 /* Log utilities */

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -73,7 +73,7 @@ void setCurrentThreadPriority(int priority);
 /* Get the font fallback ordered by importance, 0 being the first fallback
  * (e.g. the fallback more willing resolve the glyph codepoint)
  */
-std::string systemFontFallbackPath(int _order, int _weightHint);
+std::string systemFontFallbackPath(int _importance, int _weightHint);
 
 void initGLExtensions();
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -93,6 +93,14 @@ void initialize(const char* _scenePath) {
     m_view->setPosition(projPos.x, projPos.y);
     m_view->setZoom(m_scene->startZoom);
 
+    int i = 0;
+    int boldHint = 500;
+    std::string fontFallback = systemFontFallbackPath(i, boldHint);
+    while (fontFallback.empty()) {
+        LOGS("%s", fontFallback.c_str());
+        fontFallback = systemFontFallbackPath(i++, boldHint);
+    }
+
     LOG("finish initialize");
 
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -96,8 +96,8 @@ void initialize(const char* _scenePath) {
     int i = 0;
     int boldHint = 500;
     std::string fontFallback = systemFontFallbackPath(i, boldHint);
-    while (fontFallback.empty()) {
-        LOGS("%s", fontFallback.c_str());
+    while (!fontFallback.empty()) {
+        LOG("%s", fontFallback.c_str());
         fontFallback = systemFontFallbackPath(i++, boldHint);
     }
 

--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -14,9 +14,9 @@ NSURLSession* defaultSession;
 static NSMutableString* s_resourceRoot = NULL;
 
 void init(ViewController* _controller) {
-    
+
     viewController = _controller;
-    
+
     /* Setup NSURLSession configuration : cache path and size */
     NSURLSessionConfiguration *defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSString *cachePath = @"/tile_cache";
@@ -25,10 +25,10 @@ void init(ViewController* _controller) {
     defaultConfigObject.requestCachePolicy = NSURLRequestUseProtocolCachePolicy;
     defaultConfigObject.timeoutIntervalForRequest = 30;
     defaultConfigObject.timeoutIntervalForResource = 60;
-    
+
     /* create a default NSURLSession using the defaultConfigObject*/
     defaultSession = [NSURLSession sessionWithConfiguration: defaultConfigObject ];
-    
+
 }
 
 void logMsg(const char* fmt, ...) {
@@ -41,21 +41,21 @@ void logMsg(const char* fmt, ...) {
 }
 
 void requestRender() {
-    
+
     [viewController renderOnce];
-    
+
 }
 
 void setContinuousRendering(bool _isContinuous) {
-    
+
     [viewController setContinuous:_isContinuous];
-    
+
 }
 
 bool isContinuousRendering() {
-    
+
     return [viewController continuous];
-    
+
 }
 
 std::string setResourceRoot(const char* _path) {
@@ -92,7 +92,7 @@ NSString* resolvePath(const char* _path, PathType _type) {
 }
 
 std::string stringFromFile(const char* _path, PathType _type) {
-    
+
     NSString* path = resolvePath(_path, _type);
     NSString* str = [NSString stringWithContentsOfFile:path
                                           usedEncoding:NULL
@@ -102,7 +102,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
         logMsg("Failed to read file at path: %s\n", [path UTF8String]);
         return std::string();
     }
-    
+
     return std::string([str UTF8String]);
 }
 
@@ -129,41 +129,46 @@ std::string systemFontPath(const std::string& _name, const std::string& _weight,
     return "";
 }
 
+// No system fonts fallback implementation (yet!)
+std::string systemFontFallbackPath(int _importance, int _weightHint) {
+    return "";
+}
+
 bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
 
     NSString* nsUrl = [NSString stringWithUTF8String:_url.c_str()];
-    
+
     void (^handler)(NSData*, NSURLResponse*, NSError*) = ^void (NSData* data, NSURLResponse* response, NSError* error) {
-        
+
         if(error == nil) {
-            
+
             int dataLength = [data length];
             std::vector<char> rawDataVec;
             rawDataVec.resize(dataLength);
             memcpy(rawDataVec.data(), (char *)[data bytes], dataLength);
             _callback(std::move(rawDataVec));
-            
+
         } else {
-            
+
             logMsg("ERROR: response \"%s\" with error \"%s\".\n", response, std::string([error.localizedDescription UTF8String]).c_str());
 
         }
-        
+
     };
-    
+
     NSURLSessionDataTask* dataTask = [defaultSession dataTaskWithURL:[NSURL URLWithString:nsUrl]
                                                     completionHandler:handler];
-    
+
     [dataTask resume];
-    
+
     return true;
 
 }
 
 void cancelUrlRequest(const std::string& _url) {
-    
+
     NSString* nsUrl = [NSString stringWithUTF8String:_url.c_str()];
-    
+
     [defaultSession getTasksWithCompletionHandler:^(NSArray* dataTasks, NSArray* uploadTasks, NSArray* downloadTasks) {
         for(NSURLSessionTask* task in dataTasks) {
             if([[task originalRequest].URL.absoluteString isEqualToString:nsUrl]) {
@@ -172,7 +177,7 @@ void cancelUrlRequest(const std::string& _url) {
             }
         }
     }];
-    
+
 }
 
 void setCurrentThreadPriority(int priority) {}

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -129,6 +129,11 @@ std::string systemFontPath(const std::string& _name, const std::string& _weight,
     return "";
 }
 
+// No system fonts fallback implementation (yet!)
+std::string systemFontFallbackPath(int _importance, int _weightHint) {
+    return "";
+}
+
 bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
 
     std::unique_ptr<UrlTask> task(new UrlTask(_url, _callback));

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -116,6 +116,11 @@ std::string systemFontPath(const std::string& _name, const std::string& _weight,
     return "";
 }
 
+// No system fonts fallback implementation (yet!)
+std::string systemFontFallbackPath(int _importance, int _weightHint) {
+    return "";
+}
+
 bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
 
     std::unique_ptr<UrlTask> task(new UrlTask(_url, _callback));

--- a/tests/src/platform_mock.cpp
+++ b/tests/src/platform_mock.cpp
@@ -93,6 +93,10 @@ std::string systemFontPath(const std::string& _name, const std::string& _weight,
     return "";
 }
 
+std::string systemFontFallbackPath(int _importance, int _weightHint) {
+    return "";
+}
+
 bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
     return true;
 }


### PR DESCRIPTION
Android platform layer for font fallbacks
- Fallbacks are given by the platform by order of importance (determined by android order from `font_fallbacks.xml`)
- For a given _hint_ boldness `systemFontFallbackPath` would give the most appropriate font for the required bold.

For OS X, fallbacks can be found in `/System/Library/Frameworks/ApplicationServices.framework/Frameworks/CoreText.framework/Resources/DefaultFontFallbacks.plist`