### PR TITLE
Upgrade to OkHTTP3

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -16,7 +16,7 @@ import com.mapzen.tangram.Tangram;
 import com.mapzen.tangram.Coordinates;
 
 import com.mapzen.tangram.TouchInput;
-import com.squareup.okhttp.Callback;
+import okhttp3.Callback;
 
 import java.io.File;
 import java.lang.Math;

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -46,7 +46,7 @@ afterEvaluate {
 }
 
 dependencies {
-  compile 'com.squareup.okhttp:okhttp:2.5.0'
+  compile 'com.squareup.okhttp3:okhttp:3.2.0'
   compile 'xmlpull:xmlpull:1.1.3.1'
 }
 

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -6,9 +6,10 @@ import android.opengl.GLSurfaceView;
 import android.opengl.GLSurfaceView.Renderer;
 import android.util.DisplayMetrics;
 
-import com.squareup.okhttp.Callback;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Request;
+import okhttp3.Response;
 
 import java.io.IOException;
 
@@ -514,20 +515,18 @@ public class MapController implements Renderer {
         }
         httpHandler.onRequest(url, new Callback() {
             @Override
-            public void onFailure(Request request, IOException e) {
+            public void onFailure(Call call, IOException e) {
                 onUrlFailure(callbackPtr);
                 //e.printStackTrace();
             }
 
             @Override
-            public void onResponse(Response response) throws IOException {
+            public void onResponse(Call call, Response response) throws IOException {
                 if (!response.isSuccessful()) {
                     onUrlFailure(callbackPtr);
                     throw new IOException("Unexpected response code: " + response);
                 }
-                BufferedSource source = response.body().source();
-                byte[] bytes = source.readByteArray();
-                onUrlSuccess(bytes, callbackPtr);
+                onUrlSuccess(response.body().bytes(), callbackPtr);
             }
         });
         return true;


### PR DESCRIPTION
New version required some syntax changes and calls can no longer be cancelled by tag, so we now maintain a list of current calls and search that list when a cancel is made.

Resolves #573 