### PR TITLE
Outline should not be drawn when no color

### DIFF
--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -193,7 +193,6 @@ auto PolylineStyleBuilder::parseRule(const DrawRule& _rule, const Properties& _p
 
     auto& strokeWidth = _rule.findParameter(StyleParamKey::outline_width);
     if (strokeWidth |
-        _rule.get(StyleParamKey::outline_color, p.stroke.color) |
         _rule.get(StyleParamKey::outline_order, stroke.order) |
         _rule.get(StyleParamKey::outline_cap, cap) |
         _rule.get(StyleParamKey::outline_join, join)) {
@@ -201,6 +200,7 @@ auto PolylineStyleBuilder::parseRule(const DrawRule& _rule, const Properties& _p
         p.stroke.cap = static_cast<CapTypes>(cap);
         p.stroke.join = static_cast<JoinTypes>(join);
 
+        if (!_rule.get(StyleParamKey::outline_color, p.stroke.color)) { return p; }
         if (!evalWidth(strokeWidth, stroke.width, stroke.slope)) {
             return p;
         }


### PR DESCRIPTION
Before this, if no color was specified for an outline, it was rendering black (default color value in PolylineStyle
Builder is <uint32_t>(1).

However since color is a required parameter it should not draw outline, when no color is specified.
This is also the behavior with tangram-js.