### PR TITLE
TileDataSink

### DIFF
--- a/bench/src/mvtParsing.cpp
+++ b/bench/src/mvtParsing.cpp
@@ -1,0 +1,79 @@
+#include "tangram.h"
+#include "platform.h"
+#include "data/dataSource.h"
+#include "data/mvtSource.h"
+#include "util/mapProjection.h"
+#include "tile/tile.h"
+#include "tile/tileTask.h"
+
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+#include "benchmark/benchmark_api.h"
+#include "benchmark/benchmark.h"
+
+using namespace Tangram;
+
+struct TestContext {
+
+    MercatorProjection projection;
+
+    std::shared_ptr<DataSource> source;
+    std::shared_ptr<std::vector<char>> rawTileData;
+    std::shared_ptr<TileData> tileData;
+
+    void loadTile(const char* path){
+        std::ifstream resource(path, std::ifstream::ate | std::ifstream::binary);
+        if(!resource.is_open()) {
+            LOGE("Failed to read file at path: %s", path.c_str());
+            return;
+        }
+
+        size_t _size = resource.tellg();
+        resource.seekg(std::ifstream::beg);
+
+        rawTileData = std::make_shared<std::vector<char>>();
+        rawTileData->resize(_size);
+
+        resource.read(&(*rawTileData)[0], _size);
+        resource.close();
+    }
+};
+
+class MVTParsingFixture : public benchmark::Fixture {
+public:
+    TestContext ctx;
+
+    const char* tileFile = "tile.mvt";
+
+    void SetUp() override {
+        LOG("SETUP");
+        ctx.source = std::make_shared<MVTSource>("","",20);
+        ctx.loadTile(tileFile);
+    }
+    void TearDown() override {
+        LOG("TEARDOWN");
+    }
+};
+
+BENCHMARK_DEFINE_F(MVTParsingFixture, BuildTest)(benchmark::State& st) {
+
+    while (st.KeepRunning()) {
+        TileID tileId{0,0,10,10,0};
+        Tile tile(tileId, ctx.projection);
+        
+        auto task = std::make_shared<DownloadTileTask>(tileId, ctx.source);
+        task->rawTileData = ctx.rawTileData;
+
+        auto tileData = ctx.source->parse(*task, ctx.projection);
+
+        benchmark::DoNotOptimize(tileData);
+    }
+}
+
+BENCHMARK_REGISTER_F(MVTParsingFixture, BuildTest);
+
+
+
+BENCHMARK_MAIN();

--- a/core/deps/pbf/pbf.hpp
+++ b/core/deps/pbf/pbf.hpp
@@ -47,6 +47,7 @@ public:
     PBF_INLINE uint64_t varint2();
     PBF_INLINE int64_t svarint();
     PBF_INLINE std::string string();
+    PBF_INLINE std::pair<size_t, const char*> chunk();
     PBF_INLINE float float32();
     PBF_INLINE double float64();
     PBF_INLINE int64_t int64();
@@ -149,6 +150,14 @@ std::string message::string()
     value_type string = static_cast<value_type>(data_);
     skipBytes(len);
     return std::string(string, len);
+}
+
+std::pair<size_t, const char*> message::chunk()
+{
+    uint64_t len = varint();
+    value_type string = static_cast<value_type>(data_);
+    skipBytes(len);
+    return { len, string };
 }
 
 float message::float32()

--- a/core/include/tangram/data/clientGeoJsonSource.h
+++ b/core/include/tangram/data/clientGeoJsonSource.h
@@ -40,8 +40,9 @@ public:
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const TileTask& _task,
-                                            const MapProjection& _projection) const override;
+    virtual bool process(const TileTask& _task,
+                         const MapProjection& _projection,
+                         TileDataSink& _sink) const override;
 
     std::unique_ptr<ClientGeoJsonData> m_store;
 

--- a/core/include/tangram/data/properties.h
+++ b/core/include/tangram/data/properties.h
@@ -54,7 +54,7 @@ struct Properties {
     //     sort();
     // }
 
-    const std::vector<Item>& items() const { return props; }
+    std::vector<Item>& items() { return props; }
 
     int32_t sourceId;
 

--- a/core/include/tangram/data/propertyItem.h
+++ b/core/include/tangram/data/propertyItem.h
@@ -5,6 +5,8 @@
 namespace Tangram {
 
 struct PropertyItem {
+    PropertyItem() {}
+
     PropertyItem(std::string _key, Value _value) :
         key(std::move(_key)), value(std::move(_value)) {}
 

--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -18,6 +18,9 @@ class TileManager;
 struct RawCache;
 class Texture;
 
+struct Feature;
+struct TileDataSink;
+
 class TileSource : public std::enable_shared_from_this<TileSource> {
 
 public:
@@ -68,8 +71,8 @@ public:
     /* Stops any running I/O tasks pertaining to @_tile */
     virtual void cancelLoadingTile(const TileID& _tile);
 
-    /* Parse a <TileTask> with data into a <TileData>, returning an empty TileData on failure */
-    virtual std::shared_ptr<TileData> parse(const TileTask& _task, const MapProjection& _projection) const = 0;
+    /* FIXME doc /Parse a <TileTask> with data into a <TileData>, returning an empty TileData on failure */
+    virtual bool process(const TileTask& _task, const MapProjection& _projection, TileDataSink& _sink) const = 0;
 
     /* Clears all data associated with this TileSource */
     virtual void clearData();

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -10,21 +10,22 @@
 
 namespace Tangram {
 
-std::shared_ptr<TileData> GeoJsonSource::parse(const TileTask& _task,
-                                               const MapProjection& _projection) const {
+bool GeoJsonSource::process(const TileTask& _task, const MapProjection& _projection,
+                            TileDataSink& _sink) const {
 
     auto& task = static_cast<const BinaryTileTask&>(_task);
-
-    std::shared_ptr<TileData> tileData = std::make_shared<TileData>();
 
     // Parse data into a JSON document
     const char* error;
     size_t offset;
-    auto document = JsonParseBytes(task.rawTileData->data(), task.rawTileData->size(), &error, &offset);
+    auto document = JsonParseBytes(task.rawTileData->data(),
+                                   task.rawTileData->size(),
+                                   &error, &offset);
 
     if (error) {
-        LOGE("Json parsing failed on tile [%s]: %s (%u)", task.tileId().toString().c_str(), error, offset);
-        return tileData;
+        LOGE("Json parsing failed on tile [%s]: %s (%u)",
+             task.tileId().toString().c_str(), error, offset);
+        return true;
     }
 
     BoundingBox tileBounds(_projection.TileBounds(task.tileId()));
@@ -42,21 +43,21 @@ std::shared_ptr<TileData> GeoJsonSource::parse(const TileTask& _task,
 
     // Transform JSON data into TileData using GeoJson functions
     if (GeoJson::isFeatureCollection(document)) {
-        tileData->layers.push_back(GeoJson::getLayer(document, projFn, m_id));
+        _sink.beginLayer("");
+        GeoJson::processLayer(document, projFn, m_id, _sink);
     } else {
         for (auto layer = document.MemberBegin(); layer != document.MemberEnd(); ++layer) {
             if (GeoJson::isFeatureCollection(layer->value)) {
-                tileData->layers.push_back(GeoJson::getLayer(layer->value, projFn, m_id));
-                tileData->layers.back().name = layer->name.GetString();
+                if (_sink.beginLayer(layer->name.GetString())) {
+                    GeoJson::processLayer(layer->value, projFn, m_id, _sink);
+                }
             }
         }
     }
 
+    // Discard original JSON object
 
-    // Discard original JSON object and return TileData
-
-    return tileData;
-
+    return true;
 }
 
 }

--- a/core/src/data/geoJsonSource.h
+++ b/core/src/data/geoJsonSource.h
@@ -11,8 +11,9 @@ public:
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const TileTask& _task,
-                                            const MapProjection& _projection) const override;
+    virtual bool process(const TileTask& _task,
+                         const MapProjection& _projection,
+                         TileDataSink& _sink) const override;
 
     // http://www.iana.org/assignments/media-types/application/geo+json
     virtual const char* mimeType() override { return "application/geo+json"; };

--- a/core/src/data/mvtSource.h
+++ b/core/src/data/mvtSource.h
@@ -11,8 +11,9 @@ public:
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const TileTask& _task,
-                                            const MapProjection& _projection) const override;
+    virtual bool process(const TileTask& _task,
+                         const MapProjection& _projection,
+                         TileDataSink& _sink) const override;
 
     // http://www.iana.org/assignments/media-types/application/vnd.mapbox-vector-tile
     virtual const char* mimeType() override { return "application/vnd.mapbox-vector-tile"; };

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -89,6 +89,7 @@ std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _r
     return texture;
 }
 
+// <<<<<<< HEAD
 void RasterSource::loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) {
     // TODO, remove this
     // Overwrite cb to set empty texture on failure
@@ -104,7 +105,8 @@ void RasterSource::loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb)
     TileSource::loadTileData(_task, cb);
 }
 
-std::shared_ptr<TileData> RasterSource::parse(const TileTask& _task, const MapProjection& _projection) const {
+bool RasterSource::process(const TileTask& _task, const MapProjection& _projection,
+                           TileDataSink& _sink) const {
 
     std::shared_ptr<TileData> tileData = std::make_shared<TileData>();
 
@@ -119,10 +121,12 @@ std::shared_ptr<TileData> RasterSource::parse(const TileTask& _task, const MapPr
                                  } } };
     rasterFeature.props = Properties();
 
-    tileData->layers.emplace_back("");
-    tileData->layers.back().features.push_back(rasterFeature);
-    return tileData;
+    _sink.beginLayer("");
+    if (_sink.matchFeature(rasterFeature)) {
+        _sink.addFeature(rasterFeature);
+    }
 
+    return true;
 }
 
 std::shared_ptr<TileTask> RasterSource::createTask(TileID _tileId, int _subTask) {

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -23,8 +23,7 @@ class RasterSource : public TileSource {
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const TileTask& _task,
-                                            const MapProjection& _projection) const override;
+    virtual bool process(const TileTask& _task, const MapProjection& _projection, TileDataSink& _sink) const override;
 
 public:
 

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -98,4 +98,10 @@ struct TileData {
 
 };
 
+struct TileDataSink {
+    virtual bool beginLayer(const std::string& _layer) = 0;
+    virtual bool matchFeature(const Feature& _feature) = 0;
+    virtual void addFeature(const Feature& _feature) = 0;
+};
+
 }

--- a/core/src/data/topoJsonSource.cpp
+++ b/core/src/data/topoJsonSource.cpp
@@ -9,21 +9,22 @@
 
 namespace Tangram {
 
-std::shared_ptr<TileData> TopoJsonSource::parse(const TileTask& _task,
-                                                const MapProjection& _projection) const {
+bool TopoJsonSource::process(const TileTask& _task, const MapProjection& _projection,
+                             TileDataSink& _sink) const {
 
     auto& task = static_cast<const BinaryTileTask&>(_task);
-
-    std::shared_ptr<TileData> tileData = std::make_shared<TileData>();
 
     // Parse data into a JSON document
     const char* error;
     size_t offset;
-    auto document = JsonParseBytes(task.rawTileData->data(), task.rawTileData->size(), &error, &offset);
+    auto document = JsonParseBytes(task.rawTileData->data(),
+                                   task.rawTileData->size(),
+                                   &error, &offset);
 
     if (error) {
-        LOGE("Json parsing failed on tile [%s]: %s (%u)", task.tileId().toString().c_str(), error, offset);
-        return tileData;
+        LOGE("Json parsing failed on tile [%s]: %s (%u)",
+             task.tileId().toString().c_str(), error, offset);
+        return false;
     }
 
     // Transform JSON data into a TileData using TopoJson functions
@@ -45,15 +46,16 @@ std::shared_ptr<TileData> TopoJsonSource::parse(const TileTask& _task,
 
     // Parse each TopoJson object as a data layer
     auto objectsIt = document.FindMember("objects");
-    if (objectsIt == document.MemberEnd()) { return tileData; }
+    if (objectsIt == document.MemberEnd()) {
+        return true;
+    }
     auto& objects = objectsIt->value;
     for (auto layer = objects.MemberBegin(); layer != objects.MemberEnd(); ++layer) {
-        tileData->layers.push_back(TopoJson::getLayer(layer, topology, m_id));
+        TopoJson::processLayer(layer, topology, m_id, _sink);
     }
 
-    // Discard JSON object and return TileData
-    return tileData;
-
+    // Discard JSON object
+    return true;
 }
 
 }

--- a/core/src/data/topoJsonSource.h
+++ b/core/src/data/topoJsonSource.h
@@ -11,8 +11,9 @@ public:
 
 protected:
 
-    virtual std::shared_ptr<TileData> parse(const TileTask& _task,
-                                            const MapProjection& _projection) const override;
+    virtual bool process(const TileTask& _task,
+                         const MapProjection& _projection,
+                         TileDataSink& _sink) const override;
 
     // TODO: We need to register this MIME Media Type with the IANA
     virtual const char* mimeType() override { return "application/topo+json"; };

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -96,6 +96,10 @@ bool TileBuilder::beginLayer(const std::string& _layerName) {
 
     for (const auto& layer : m_scene->layers()) {
 
+        if (layer.source() != m_activeSource) {
+            continue;
+        }
+
         if (!_layerName.empty()) {
             const auto& dlc = layer.collections();
             if (std::find(dlc.begin(), dlc.end(), _layerName) == dlc.end()) {
@@ -163,6 +167,8 @@ std::shared_ptr<Tile> TileBuilder::build(TileTask& _task) {
             builder.second->setup(*tile);
         }
     }
+
+    m_activeSource = _task.source().name();
 
     // Pass 'this' as TileDataSink
     if (!_task.source().process(_task, *m_scene->mapProjection(), *this)) {

--- a/core/src/tile/tileBuilder.h
+++ b/core/src/tile/tileBuilder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "data/tileData.h"
 #include "data/tileSource.h"
 #include "labels/labelCollider.h"
 #include "scene/styleContext.h"
@@ -13,10 +14,11 @@ class Tile;
 class TileSource;
 struct Feature;
 struct Properties;
-struct TileData;
+class Tile;
+class TileTask;
+class StyleBuilder;
 
-class TileBuilder {
-
+class TileBuilder : public TileDataSink {
 public:
 
     TileBuilder(std::shared_ptr<Scene> _scene);
@@ -25,7 +27,13 @@ public:
 
     StyleBuilder* getStyleBuilder(const std::string& _name);
 
-    std::shared_ptr<Tile> build(TileID _tileID, const TileData& _data, const TileSource& _source);
+    // Process TileTask. On sucess _task.isReady() is true
+    // and _task.tile() returns the created tile.
+    std::shared_ptr<Tile> build(TileTask& _task);
+
+    virtual bool beginLayer(const std::string& _layer) override;
+    virtual bool matchFeature(const Feature& _feature) override;
+    virtual void addFeature(const Feature& _feature) override;
 
     const Scene& scene() const { return *m_scene; }
 
@@ -44,6 +52,11 @@ private:
     fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilder;
 
     fastmap<uint32_t, std::shared_ptr<Properties>> m_selectionFeatures;
+
+    std::vector<const DataLayer*> m_activeLayers;
+    const DataLayer* m_matchedLayer = nullptr;
+
+    std::shared_ptr<Tile> m_tile;
 };
 
 }

--- a/core/src/tile/tileBuilder.h
+++ b/core/src/tile/tileBuilder.h
@@ -53,6 +53,7 @@ private:
 
     fastmap<uint32_t, std::shared_ptr<Properties>> m_selectionFeatures;
 
+    std::string m_activeSource;
     std::vector<const DataLayer*> m_activeLayers;
     const DataLayer* m_matchedLayer = nullptr;
 

--- a/core/src/tile/tileTask.cpp
+++ b/core/src/tile/tileTask.cpp
@@ -16,14 +16,7 @@ TileTask::TileTask(TileID& _tileId, std::shared_ptr<TileSource> _source, int _su
     m_priority(0) {}
 
 void TileTask::process(TileBuilder& _tileBuilder) {
-
-    auto tileData = m_source->parse(*this, *_tileBuilder.scene().mapProjection());
-
-    if (tileData) {
-        m_tile = _tileBuilder.build(m_tileId, *tileData, *m_source);
-    } else {
-        cancel();
-    }
+    m_tile = _tileBuilder.build(*this);
 }
 
 void TileTask::complete() {

--- a/core/src/util/geoJson.cpp
+++ b/core/src/util/geoJson.cpp
@@ -136,22 +136,25 @@ Feature GeoJson::getFeature(const JsonValue& _in, const Transform& _proj, int32_
 
 }
 
-Layer GeoJson::getLayer(const JsonValue& _in, const Transform& _proj, int32_t _sourceId) {
-
-    Layer layer("");
+bool GeoJson::processLayer(const JsonValue& _in, const Transform& _proj,
+                            int32_t _sourceId, TileDataSink& _sink) {
 
     auto features = _in.FindMember("features");
 
     if (features == _in.MemberEnd()) {
         LOGE("GeoJSON missing 'features' member");
-        return layer;
+        return false;
     }
 
     for (auto featureIt = features->value.Begin(); featureIt != features->value.End(); ++featureIt) {
-        layer.features.push_back(getFeature(*featureIt, _proj, _sourceId));
+        auto feat = getFeature(*featureIt, _proj, _sourceId);
+        // TODO could be optimized by skipping geometry parsing for unmatched features
+        if (_sink.matchFeature(feat)) {
+            _sink.addFeature(feat);
+        }
     }
 
-    return layer;
+    return true;
 
 }
 

--- a/core/src/util/geoJson.h
+++ b/core/src/util/geoJson.h
@@ -23,7 +23,8 @@ Properties getProperties(const JsonValue& _in, int32_t _sourceId);
 
 Feature getFeature(const JsonValue& _in, const Transform& _proj, int32_t _sourceId);
 
-Layer getLayer(const JsonValue& _in, const Transform& _proj, int32_t _sourceId);
+bool processLayer(const JsonValue& _in, const Transform& _proj,
+                  int32_t _sourceId, TileDataSink& _sink);
 
 }
 

--- a/core/src/util/pbfParser.cpp
+++ b/core/src/util/pbfParser.cpp
@@ -24,6 +24,9 @@ namespace Tangram {
 
 void PbfParser::extractGeometry(ParserContext& _ctx, protobuf::message& _geomIn) {
 
+    _ctx.coordinates.clear();
+    _ctx.numCoordinates.clear();
+
     pbfGeomCmd cmd = pbfGeomCmd::moveTo;
     uint32_t cmdRepeat = 0;
 
@@ -132,9 +135,6 @@ struct update_visitor {
 };
 
 bool PbfParser::extractTags(ParserContext& _ctx, protobuf::message& _tagsMsg) {
-
-    _ctx.coordinates.clear();
-    _ctx.numCoordinates.clear();
 
     // keep previous tags to check which tags changed
     _ctx.featureTags.swap(_ctx.previousTags);
@@ -247,11 +247,11 @@ void PbfParser::extractFeature(ParserContext& _ctx, protobuf::message& _featureI
         }
     }
 
-    if (!geomMsg || !tagsMsg || feature.geometryType == GeometryType::unknown) {
+    if (!geomMsg || feature.geometryType == GeometryType::unknown) {
         return;
     }
 
-    if (!extractTags(_ctx, tagsMsg)) {
+    if (tagsMsg && !extractTags(_ctx, tagsMsg)) {
         return;
     }
 

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -9,37 +9,36 @@
 
 namespace Tangram {
 
-class Tile;
-
 namespace PbfParser {
 
-    struct Geometry {
-        std::vector<Point> coordinates;
-        std::vector<int> sizes;
-    };
-
     struct ParserContext {
-        ParserContext(int32_t _sourceId) : sourceId(_sourceId){}
+        ParserContext(int32_t _sourceId) {
+            values.reserve(256);
+            coordinates.reserve(256);
+            feature.props.sourceId = _sourceId;
+        }
 
-        int32_t sourceId;
         std::vector<std::string> keys;
         std::vector<Value> values;
         std::vector<protobuf::message> featureMsgs;
-        Geometry geometry;
+        std::vector<Point> coordinates;
+        std::vector<int> numCoordinates;
         // Map Key ID -> Tag values
         std::vector<int> featureTags;
+        std::vector<int> previousTags;
         // Key IDs sorted by Property key ordering
         std::vector<int> orderedKeys;
+        Feature feature;
 
         int tileExtent = 0;
         int winding = 0;
     };
 
-    Geometry getGeometry(ParserContext& _ctx, protobuf::message _geomIn);
+    void extractGeometry(ParserContext& _ctx, protobuf::message& _geomIn);
 
-    Feature getFeature(ParserContext& _ctx, protobuf::message _featureIn);
+    void extractFeature(ParserContext& _ctx, protobuf::message& _featureIn, TileDataSink& _sink);
 
-    Layer getLayer(ParserContext& _ctx, protobuf::message _layerIn);
+    void extractLayer(ParserContext& _ctx, protobuf::message& _in, TileDataSink& _sink);
 
     enum pbfGeomCmd {
         moveTo = 1,

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -12,7 +12,7 @@ namespace Tangram {
 namespace PbfParser {
 
     using StringView = std::pair<size_t, const char*>;
-    using TagValue = variant<none_type, double, StringView>;
+    using TagValue = variant<StringView, double, none_type>;
 
     struct ParserContext {
         ParserContext(int32_t _sourceId) {
@@ -38,6 +38,8 @@ namespace PbfParser {
     };
 
     void extractGeometry(ParserContext& _ctx, protobuf::message& _geomIn);
+
+    bool extractTags(ParserContext& _ctx, protobuf::message& _tagsIn);
 
     void extractFeature(ParserContext& _ctx, protobuf::message& _featureIn, TileDataSink& _sink);
 

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -11,6 +11,9 @@ namespace Tangram {
 
 namespace PbfParser {
 
+    using StringView = std::pair<size_t, const char*>;
+    using TagValue = variant<none_type, double, StringView>;
+
     struct ParserContext {
         ParserContext(int32_t _sourceId) {
             values.reserve(256);
@@ -19,7 +22,7 @@ namespace PbfParser {
         }
 
         std::vector<std::string> keys;
-        std::vector<Value> values;
+        std::vector<TagValue> values;
         std::vector<protobuf::message> featureMsgs;
         std::vector<Point> coordinates;
         std::vector<int> numCoordinates;

--- a/core/src/util/topoJson.cpp
+++ b/core/src/util/topoJson.cpp
@@ -223,9 +223,12 @@ Feature getFeature(const JsonValue& _geometry, const Topology& _topology, int32_
 
 }
 
-Layer getLayer(JsonValue::MemberIterator& _objectIt, const Topology& _topology, int32_t _source) {
+bool processLayer(JsonValue::MemberIterator& _objectIt, const Topology& _topology,
+                  int32_t _source, TileDataSink& _sink) {
 
-    Layer layer(_objectIt->name.GetString());
+    if (!_sink.beginLayer(_objectIt->name.GetString())) {
+        return false;
+    }
 
     JsonValue& object = _objectIt->value;
     auto type = object.FindMember("type");
@@ -233,12 +236,18 @@ Layer getLayer(JsonValue::MemberIterator& _objectIt, const Topology& _topology, 
         auto geometries = object.FindMember("geometries");
         if (geometries != object.MemberEnd() && geometries->value.IsArray()) {
             for (auto it = geometries->value.Begin(); it != geometries->value.End(); ++it) {
-                layer.features.push_back(getFeature(*it, _topology, _source));
+
+                auto feat = getFeature(*it, _topology, _source);
+
+                // TODO could be optimized by skipping geometry parsing for unmatched features
+                if (_sink.matchFeature(feat)) {
+                    _sink.addFeature(feat);
+                }
             }
         }
     }
 
-    return layer;
+    return true;
 
 }
 

--- a/core/src/util/topoJson.h
+++ b/core/src/util/topoJson.h
@@ -29,7 +29,8 @@ Polygon getPolygon(const JsonValue& _arcs, const Topology& _topology);
 
 Feature getFeature(const JsonValue& _geometry, const Topology& _topology, int32_t _sourceId);
 
-Layer getLayer(JsonValue::MemberIterator& _object, const Topology& _topology, int32_t _sourceId);
+bool processLayer(JsonValue::MemberIterator& _object, const Topology& _topology,
+                  int32_t _sourceId, TileDataSink& _sink);
 
 }
 

--- a/tests/unit/tileManagerTests.cpp
+++ b/tests/unit/tileManagerTests.cpp
@@ -95,9 +95,10 @@ struct TestTileSource : TileSource {
 
     void cancelLoadingTile(const TileID& _tile) override {}
 
-    std::shared_ptr<TileData> parse(const TileTask& _task,
-                                    const MapProjection& _projection) const override{
-        return nullptr;
+    virtual bool process(const TileTask& _task,
+                         const MapProjection& _projection,
+                         TileDataSink& _builder) const override {
+        return true;
     };
 
     void clearData() override {}


### PR DESCRIPTION
Replacing TileData container with TileDataSink callbacks. With this a single Feature object can be reused for tile creation. Unmatched layers can be skipped directly, unmatched features (by props and geometry type) can be skipped without extracting the geometry. 
