### PR TITLE
Fix vertex attribute enabling for non-buffered vertex arrays

### DIFF
--- a/core/src/gl/vertexLayout.cpp
+++ b/core/src/gl/vertexLayout.cpp
@@ -97,7 +97,7 @@ void VertexLayout::enable(ShaderProgram& _program, size_t _byteOffset, void* _pt
                 loc = glProgram;
             }
 
-            void* data = _ptr ? _ptr : ((unsigned char*) attrib.offset) + _byteOffset;
+            void* data = (unsigned char*)_ptr + attrib.offset + _byteOffset;
             glVertexAttribPointer(location, attrib.size, attrib.type, attrib.normalized, m_stride, data);
         }
     }


### PR DESCRIPTION
This bug had me seriously questioning my sanity last night. In the current code, calling `enable` on a `VertexLayout` for non-buffered arrays of vertex data will only correctly enable the first vertex attribute; all subsequent attributes will be pointed to the same data as the first attribute because `attrib.offset` is not applied to the input pointer. This change just adds the offset to the input pointer whether or not it is `nullptr`. 