### PR TITLE
fix:  lighting 'false' option

### DIFF
--- a/core/resources/shaders/polygon.fs
+++ b/core/resources/shaders/polygon.fs
@@ -49,19 +49,18 @@ void main(void) {
     vec4 color = v_color;
     vec3 normal = v_normal;
 
+    // Modify material properties before lighting
     #ifdef TANGRAM_MATERIAL_NORMAL_TEXTURE
         calculateNormal(normal);
     #endif
 
-    // Modify normal before lighting
-    #pragma tangram: normal
-
-    // Modify color and material properties before lighting
-    #ifndef TANGRAM_LIGHTING_VERTEX
-        #pragma tangram: color
-    #endif
-
     #ifdef TANGRAM_LIGHTING_FRAGMENT
+        // Modify color before lighting
+        #pragma tangram: color
+
+        // Modify normal before lighting
+        #pragma tangram: normal
+
         color = calculateLighting(v_position.xyz, normal, color);
     #else
         #ifdef TANGRAM_LIGHTING_VERTEX

--- a/core/resources/shaders/polygon.vs
+++ b/core/resources/shaders/polygon.vs
@@ -87,7 +87,7 @@ void main() {
     // Set position varying to the camera-space vertex position
     v_position = u_view * position;
 
-    #ifdef TANGRAM_LIGHTING_VERTEX
+    #ifndef TANGRAM_LIGHTING_FRAGMENT
         vec4 color = v_color;
         vec3 normal = v_normal;
 
@@ -97,7 +97,10 @@ void main() {
         // Modify color and material properties before lighting
         #pragma tangram: color
 
-        v_lighting = calculateLighting(v_position.xyz, normal, color);
+        #ifdef TANGRAM_LIGHTING_VERTEX
+            v_lighting = calculateLighting(v_position.xyz, normal, color);
+        #endif
+
         v_color = color;
         v_normal = normal;
     #endif

--- a/core/resources/shaders/polyline.fs
+++ b/core/resources/shaders/polyline.fs
@@ -49,19 +49,17 @@ void main(void) {
     vec4 color = v_color;
     vec3 normal = v_normal;
 
+    // Modify material properties before lighting
     #ifdef TANGRAM_MATERIAL_NORMAL_TEXTURE
         calculateNormal(normal);
     #endif
 
-    // Modify normal before lighting
-    #pragma tangram: normal
-
-    // Modify color and material properties before lighting
-    #ifndef TANGRAM_LIGHTING_VERTEX
-        #pragma tangram: color
-    #endif
-
     #ifdef TANGRAM_LIGHTING_FRAGMENT
+        // Modify normal and color before lighting
+        #pragma tangram: normal
+
+        #pragma tangram: color
+
         color = calculateLighting(v_position.xyz, normal, color);
     #else
         #ifdef TANGRAM_LIGHTING_VERTEX

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -105,7 +105,7 @@ void main() {
     // Set position varying to the camera-space vertex position
     v_position = u_view * position;
 
-    #ifdef TANGRAM_LIGHTING_VERTEX
+    #ifndef TANGRAM_LIGHTING_FRAGMENT
         vec4 color = v_color;
         vec3 normal = v_normal;
 
@@ -115,7 +115,9 @@ void main() {
         // Modify color and material properties before lighting
         #pragma tangram: color
 
-        v_lighting = calculateLighting(v_position.xyz, normal, color);
+        #ifdef TANGRAM_LIGHTING_VERTEX
+            v_lighting = calculateLighting(v_position.xyz, normal, color);
+        #endif
         v_color = color;
         v_normal = normal;
     #endif


### PR DESCRIPTION
This one needs a careful look:

- the color block was not applied in vertex shader when lighting mode is ```none```
- normal blocks were applied in vertex and fragment shader for vertex lighting