### PR TITLE
Use first poly ring to determine winding order

### DIFF
--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -167,7 +167,7 @@ std::shared_ptr<TileData> ClientGeoJsonSource::parse(const TileTask& _task,
                     }
                     // Polygons are in a flat list of rings, with ccw rings indicating
                     // the beginning of a new polygon
-                    if (signedArea(line) >= 0 || feat.polygons.empty()) {
+                    if (signedArea(line.begin(), line.end()) >= 0 || feat.polygons.empty()) {
                         feat.polygons.emplace_back();
                     }
                     feat.polygons.back().push_back(std::move(line));

--- a/core/src/util/geom.cpp
+++ b/core/src/util/geom.cpp
@@ -55,18 +55,6 @@ glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosit
     return clipToScreenSpace(worldToClipSpace(_mvp, _worldPosition), _screenSize);
 }
 
-float signedArea(const std::vector<glm::vec3>& _polygon) {
-    if (_polygon.empty()) { return 0; }
-    float area = 0;
-    auto prev = _polygon.back();
-    for (const auto& curr : _polygon) {
-        area += curr.x * prev.y - curr.y * prev.x;
-        prev = curr;
-    }
-    return 0.5 * area;
-}
-
-
 glm::vec2 centroid(const std::vector<std::vector<glm::vec3>>& _polygon) {
     glm::vec2 centroid;
     int n = 0;

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -65,6 +65,18 @@ struct BoundingBox {
     glm::dvec2 center() const { return 0.5 * (min + max); }
 };
 
+template<class InputIt>
+float signedArea(InputIt _begin, InputIt _end) {
+    if (_begin == _end) { return 0; }
+    float area = 0;
+    auto prev = _end - 1;
+    for (auto curr = _begin; curr != _end; ++curr) {
+        area += curr->x * prev->y - curr->y * prev->x;
+        prev = curr;
+    }
+    return 0.5 * area;
+}
+
 /* Map a value from the range [_inputMin, _inputMax] into the range [_outputMin, _outputMax];
  * If _clamp is true, the output is strictly within the output range.
  * Ex: mapValue(5, 0, 10, 0, 360) == 180
@@ -83,8 +95,6 @@ glm::vec2 clipToScreenSpace(const glm::vec4& _clipCoords, const glm::vec2& _scre
 
 /* Computes the screen coordinates from a world position, a model view matrix and a screen size */
 glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosition, const glm::vec2& _screenSize);
-
-float signedArea(const std::vector<glm::vec3>& _polygon);
 
 /* Computes the geometric center of the two dimentionnal region defined by the polygon */
 glm::vec2 centroid(const std::vector<std::vector<glm::vec3>>& _polygon);

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -32,7 +32,7 @@ namespace PbfParser {
         std::vector<int> orderedKeys;
 
         int tileExtent = 0;
-        double windingOrder = 0.0;
+        int winding = 0;
     };
 
     Geometry getGeometry(ParserContext& _ctx, protobuf::message _geomIn);

--- a/core/src/util/pbfParser.h
+++ b/core/src/util/pbfParser.h
@@ -32,6 +32,7 @@ namespace PbfParser {
         std::vector<int> orderedKeys;
 
         int tileExtent = 0;
+        double windingOrder = 0.0;
     };
 
     Geometry getGeometry(ParserContext& _ctx, protobuf::message _geomIn);


### PR DESCRIPTION
- If 1st poly in the pbf data being parsed is ccw, then make outer ring ccw and inner cw
- If 1st poly in the pbf data being parsed is cw, then make outer ring cw and inner ccw
- Its done in such a way that the core TileData is canonical in its data representation (follows CCW)

Fixes #519