### PR TITLE
Outline styles

### DIFF
--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -48,19 +48,6 @@ DrawRule::DrawRule(const DrawRuleData& _ruleData, const SceneLayer& _layer) :
     }
 }
 
-DrawRule::DrawRule(const DrawRule& _other) : active(_other.active), name(_other.name),
-    id(_other.id), dummyOutline(_other.dummyOutline) {
-
-    for (size_t i = 0; i < StyleParamKeySize; ++i) {
-
-        if (!_other.active[i]) {
-            continue;
-        }
-
-        params[i] = _other.params[i];
-    }
-}
-
 void DrawRule::merge(const DrawRuleData& _ruleData, const SceneLayer& _layer) {
 
     evalConflict(*this, _ruleData, _layer);
@@ -122,12 +109,6 @@ size_t DrawRule::getParamSetHash() const {
         if (active[i]) { hash_combine(seed, params[i].name); }
     }
     return seed;
-}
-
-DrawRule DrawRule::outlineRule() const {
-    DrawRule outlineRule(*this);
-    outlineRule.dummyOutline = true;
-    return outlineRule;
 }
 
 void DrawRule::logGetError(StyleParamKey _expectedKey, const StyleParam& _param) const {
@@ -241,7 +222,9 @@ void DrawRuleMergeSet::apply(const Feature& _feature, const SceneLayer& _layer,
                 if (!outlineStyle) {
                     LOGE("Invalid style %s", styleName.c_str());
                 } else {
-                    outlineStyle->addFeature(_feature, rule.outlineRule());
+                    rule.isOutlineOnly = true;
+                    outlineStyle->addFeature(_feature, rule);
+                    rule.isOutlineOnly = false;
                 }
             }
 

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -73,10 +73,9 @@ struct DrawRule {
     // draw-style name and id
     const std::string* name = nullptr;
     int id;
-    bool dummyOutline = false;
+    bool isOutlineOnly = false;
 
     DrawRule(const DrawRuleData& _ruleData, const SceneLayer& _layer);
-    DrawRule(const DrawRule& _other);
 
     void merge(const DrawRuleData& _ruleData, const SceneLayer& _layer);
 
@@ -91,8 +90,6 @@ struct DrawRule {
     size_t getParamSetHash() const;
 
     const StyleParam& findParameter(StyleParamKey _key) const;
-
-    DrawRule outlineRule() const;
 
     template<typename T>
     bool get(StyleParamKey _key, T& _value) const {

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -73,8 +73,10 @@ struct DrawRule {
     // draw-style name and id
     const std::string* name = nullptr;
     int id;
+    bool dummyOutline = false;
 
     DrawRule(const DrawRuleData& _ruleData, const SceneLayer& _layer);
+    DrawRule(const DrawRule& _other);
 
     void merge(const DrawRuleData& _ruleData, const SceneLayer& _layer);
 
@@ -89,6 +91,8 @@ struct DrawRule {
     size_t getParamSetHash() const;
 
     const StyleParam& findParameter(StyleParamKey _key) const;
+
+    DrawRule outlineRule() const;
 
     template<typename T>
     bool get(StyleParamKey _key, T& _value) const {

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -41,6 +41,7 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"outline:miter_limit", StyleParamKey::outline_miter_limit},
     {"outline:order", StyleParamKey::outline_order},
     {"outline:width", StyleParamKey::outline_width},
+    {"outline:style", StyleParamKey::outline_style},
     {"priority", StyleParamKey::priority},
     {"repeat_distance", StyleParamKey::repeat_distance},
     {"repeat_group", StyleParamKey::repeat_group},
@@ -170,6 +171,7 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::sprite:
     case StyleParamKey::sprite_default:
     case StyleParamKey::style:
+    case StyleParamKey::outline_style:
     case StyleParamKey::repeat_group:
         return _value;
     case StyleParamKey::font_size: {

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -36,6 +36,7 @@ enum class StyleParamKey : uint8_t {
     outline_miter_limit,
     outline_order,
     outline_width,
+    outline_style,
     priority,
     repeat_distance,
     repeat_group,

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -227,7 +227,7 @@ auto PolylineStyleBuilder<V>::parseRule(const DrawRule& _rule, const Properties&
     height *= m_tileUnitsPerMeter;
 
     p.fill.set(fill.width, fill.slope, height, fill.order);
-    p.lineOn = !_rule.dummyOutline;
+    p.lineOn = !_rule.isOutlineOnly;
 
     stroke.order = fill.order;
     p.stroke.cap = p.fill.cap;

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -112,6 +112,7 @@ public:
 
         bool keepTileEdges = false;
         bool outlineOn = false;
+        bool lineOn = true;
     };
 
     void setup(const Tile& _tile) override;
@@ -226,6 +227,7 @@ auto PolylineStyleBuilder<V>::parseRule(const DrawRule& _rule, const Properties&
     height *= m_tileUnitsPerMeter;
 
     p.fill.set(fill.width, fill.slope, height, fill.order);
+    p.lineOn = !_rule.dummyOutline;
 
     stroke.order = fill.order;
     p.stroke.cap = p.fill.cap;
@@ -233,34 +235,36 @@ auto PolylineStyleBuilder<V>::parseRule(const DrawRule& _rule, const Properties&
     p.stroke.miterLimit = p.fill.miterLimit;
 
     auto& strokeWidth = _rule.findParameter(StyleParamKey::outline_width);
-    if (strokeWidth |
-        _rule.get(StyleParamKey::outline_order, stroke.order) |
-        _rule.get(StyleParamKey::outline_cap, cap) |
-        _rule.get(StyleParamKey::outline_join, join) |
-        _rule.get(StyleParamKey::outline_miter_limit, p.stroke.miterLimit)) {
+    if (!p.lineOn || !_rule.findParameter(StyleParamKey::outline_style)) {
+        if (strokeWidth |
+            _rule.get(StyleParamKey::outline_order, stroke.order) |
+            _rule.get(StyleParamKey::outline_cap, cap) |
+            _rule.get(StyleParamKey::outline_join, join) |
+            _rule.get(StyleParamKey::outline_miter_limit, p.stroke.miterLimit)) {
 
-        p.stroke.cap = static_cast<CapTypes>(cap);
-        p.stroke.join = static_cast<JoinTypes>(join);
+            p.stroke.cap = static_cast<CapTypes>(cap);
+            p.stroke.join = static_cast<JoinTypes>(join);
 
-        if (!_rule.get(StyleParamKey::outline_color, p.stroke.color)) { return p; }
-        if (!evalWidth(strokeWidth, stroke.width, stroke.slope)) {
-            return p;
+            if (!_rule.get(StyleParamKey::outline_color, p.stroke.color)) { return p; }
+            if (!evalWidth(strokeWidth, stroke.width, stroke.slope)) {
+                return p;
+            }
+
+            // NB: Multiply by 2 for the stroke to get the expected stroke pixel width.
+            stroke.width *= 2.0f;
+            stroke.slope *= 2.0f;
+            stroke.slope -= stroke.width;
+
+            stroke.width += fill.width;
+            stroke.slope += fill.slope;
+
+            stroke.order = std::min(stroke.order, fill.order);
+
+            p.stroke.set(stroke.width, stroke.slope,
+                    height, stroke.order - 0.5f);
+
+            p.outlineOn = true;
         }
-
-        // NB: Multiply by 2 for the stroke to get the expected stroke pixel width.
-        stroke.width *= 2.0f;
-        stroke.slope *= 2.0f;
-        stroke.slope -= stroke.width;
-
-        stroke.width += fill.width;
-        stroke.slope += fill.slope;
-
-        stroke.order = std::min(stroke.order, fill.order);
-
-        p.stroke.set(stroke.width, stroke.slope,
-                     height, stroke.order - 0.5f);
-
-        p.outlineOn = true;
     }
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::proxy_colors)) {
@@ -374,11 +378,12 @@ void PolylineStyleBuilder<V>::addMesh(const Line& _line, const Parameters& _para
     m_builder.miterLimit = _params.fill.miterLimit;
     m_builder.keepTileEdges = _params.keepTileEdges;
 
-    buildLine(_line, _params.fill, m_meshData[0]);
+    if (_params.lineOn) { buildLine(_line, _params.fill, m_meshData[0]); }
 
     if (!_params.outlineOn) { return; }
 
-    if (_params.stroke.cap != _params.fill.cap ||
+    if (!_params.lineOn ||
+        _params.stroke.cap != _params.fill.cap ||
         _params.stroke.join != _params.fill.join ||
         _params.stroke.miterLimit != _params.fill.miterLimit) {
         // need to re-triangulate with different cap and/or join


### PR DESCRIPTION
Current approach

- Create a dummy rule for outlines which define their own drawing style
- Use this dummy rule to draw these outlines
- original draw rule will skip drawing this "outline"
- and dummy draw rule will skip drawing the "line"

Current implementation keeps the current architecture intact. 
However, things can be further improved by consolidating `polylinestyle` to only build "lines", and pass on lines and outlines drawing individually to the style builder. However this will require some architectural changes (specifically related to dependency of outline/stroke paramaters on parent line parameters, example: width), which I would like to discuss first.

Note: This is rebased off: https://github.com/tangrams/tangram-es/tree/fix-no-outline-color, request to lookat/merge #604 first.

Fixes #544 