### PR TITLE
Npot texture fallback

### DIFF
--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -225,8 +225,19 @@ void Texture::resize(const unsigned int _width, const unsigned int _height) {
     m_width = _width;
     m_height = _height;
 
+    if (isPowerOfTwo(m_width) && isPowerOfTwo(m_height)
+        && (m_generateMipmaps || isRepeatWrapping(m_options.m_wrapping))) {
+        LOGW("OpenGL ES doesn't support texture repeat wrapping for NPOT textures nor mipmap textures");
+        LOGW("Falling back to LINEAR Filtering");
+        m_options.m_filtering = {GL_LINEAR, GL_LINEAR};
+    }
+
     m_shouldResize = true;
     m_dirtyRanges.clear();
+}
+
+bool Texture::isRepeatWrapping(TextureWrapping _wrapping) {
+    return _wrapping.m_wraps == GL_REPEAT || _wrapping.m_wrapt == GL_REPEAT;
 }
 
 size_t Texture::bytesPerPixel() {

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -139,11 +139,11 @@ void Texture::generate(GLuint _textureUnit) {
 
     bind(_textureUnit);
 
-    glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, m_options.m_filtering.m_min);
-    glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, m_options.m_filtering.m_mag);
+    glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, m_options.filtering.min);
+    glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, m_options.filtering.mag);
 
-    glTexParameteri(m_target, GL_TEXTURE_WRAP_S, m_options.m_wrapping.m_wraps);
-    glTexParameteri(m_target, GL_TEXTURE_WRAP_T, m_options.m_wrapping.m_wrapt);
+    glTexParameteri(m_target, GL_TEXTURE_WRAP_S, m_options.wrapping.wraps);
+    glTexParameteri(m_target, GL_TEXTURE_WRAP_T, m_options.wrapping.wrapt);
 
     m_generation = RenderState::generation();
 }
@@ -197,8 +197,8 @@ void Texture::update(GLuint _textureUnit, const GLuint* data) {
             LOGW("The hardware maximum texture size is currently reached");
         }
 
-        glTexImage2D(m_target, 0, m_options.m_internalFormat,
-                     m_width, m_height, 0, m_options.m_format,
+        glTexImage2D(m_target, 0, m_options.internalFormat,
+                     m_width, m_height, 0, m_options.format,
                      GL_UNSIGNED_BYTE, data);
 
         if (data && m_generateMipmaps) {
@@ -215,7 +215,7 @@ void Texture::update(GLuint _textureUnit, const GLuint* data) {
     for (auto& range : m_dirtyRanges) {
         size_t offset =  (range.min * m_width) / divisor;
         glTexSubImage2D(m_target, 0, 0, range.min, m_width, range.max - range.min,
-                        m_options.m_format, GL_UNSIGNED_BYTE,
+                        m_options.format, GL_UNSIGNED_BYTE,
                         data + offset);
     }
     m_dirtyRanges.clear();
@@ -225,11 +225,11 @@ void Texture::resize(const unsigned int _width, const unsigned int _height) {
     m_width = _width;
     m_height = _height;
 
-    if (isPowerOfTwo(m_width) && isPowerOfTwo(m_height)
-        && (m_generateMipmaps || isRepeatWrapping(m_options.m_wrapping))) {
+    if (!(isPowerOfTwo(m_width) && isPowerOfTwo(m_height)) && (m_generateMipmaps || isRepeatWrapping(m_options.wrapping))) {
         LOGW("OpenGL ES doesn't support texture repeat wrapping for NPOT textures nor mipmap textures");
         LOGW("Falling back to LINEAR Filtering");
-        m_options.m_filtering = {GL_LINEAR, GL_LINEAR};
+        m_options.filtering = {GL_LINEAR, GL_LINEAR};
+        m_generateMipmaps = false;
     }
 
     m_shouldResize = true;
@@ -237,11 +237,11 @@ void Texture::resize(const unsigned int _width, const unsigned int _height) {
 }
 
 bool Texture::isRepeatWrapping(TextureWrapping _wrapping) {
-    return _wrapping.m_wraps == GL_REPEAT || _wrapping.m_wrapt == GL_REPEAT;
+    return _wrapping.wraps == GL_REPEAT || _wrapping.wrapt == GL_REPEAT;
 }
 
 size_t Texture::bytesPerPixel() {
-    switch (m_options.m_internalFormat) {
+    switch (m_options.internalFormat) {
         case GL_ALPHA:
         case GL_LUMINANCE:
             return 1;

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -73,6 +73,8 @@ public:
 
     static void invalidateAllTextures();
 
+    static bool isRepeatWrapping(TextureWrapping _wrapping);
+
 protected:
     void generate(GLuint _textureUnit);
     void checkValidity();

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -9,20 +9,20 @@
 namespace Tangram {
 
 struct TextureFiltering {
-    GLenum m_min;
-    GLenum m_mag;
+    GLenum min;
+    GLenum mag;
 };
 
 struct TextureWrapping {
-    GLenum m_wraps;
-    GLenum m_wrapt;
+    GLenum wraps;
+    GLenum wrapt;
 };
 
 struct TextureOptions {
-    GLenum m_internalFormat;
-    GLenum m_format;
-    TextureFiltering m_filtering;
-    TextureWrapping m_wrapping;
+    GLenum internalFormat;
+    GLenum format;
+    TextureFiltering filtering;
+    TextureWrapping wrapping;
 };
 
 #define TANGRAM_MAX_TEXTURE_UNIT    6

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -97,7 +97,6 @@ protected:
     GLenum m_target;
 
     int m_generation;
-    static int s_validGeneration;
 
 private:
 

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -74,7 +74,7 @@ void TextureCube::update(GLuint _textureUnit) {
 
     for (int i = 0; i < 6; ++i) {
         Face& f = m_faces[i];
-        glTexImage2D(CubeMapFace[i], 0, m_options.m_internalFormat, m_width, m_height, 0, m_options.m_format, GL_UNSIGNED_BYTE, f.m_data.data());
+        glTexImage2D(CubeMapFace[i], 0, m_options.internalFormat, m_width, m_height, 0, m_options.format, GL_UNSIGNED_BYTE, f.m_data.data());
     }
 }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -390,11 +390,11 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
 
     if (Node filtering = textureConfig["filtering"]) {
         std::string f = filtering.as<std::string>();
-        if (f == "linear") { options.m_filtering = { GL_LINEAR, GL_LINEAR }; }
+        if (f == "linear") { options.filtering = { GL_LINEAR, GL_LINEAR }; }
         else if (f == "mipmap") {
-            options.m_filtering = { GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR };
+            options.filtering = { GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR };
             generateMipmaps = true;
-        } else if (f == "nearest") { options.m_filtering = { GL_NEAREST, GL_NEAREST }; }
+        } else if (f == "nearest") { options.filtering = { GL_NEAREST, GL_NEAREST }; }
     }
 
     std::shared_ptr<Texture> texture(new Texture(file, options, generateMipmaps));

--- a/core/src/util/geom.cpp
+++ b/core/src/util/geom.cpp
@@ -96,4 +96,8 @@ float sqSegmentDistance(const glm::vec2& _p, const glm::vec2& _p1, const glm::ve
     return glm::length2(_p - _p1);
 }
 
+bool isPowerOfTwo(int _value) {
+    return (_value & (_value - 1)) == 0;
+}
+
 }

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -101,4 +101,6 @@ glm::vec2 centroid(const std::vector<std::vector<glm::vec3>>& _polygon);
 
 float sqSegmentDistance(const glm::vec2& _p, const glm::vec2& _p1, const glm::vec2& _p2);
 
+bool isPowerOfTwo(int _value);
+
 }


### PR DESCRIPTION
Addressing #568 , fallback to linear filtering when repeat or mipmaps is used for npot textures.