### PR TITLE
Fix point light ground attachment on tilted view

### DIFF
--- a/core/src/scene/pointLight.cpp
+++ b/core/src/scene/pointLight.cpp
@@ -67,8 +67,8 @@ void PointLight::setupProgram(const View& _view, LightUniforms& _uniforms) {
         position.z = position.z - _view.getEye().z;
 
     } else if (m_origin == LightOrigin::ground) {
-        // Leave light's xy in camera space, but z needs to be moved relative to ground plane
-        position.z = position.z - _view.getPosition().z;
+        // Move light position relative to the eye position in world space
+        position -= glm::vec4(_view.getEye(), 0.0);
     }
 
     if (m_origin == LightOrigin::world || m_origin == LightOrigin::ground) {


### PR DESCRIPTION
Fix point light attachment when `ground` option is on for tilted view, now relative to _eye_ position:

This branch,
![relativetoview](https://cloud.githubusercontent.com/assets/7061573/13534668/5c86e938-e204-11e5-9a27-4d9f1f9f7bd1.gif)
Master,
![nonrelativetoeye](https://cloud.githubusercontent.com/assets/7061573/13534670/5d81aa94-e204-11e5-9c48-c95b011b7c1d.gif)
