### PR TITLE
Fix point light world attachment on tilted view

### DIFF
--- a/core/src/scene/pointLight.cpp
+++ b/core/src/scene/pointLight.cpp
@@ -62,9 +62,9 @@ void PointLight::setupProgram(const View& _view, LightUniforms& _uniforms) {
 
         // Move light's world position into camera space
         glm::dvec2 camSpace = _view.getMapProjection().LonLatToMeters(glm::dvec2(m_position.x, m_position.y));
-        position.x = camSpace.x - _view.getPosition().x;
-        position.y = camSpace.y - _view.getPosition().y;
-        position.z = position.z - _view.getPosition().z;
+        position.x = camSpace.x - (_view.getPosition().x + _view.getEye().x);
+        position.y = camSpace.y - (_view.getPosition().y + _view.getEye().y);
+        position.z = position.z - _view.getEye().z;
 
     } else if (m_origin == LightOrigin::ground) {
         // Leave light's xy in camera space, but z needs to be moved relative to ground plane

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -109,6 +109,9 @@ public:
 
     const glm::mat3& getInverseNormalMatrix() const { return m_invNormalMatrix; }
 
+    /* Returns the eye position in world space */
+    const glm::vec3& getEye() const { return m_eye; }
+
     /* Returns a rectangle of the current view range as [[x_min, y_min], [x_max, y_max]] */
     glm::dmat2 getBoundsRect() const;
 


### PR DESCRIPTION
Same as #597 , for `world` attachment.

This branch,
![relativetoview-world](https://cloud.githubusercontent.com/assets/7061573/13540081/69f8af5c-e222-11e5-9abf-7e638b52f3d5.gif)

Master,
![nonrelativetoeye-world](https://cloud.githubusercontent.com/assets/7061573/13540064/52fd2788-e222-11e5-86d5-f93079a644aa.gif)
