### PR TITLE
Fix recursive filters within a "not" filter

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -876,10 +876,7 @@ Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
             filters.emplace_back(generateFilter(filt, scene));
         }
     } else if (_filter.IsMap()) { // not case
-        for (const auto& filt : _filter) {
-            std::string keyFilter = filt.first.as<std::string>();
-            filters.emplace_back(generatePredicate(_filter[keyFilter], keyFilter));
-        }
+        filters.emplace_back(generateFilter(_filter, scene));
     } else {
         LOGW("Invalid filter. 'None' expects a list or an object.");
         return Filter();

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -149,10 +149,10 @@ TEST_CASE( "yaml-filter-tests: none", "[filters][core][yaml]") {
 //9. not
 TEST_CASE( "yaml-filter-tests: not", "[filters][core][yaml]") {
     init();
-    Filter filter = load("filter: {not : {name : civic}}");
+    Filter filter = load("filter: {not : { any: [{name : civic}, {name : bmw320i}]}}");
 
     REQUIRE(!filter.eval(civic, ctx));
-    REQUIRE(filter.eval(bmw1, ctx));
+    REQUIRE(!filter.eval(bmw1, ctx));
     REQUIRE(filter.eval(bike, ctx));
 
 }


### PR DESCRIPTION
The previous code assumed that "not" could only contain a predicate.