### PR TITLE
[rfc] Run time atlas packing for icons

### DIFF
--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -52,7 +52,7 @@ public class MapController implements Renderer {
      */
     public MapController(Activity mainApp, MapView view) {
 
-        this(mainApp, view, "scene.yaml");
+        this(mainApp, view, "eraser-map.yaml");
     }
 
     /**

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -71,7 +71,11 @@ public:
 
     typedef std::pair<GLuint, GLuint> TextureSlot;
 
+    std::vector<GLuint>& data() { return m_data; }
+
     static void invalidateAllTextures();
+
+    size_t bytesPerPixel();
 
 protected:
     void generate(GLuint _textureUnit);
@@ -98,8 +102,6 @@ protected:
     static int s_validGeneration;
 
 private:
-
-    size_t bytesPerPixel();
 
     bool m_generateMipmaps;
 };

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -419,6 +419,9 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
                 atlas->addSpriteNode(spriteName, pos, size);
             }
         }
+
+        atlas->pack();
+
         scene.spriteAtlases()[name] = atlas;
     }
     scene.textures().emplace(name, texture);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -21,6 +21,7 @@
 #include "scene/spriteAtlas.h"
 #include "scene/stops.h"
 #include "util/yamlHelper.h"
+#include "debug/textDisplay.h"
 #include "view/view.h"
 
 #include "yaml-cpp/yaml.h"
@@ -420,7 +421,11 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
             }
         }
 
+        clock_t start = clock();
         atlas->pack();
+        clock_t end = clock();
+        float time = float(end - start) / CLOCKS_PER_SEC * 1000.f;
+        LOGS("Packing time %f ms", time);
 
         scene.spriteAtlases()[name] = atlas;
     }

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -1,17 +1,23 @@
 #include "spriteAtlas.h"
 #include "platform.h"
+#include <algorithm>
 
 namespace Tangram {
 
-SpriteAtlas::SpriteAtlas(std::shared_ptr<Texture> _texture, const std::string& _file) : m_file(_file), m_texture(_texture) {}
+// TODO: make it auto resizable
+#define SPRITE_ATLAS_PACK_SIZE 1024
+
+SpriteAtlas::SpriteAtlas(std::shared_ptr<Texture> _texture, const std::string& _file) :
+    m_file(_file),
+    m_texture(_texture)
+{}
 
 void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size) {
-
     glm::vec2 atlasSize = {m_texture->getWidth(), m_texture->getHeight()};
     glm::vec2 uvBL = _origin / atlasSize;
     glm::vec2 uvTR = (_origin + _size) / atlasSize;
 
-    m_spritesNodes[_name] = SpriteNode { uvBL, uvTR, _size };
+    m_spritesNodes[_name] = SpriteNode { uvBL, uvTR, _size, _origin };
 }
 
 bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) const {
@@ -21,6 +27,161 @@ bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) con
     }
 
     _node = it->second;
+    return true;
+}
+
+// Adapted from Fontstash/Alfons, originally from Jukka Jylänki binpack algorithm
+void SpriteAtlas::addSkylineLevel(uint32_t _idx, int _x, int _y, int _w, int _h) {
+    m_packedNodes.insert(m_packedNodes.begin() + _idx, {_x, _y + _h, _w});
+
+    // Delete skyline segments that fall under the shadow of the new segment.
+    for (size_t i = _idx + 1; i < m_packedNodes.size(); i++) {
+        int shrink = (m_packedNodes[i - 1].x + m_packedNodes[i - 1].width) - m_packedNodes[i].x;
+
+        if (shrink > 0) {
+            int nw = m_packedNodes[i].width - shrink;
+
+            if (nw > 0) {
+                m_packedNodes[i].x += shrink;
+                m_packedNodes[i].width = nw;
+
+                break;
+            } else {
+                m_packedNodes.erase(m_packedNodes.begin() + i);
+                i--;
+            }
+        } else {
+            break;
+        }
+    }
+
+    // Merge same height skyline segments that are next to each other.
+    for (size_t i = 0; i < m_packedNodes.size() - 1; i++) {
+        if (m_packedNodes[i].y == m_packedNodes[i + 1].y) {
+            m_packedNodes[i].width += m_packedNodes[i + 1].width;
+            m_packedNodes.erase(m_packedNodes.begin() + i + 1);
+            i--;
+        }
+    }
+}
+
+int SpriteAtlas::rectFits(uint32_t _i, int _w, int _h) {
+    static const int defaultTextureWidth = SPRITE_ATLAS_PACK_SIZE;
+    static const int defaultTextureHeight = SPRITE_ATLAS_PACK_SIZE;
+
+    if (m_packedNodes[_i].x + _w > defaultTextureWidth) {
+        return -1;
+    }
+
+    int spaceLeft = _w;
+    int y = m_packedNodes[_i].y;
+
+    while (spaceLeft > 0) {
+        if (_i == m_packedNodes.size()) {
+            return -1;
+        }
+
+        y = std::max(y, m_packedNodes[_i].y);
+        if (y + _h > defaultTextureHeight) { return -1; }
+
+        spaceLeft -= m_packedNodes[_i].width;
+
+        ++_i;
+    }
+
+    return y;
+}
+
+bool SpriteAtlas::addNode(const SpriteNode& _in, SpriteNode& _out) {
+    int besth = SPRITE_ATLAS_PACK_SIZE;
+    int bestw = SPRITE_ATLAS_PACK_SIZE;
+    int bestx = -1, besty = -1, besti = -1;
+
+    for (size_t i = 0; i < m_packedNodes.size(); i++) {
+        int y = rectFits(i, _in.size.x, _in.size.y);
+
+        if (y != -1) {
+            if ((y + _in.size.y < besth) ||
+                ((y + _in.size.y == besth) && (m_packedNodes[i].width < bestw))) {
+                besti = i;
+                bestw = m_packedNodes[i].width;
+                besth = y + _in.size.y;
+                bestx = m_packedNodes[i].x;
+                besty = y;
+            }
+        }
+    }
+
+    if (besti == -1) {
+        return false;
+    }
+
+    // Perform the actual packing.
+    addSkylineLevel(besti, bestx, besty, _in.size.x, _in.size.y);
+
+    _out = _in;
+
+    _out.origin.x = bestx;
+    _out.origin.y = besty;
+
+    return true;
+}
+
+bool SpriteAtlas::pack() {
+    std::vector<std::pair<SpriteNode, SpriteNode>> packedNodes;
+
+    m_packedNodes.clear();
+    m_packedNodes.push_back({0, 0, SPRITE_ATLAS_PACK_SIZE});
+
+    packedNodes.reserve(m_spritesNodes.size());
+
+    for (auto& sprite : m_spritesNodes) {
+        SpriteNode packed;
+
+        if (!addNode(sprite.second, packed)) {
+            // TODO: handle atlas resize in this case
+            return false;
+        }
+
+        // update new uvs
+        packed.uvBL = packed.origin / glm::vec2(SPRITE_ATLAS_PACK_SIZE);
+        packed.uvTR = (packed.origin + packed.size) / glm::vec2(SPRITE_ATLAS_PACK_SIZE);
+
+        packedNodes.emplace_back(sprite.second, packed);
+        sprite.second = packed;
+    }
+
+    auto& textureData = m_texture->data();
+    TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
+    std::shared_ptr<Texture> newTexture = std::make_shared<Texture>(SPRITE_ATLAS_PACK_SIZE, SPRITE_ATLAS_PACK_SIZE, options);
+
+    GLuint* newTextureData = new GLuint[SPRITE_ATLAS_PACK_SIZE * SPRITE_ATLAS_PACK_SIZE];
+
+    for (const auto& packedNodePair : packedNodes) {
+        const auto& src = packedNodePair.first;
+        const auto& dst = packedNodePair.second;
+
+        assert(dst.size.x * dst.size.y == src.size.x * src.size.y);
+
+        for (int y = 0; y < dst.size.y; ++y) {
+            int srcy = (src.origin.y + y) * m_texture->getWidth();
+            int dsty = (dst.origin.y + y) * SPRITE_ATLAS_PACK_SIZE;
+
+            for (int x = 0; x < dst.size.x; ++x) {
+                int srcx = src.origin.x + x;
+                int dstx = dst.origin.x + x;
+
+                newTextureData[dstx + dsty] = textureData[srcx + srcy];
+            }
+        }
+    }
+
+    newTexture->setData(newTextureData, SPRITE_ATLAS_PACK_SIZE * SPRITE_ATLAS_PACK_SIZE);
+    delete[] newTextureData;
+
+    // FIXME: don't recopy texture like this, keep a blob of data from original texture
+    m_texture = newTexture;
+
     return true;
 }
 

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -167,13 +167,10 @@ bool SpriteAtlas::pack() {
         for (int y = 0; y < dst.size.y; ++y) {
             int srcy = (src.origin.y + y) * m_texture->getWidth();
             int dsty = (dst.origin.y + y) * SPRITE_ATLAS_PACK_SIZE;
+            int srcx = src.origin.x;
+            int dstx = dst.origin.x;
 
-            for (int x = 0; x < dst.size.x; ++x) {
-                int srcx = src.origin.x + x;
-                int dstx = dst.origin.x + x;
-
-                newTextureData[dstx + dsty] = textureData[srcx + srcy];
-            }
+            std::memcpy(newTextureData + dsty + dstx, &textureData[srcy + srcx], sizeof(GLuint) * src.size.x);
         }
     }
 

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -1,6 +1,7 @@
 #include "spriteAtlas.h"
 #include "platform.h"
 #include "debug/textDisplay.h"
+#include "glm/gtx/norm.hpp"
 #include <algorithm>
 
 namespace Tangram {
@@ -129,6 +130,39 @@ bool SpriteAtlas::addNode(const SpriteNode& _in, SpriteNode& _out) {
 }
 
 bool SpriteAtlas::pack() {
+    static const int maxint = std::numeric_limits<int>::max();
+
+    bool badPacking = false;
+    int minDist2, minsx, minsy;
+
+    for (const auto& sprite1 : m_spritesNodes) {
+        minDist2 = minsx = minsy = maxint;
+
+        for (const auto& sprite2 : m_spritesNodes) {
+            if (sprite1.first == sprite2.first) {
+                continue;
+            }
+
+            int dist2 = glm::distance2(sprite1.second.origin, sprite2.second.origin);
+
+            if (dist2 < minDist2) {
+                minDist2 = dist2;
+                minsx = std::min(sprite1.second.size.x, sprite2.second.size.x);
+                minsy = std::min(sprite1.second.size.y, sprite2.second.size.y);
+            }
+        }
+
+        float minDist = sqrtf(minDist2);
+        if (minDist > minsy && minDist > minsy) {
+            badPacking = true;
+            break;
+        }
+    }
+
+    if (!badPacking) {
+        return true;
+    }
+
     std::vector<std::pair<SpriteNode, SpriteNode>> packedNodes;
 
     m_packedNodes.clear();

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -1,5 +1,6 @@
 #include "spriteAtlas.h"
 #include "platform.h"
+#include "debug/textDisplay.h"
 #include <algorithm>
 
 namespace Tangram {
@@ -176,10 +177,16 @@ bool SpriteAtlas::pack() {
         }
     }
 
+    size_t origSize = (m_texture->getWidth() * m_texture->getHeight() * sizeof(GLuint)) / (1024 * 1024);
+    size_t newSize = (SPRITE_ATLAS_PACK_SIZE * SPRITE_ATLAS_PACK_SIZE * sizeof(GLuint)) / (1024 * 1024);
+    size_t diff = origSize - newSize;
+    LOGS("Original uncompressed size %d mb", origSize);
+    LOGS("New uncompressed size %d mb", newSize);
+    LOGS("Saved memory %d mb", diff);
     newTexture->setData(newTextureData, SPRITE_ATLAS_PACK_SIZE * SPRITE_ATLAS_PACK_SIZE);
     delete[] newTextureData;
 
-    // FIXME: don't recopy texture like this, keep a blob of data from original texture
+    // FIXME: don't copy texture like this, keep a blob of data from original texture
     m_texture = newTexture;
 
     return true;

--- a/core/src/scene/spriteAtlas.h
+++ b/core/src/scene/spriteAtlas.h
@@ -8,9 +8,10 @@
 namespace Tangram {
 
 struct SpriteNode {
-    glm::vec2 m_uvBL;
-    glm::vec2 m_uvTR;
-    glm::vec2 m_size;
+    glm::vec2 uvBL;
+    glm::vec2 uvTR;
+    glm::vec2 size;
+    glm::vec2 origin;
 };
 
 class SpriteAtlas {
@@ -24,11 +25,22 @@ public:
 
     /* Bind the atlas in the driver */
     void bind(GLuint _slot);
+    bool pack();
 
 private:
+    struct PackedNode {
+        int x, y, width;
+    };
+
+    int rectFits(uint32_t _i, int _w, int _h);
+    void addSkylineLevel(uint32_t _idx, int _x, int _y, int _w, int _h);
+    bool addNode(const SpriteNode& _in, SpriteNode& _out);
+
     std::map<std::string, SpriteNode> m_spritesNodes;
     std::string m_file;
     std::shared_ptr<Texture> m_texture;
+    
+    std::vector<PackedNode> m_packedNodes;
 };
 
 }

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -199,13 +199,13 @@ bool PointStyleBuilder::getUVQuad(PointStyle::Parameters& _params, glm::vec4& _q
         }
 
         if (std::isnan(_params.size.x)) {
-            _params.size = spriteNode.m_size;
+            _params.size = spriteNode.size;
         }
 
-        _quad.x = spriteNode.m_uvBL.x;
-        _quad.y = spriteNode.m_uvBL.y;
-        _quad.z = spriteNode.m_uvTR.x;
-        _quad.w = spriteNode.m_uvTR.y;
+        _quad.x = spriteNode.uvBL.x;
+        _quad.y = spriteNode.uvBL.y;
+        _quad.z = spriteNode.uvTR.x;
+        _quad.w = spriteNode.uvTR.y;
     } else {
         // default point size
         if (std::isnan(_params.size.x)) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -88,7 +88,11 @@ void initialize(const char* _scenePath) {
     // label setup
     m_labels = std::make_unique<Labels>();
 
+    clock_t start = clock();
     loadScene(_scenePath, true);
+    clock_t end = clock();
+    float time = float(end - start) / CLOCKS_PER_SEC * 1000.f;
+    LOGS("Loading scene time %f ms", time);
 
     glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
     m_view->setPosition(projPos.x, projPos.y);
@@ -236,6 +240,7 @@ void render() {
 
     m_labels->drawDebug(*m_view);
 
+    setDebugFlag(Tangram::DebugFlags::tangram_infos, true);
     if (Tangram::getDebugFlag(Tangram::DebugFlags::tangram_infos)) {
 
         // Force opengl to finish commands (for accurate frame time)

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -9,7 +9,7 @@
 // Forward declaration
 void init_main_window();
 
-std::string sceneFile = "scene.yaml";
+std::string sceneFile = "eraser-map.yaml";
 
 GLFWwindow* main_window = nullptr;
 int width = 800;


### PR DESCRIPTION
Pack icon atlases at runtime; I'm not especially in favor of a runtime process on that, just pointing out an issue that needs to be addressed, either at runtime or offline, so let's discuss.

Current status on this shown below (benchmark results on S6). As @blair1618 mentioned, the data can also be reinterpreted at runtime for a better internal compressed texture format like PVRTC and others.

Packing takes ~1% of scene loading here, and can be improved.

![screenshot_2016-02-05-14-59-17](https://cloud.githubusercontent.com/assets/7061573/12857608/2838b6e4-cc19-11e5-894c-f29482ba7939.png)

![screen shot 2016-02-05 at 2 30 20 pm](https://cloud.githubusercontent.com/assets/7061573/12902178/ac1609be-ce8d-11e5-83ea-4b6c327f2323.png)
