### PR TITLE
Uniform entries

### DIFF
--- a/bench/src/uniform.cpp
+++ b/bench/src/uniform.cpp
@@ -1,0 +1,38 @@
+#include "gl.h"
+#include "platform.h"
+#include "tangram.h"
+#include "gl/shaderProgram.h"
+
+#include "benchmark/benchmark_api.h"
+#include "benchmark/benchmark.h"
+
+using namespace Tangram;
+
+#define BENCH_UNIFORM_ENTRY
+
+ShaderProgram program;
+float value = 0.f;
+
+#ifdef BENCH_UNIFORM_ENTRY
+UniformEntries::EntryId entry = 0;
+#endif
+
+static void BM_Tangram_SetUniform(benchmark::State& state) {
+#ifdef BENCH_UNIFORM_ENTRY
+    UniformEntries::lazyGenEntry(&entry, "u_uniformValue");
+
+    while(state.KeepRunning()) {
+        value += 0.5;
+        program.setUniformf(UniformEntries::getEntry(entry), value);
+    }
+#else
+    while(state.KeepRunning()) {
+        value += 0.5;
+        program.setUniformf("u_uniformValue", value);
+    }
+
+#endif
+}
+BENCHMARK(BM_Tangram_SetUniform);
+
+BENCHMARK_MAIN();

--- a/core/src/debug/textDisplay.cpp
+++ b/core/src/debug/textDisplay.cpp
@@ -112,10 +112,10 @@ void TextDisplay::draw(const std::vector<std::string>& _infos) {
     m_shader->use();
 
     glm::mat4 orthoProj = glm::ortho(0.f, (float)m_textDisplayResolution.x, (float)m_textDisplayResolution.y, 0.f, -1.f, 1.f);
-    m_shader->setUniformMatrix4f("u_orthoProj", orthoProj);
+    m_shader->setUniformMatrix4f(UniformEntries::getEntry(Uniform::orthoProj), orthoProj);
 
     // Display Tangram info messages
-    m_shader->setUniformf("u_color", 0.f, 0.f, 0.f);
+    m_shader->setUniformf(UniformEntries::getEntry(Uniform::color), 0.f, 0.f, 0.f);
     int offset = 0;
     for (auto& text : _infos) {
         draw(text, 3, 3 + offset);
@@ -124,7 +124,7 @@ void TextDisplay::draw(const std::vector<std::string>& _infos) {
 
     // Display screen log
     offset = 0;
-    m_shader->setUniformf("u_color", 51 / 255.f, 73 / 255.f, 120 / 255.f);
+    m_shader->setUniformf(UniformEntries::getEntry(Uniform::color), 51 / 255.f, 73 / 255.f, 120 / 255.f);
     for (int i = 0; i < LOG_CAPACITY; ++i) {
         draw(m_log[i], 3, m_textDisplayResolution.y - 10 + offset);
         offset -= 10;

--- a/core/src/gl/primitives.cpp
+++ b/core/src/gl/primitives.cpp
@@ -100,14 +100,14 @@ void setColor(unsigned int _color) {
     float g = (_color >> 8  & 0xff) / 255.0;
     float b = (_color       & 0xff) / 255.0;
 
-    s_shader->setUniformf("u_color", r, g, b);
+    s_shader->setUniformf(UniformEntries::getEntry(Uniform::color), r, g, b);
 }
 
 void setResolution(float _width, float _height) {
     init();
 
     glm::mat4 proj = glm::ortho(0.f, _width, _height, 0.f, -1.f, 1.f);
-    s_shader->setUniformMatrix4f("u_proj", proj);
+    s_shader->setUniformMatrix4f(UniformEntries::getEntry(Uniform::proj), proj);
 }
 
 }

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -120,21 +120,6 @@ GLint ShaderProgram::getAttribLocation(const std::string& _attribName) {
 
 }
 
-GLint ShaderProgram::getUniformLocation(const std::string& _uniformName) {
-
-    //// Get uniform location at this key, or create one valued at -2 if absent
-    //GLint& location = m_uniformMap[(intptr_t)&_uniformName].loc;
-
-    //// -2 means this is a new entry
-    //if (location == -2) {
-    //    // Get the actual location from OpenGL
-    //    location = glGetUniformLocation(m_glProgram, _uniformName.c_str());
-    //}
-
-    //return location;
-
-}
-
 GLint ShaderProgram::getUniformLocation(const UniformEntries::UniformEntry* _entry) {
 
     if (_entry == nullptr) {

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -11,6 +11,42 @@
 
 namespace Tangram {
 
+namespace Uniform {
+    UniformEntries::EntryId color;
+    UniformEntries::EntryId time;
+    UniformEntries::EntryId model;
+    UniformEntries::EntryId tileOrigin;
+    UniformEntries::EntryId devicePixelRatio;
+    UniformEntries::EntryId resolution;
+    UniformEntries::EntryId mapPosition;
+    UniformEntries::EntryId normalMatrix;
+    UniformEntries::EntryId inverseNormalMatrix;
+    UniformEntries::EntryId metersPerPixel;
+    UniformEntries::EntryId view;
+    UniformEntries::EntryId proj;
+    UniformEntries::EntryId ortho;
+    UniformEntries::EntryId orthoProj;
+    UniformEntries::EntryId modelViewProj;
+    UniformEntries::EntryId tex;
+    UniformEntries::EntryId pass;
+    UniformEntries::EntryId uvScaleFactor;
+    UniformEntries::EntryId materialEmission;
+    UniformEntries::EntryId materialEmissionTexture;
+    UniformEntries::EntryId materialEmissionScale;
+    UniformEntries::EntryId materialAmbiant;
+    UniformEntries::EntryId materialAmbiantTexture;
+    UniformEntries::EntryId materialAmbiantScale;
+    UniformEntries::EntryId materialDiffuse;
+    UniformEntries::EntryId materialDiffuseTexture;
+    UniformEntries::EntryId materialDiffuseScale;
+    UniformEntries::EntryId materialShininess;
+    UniformEntries::EntryId materialSpecular;
+    UniformEntries::EntryId materialSpecularTexture;
+    UniformEntries::EntryId materialSpecularScale;
+    UniformEntries::EntryId materialNormalTexture;
+    UniformEntries::EntryId materialNormalScale;
+    UniformEntries::EntryId materialNormalAmount;
+}
 
 ShaderProgram::ShaderProgram() {
 
@@ -86,13 +122,33 @@ GLint ShaderProgram::getAttribLocation(const std::string& _attribName) {
 
 GLint ShaderProgram::getUniformLocation(const std::string& _uniformName) {
 
+    //// Get uniform location at this key, or create one valued at -2 if absent
+    //GLint& location = m_uniformMap[(intptr_t)&_uniformName].loc;
+
+    //// -2 means this is a new entry
+    //if (location == -2) {
+    //    // Get the actual location from OpenGL
+    //    location = glGetUniformLocation(m_glProgram, _uniformName.c_str());
+    //}
+
+    //return location;
+
+}
+
+GLint ShaderProgram::getUniformLocation(const UniformEntries::UniformEntry* _entry) {
+
+    if (_entry == nullptr) {
+        LOGW("Trying to access null entry");
+        return -1;
+    }
+
     // Get uniform location at this key, or create one valued at -2 if absent
-    GLint& location = m_uniformMap[_uniformName].loc;
+    GLint& location = m_uniformMap[_entry->id].loc;
 
     // -2 means this is a new entry
     if (location == -2) {
         // Get the actual location from OpenGL
-        location = glGetUniformLocation(m_glProgram, _uniformName.c_str());
+        location = glGetUniformLocation(m_glProgram, _entry->name.c_str());
     }
 
     return location;
@@ -310,115 +366,160 @@ void ShaderProgram::checkValidity() {
     }
 }
 
-void ShaderProgram::setUniformi(const std::string& _name, int _value) {
+void ShaderProgram::setUniformi(const UniformEntries::UniformEntry* _entry, int _value) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
         if (!cached) { glUniform1i(location, _value); }
     }
 }
 
-void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1) {
+void ShaderProgram::setUniformi(const UniformEntries::UniformEntry* _entry, int _value0, int _value1) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = getFromCache(location, glm::vec2(_value0, _value1));
         if (!cached) { glUniform2i(location, _value0, _value1); }
     }
 }
 
-void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1, int _value2) {
+void ShaderProgram::setUniformi(const UniformEntries::UniformEntry* _entry, int _value0, int _value1, int _value2) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = getFromCache(location, glm::vec3(_value0, _value1, _value2));
         if (!cached) { glUniform3i(location, _value0, _value1, _value2); }
     }
 }
 
-void ShaderProgram::setUniformi(const std::string& _name, int _value0, int _value1, int _value2, int _value3) {
+void ShaderProgram::setUniformi(const UniformEntries::UniformEntry* _entry, int _value0, int _value1, int _value2, int _value3) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = getFromCache(location, glm::vec4(_value0, _value1, _value2, _value3));
         if (!cached) { glUniform4i(location, _value0, _value1, _value2, _value3); }
     }
 }
 
-void ShaderProgram::setUniformf(const std::string& _name, float _value) {
+void ShaderProgram::setUniformf(const UniformEntries::UniformEntry* _entry, float _value) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
         if (!cached) { glUniform1f(location, _value); }
     }
 }
 
-void ShaderProgram::setUniformf(const std::string& _name, float _value0, float _value1) {
-    setUniformf(_name, glm::vec2(_value0, _value1));
+void ShaderProgram::setUniformf(const UniformEntries::UniformEntry* _entry, float _value0, float _value1) {
+    setUniformf(_entry, glm::vec2(_value0, _value1));
 }
 
-void ShaderProgram::setUniformf(const std::string& _name, float _value0, float _value1, float _value2) {
-    setUniformf(_name, glm::vec3(_value0, _value1, _value2));
+void ShaderProgram::setUniformf(const UniformEntries::UniformEntry* _entry, float _value0, float _value1, float _value2) {
+    setUniformf(_entry, glm::vec3(_value0, _value1, _value2));
 }
 
-void ShaderProgram::setUniformf(const std::string& _name, float _value0, float _value1, float _value2, float _value3) {
-    setUniformf(_name, glm::vec4(_value0, _value1, _value2, _value3));
+void ShaderProgram::setUniformf(const UniformEntries::UniformEntry* _entry, float _value0, float _value1, float _value2, float _value3) {
+    setUniformf(_entry, glm::vec4(_value0, _value1, _value2, _value3));
 }
 
-void ShaderProgram::setUniformf(const std::string& _name, const glm::vec2& _value) {
+void ShaderProgram::setUniformf(const UniformEntries::UniformEntry* _entry, const glm::vec2& _value) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
         if (!cached) { glUniform2f(location, _value.x, _value.y); }
     }
 }
 
-void ShaderProgram::setUniformf(const std::string& _name, const glm::vec3& _value) {
+void ShaderProgram::setUniformf(const UniformEntries::UniformEntry* _entry, const glm::vec3& _value) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
         if (!cached) { glUniform3f(location, _value.x, _value.y, _value.z); }
     }
 }
 
-void ShaderProgram::setUniformf(const std::string& _name, const glm::vec4& _value) {
+void ShaderProgram::setUniformf(const UniformEntries::UniformEntry* _entry, const glm::vec4& _value) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
         if (!cached) { glUniform4f(location, _value.x, _value.y, _value.z, _value.w); }
     }
 }
 
-void ShaderProgram::setUniformMatrix2f(const std::string& _name, const glm::mat2& _value, bool _transpose) {
+void ShaderProgram::setUniformMatrix2f(const UniformEntries::UniformEntry* _entry, const glm::mat2& _value, bool _transpose) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = !_transpose && getFromCache(location, _value);
         if (!cached) { glUniformMatrix2fv(location, 1, _transpose, glm::value_ptr(_value)); }
     }
 }
 
-void ShaderProgram::setUniformMatrix3f(const std::string& _name, const glm::mat3& _value, bool _transpose) {
+void ShaderProgram::setUniformMatrix3f(const UniformEntries::UniformEntry* _entry, const glm::mat3& _value, bool _transpose) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = !_transpose && getFromCache(location, _value);
         if (!cached) { glUniformMatrix3fv(location, 1, _transpose, glm::value_ptr(_value)); }
     }
 }
 
-void ShaderProgram::setUniformMatrix4f(const std::string& _name, const glm::mat4& _value, bool _transpose) {
+void ShaderProgram::setUniformMatrix4f(const UniformEntries::UniformEntry* _entry, const glm::mat4& _value, bool _transpose) {
     use();
-    GLint location = getUniformLocation(_name);
+    GLint location = getUniformLocation(_entry);
     if (location >= 0) {
         bool cached = !_transpose && getFromCache(location, _value);
         if (!cached) { glUniformMatrix4fv(location, 1, _transpose, glm::value_ptr(_value)); }
     }
+}
+
+void ShaderProgram::allocateUniformEntries() {
+    static bool allocated = false;
+
+    if (allocated) {
+        return;
+    }
+
+    UniformEntries::genEntry(&Uniform::color, "u_color");
+    UniformEntries::genEntry(&Uniform::time, "u_time");
+    UniformEntries::genEntry(&Uniform::model, "u_model");
+    UniformEntries::genEntry(&Uniform::tileOrigin, "u_tile_origin");
+    UniformEntries::genEntry(&Uniform::devicePixelRatio, "u_device_pixel_ratio");
+    UniformEntries::genEntry(&Uniform::resolution, "u_resolution");
+    UniformEntries::genEntry(&Uniform::mapPosition, "u_map_position");
+    UniformEntries::genEntry(&Uniform::normalMatrix, "u_normalMatrix");
+    UniformEntries::genEntry(&Uniform::inverseNormalMatrix, "u_inverseNormalMatrix");
+    UniformEntries::genEntry(&Uniform::metersPerPixel, "u_meters_per_pixel");
+    UniformEntries::genEntry(&Uniform::view, "u_view");
+    UniformEntries::genEntry(&Uniform::proj, "u_proj");
+    UniformEntries::genEntry(&Uniform::ortho, "u_ortho");
+    UniformEntries::genEntry(&Uniform::orthoProj, "u_orthoProj");
+    UniformEntries::genEntry(&Uniform::modelViewProj, "u_modelViewProj");
+    UniformEntries::genEntry(&Uniform::tex, "u_tex");
+    UniformEntries::genEntry(&Uniform::pass, "u_pass");
+    UniformEntries::genEntry(&Uniform::uvScaleFactor, "u_uv_scale_factor");
+    UniformEntries::genEntry(&Uniform::materialEmission, "u_material.emission");
+    UniformEntries::genEntry(&Uniform::materialEmissionTexture, "u_material_emission_texture");
+    UniformEntries::genEntry(&Uniform::materialEmissionScale, "u_material.emissionScale");
+    UniformEntries::genEntry(&Uniform::materialAmbiant, "u_material.ambient");
+    UniformEntries::genEntry(&Uniform::materialAmbiantTexture, "u_material_ambient_texture");
+    UniformEntries::genEntry(&Uniform::materialAmbiantScale, "u_material.ambientScale");
+    UniformEntries::genEntry(&Uniform::materialDiffuse, "u_material.diffuse");
+    UniformEntries::genEntry(&Uniform::materialDiffuseTexture, "u_material_diffuse_texture");
+    UniformEntries::genEntry(&Uniform::materialDiffuseScale, "u_material.diffuseScale");
+    UniformEntries::genEntry(&Uniform::materialShininess, "u_material.shininess");
+    UniformEntries::genEntry(&Uniform::materialSpecular, "u_material.specular");
+    UniformEntries::genEntry(&Uniform::materialSpecularTexture, "u_material_specular_texture");
+    UniformEntries::genEntry(&Uniform::materialSpecularScale, "u_material.specularScale");
+    UniformEntries::genEntry(&Uniform::materialNormalTexture, "u_material_normal_texture");
+    UniformEntries::genEntry(&Uniform::materialNormalScale, "u_material.normalScale");
+    UniformEntries::genEntry(&Uniform::materialNormalAmount, "u_material.normalAmount");
+
+    allocated = true;
 }
 
 }

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -4,7 +4,7 @@
 #include "glm/glm.hpp"
 #include "util/fastmap.h"
 #include "util/uniform.h"
-#include "gl/uniformBlock.h"
+#include "gl/uniformEntries.h"
 
 #include <string>
 #include <vector>
@@ -48,8 +48,6 @@ public:
     /*
      * Fetches the location of a shader uniform, caching the result
      */
-    GLint getUniformLocation(const std::string& _uniformName);
-
     GLint getUniformLocation(const UniformEntries::UniformEntry* _entry);
 
     /*

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -4,6 +4,7 @@
 #include "glm/glm.hpp"
 #include "util/fastmap.h"
 #include "util/uniform.h"
+#include "gl/uniformBlock.h"
 
 #include <string>
 #include <vector>
@@ -49,6 +50,8 @@ public:
      */
     GLint getUniformLocation(const std::string& _uniformName);
 
+    GLint getUniformLocation(const UniformEntries::UniformEntry* _entry);
+
     /*
      * Returns true if this object represents a valid OpenGL shader program
      */
@@ -63,28 +66,29 @@ public:
 
     /*
      * Ensures the program is bound and then sets the named uniform to the given value(s)
+     * Note: _name shoud have the same address for consistent uniform location caching
      */
-    void setUniformi(const std::string& _name, int _value);
-    void setUniformi(const std::string& _name, int _value0, int _value1);
-    void setUniformi(const std::string& _name, int _value0, int _value1, int _value2);
-    void setUniformi(const std::string& _name, int _value0, int _value1, int _value2, int _value3);
+    void setUniformi(const UniformEntries::UniformEntry* _entry, int _value);
+    void setUniformi(const UniformEntries::UniformEntry* _entry, int _value0, int _value1);
+    void setUniformi(const UniformEntries::UniformEntry* _entry, int _value0, int _value1, int _value2);
+    void setUniformi(const UniformEntries::UniformEntry* _entry, int _value0, int _value1, int _value2, int _value3);
 
-    void setUniformf(const std::string& _name, float _value);
-    void setUniformf(const std::string& _name, float _value0, float _value1);
-    void setUniformf(const std::string& _name, float _value0, float _value1, float _value2);
-    void setUniformf(const std::string& _name, float _value0, float _value1, float _value2, float _value3);
+    void setUniformf(const UniformEntries::UniformEntry* _entry, float _value);
+    void setUniformf(const UniformEntries::UniformEntry* _entry, float _value0, float _value1);
+    void setUniformf(const UniformEntries::UniformEntry* _entry, float _value0, float _value1, float _value2);
+    void setUniformf(const UniformEntries::UniformEntry* _entry, float _value0, float _value1, float _value2, float _value3);
 
-    void setUniformf(const std::string& _name, const glm::vec2& _value);
-    void setUniformf(const std::string& _name, const glm::vec3& _value);
-    void setUniformf(const std::string& _name, const glm::vec4& _value);
+    void setUniformf(const UniformEntries::UniformEntry* _entry, const glm::vec2& _value);
+    void setUniformf(const UniformEntries::UniformEntry* _entry, const glm::vec3& _value);
+    void setUniformf(const UniformEntries::UniformEntry* _entry, const glm::vec4& _value);
 
     /*
      * Ensures the program is bound and then sets the named uniform to the values
      * beginning at the pointer _value; 4 values are used for a 2x2 matrix, 9 values for a 3x3, etc.
      */
-    void setUniformMatrix2f(const std::string& _name, const glm::mat2& _value, bool transpose = false);
-    void setUniformMatrix3f(const std::string& _name, const glm::mat3& _value, bool transpose = false);
-    void setUniformMatrix4f(const std::string& _name, const glm::mat4& _value, bool transpose = false);
+    void setUniformMatrix2f(const UniformEntries::UniformEntry* _entry, const glm::mat2& _value, bool transpose = false);
+    void setUniformMatrix3f(const UniformEntries::UniformEntry* _entry, const glm::mat3& _value, bool transpose = false);
+    void setUniformMatrix4f(const UniformEntries::UniformEntry* _entry, const glm::mat4& _value, bool transpose = false);
 
     /* Invalidates all managed ShaderPrograms
      *
@@ -92,6 +96,8 @@ public:
      * handles are invalidated and immediately recreated.
      */
     static void invalidateAllPrograms();
+
+    static void allocateUniformEntries();
 
     auto getSourceBlocks() const { return  m_sourceBlocks; }
 
@@ -134,7 +140,7 @@ private:
     GLuint m_glVertexShader;
 
     fastmap<std::string, ShaderLocation> m_attribMap;
-    fastmap<std::string, ShaderLocation> m_uniformMap;
+    fastmap<UniformEntries::EntryId, ShaderLocation> m_uniformMap;
     fastmap<GLint, UniformValue> m_uniformCache;
 
     std::string m_fragmentShaderSource;
@@ -151,6 +157,43 @@ private:
 
     std::string applySourceBlocks(const std::string& source, bool fragShader);
 
+};
+
+namespace Uniform {
+    extern UniformEntries::EntryId color;
+    extern UniformEntries::EntryId time;
+    extern UniformEntries::EntryId model;
+    extern UniformEntries::EntryId tileOrigin;
+    extern UniformEntries::EntryId devicePixelRatio;
+    extern UniformEntries::EntryId resolution;
+    extern UniformEntries::EntryId mapPosition;
+    extern UniformEntries::EntryId normalMatrix;
+    extern UniformEntries::EntryId inverseNormalMatrix;
+    extern UniformEntries::EntryId metersPerPixel;
+    extern UniformEntries::EntryId view;
+    extern UniformEntries::EntryId proj;
+    extern UniformEntries::EntryId ortho;
+    extern UniformEntries::EntryId orthoProj;
+    extern UniformEntries::EntryId modelViewProj;
+    extern UniformEntries::EntryId tex;
+    extern UniformEntries::EntryId pass;
+    extern UniformEntries::EntryId uvScaleFactor;
+    extern UniformEntries::EntryId materialEmission;
+    extern UniformEntries::EntryId materialEmissionTexture;
+    extern UniformEntries::EntryId materialEmissionScale;
+    extern UniformEntries::EntryId materialAmbiant;
+    extern UniformEntries::EntryId materialAmbiantTexture;
+    extern UniformEntries::EntryId materialAmbiantScale;
+    extern UniformEntries::EntryId materialDiffuse;
+    extern UniformEntries::EntryId materialDiffuseTexture;
+    extern UniformEntries::EntryId materialDiffuseScale;
+    extern UniformEntries::EntryId materialShininess;
+    extern UniformEntries::EntryId materialSpecular;
+    extern UniformEntries::EntryId materialSpecularTexture;
+    extern UniformEntries::EntryId materialSpecularScale;
+    extern UniformEntries::EntryId materialNormalTexture;
+    extern UniformEntries::EntryId materialNormalScale;
+    extern UniformEntries::EntryId materialNormalAmount;
 };
 
 }

--- a/core/src/gl/uniformBlock.cpp
+++ b/core/src/gl/uniformBlock.cpp
@@ -1,0 +1,49 @@
+#include "uniformBlock.h"
+#include "platform.h"
+#include <vector>
+
+namespace Tangram {
+
+namespace UniformEntries {
+
+std::vector<std::unique_ptr<UniformEntry>> entries;
+EntryId ids = 0;
+
+bool entryExistsForName(const std::string& _name) {
+    for (const auto& entry : entries) {
+        if (entry->name == _name) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void genEntry(EntryId* _id, const std::string& _name) {
+    *_id = ++ids;
+
+    if (entryExistsForName(_name)) {
+        LOGW("Uniform entry with name %s already exists", _name.c_str());
+    }
+
+    std::unique_ptr<UniformEntry> entry = std::unique_ptr<UniformEntry>(new UniformEntry{*_id, _name});
+    entries.push_back(std::move(entry));
+}
+
+const UniformEntry* getEntry(EntryId _id) {
+    if (_id > entries.size()) {
+        LOGW("Accessing out of bound entry id");
+        return nullptr;
+    }
+
+    return entries[_id - 1].get();
+}
+
+void lazyGenEntry(EntryId* _id, const std::string& _name) {
+    if (!entryExistsForName(_name)) {
+        genEntry(_id, _name);
+    }
+}
+
+}
+
+}

--- a/core/src/gl/uniformBlock.h
+++ b/core/src/gl/uniformBlock.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace Tangram {
+
+namespace UniformEntries {
+
+typedef uint16_t EntryId;
+
+struct UniformEntry {
+    EntryId id;
+    std::string name;
+};
+
+bool entryExistsForName(const std::string& _name);
+
+void genEntry(EntryId* _id, const std::string& _name);
+
+const UniformEntry* getEntry(EntryId _id);
+
+void lazyGenEntry(EntryId* _id, const std::string& _name);
+
+}
+
+}

--- a/core/src/gl/uniformEntries.cpp
+++ b/core/src/gl/uniformEntries.cpp
@@ -1,4 +1,4 @@
-#include "uniformBlock.h"
+#include "uniformEntries.h"
 #include "platform.h"
 #include <vector>
 

--- a/core/src/gl/uniformEntries.h
+++ b/core/src/gl/uniformEntries.h
@@ -15,12 +15,20 @@ struct UniformEntry {
     std::string name;
 };
 
+/* Checks whether a uniform entry exists for a given uniform name */
 bool entryExistsForName(const std::string& _name);
 
+/* Generate a uniform entry (0 being a non valid EntryId) */
 void genEntry(EntryId* _id, const std::string& _name);
 
+/* Get a uniform entry for the given EntryId
+ * Returns nullptr if the entry has not been found
+ */
 const UniformEntry* getEntry(EntryId _id);
 
+/* Generates an entry only if the uniform entry with the given name _name
+ * has not been found in the set of uniform entries
+ */
 void lazyGenEntry(EntryId* _id, const std::string& _name);
 
 }

--- a/core/src/scene/directionalLight.cpp
+++ b/core/src/scene/directionalLight.cpp
@@ -26,7 +26,6 @@ void DirectionalLight::setDirection(const glm::vec3 &_dir) {
 }
 
 void DirectionalLight::setupProgram(const View& _view, ShaderProgram& _shader ) {
-
     glm::vec3 direction = m_direction;
     if (m_origin == LightOrigin::world) {
         direction = _view.getNormalMatrix() * direction;
@@ -34,7 +33,16 @@ void DirectionalLight::setupProgram(const View& _view, ShaderProgram& _shader ) 
 
 	if (m_dynamic) {
 		Light::setupProgram(_view, _shader);
-		_shader.setUniformf(getUniformName()+".direction", direction);
+
+        if (m_uniformEntry == 0) {
+            std::string directionUniformName = getUniformName() + ".direction";
+
+            if (!UniformEntries::entryExistsForName(directionUniformName)) {
+                UniformEntries::genEntry(&m_uniformEntry, directionUniformName);
+            }
+        }
+
+		_shader.setUniformf(UniformEntries::getEntry(m_uniformEntry), direction);
 	}
 }
 

--- a/core/src/scene/directionalLight.h
+++ b/core/src/scene/directionalLight.h
@@ -2,6 +2,7 @@
 
 #include "light.h"
 #include "glm/vec3.hpp"
+#include "gl/uniformBlock.h"
 
 namespace Tangram {
 
@@ -31,6 +32,7 @@ protected:
 private:
 
     static std::string s_typeName;
+    UniformEntries::EntryId m_uniformEntry = 0;
     
 };
 

--- a/core/src/scene/directionalLight.h
+++ b/core/src/scene/directionalLight.h
@@ -2,7 +2,6 @@
 
 #include "light.h"
 #include "glm/vec3.hpp"
-#include "gl/uniformBlock.h"
 
 namespace Tangram {
 

--- a/core/src/scene/light.cpp
+++ b/core/src/scene/light.cpp
@@ -63,9 +63,13 @@ void Light::injectOnProgram(ShaderProgram& _shader) {
 
 void Light::setupProgram(const View& _view, ShaderProgram& _shader) {
     if (m_dynamic) {
-        _shader.setUniformf(getUniformName()+".ambient", m_ambient);
-        _shader.setUniformf(getUniformName()+".diffuse", m_diffuse);
-        _shader.setUniformf(getUniformName()+".specular", m_specular);
+        if (m_ambiantUniform == 0) { UniformEntries::lazyGenEntry(&m_ambiantUniform, getUniformName() + ".ambient"); }
+        if (m_diffuseUniform == 0) { UniformEntries::lazyGenEntry(&m_diffuseUniform, getUniformName() + ".diffuse"); }
+        if (m_specularUniform == 0) { UniformEntries::lazyGenEntry(&m_specularUniform, getUniformName() + ".specular"); }
+
+        _shader.setUniformf(UniformEntries::getEntry(m_ambiantUniform), m_ambient);
+        _shader.setUniformf(UniformEntries::getEntry(m_diffuseUniform), m_diffuse);
+        _shader.setUniformf(UniformEntries::getEntry(m_specularUniform), m_specular);
     }
 }
 

--- a/core/src/scene/light.h
+++ b/core/src/scene/light.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "gl/uniformBlock.h"
+#include "gl/uniformEntries.h"
 
 namespace Tangram {
 

--- a/core/src/scene/light.h
+++ b/core/src/scene/light.h
@@ -1,11 +1,13 @@
 #pragma once
- 
+
 #include "glm/vec4.hpp"
 
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include "gl/uniformBlock.h"
 
 namespace Tangram {
 
@@ -107,6 +109,10 @@ protected:
     bool m_dynamic;
 
 private:
+
+    UniformEntries::EntryId m_ambiantUniform = 0;
+    UniformEntries::EntryId m_diffuseUniform = 0;
+    UniformEntries::EntryId m_specularUniform = 0;
 
     static std::string s_mainLightingBlock;
 

--- a/core/src/scene/pointLight.cpp
+++ b/core/src/scene/pointLight.cpp
@@ -72,18 +72,34 @@ void PointLight::setupProgram(const View& _view, ShaderProgram& _shader) {
             position = _view.getViewMatrix() * position;
         }
 
-        _shader.setUniformf(getUniformName()+".position", position);
+        if (m_positionUniform == 0) {
+            std::string positionUniformName = getUniformName() + ".position";
+            if (UniformEntries::entryExistsForName(positionUniformName)) {
+                UniformEntries::genEntry(&m_positionUniform, positionUniformName);
+            }
+        }
 
-        if (m_attenuation!=0.0) {
-            _shader.setUniformf(getUniformName()+".attenuation", m_attenuation);
+        _shader.setUniformf(UniformEntries::getEntry(m_positionUniform), position);
+
+        if (m_attenuation != 0.0) {
+            if (m_attenuationUniform == 0) {
+                UniformEntries::lazyGenEntry(&m_attenuationUniform, getUniformName() + ".attenuation");
+            }
+            _shader.setUniformf(UniformEntries::getEntry(m_attenuationUniform), m_attenuation);
         }
 
         if (m_innerRadius!=0.0) {
-            _shader.setUniformf(getUniformName()+".innerRadius", m_innerRadius);
+            if (m_innerRadiusUniform == 0) {
+                UniformEntries::lazyGenEntry(&m_innerRadiusUniform, getUniformName() + ".innerRadius");
+            }
+            _shader.setUniformf(UniformEntries::getEntry(m_innerRadiusUniform), m_innerRadius);
         }
 
         if (m_outerRadius!=0.0) {
-            _shader.setUniformf(getUniformName()+".outerRadius", m_outerRadius);
+            if (m_outerRadiusUniform == 0) {
+                UniformEntries::lazyGenEntry(&m_outerRadiusUniform, getUniformName() + ".outerRadius");
+            }
+            _shader.setUniformf(UniformEntries::getEntry(m_outerRadiusUniform), m_outerRadius);
         }
     }
 }

--- a/core/src/scene/pointLight.h
+++ b/core/src/scene/pointLight.h
@@ -9,7 +9,7 @@ public:
 
 	PointLight(const std::string& _name, bool _dynamic = false);
 	virtual ~PointLight();
-    
+
     /*  Set the position relative to the camera */
     virtual void setPosition(const glm::vec3& _pos);
 
@@ -19,9 +19,9 @@ public:
     /*  Set the constant outer radius or inner/outer radius*/
     virtual void setRadius(float _outer);
     virtual void setRadius(float _inner, float _outer);
-    
+
     virtual void setupProgram(const View& _view, ShaderProgram& _program) override;
-    
+
 protected:
 
     /*  GLSL block code with structs and need functions for this light type */
@@ -29,9 +29,9 @@ protected:
     virtual std::string getInstanceDefinesBlock() override;
     virtual std::string getInstanceAssignBlock() override;
     virtual const std::string& getTypeName() override;
-    
+
     static std::string s_classBlock;
-    
+
     glm::vec4 m_position;
 
     float m_attenuation;
@@ -41,6 +41,11 @@ protected:
 private:
 
     static std::string s_typeName;
+
+    UniformEntries::EntryId m_positionUniform = 0;
+    UniformEntries::EntryId m_attenuationUniform = 0;
+    UniformEntries::EntryId m_innerRadiusUniform = 0;
+    UniformEntries::EntryId m_outerRadiusUniform = 0;
 
 };
 

--- a/core/src/scene/skybox.cpp
+++ b/core/src/scene/skybox.cpp
@@ -51,8 +51,8 @@ void Skybox::draw(const View& _view) {
     // Remove translation so that skybox is centered on view
     vp[3] = { 0, 0, 0, 0 };
 
-    m_shader->setUniformMatrix4f("u_modelViewProj", vp);
-    m_shader->setUniformi("u_tex", 0);
+    m_shader->setUniformMatrix4f(UniformEntries::getEntry(Uniform::modelViewProj), vp);
+    m_shader->setUniformi(UniformEntries::getEntry(Uniform::tex), 0);
 
     RenderState::blending(GL_FALSE);
     RenderState::depthTest(GL_TRUE);

--- a/core/src/scene/spotLight.cpp
+++ b/core/src/scene/spotLight.cpp
@@ -47,9 +47,21 @@ void SpotLight::setupProgram(const View& _view, ShaderProgram& _shader ) {
             direction = glm::normalize(_view.getNormalMatrix() * direction);
         }
 
-        _shader.setUniformf(getUniformName()+".direction", direction);
-        _shader.setUniformf(getUniformName()+".spotCosCutoff", m_spotCosCutoff);
-        _shader.setUniformf(getUniformName()+".spotExponent", m_spotExponent);
+        if (m_directionUniform == 0) {
+            UniformEntries::lazyGenEntry(&m_directionUniform, getUniformName() + ".direction");
+        }
+
+        if (m_spotCosCutoffUniform == 0) {
+            UniformEntries::lazyGenEntry(&m_spotCosCutoffUniform, getUniformName() + ".spotCosCutoff");
+        }
+
+        if (m_spotExponentUniform == 0) {
+            UniformEntries::lazyGenEntry(&m_spotExponentUniform, getUniformName() + ".spotExponent");
+        }
+
+        _shader.setUniformf(UniformEntries::getEntry(m_directionUniform), direction);
+        _shader.setUniformf(UniformEntries::getEntry(m_spotCosCutoffUniform), m_spotCosCutoff);
+        _shader.setUniformf(UniformEntries::getEntry(m_spotExponentUniform), m_spotExponent);
     }
 }
 

--- a/core/src/scene/spotLight.h
+++ b/core/src/scene/spotLight.h
@@ -38,6 +38,10 @@ protected:
 private:
 
     static std::string s_typeName;
+
+    UniformEntries::EntryId m_directionUniform = 0;
+    UniformEntries::EntryId m_spotCosCutoffUniform = 0;
+    UniformEntries::EntryId m_spotExponentUniform = 0;
     
 };
 

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -158,56 +158,56 @@ void Material::injectOnProgram(ShaderProgram& _shader ) {
 void Material::setupProgram(ShaderProgram& _shader) {
 
     if (m_bEmission) {
-        _shader.setUniformf("u_material.emission", m_emission);
+        _shader.setUniformf(UniformEntries::getEntry(Uniform::materialEmission), m_emission);
 
         if (m_emission_texture.tex) {
             m_emission_texture.tex->update(1);
             m_emission_texture.tex->bind(1);
-            _shader.setUniformi("u_material_emission_texture", 1);
-            _shader.setUniformf("u_material.emissionScale", m_emission_texture.scale);
+            _shader.setUniformi(UniformEntries::getEntry(Uniform::materialDiffuseTexture), 1);
+            _shader.setUniformf(UniformEntries::getEntry(Uniform::materialEmissionScale), m_emission_texture.scale);
         }
     }
 
     if (m_bAmbient) {
-        _shader.setUniformf("u_material.ambient", m_ambient);
+        _shader.setUniformf(UniformEntries::getEntry(Uniform::materialAmbiant), m_ambient);
 
         if (m_ambient_texture.tex) {
             m_ambient_texture.tex->update(2);
             m_ambient_texture.tex->bind(2);
-            _shader.setUniformi("u_material_ambient_texture", 2);
-            _shader.setUniformf("u_material.ambientScale", m_ambient_texture.scale);
+            _shader.setUniformi(UniformEntries::getEntry(Uniform::materialAmbiantTexture), 2);
+            _shader.setUniformf(UniformEntries::getEntry(Uniform::materialAmbiantScale), m_ambient_texture.scale);
         }
     }
 
     if (m_bDiffuse) {
-        _shader.setUniformf("u_material.diffuse", m_diffuse);
+        _shader.setUniformf(UniformEntries::getEntry(Uniform::materialDiffuse), m_diffuse);
 
         if (m_diffuse_texture.tex) {
             m_diffuse_texture.tex->update(3);
             m_diffuse_texture.tex->bind(3);
-            _shader.setUniformi("u_material_diffuse_texture", 3);
-            _shader.setUniformf("u_material.diffuseScale", m_diffuse_texture.scale);
+            _shader.setUniformi(UniformEntries::getEntry(Uniform::materialDiffuseTexture), 3);
+            _shader.setUniformf(UniformEntries::getEntry(Uniform::materialDiffuseScale), m_diffuse_texture.scale);
         }
     }
 
     if (m_bSpecular) {
-        _shader.setUniformf("u_material.specular", m_specular);
-        _shader.setUniformf("u_material.shininess", m_shininess);
+        _shader.setUniformf(UniformEntries::getEntry(Uniform::materialSpecular), m_specular);
+        _shader.setUniformf(UniformEntries::getEntry(Uniform::materialShininess), m_shininess);
 
         if (m_specular_texture.tex) {
             m_specular_texture.tex->update(4);
             m_specular_texture.tex->bind(4);
-            _shader.setUniformi("u_material_specular_texture", 4);
-            _shader.setUniformf("u_material.specularScale", m_specular_texture.scale);
+            _shader.setUniformi(UniformEntries::getEntry(Uniform::materialSpecularTexture), 4);
+            _shader.setUniformf(UniformEntries::getEntry(Uniform::materialSpecularScale), m_specular_texture.scale);
         }
     }
 
     if (m_normal_texture.tex) {
         m_normal_texture.tex->update(5);
         m_normal_texture.tex->bind(5);
-        _shader.setUniformi("u_material_normal_texture", 5);
-        _shader.setUniformf("u_material.normalScale", m_normal_texture.scale);
-        _shader.setUniformf("u_material.normalAmount", m_normal_texture.amount);
+        _shader.setUniformi(UniformEntries::getEntry(Uniform::materialNormalTexture), 5);
+        _shader.setUniformf(UniformEntries::getEntry(Uniform::materialNormalScale), m_normal_texture.scale);
+        _shader.setUniformf(UniformEntries::getEntry(Uniform::materialNormalAmount), m_normal_texture.amount);
     }
 }
 

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -61,8 +61,8 @@ void PointStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _texture
         m_texture->bind(0);
     }
 
-    m_shaderProgram->setUniformi("u_tex", 0);
-    m_shaderProgram->setUniformMatrix4f("u_ortho", _view.getOrthoViewportMatrix());
+    m_shaderProgram->setUniformi(UniformEntries::getEntry(Uniform::tex), 0);
+    m_shaderProgram->setUniformMatrix4f(UniformEntries::getEntry(Uniform::ortho), _view.getOrthoViewportMatrix());
 
     Style::onBeginDrawFrame(_view, _scene, 1);
 }

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -3,6 +3,7 @@
 #include "gl.h"
 #include "data/tileData.h"
 #include "util/uniform.h"
+#include "gl/uniformBlock.h"
 
 #include <memory>
 #include <string>
@@ -84,8 +85,6 @@ protected:
  */
 class Style {
 
-using StyleUniform = std::pair< std::string, UniformValue >;
-
 protected:
 
     /* The platform pixel scale */
@@ -132,6 +131,14 @@ protected:
     void setupShaderUniforms(int _textureUnit, Scene& _scene);
 
 private:
+
+    struct CustomStyleUniform {
+        CustomStyleUniform(UniformValue& value) : value(value) {}
+        UniformValue value;
+        UniformEntries::EntryId entry = 0;
+    };
+
+    using StyleUniform = std::pair<std::string, CustomStyleUniform>;
 
     std::vector<StyleUniform> m_styleUniforms;
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -3,7 +3,7 @@
 #include "gl.h"
 #include "data/tileData.h"
 #include "util/uniform.h"
-#include "gl/uniformBlock.h"
+#include "gl/uniformEntries.h"
 
 #include <memory>
 #include <string>

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -59,10 +59,10 @@ void TextStyle::constructShaderProgram() {
 void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit) {
     m_fontContext->bindAtlas(0);
 
-    m_shaderProgram->setUniformf("u_uv_scale_factor",
+    m_shaderProgram->setUniformf(UniformEntries::getEntry(Uniform::uvScaleFactor),
                                  1.0f / m_fontContext->getAtlasResolution());
-    m_shaderProgram->setUniformi("u_tex", 0);
-    m_shaderProgram->setUniformMatrix4f("u_ortho", _view.getOrthoViewportMatrix());
+    m_shaderProgram->setUniformi(UniformEntries::getEntry(Uniform::tex), 0);
+    m_shaderProgram->setUniformMatrix4f(UniformEntries::getEntry(Uniform::ortho), _view.getOrthoViewportMatrix());
 
     Style::onBeginDrawFrame(_view, _scene, 1);
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -538,6 +538,8 @@ void setupGL() {
         m_tileManager->clearTileSets();
     }
 
+    ShaderProgram::allocateUniformEntries();
+
     // Reconfigure the render states. Increases context 'generation'.
     // The OpenGL context has been destroyed since the last time resources were
     // created, so we invalidate all data that depends on OpenGL object handles.

--- a/core/src/text/textBuffer.cpp
+++ b/core/src/text/textBuffer.cpp
@@ -168,9 +168,9 @@ std::string TextBuffer::Builder::applyTextTransform(const TextStyle::Parameters&
 void TextBuffer::draw(ShaderProgram& _shader) {
 
     if (m_strokePass) {
-        _shader.setUniformi("u_pass", 1);
+        _shader.setUniformi(UniformEntries::getEntry(Uniform::pass), 1);
         LabelMesh::draw(_shader);
-        _shader.setUniformi("u_pass", 0);
+        _shader.setUniformi(UniformEntries::getEntry(Uniform::pass), 0);
     }
 
     LabelMesh::draw(_shader);

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -73,7 +73,7 @@ void Tile::setMesh(const Style& _style, std::unique_ptr<StyledMesh> _mesh) {
     size_t id = _style.getID();
     if (id >= m_geometry.size()) {
         m_geometry.resize(id+1);
-    }
+   }
     m_geometry[_style.getID()] = std::move(_mesh);
 }
 


### PR DESCRIPTION
Optimize string allocations for uniforms
- Statically allocate uniform strings to reduce redundant allocations
- Shader location cache: Hash on the id of the uniform (`uint16_t`) entry instead of the string

Update, (order of speedup is comparable on mobile):

master branch,
```
build/bench/bin  master ✗
> ./bench/uniform.out
Run on (8 X 1000 MHz CPU s)
2016-02-29 12:56:20
Benchmark               Time(ns)    CPU(ns) Iterations
------------------------------------------------------
BM_Tangram_SetUniform        159         61   10803970                                 
```
uniform-entries branch,
```

build/bench/bin  uniform-entries ✗
> ./bench/uniform.out 
Run on (8 X 1000 MHz CPU s)
2016-02-29 12:59:06
Benchmark               Time(ns)    CPU(ns) Iterations
------------------------------------------------------
BM_Tangram_SetUniform          8         17   36471060    
```