### PR TITLE
Allow GeoJsonSource to parse a root object FeatureCollection

### DIFF
--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -45,8 +45,15 @@ std::shared_ptr<TileData> GeoJsonSource::parse(const TileTask& _task,
     };
 
     // Transform JSON data into TileData using GeoJson functions
-    for (auto layer = document.MemberBegin(); layer != document.MemberEnd(); ++layer) {
-        tileData->layers.push_back(GeoJson::getLayer(layer, projFn, m_id));
+    if (GeoJson::isFeatureCollection(document)) {
+        tileData->layers.push_back(GeoJson::getLayer(document, projFn, m_id));
+    } else {
+        for (auto layer = document.MemberBegin(); layer != document.MemberEnd(); ++layer) {
+            if (GeoJson::isFeatureCollection(layer->value)) {
+                tileData->layers.push_back(GeoJson::getLayer(layer->value, projFn, m_id));
+                tileData->layers.back().name = layer->name.GetString();
+            }
+        }
     }
 
 

--- a/core/src/util/geoJson.cpp
+++ b/core/src/util/geoJson.cpp
@@ -6,6 +6,27 @@
 
 namespace Tangram {
 
+bool GeoJson::isFeatureCollection(const JsonValue& _in) {
+
+    // A FeatureCollection must have a "type" of "FeatureCollection"
+    // and a member named "features" that is an array.
+    // http://geojson.org/geojson-spec.html#feature-collection-objects
+
+    auto type = _in.FindMember("type");
+    if (type == _in.MemberEnd() || !type->value.IsString() ||
+        std::strcmp(type->value.GetString(), "FeatureCollection") != 0) {
+        return false;
+    }
+
+    auto features = _in.FindMember("features");
+    if (features == _in.MemberEnd() || !features->value.IsArray()) {
+        return false;
+    }
+
+    return true;
+
+}
+
 Point GeoJson::getPoint(const JsonValue& _in, const Transform& _proj) {
     return _proj(glm::dvec2(_in[0].GetDouble(), _in[1].GetDouble()));
 }
@@ -113,13 +134,13 @@ Feature GeoJson::getFeature(const JsonValue& _in, const Transform& _proj, int32_
 
 }
 
-Layer GeoJson::getLayer(const JsonDocument::MemberIterator& _in, const Transform& _proj, int32_t _sourceId) {
+Layer GeoJson::getLayer(const JsonValue& _in, const Transform& _proj, int32_t _sourceId) {
 
-    Layer layer(_in->name.GetString());
+    Layer layer("");
 
-    auto features = _in->value.FindMember("features");
+    auto features = _in.FindMember("features");
 
-    if (features == _in->value.MemberEnd()) {
+    if (features == _in.MemberEnd()) {
         LOGE("GeoJSON missing 'features' member");
         return layer;
     }

--- a/core/src/util/geoJson.h
+++ b/core/src/util/geoJson.h
@@ -11,6 +11,8 @@ namespace GeoJson {
 
 using Transform = std::function<Point(glm::dvec2 _lonLat)>;
 
+bool isFeatureCollection(const JsonValue& _in);
+
 Point getPoint(const JsonValue& _in, const Transform& _proj);
 
 Line getLine(const JsonValue& _in, const Transform& _proj);
@@ -21,7 +23,7 @@ Properties getProperties(const JsonValue& _in, int32_t _sourceId);
 
 Feature getFeature(const JsonValue& _in, const Transform& _proj, int32_t _sourceId);
 
-Layer getLayer(const JsonDocument::MemberIterator& _in, const Transform& _proj, int32_t _sourceId);
+Layer getLayer(const JsonValue& _in, const Transform& _proj, int32_t _sourceId);
 
 }
 


### PR DESCRIPTION
Fixes https://github.com/tangrams/tangram-es/issues/535

With this change, `GeoJsonSource` will accept a JSON input whose root object is either a GeoJSON FeatureCollection object or a mapping of layer names to FeatureCollection objects. If the root object is a FeatureCollection, the resulting data has an empty layer name and no top-level layer filtering can be applied. 