### PR TITLE
More generous view limits

### DIFF
--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -4,8 +4,9 @@
 #include "glm/vec4.hpp"
 #include "glm/vec3.hpp"
 
-#include "util/mapProjection.h"
 #include "tile/tileID.h"
+#include "util/mapProjection.h"
+#include "view/viewConstraint.h"
 
 #include <set>
 #include <memory>
@@ -88,7 +89,7 @@ public:
     float getPitch() const { return m_pitch; }
 
     /* Updates the view and projection matrices if properties have changed */
-    void update();
+    void update(bool _constrainToWorldBounds = true);
 
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
     const glm::dvec3& getPosition() const { return m_pos; }
@@ -150,8 +151,9 @@ protected:
     std::shared_ptr<MapProjection> m_projection;
     std::set<TileID> m_visibleTiles;
 
+    ViewConstraint m_constraint;
+
     glm::dvec3 m_pos;
-    glm::dvec3 m_pos_prev = glm::dvec3(0.0, 0.0, 0.0);
     glm::vec3 m_eye;
     glm::vec2 m_obliqueAxis;
 
@@ -163,12 +165,9 @@ protected:
     glm::mat3 m_normalMatrix;
 
     float m_roll = 0.f;
-    float m_roll_prev = 0.f;
     float m_pitch = 0.f;
-    float m_pitch_prev = 0.f;
 
     float m_zoom = 0.f;
-    float m_zoom_prev = 0.f;
 
     float m_width;
     float m_height;

--- a/core/src/view/viewConstraint.cpp
+++ b/core/src/view/viewConstraint.cpp
@@ -1,0 +1,68 @@
+#include "viewConstraint.h"
+
+namespace Tangram {
+
+void ViewConstraint::setLimitsY(double yMin, double yMax) {
+
+    m_yMin = yMin;
+    m_yMax = yMax;
+
+}
+
+void ViewConstraint::setLimitsX(double xMin, double xMax) {
+
+    m_xMin = xMin;
+    m_xMax = xMax;
+
+}
+
+void ViewConstraint::setRadius(double r) {
+
+    m_radius = r;
+
+}
+
+auto ViewConstraint::getConstrainedX(double x) -> double {
+
+    return constrain(x, m_radius, m_xMin, m_xMax);
+
+}
+
+auto ViewConstraint::getConstrainedY(double y) -> double {
+
+    return constrain(y, m_radius, m_yMin, m_yMax);
+
+}
+
+auto ViewConstraint::getConstrainedScale() -> double {
+
+    double xScale = 1.0, yScale = 1.0;
+    double xRange = m_xMax - m_xMin;
+    double yRange = m_yMax - m_yMin;
+    double diameter = 2.0 * m_radius;
+
+    if (diameter > yRange) { yScale = yRange / diameter; }
+    if (diameter > xRange) { xScale = xRange / diameter; }
+
+    return std::fmin(xScale, yScale);
+
+}
+
+auto ViewConstraint::constrain(double pos, double radius, double min, double max) -> double {
+
+    double upperSpace = max - (pos + radius);
+    double lowerSpace = (pos - radius) - min;
+
+    if (upperSpace < 0.0 && lowerSpace < 0.0) {
+        return 0.5 * (max + min);
+    } else if (upperSpace < 0.0) {
+        return max - radius;
+    } else if (lowerSpace < 0.0) {
+        return min + radius;
+    }
+
+    return pos;
+
+}
+
+}

--- a/core/src/view/viewConstraint.h
+++ b/core/src/view/viewConstraint.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <cmath>
+
+namespace Tangram {
+
+class ViewConstraint {
+
+public:
+
+    void setLimitsY(double yMin, double yMax);
+    void setLimitsX(double xMin, double xMax);
+    void setRadius(double r);
+    auto getConstrainedX(double x) -> double;
+    auto getConstrainedY(double y) -> double;
+    auto getConstrainedScale() -> double;
+
+private:
+
+    auto constrain(double pos, double radius, double min, double max) -> double;
+
+    double m_xMax = INFINITY;
+    double m_yMax = INFINITY;
+    double m_xMin = -INFINITY;
+    double m_yMin = -INFINITY;
+    double m_radius = 0.0;
+
+};
+
+}

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Test getFeaturesAtPoint", "[Labels][FeaturePicking]") {
     View view(256, 256);
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update();
+    view.update(false);
 
     struct TestLabelMesh : public LabelMesh {
         using LabelMesh::LabelMesh;


### PR DESCRIPTION
This is a looser, more approximate, but more practical approach to limiting the map view to the bounds of the world. It constrains the view position and zoom according to a characteristic radius that approximates the extent of the view in world space on all sides; basically it's just colliding a circle against the specified boundaries in x and or y. This means that, in contrast with the previous implementation, you're always allowed to tilt and rotate the view - which means that it's possible to view areas beyond the world bounds. However, this also means that the view no longer gets "stuck" against the edge of the world and when a position/zoom is requested that can't be exactly satisfied, the view will now get as close as possible to that position/zoom instead of doing nothing.

The easiest way to see the difference here is just to try it yourself :)

Fixes #531 