### PR TITLE
View cleanup

### DIFF
--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -25,9 +25,9 @@ Labels::Labels()
 
 Labels::~Labels() {}
 
-int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
-    return (int) MIN(floor(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5)), MAX_LOD);
-}
+// int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
+//     return (int) MIN(floor(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5)), MAX_LOD);
+// }
 
 void Labels::updateLabels(const std::vector<std::unique_ptr<Style>>& _styles,
                           const std::vector<std::shared_ptr<Tile>>& _tiles,

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -63,6 +63,9 @@ struct BoundingBox {
     double width() const { return glm::abs(max.x - min.x); }
     double height() const { return glm::abs(max.y - min.y); }
     glm::dvec2 center() const { return 0.5 * (min + max); }
+    bool containsX(double x) const { return x >= min.x && x <= max.x; }
+    bool containsY(double y) const { return y >= min.y && y <= max.y; }
+    bool contains(double x, double y) const { return containsX(x) && containsY(y); }
 };
 
 template<class InputIt>

--- a/core/src/util/rasterize.cpp
+++ b/core/src/util/rasterize.cpp
@@ -1,0 +1,67 @@
+#include "rasterize.h"
+
+namespace Tangram {
+namespace Rasterize {
+
+// Triangle rasterization adapted from Polymaps: https://github.com/simplegeo/polymaps/blob/master/src/Layer.js#L333-L383
+
+Edge::Edge(glm::dvec2 _a, glm::dvec2 _b) {
+    if (_a.y > _b.y) { std::swap(_a, _b); }
+    x0 = _a.x;
+    y0 = _a.y;
+    x1 = _b.x;
+    y1 = _b.y;
+    dx = x1 - x0;
+    dy = y1 - y0;
+}
+
+void scanLine(int _x0, int _x1, int _y, const ScanCallback& _s) {
+    for (int x = _x0; x < _x1; x++) {
+        _s(x, _y);
+    }
+}
+
+void scanSpan(Edge _e0, Edge _e1, int _min, int _max, const ScanCallback& _s) {
+
+    // _e1 has a shorter y-span, so we'll use it to limit our y coverage
+    int y0 = fmax(_min, floor(_e1.y0));
+    int y1 = fmin(_max, ceil(_e1.y1));
+
+    // sort edges by x-coordinate
+    if (_e0.x0 == _e1.x0 && _e0.y0 == _e1.y0) {
+        if (_e0.x0 + _e1.dy / _e0.dy * _e0.dx < _e1.x1) { std::swap(_e0, _e1); }
+    } else {
+        if (_e0.x1 - _e1.dy / _e0.dy * _e0.dx < _e1.x0) { std::swap(_e0, _e1); }
+    }
+
+    // scan lines!
+    double m0 = _e0.dx / _e0.dy;
+    double m1 = _e1.dx / _e1.dy;
+    double d0 = _e0.dx > 0 ? 1.0 : 0.0;
+    double d1 = _e1.dx < 0 ? 1.0 : 0.0;
+    for (int y = y0; y < y1; y++) {
+        double x0 = m0 * fmax(0.0, fmin(_e0.dy, y + d0 - _e0.y0)) + _e0.x0;
+        double x1 = m1 * fmax(0.0, fmin(_e1.dy, y + d1 - _e1.y0)) + _e1.x0;
+        scanLine(floor(x1), ceil(x0), y, _s);
+    }
+
+}
+
+void scanTriangle(glm::dvec2& _a, glm::dvec2& _b, glm::dvec2& _c, int _min, int _max, const ScanCallback& _s) {
+
+    Edge ab = Edge(_a, _b);
+    Edge bc = Edge(_b, _c);
+    Edge ca = Edge(_c, _a);
+
+    // place edge with greatest y distance in ca
+    if (ab.dy > ca.dy) { std::swap(ab, ca); }
+    if (bc.dy > ca.dy) { std::swap(bc, ca); }
+
+    // scan span! scan span!
+    if (ab.dy > 0) { scanSpan(ca, ab, _min, _max, _s); }
+    if (bc.dy > 0) { scanSpan(ca, bc, _min, _max, _s); }
+
+}
+
+}
+}

--- a/core/src/util/rasterize.h
+++ b/core/src/util/rasterize.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "glm/vec2.hpp"
+#include <cmath>
+#include <functional>
+
+namespace Tangram {
+namespace Rasterize {
+
+using ScanCallback = std::function<void (int, int)>;
+
+struct Edge { // An edge between two points; oriented such that y is non-decreasing
+    double x0 = 0, y0 = 0;
+    double x1 = 0, y1 = 0;
+    double dx = 0, dy = 0;
+    Edge(glm::dvec2 _a, glm::dvec2 _b);
+};
+
+void scanLine(int _x0, int _x1, int _y, const ScanCallback& _s);
+
+void scanSpan(Edge _e0, Edge _e1, int _min, int _max, const ScanCallback& _s);
+
+void scanTriangle(glm::dvec2& _a, glm::dvec2& _b, glm::dvec2& _c, int _min, int _max, const ScanCallback& _s);
+
+}
+}

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -73,11 +73,6 @@ void View::setSize(int _width, int _height) {
 
 }
 
-bool contains(const glm::dvec2& _point, const BoundingBox& _bounds) {
-    if ( _point.y < _bounds.min.y || _point.y > _bounds.max.y ) { return false; }
-    return true;
-}
-
 bool View::checkMapBound() {
 
     auto mapBounds = m_projection->MapBounds();
@@ -91,19 +86,19 @@ bool View::checkMapBound() {
 
     screenToGroundPlane(bottomLeft.x, bottomLeft.y);
     bottomLeft += glm::dvec2(m_pos.x, m_pos.y);
-    if (!contains(bottomLeft, mapBounds)) { return false; }
+    if (!mapBounds.containsY(bottomLeft.y)) { return false; }
 
     screenToGroundPlane(bottomRight.x, bottomRight.y);
     bottomRight += glm::dvec2(m_pos.x, m_pos.y);
-    if (!contains(bottomRight, mapBounds)) { return false; }
+    if (!mapBounds.containsY(bottomRight.y)) { return false; }
 
     screenToGroundPlane(topRight.x, topRight.y);
     topRight += glm::dvec2(m_pos.x, m_pos.y);
-    if (!contains(topRight, mapBounds)) { return false; }
+    if (!mapBounds.containsY(topRight.y)) { return false; }
 
     screenToGroundPlane(topLeft.x, topLeft.y);
     topLeft += glm::dvec2(m_pos.x, m_pos.y);
-    if (!contains(topLeft, mapBounds)) { return false; }
+    if (!mapBounds.containsY(topLeft.y)) { return false; }
 
     return true;
 }

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -8,9 +8,9 @@
 #include <cmath>
 #include <functional>
 
-namespace Tangram {
+#define MAX_LOD 6
 
-constexpr float View::s_maxZoom; // Create a stack reference to the static member variable
+namespace Tangram {
 
 double invLodFunc(double d) {
     return exp2(d) - 1.0;
@@ -25,8 +25,7 @@ View::View(int _width, int _height, ProjectionType _projType) :
 
     setMapProjection(_projType);
     setSize(_width, _height);
-    setZoom(m_initZoom); // Arbitrary zoom for testing
-
+    setZoom(m_zoom);
     setPosition(0.0, 0.0);
 }
 
@@ -45,10 +44,6 @@ void View::setMapProjection(ProjectionType _projType) {
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
 
-}
-
-const MapProjection& View::getMapProjection() const {
-    return *m_projection.get();
 }
 
 void View::setPixelScale(float _pixelsPerPoint) {

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -10,8 +10,6 @@
 #include <set>
 #include <memory>
 
-#define MAX_LOD 6
-
 namespace Tangram {
 
 enum class CameraType : uint8_t {
@@ -38,7 +36,7 @@ public:
     void setMapProjection(ProjectionType _projType);
 
     /* Gets the current map projection */
-    const MapProjection& getMapProjection() const;
+    const MapProjection& getMapProjection() const { return *m_projection.get(); }
 
     void setCameraType(CameraType _type);
     auto cameraType() const { return m_type; }
@@ -47,7 +45,6 @@ public:
     auto obliqueAxis() const { return m_obliqueAxis; }
 
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
-     *
      * If unset, default is 1.0
      */
     void setPixelScale(float _pixelsPerPoint);
@@ -57,7 +54,6 @@ public:
 
     /* Sets the position of the view within the world (in projection units) */
     void setPosition(double _x, double _y);
-
     void setPosition(const glm::dvec3 pos) { setPosition(pos.x, pos.y); }
     void setPosition(const glm::dvec2 pos) { setPosition(pos.x, pos.y); }
 
@@ -121,9 +117,8 @@ public:
      * replacing the input coordinates with world-space coordinates
      * @return the un-normalized distance 'into the screen' to the ground plane
      * (if < 0, intersection is behind the screen)
-    */
+     */
     double screenToGroundPlane(double& _screenX, double& _screenY);
-    /* Provide an overloaded method for platform specific API support, which pass float screen positions */
     double screenToGroundPlane(float& _screenX, float& _screenY);
 
     /* Returns the set of all tiles visible at the current position and zoom */
@@ -131,8 +126,6 @@ public:
 
     /* Returns true if the view properties have changed since the last call to update() */
     bool changedOnLastUpdate() const { return m_changed; }
-
-    virtual ~View() {}
 
     /* TODO: API for setting these */
     constexpr static float s_maxZoom = 20.5;
@@ -174,9 +167,8 @@ protected:
     float m_pitch = 0.f;
     float m_pitch_prev = 0.f;
 
-    float m_zoom;
-    float m_zoom_prev = 0.0f;
-    float m_initZoom = 16.0;
+    float m_zoom = 0.f;
+    float m_zoom_prev = 0.f;
 
     float m_width;
     float m_height;


### PR DESCRIPTION
This is just a bit of tidying for `View`. Moving the rasterization functions into a separate file cleans up `view.cpp` nicely and also means we could use raster scanning in other contexts. 