### PR TITLE
Uniform arrays

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -42,20 +42,26 @@ textures:
             info: [0, 1110, 32, 32]
             hotel: [0, 259, 32, 32]
             bookstore: [0, 333, 32, 32]
+    texture0:
+        url: img/cross.png
+    texture1:
+        url: img/sem.jpg
 
 styles:
     flatcolor:
         base: polygons
-        lighting: false
+        #lighting: false
     heightglow:
         base: polygons
-        lighting: vertex
+        #lighting: vertex
+        texcoords: true
         shaders:
             uniforms:
                 u_test: [0.5, 0.5, 0.5, 0.5, 0.9]
-                #u_vec: [0.5, 0.5, 0.5]
+                u_textures: [texture0, texture1]
             blocks:
-                color: "color.rgb *= u_test[4];"
+                #color: "color.rgb *= u_test[4];"
+                color: "color.rgb *= texture2D(u_textures[0], v_texcoord).rgb;"
     heightglowline:
         base: lines
         mix: heightglow

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -48,9 +48,8 @@ textures:
         url: img/sem.jpg
 
 styles:
-    #flatcolor:
-    #    base: polygons
-    #    #lighting: false
+    flatcolor:
+        base: polygons
     heightglow:
         base: polygons
         #lighting: vertex
@@ -60,14 +59,13 @@ styles:
                 u_test: [0.5, 0.5, 1.0, 0.5, 0.9]
                 u_textures: [texture0, texture1]
             blocks:
-                #color: "color.rgb *= u_test[4];"
                 color: "color.rgb *= mix(texture2D(u_textures[1], v_texcoord).rgb, vec3(u_test[0], u_test[1], u_test[4]), 0.5);"
-    #heightglowline:
-    #    base: lines
-    ##    mix: heightglow
-    #icons:
-    #    base: points
-    #    texture: pois
+    heightglowline:
+        base: lines
+    #    mix: heightglow
+    icons:
+        base: points
+        texture: pois
 
 sources:
     osm:
@@ -76,233 +74,233 @@ sources:
         max_zoom: 18
 
 layers:
-    #touch:
-    #    data: { source: touch }
-    #    line:
-    #      filter: { type: line }
-    #      draw:
-    #        lines:
-    #          color: function () { return feature.color || 'black'; }
-    #          order: 50
-    #          width: 2px
-    #    poly:
-    #        filter: { type: poly }
-    #        draw:
-    #          polygons:
-    #            color: magenta
-    #            order: 40
-    #    point:
-    #        filter: { type: point }
-    #        draw:
-    #          icons:
-    #            sprite: sunburst
-    #            collide: false
-    #            transition:
-    #                [show, hide]:
-    #                    time: 0s
+    touch:
+        data: { source: touch }
+        line:
+          filter: { type: line }
+          draw:
+            lines:
+              color: function () { return feature.color || 'black'; }
+              order: 50
+              width: 2px
+        poly:
+            filter: { type: poly }
+            draw:
+              polygons:
+                color: magenta
+                order: 40
+        point:
+            filter: { type: point }
+            draw:
+              icons:
+                sprite: sunburst
+                collide: false
+                transition:
+                    [show, hide]:
+                        time: 0s
 
-    #earth:
-    #    data: { source: osm }
-    #    draw:
-    #        polygons:
-    #            order: 0
-    #            color: '#f0ebeb'
-    #landuse:
-    #    data: { source: osm }
-    #    filter:
-    #        name: true
-    #        any:
-    #            - { $zoom: { min: 9 }, area: { min: 10000000 } }
-    #            - { $zoom: { min: 10 }, area: { min: 3300000 } }
-    #            - { $zoom: { min: 12 }, area: { min: 1000000 } }
-    #            - { $zoom: { min: 13 }, area: { min: 10000 } }
-    #            - { $zoom: { min: 15 } }
-    #    draw:
-    #        polygons:
-    #            order: 1
-    #            color: '#fffffa'
-    #            interactive: true # currently ignored
-    #    green:
-    #        filter: { kind: [park, graveyard, cemetery, forest, recreation_ground] }
-    #        draw:
-    #            polygons:
-    #                order: 2
-    #                color: '#89ab84'
-    #    blue:
-    #        filter: { kind: [commercial, industrial] }
-    #        draw:
-    #            polygons:
-    #                color: '#C0CDCD'
-    #    orange:
-    #        filter: { kind: [university] }
-    #        draw:
-    #            polygons:
-    #                color: '#D9CFC3'
+    earth:
+        data: { source: osm }
+        draw:
+            polygons:
+                order: 0
+                color: '#f0ebeb'
+    landuse:
+        data: { source: osm }
+        filter:
+            name: true
+            any:
+                - { $zoom: { min: 9 }, area: { min: 10000000 } }
+                - { $zoom: { min: 10 }, area: { min: 3300000 } }
+                - { $zoom: { min: 12 }, area: { min: 1000000 } }
+                - { $zoom: { min: 13 }, area: { min: 10000 } }
+                - { $zoom: { min: 15 } }
+        draw:
+            polygons:
+                order: 1
+                color: '#fffffa'
+                interactive: true # currently ignored
+        green:
+            filter: { kind: [park, graveyard, cemetery, forest, recreation_ground] }
+            draw:
+                polygons:
+                    order: 2
+                    color: '#89ab84'
+        blue:
+            filter: { kind: [commercial, industrial] }
+            draw:
+                polygons:
+                    color: '#C0CDCD'
+        orange:
+            filter: { kind: [university] }
+            draw:
+                polygons:
+                    color: '#D9CFC3'
 
-    #water:
-    #    data: { source: osm }
-    #    filter:
-    #        any:
-    #            # show smaller water areas at higher zooms
-    #            - { $zoom: { min: 0 }, area: { min: 10000000 } }
-    #            - { $zoom: { min: 10 }, area: { min: 1000000 } }
-    #            - { $zoom: { min: 12 }, area: { min: 100000 } }
-    #            - { $zoom: { min: 15 }, area: { min: 1000 } }
-    #            - { $zoom: { min: 18 } }
-    #    draw:
-    #        flatcolor:
-    #            order: 3
-    #            color: '#8db7d5'
+    water:
+        data: { source: osm }
+        filter:
+            any:
+                # show smaller water areas at higher zooms
+                - { $zoom: { min: 0 }, area: { min: 10000000 } }
+                - { $zoom: { min: 10 }, area: { min: 1000000 } }
+                - { $zoom: { min: 12 }, area: { min: 100000 } }
+                - { $zoom: { min: 15 }, area: { min: 1000 } }
+                - { $zoom: { min: 18 } }
+        draw:
+            flatcolor:
+                order: 3
+                color: '#8db7d5'
 
-    #roads:
-    #    data: { source: osm }
-    #    filter:
-    #        not: { kind: [rail] }
-    #    draw:
-    #        lines:
-    #            color: white
-    #            width: 12.
-    #            order: 'function() { return feature.sort_key + 5 }'
-    #            outline:
-    #                color: [[16, '#999'], [18, '#aaa']]
-    #                width: [[10, 0], [16, 2]]
+    roads:
+        data: { source: osm }
+        filter:
+            not: { kind: [rail] }
+        draw:
+            lines:
+                color: white
+                width: 12.
+                order: 'function() { return feature.sort_key + 5 }'
+                outline:
+                    color: [[16, '#999'], [18, '#aaa']]
+                    width: [[10, 0], [16, 2]]
 
-    #    rounded:
-    #        filter: { $zoom: { min: 18 } }
-    #        draw:
-    #            lines:
-    #                cap: round
-    #    # rail:
-    #    #     filter: { kind: rail }
-    #    #     draw:
-    #    #        lines:
-    #    #           cap: butt
-    #    #           color: '#333'
-    #    #           width: 1.
-    #    #           order: 8
-    #    #           outline:
-    #    #             color: '#555'
-    #    #             width: 1.5
-    #    routes:
-    #        filter: { $zoom: { max: 10 } }
-    #        draw:
-    #            lines:
-    #                color: '#aaa'
-    #                width: 2.
-    #    highway:
-    #        filter: { kind: highway }
-    #        draw:
-    #            lines:
-    #                color: '#D16768'
-    #                width: [[14, 2px], [15, 12]]
-    #                outline:
-    #                    width: [[14, 0], [15, 2]]
-    #        link:
-    #            filter: { is_link: yes }
-    #            draw:
-    #                lines:
-    #                    color: '#aaa'
-    #                    width: [[13, 1px], [14, 12]]
-    #    major_road:
-    #        filter: { kind: major_road, $zoom: { min: 10 } }
-    #        draw:
-    #            lines:
-    #                color: '#aaaaa4'
-    #                width: [[10, 1px], [13, 2px], [14, 2px], [16, 12]]
-    #                outline:
-    #                    width: [[16, 0], [17, 1]]
-    #    minor_road:
-    #        filter: { kind: minor_road }
-    #        draw:
-    #            lines:
-    #                color: '#bbbbb8'
-    #                width: [[13, 1px], [14, 1px], [15, 8]]
-    #                outline:
-    #                    width: [[17, 0], [18, 1]]
-    #    paths:
-    #        filter: { kind: path }
-    #        draw:
-    #            lines:
-    #                color: '#fff'
-    #                width: [[15, 1px], [17, 2px]]
-    #                outline:
-    #                    width: 0
-    #    airports:
-    #        filter: { aeroway: true }
-    #        draw:
-    #            lines:
-    #                color: '#f00'
-    #        taxiways:
-    #            filter: { aeroway: taxiway }
-    #            draw:
-    #                lines:
-    #                    width: [[13, 1px], [14, 2.0], [17, 5.0]]
-    #        runways:
-    #            filter: { aeroway: runway }
-    #            draw:
-    #                lines:
-    #                    color: [[13, '#FFE4B5'], [16, white]]
-    #                    width: [[11, 2.], [12, 3.], [13, 4.], [17, 8.]]
-    #                    order: 39
-    #                    cap: square
-    #                    outline:
-    #                        color: orange
-    #                        width: [[11, 0], [12, 1.], [17, 2.]]
+        rounded:
+            filter: { $zoom: { min: 18 } }
+            draw:
+                lines:
+                    cap: round
+        #rail:
+        #    filter: { kind: rail }
+        #    draw:
+        #       lines:
+        #          cap: butt
+        #          color: '#333'
+        #          width: 1.
+        #          order: 8
+        #          outline:
+        #            color: '#555'
+        #            width: 1.5
+        routes:
+            filter: { $zoom: { max: 10 } }
+            draw:
+                lines:
+                    color: '#aaa'
+                    width: 2.
+        highway:
+            filter: { kind: highway }
+            draw:
+                lines:
+                    color: '#D16768'
+                    width: [[14, 2px], [15, 12]]
+                    outline:
+                        width: [[14, 0], [15, 2]]
+            link:
+                filter: { is_link: yes }
+                draw:
+                    lines:
+                        color: '#aaa'
+                        width: [[13, 1px], [14, 12]]
+        major_road:
+            filter: { kind: major_road, $zoom: { min: 10 } }
+            draw:
+                lines:
+                    color: '#aaaaa4'
+                    width: [[10, 1px], [13, 2px], [14, 2px], [16, 12]]
+                    outline:
+                        width: [[16, 0], [17, 1]]
+        minor_road:
+            filter: { kind: minor_road }
+            draw:
+                lines:
+                    color: '#bbbbb8'
+                    width: [[13, 1px], [14, 1px], [15, 8]]
+                    outline:
+                        width: [[17, 0], [18, 1]]
+        paths:
+            filter: { kind: path }
+            draw:
+                lines:
+                    color: '#fff'
+                    width: [[15, 1px], [17, 2px]]
+                    outline:
+                        width: 0
+        airports:
+            filter: { aeroway: true }
+            draw:
+                lines:
+                    color: '#f00'
+            taxiways:
+                filter: { aeroway: taxiway }
+                draw:
+                    lines:
+                        width: [[13, 1px], [14, 2.0], [17, 5.0]]
+            runways:
+                filter: { aeroway: runway }
+                draw:
+                    lines:
+                        color: [[13, '#FFE4B5'], [16, white]]
+                        width: [[11, 2.], [12, 3.], [13, 4.], [17, 8.]]
+                        order: 39
+                        cap: square
+                        outline:
+                            color: orange
+                            width: [[11, 0], [12, 1.], [17, 2.]]
 
-    #poi_icons:
-    #    data: { source: osm, layer: pois }
-    #    filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
-    #    draw:
-    #        icons:
-    #            interactive: true
-    #            #offset: [0px, -15px]
-    #            size: 20px
-    #            priority: 5
-    #            collide: true
-    #            transition:
-    #                [show, hide]:
-    #                    time: 1s
-    #            #size: [[13, 12px], [15, 18px]]
-    #            #interactive: true
+    poi_icons:
+        data: { source: osm, layer: pois }
+        filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
+        draw:
+            icons:
+                interactive: true
+                #offset: [0px, -15px]
+                size: 20px
+                priority: 5
+                collide: true
+                transition:
+                    [show, hide]:
+                        time: 1s
+                #size: [[13, 12px], [15, 18px]]
+                #interactive: true
 
-    #    # add generic icon at high zoom
-    #    generic:
-    #        filter: { $zoom: { min: 18 } }
-    #        draw:
-    #            icons:
-    #                sprite: function() { return feature.kind; }
-    #                sprite_default: info
-    #                #sprite: info
+        # add generic icon at high zoom
+        generic:
+            filter: { $zoom: { min: 18 } }
+            draw:
+                icons:
+                    sprite: function() { return feature.kind; }
+                    sprite_default: info
+                    #sprite: info
 
-    #    # examples of different icons mapped to feature properties
-    #    icons:
-    #        restaurant:
-    #            filter: { kind: [restaurant] }
-    #            draw: { icons: { sprite: restaurant } }
-    #        cafe:
-    #            filter: { kind: [cafe, convenience] }
-    #            draw: { icons: { sprite: cafe } }
-    #        bar:
-    #            filter: { kind: [bar, pub] }
-    #            draw: { icons: { sprite: bar } }
-    #        culture:
-    #            filter: { kind: [museum, library, church, place_of_worship, bank] }
-    #            draw: { icons: { sprite: museum } }
-    #        station:
-    #            filter: { kind: [station] }
-    #            draw: { icons: { sprite: train } }
-    #        hospital:
-    #            filter: { kind: [hospital, pharmacy] }
-    #            draw: { icons: { sprite: hospital } }
-    #        hotel:
-    #            filter: { kind: [hotel, hostel] }
-    #            draw: { icons: { sprite: hotel } }
-    #        bus_stop:
-    #            filter: { kind: [bus_stop] }
-    #            draw: { icons: { sprite: bus } }
-    #        bookstore:
-    #            filter: { kind: [bookstore] }
-    #            draw: { icons: { sprite: bookstore } }
+        # examples of different icons mapped to feature properties
+        icons:
+            restaurant:
+                filter: { kind: [restaurant] }
+                draw: { icons: { sprite: restaurant } }
+            cafe:
+                filter: { kind: [cafe, convenience] }
+                draw: { icons: { sprite: cafe } }
+            bar:
+                filter: { kind: [bar, pub] }
+                draw: { icons: { sprite: bar } }
+            culture:
+                filter: { kind: [museum, library, church, place_of_worship, bank] }
+                draw: { icons: { sprite: museum } }
+            station:
+                filter: { kind: [station] }
+                draw: { icons: { sprite: train } }
+            hospital:
+                filter: { kind: [hospital, pharmacy] }
+                draw: { icons: { sprite: hospital } }
+            hotel:
+                filter: { kind: [hotel, hostel] }
+                draw: { icons: { sprite: hotel } }
+            bus_stop:
+                filter: { kind: [bus_stop] }
+                draw: { icons: { sprite: bus } }
+            bookstore:
+                filter: { kind: [bookstore] }
+                draw: { icons: { sprite: bookstore } }
 
     buildings:
         data: { source: osm }
@@ -323,161 +321,161 @@ layers:
             draw:
                 polygons:
                     extrude: true
-                #lines:
-                #    style: heightglowline
-                #    width: 1.0
-                #    color: [.75, .75, .73]
-                #    order: 52
-                #    extrude: true
-    #    high-line:
-    #        filter: {roof_material: grass}
-    #        draw:
-    #            polygons:
-    #                style: polygons
-    #                color: '#bddec5'
-    #poi_labels:
-    #    data: { source: osm, layer: pois }
-    #    filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
-    #    draw:
-    #        text:
-    #            interactive: true
-    #            #offset: [0, 12px]
-    #            align: right
-    #            text_wrap: 20
-    #            font:
-    #                family: sans-serif
-    #                weight: 400
-    #                style: normal
-    #                size: 1.2em
-    #                fill: white
-    #road_labels:
-    #    data: {source: osm, layer: roads}
-    #    filter: { name: true, aeroway: false, tunnel: false, railway: false, not: { kind: rail }, $zoom: { min: 10 } }
-    #    draw:
-    #        text:
-    #            interactive: true
-    #            visible: true
-    #            priority: 2
-    #            offset: [0, 8px]
-    #            transition:
-    #                [show, hide]:
-    #                    time: 1s
-    #            offset: [[16, [0, 8px]], [18, [0, 120px]]]
-    #            font:
-    #                family: sans-serif
-    #                weight: 400
-    #                style: normal
-    #                size: 1.em
-    #                fill: black
-    #                stroke: { color: white, width: 2 }
-    #    highway:
-    #        filter: { kind: highway }
-    #        draw:
-    #            text:
-    #                repeat_distance: 200px
-    #                repeat_group: road_labels
-    #                visible: true
-    #                #offset: [0px, 5px]
-    #                priority: 1
-    #                transition:
-    #                    [show, hide]:
-    #                        time: 1s
-    #                font:
-    #                    family: sans-serif
-    #                    weight: 400
-    #                    style: normal
-    #                    size: 25px
-    #                    fill: black
-    #                    transform: capitalize
-    #    major_road:
-    #        filter: { kind: major_road }
-    #        draw:
-    #            text:
-    #                repeat_distance: 100px
-    #                repeat_group: roads
-    #                interactive: true
-    #                visible: true
-    #                priority: 3
-    #                transition:
-    #                    [show, hide]:
-    #                        time: 1s
-    #                font:
-    #                    family: sans-serif
-    #                    weight: 400
-    #                    style: normal
-    #                    size: 20.5pt
-    #places:
-    #    data: { sources: osm }
-    #    filter:
-    #        name: true
-    #        not: { kind: [county, state, island] }
-    #        any:
-    #            - { $zoom: { min: 1 }, kind: ocean }
-    #            - { $zoom: { min: 2, max: 5 }, kind: continent }
-    #            #important contries
-    #            - { $zoom: { min: 4 }, name: ["United States of America", "Brasil", "Россия", "中华人民共和国"] }
-    #            # unimportant countries
-    #            - { $zoom: { min: 5 }, kind: country }
-    #            # this function matches the "cities" sublayer
-    #            #- function() {return (feature.scalerank * .75) <= ($zoom - 4); }
-    #    draw:
-    #        text:
-    #            text_source: [name:en, name, area, volume]
-    #            repeat_distance: 0
-    #            interactive: true
-    #            priority: 5
-    #            transition:
-    #                [show, hide]:
-    #                    time: 1s
-    #            font:
-    #                family: sans-serif
-    #                weight: 400
-    #                style: normal
-    #                size: 15.5px
-    #                fill: black
-    #    continents:
-    #        filter: { kind: continent }
-    #        draw: {}
-    #    countries:
-    #        filter: { kind: country }
-    #        draw: {}
-    #    oceans:
-    #        filter: { kind: ocean }
-    #        draw: {}
-    #    minor-places:
-    #        filter: { kind: [hamlet, village, town, neighbourhood, suburb, quarter], $zoom: { max: 13 } }
-    #        draw: {}
-    #        #visible: false
-    #    #cities:
-    #        # this filter shows lower scaleranks at higher zooms, starting at z4
-    #        #filter: function() { return (feature.scalerank * .75) <= ($zoom - 4); }
-    #landuse_labels:
-    #    data: { source: osm, layer: [landuse_labels, pois] }
-    #    filter:
-    #        name: true
-    #        kind: [park, forest, cemetery, graveyard]
-    #        any:
-    #            # show labels for smaller landuse areas at higher zooms
-    #            - { $zoom: { min: 9 }, area: { min: 100000000 } }
-    #            - { $zoom: { min: 10 }, area: { min: 10000000 } }
-    #            - { $zoom: { min: 12 }, area: { min: 1000000 } }
-    #            - { $zoom: { min: 15 }, area: { min: 10000 } }
-    #            - { $zoom: { min: 18 } }
-    #    draw:
-    #        text:
-    #            interactive: true
-    #            priority: 0
-    #            transition:
-    #                [show, hide]:
-    #                    time: 1s
-    #            font:
-    #                family: sans-serif
-    #                weight: 400
-    #                style: normal
-    #                size: 20px
-    #                fill: darkgreen
+                lines:
+                    style: heightglowline
+                    width: 1.0
+                    color: [.75, .75, .73]
+                    order: 52
+                    extrude: true
+        high-line:
+            filter: {roof_material: grass}
+            draw:
+                polygons:
+                    style: polygons
+                    color: '#bddec5'
+    poi_labels:
+        data: { source: osm, layer: pois }
+        filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
+        draw:
+            text:
+                interactive: true
+                #offset: [0, 12px]
+                align: right
+                text_wrap: 20
+                font:
+                    family: sans-serif
+                    weight: 400
+                    style: normal
+                    size: 1.2em
+                    fill: white
+    road_labels:
+        data: {source: osm, layer: roads}
+        filter: { name: true, aeroway: false, tunnel: false, railway: false, not: { kind: rail }, $zoom: { min: 10 } }
+        draw:
+            text:
+                interactive: true
+                visible: true
+                priority: 2
+                offset: [0, 8px]
+                transition:
+                    [show, hide]:
+                        time: 1s
+                offset: [[16, [0, 8px]], [18, [0, 120px]]]
+                font:
+                    family: sans-serif
+                    weight: 400
+                    style: normal
+                    size: 1.em
+                    fill: black
+                    stroke: { color: white, width: 2 }
+        highway:
+            filter: { kind: highway }
+            draw:
+                text:
+                    repeat_distance: 200px
+                    repeat_group: road_labels
+                    visible: true
+                    #offset: [0px, 5px]
+                    priority: 1
+                    transition:
+                        [show, hide]:
+                            time: 1s
+                    font:
+                        family: sans-serif
+                        weight: 400
+                        style: normal
+                        size: 25px
+                        fill: black
+                        transform: capitalize
+        major_road:
+            filter: { kind: major_road }
+            draw:
+                text:
+                    repeat_distance: 100px
+                    repeat_group: roads
+                    interactive: true
+                    visible: true
+                    priority: 3
+                    transition:
+                        [show, hide]:
+                            time: 1s
+                    font:
+                        family: sans-serif
+                        weight: 400
+                        style: normal
+                        size: 20.5pt
+    places:
+        data: { sources: osm }
+        filter:
+            name: true
+            not: { kind: [county, state, island] }
+            any:
+                - { $zoom: { min: 1 }, kind: ocean }
+                - { $zoom: { min: 2, max: 5 }, kind: continent }
+                #important contries
+                - { $zoom: { min: 4 }, name: ["United States of America", "Brasil", "Россия", "中华人民共和国"] }
+                # unimportant countries
+                - { $zoom: { min: 5 }, kind: country }
+                # this function matches the "cities" sublayer
+                #- function() {return (feature.scalerank * .75) <= ($zoom - 4); }
+        draw:
+            text:
+                text_source: [name:en, name, area, volume]
+                repeat_distance: 0
+                interactive: true
+                priority: 5
+                transition:
+                    [show, hide]:
+                        time: 1s
+                font:
+                    family: sans-serif
+                    weight: 400
+                    style: normal
+                    size: 15.5px
+                    fill: black
+        continents:
+            filter: { kind: continent }
+            draw: {}
+        countries:
+            filter: { kind: country }
+            draw: {}
+        oceans:
+            filter: { kind: ocean }
+            draw: {}
+        minor-places:
+            filter: { kind: [hamlet, village, town, neighbourhood, suburb, quarter], $zoom: { max: 13 } }
+            draw: {}
+            #visible: false
+        #cities:
+            # this filter shows lower scaleranks at higher zooms, starting at z4
+            #filter: function() { return (feature.scalerank * .75) <= ($zoom - 4); }
+    landuse_labels:
+        data: { source: osm, layer: [landuse_labels, pois] }
+        filter:
+            name: true
+            kind: [park, forest, cemetery, graveyard]
+            any:
+                # show labels for smaller landuse areas at higher zooms
+                - { $zoom: { min: 9 }, area: { min: 100000000 } }
+                - { $zoom: { min: 10 }, area: { min: 10000000 } }
+                - { $zoom: { min: 12 }, area: { min: 1000000 } }
+                - { $zoom: { min: 15 }, area: { min: 10000 } }
+                - { $zoom: { min: 18 } }
+        draw:
+            text:
+                interactive: true
+                priority: 0
+                transition:
+                    [show, hide]:
+                        time: 1s
+                font:
+                    family: sans-serif
+                    weight: 400
+                    style: normal
+                    size: 20px
+                    fill: darkgreen
 
-    #pois:
-    #    data: { source: osm }
-    #    draw:
-    #        icons: {}
+    pois:
+        data: { source: osm }
+        draw:
+            icons: {}

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -57,7 +57,7 @@ styles:
         shaders:
             uniforms:
                 u_test: [0.5, 0.5, 1.0, 0.5, 0.9]
-                u_textures: [texture0, texture1]
+                u_textures: [texture0s, texture1]
             blocks:
                 color: "color.rgb *= mix(texture2D(u_textures[1], v_texcoord).rgb, vec3(u_test[0], u_test[1], u_test[4]), 0.5);"
     heightglowline:

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -48,26 +48,26 @@ textures:
         url: img/sem.jpg
 
 styles:
-    flatcolor:
-        base: polygons
-        #lighting: false
+    #flatcolor:
+    #    base: polygons
+    #    #lighting: false
     heightglow:
         base: polygons
         #lighting: vertex
         texcoords: true
         shaders:
             uniforms:
-                u_test: [0.5, 0.5, 0.5, 0.5, 0.9]
+                u_test: [0.5, 0.5, 1.0, 0.5, 0.9]
                 u_textures: [texture0, texture1]
             blocks:
                 #color: "color.rgb *= u_test[4];"
-                color: "color.rgb *= texture2D(u_textures[0], v_texcoord).rgb;"
-    heightglowline:
-        base: lines
-        mix: heightglow
-    icons:
-        base: points
-        texture: pois
+                color: "color.rgb *= mix(texture2D(u_textures[1], v_texcoord).rgb, vec3(u_test[0], u_test[1], u_test[4]), 0.5);"
+    #heightglowline:
+    #    base: lines
+    ##    mix: heightglow
+    #icons:
+    #    base: points
+    #    texture: pois
 
 sources:
     osm:
@@ -76,233 +76,233 @@ sources:
         max_zoom: 18
 
 layers:
-    touch:
-        data: { source: touch }
-        line:
-          filter: { type: line }
-          draw:
-            lines:
-              color: function () { return feature.color || 'black'; }
-              order: 50
-              width: 2px
-        poly:
-            filter: { type: poly }
-            draw:
-              polygons:
-                color: magenta
-                order: 40
-        point:
-            filter: { type: point }
-            draw:
-              icons:
-                sprite: sunburst
-                collide: false
-                transition:
-                    [show, hide]:
-                        time: 0s
+    #touch:
+    #    data: { source: touch }
+    #    line:
+    #      filter: { type: line }
+    #      draw:
+    #        lines:
+    #          color: function () { return feature.color || 'black'; }
+    #          order: 50
+    #          width: 2px
+    #    poly:
+    #        filter: { type: poly }
+    #        draw:
+    #          polygons:
+    #            color: magenta
+    #            order: 40
+    #    point:
+    #        filter: { type: point }
+    #        draw:
+    #          icons:
+    #            sprite: sunburst
+    #            collide: false
+    #            transition:
+    #                [show, hide]:
+    #                    time: 0s
 
-    earth:
-        data: { source: osm }
-        draw:
-            polygons:
-                order: 0
-                color: '#f0ebeb'
-    landuse:
-        data: { source: osm }
-        filter:
-            name: true
-            any:
-                - { $zoom: { min: 9 }, area: { min: 10000000 } }
-                - { $zoom: { min: 10 }, area: { min: 3300000 } }
-                - { $zoom: { min: 12 }, area: { min: 1000000 } }
-                - { $zoom: { min: 13 }, area: { min: 10000 } }
-                - { $zoom: { min: 15 } }
-        draw:
-            polygons:
-                order: 1
-                color: '#fffffa'
-                interactive: true # currently ignored
-        green:
-            filter: { kind: [park, graveyard, cemetery, forest, recreation_ground] }
-            draw:
-                polygons:
-                    order: 2
-                    color: '#89ab84'
-        blue:
-            filter: { kind: [commercial, industrial] }
-            draw:
-                polygons:
-                    color: '#C0CDCD'
-        orange:
-            filter: { kind: [university] }
-            draw:
-                polygons:
-                    color: '#D9CFC3'
+    #earth:
+    #    data: { source: osm }
+    #    draw:
+    #        polygons:
+    #            order: 0
+    #            color: '#f0ebeb'
+    #landuse:
+    #    data: { source: osm }
+    #    filter:
+    #        name: true
+    #        any:
+    #            - { $zoom: { min: 9 }, area: { min: 10000000 } }
+    #            - { $zoom: { min: 10 }, area: { min: 3300000 } }
+    #            - { $zoom: { min: 12 }, area: { min: 1000000 } }
+    #            - { $zoom: { min: 13 }, area: { min: 10000 } }
+    #            - { $zoom: { min: 15 } }
+    #    draw:
+    #        polygons:
+    #            order: 1
+    #            color: '#fffffa'
+    #            interactive: true # currently ignored
+    #    green:
+    #        filter: { kind: [park, graveyard, cemetery, forest, recreation_ground] }
+    #        draw:
+    #            polygons:
+    #                order: 2
+    #                color: '#89ab84'
+    #    blue:
+    #        filter: { kind: [commercial, industrial] }
+    #        draw:
+    #            polygons:
+    #                color: '#C0CDCD'
+    #    orange:
+    #        filter: { kind: [university] }
+    #        draw:
+    #            polygons:
+    #                color: '#D9CFC3'
 
-    water:
-        data: { source: osm }
-        filter:
-            any:
-                # show smaller water areas at higher zooms
-                - { $zoom: { min: 0 }, area: { min: 10000000 } }
-                - { $zoom: { min: 10 }, area: { min: 1000000 } }
-                - { $zoom: { min: 12 }, area: { min: 100000 } }
-                - { $zoom: { min: 15 }, area: { min: 1000 } }
-                - { $zoom: { min: 18 } }
-        draw:
-            flatcolor:
-                order: 3
-                color: '#8db7d5'
+    #water:
+    #    data: { source: osm }
+    #    filter:
+    #        any:
+    #            # show smaller water areas at higher zooms
+    #            - { $zoom: { min: 0 }, area: { min: 10000000 } }
+    #            - { $zoom: { min: 10 }, area: { min: 1000000 } }
+    #            - { $zoom: { min: 12 }, area: { min: 100000 } }
+    #            - { $zoom: { min: 15 }, area: { min: 1000 } }
+    #            - { $zoom: { min: 18 } }
+    #    draw:
+    #        flatcolor:
+    #            order: 3
+    #            color: '#8db7d5'
 
-    roads:
-        data: { source: osm }
-        filter:
-            not: { kind: [rail] }
-        draw:
-            lines:
-                color: white
-                width: 12.
-                order: 'function() { return feature.sort_key + 5 }'
-                outline:
-                    color: [[16, '#999'], [18, '#aaa']]
-                    width: [[10, 0], [16, 2]]
+    #roads:
+    #    data: { source: osm }
+    #    filter:
+    #        not: { kind: [rail] }
+    #    draw:
+    #        lines:
+    #            color: white
+    #            width: 12.
+    #            order: 'function() { return feature.sort_key + 5 }'
+    #            outline:
+    #                color: [[16, '#999'], [18, '#aaa']]
+    #                width: [[10, 0], [16, 2]]
 
-        rounded:
-            filter: { $zoom: { min: 18 } }
-            draw:
-                lines:
-                    cap: round
-        # rail:
-        #     filter: { kind: rail }
-        #     draw:
-        #        lines:
-        #           cap: butt
-        #           color: '#333'
-        #           width: 1.
-        #           order: 8
-        #           outline:
-        #             color: '#555'
-        #             width: 1.5
-        routes:
-            filter: { $zoom: { max: 10 } }
-            draw:
-                lines:
-                    color: '#aaa'
-                    width: 2.
-        highway:
-            filter: { kind: highway }
-            draw:
-                lines:
-                    color: '#D16768'
-                    width: [[14, 2px], [15, 12]]
-                    outline:
-                        width: [[14, 0], [15, 2]]
-            link:
-                filter: { is_link: yes }
-                draw:
-                    lines:
-                        color: '#aaa'
-                        width: [[13, 1px], [14, 12]]
-        major_road:
-            filter: { kind: major_road, $zoom: { min: 10 } }
-            draw:
-                lines:
-                    color: '#aaaaa4'
-                    width: [[10, 1px], [13, 2px], [14, 2px], [16, 12]]
-                    outline:
-                        width: [[16, 0], [17, 1]]
-        minor_road:
-            filter: { kind: minor_road }
-            draw:
-                lines:
-                    color: '#bbbbb8'
-                    width: [[13, 1px], [14, 1px], [15, 8]]
-                    outline:
-                        width: [[17, 0], [18, 1]]
-        paths:
-            filter: { kind: path }
-            draw:
-                lines:
-                    color: '#fff'
-                    width: [[15, 1px], [17, 2px]]
-                    outline:
-                        width: 0
-        airports:
-            filter: { aeroway: true }
-            draw:
-                lines:
-                    color: '#f00'
-            taxiways:
-                filter: { aeroway: taxiway }
-                draw:
-                    lines:
-                        width: [[13, 1px], [14, 2.0], [17, 5.0]]
-            runways:
-                filter: { aeroway: runway }
-                draw:
-                    lines:
-                        color: [[13, '#FFE4B5'], [16, white]]
-                        width: [[11, 2.], [12, 3.], [13, 4.], [17, 8.]]
-                        order: 39
-                        cap: square
-                        outline:
-                            color: orange
-                            width: [[11, 0], [12, 1.], [17, 2.]]
+    #    rounded:
+    #        filter: { $zoom: { min: 18 } }
+    #        draw:
+    #            lines:
+    #                cap: round
+    #    # rail:
+    #    #     filter: { kind: rail }
+    #    #     draw:
+    #    #        lines:
+    #    #           cap: butt
+    #    #           color: '#333'
+    #    #           width: 1.
+    #    #           order: 8
+    #    #           outline:
+    #    #             color: '#555'
+    #    #             width: 1.5
+    #    routes:
+    #        filter: { $zoom: { max: 10 } }
+    #        draw:
+    #            lines:
+    #                color: '#aaa'
+    #                width: 2.
+    #    highway:
+    #        filter: { kind: highway }
+    #        draw:
+    #            lines:
+    #                color: '#D16768'
+    #                width: [[14, 2px], [15, 12]]
+    #                outline:
+    #                    width: [[14, 0], [15, 2]]
+    #        link:
+    #            filter: { is_link: yes }
+    #            draw:
+    #                lines:
+    #                    color: '#aaa'
+    #                    width: [[13, 1px], [14, 12]]
+    #    major_road:
+    #        filter: { kind: major_road, $zoom: { min: 10 } }
+    #        draw:
+    #            lines:
+    #                color: '#aaaaa4'
+    #                width: [[10, 1px], [13, 2px], [14, 2px], [16, 12]]
+    #                outline:
+    #                    width: [[16, 0], [17, 1]]
+    #    minor_road:
+    #        filter: { kind: minor_road }
+    #        draw:
+    #            lines:
+    #                color: '#bbbbb8'
+    #                width: [[13, 1px], [14, 1px], [15, 8]]
+    #                outline:
+    #                    width: [[17, 0], [18, 1]]
+    #    paths:
+    #        filter: { kind: path }
+    #        draw:
+    #            lines:
+    #                color: '#fff'
+    #                width: [[15, 1px], [17, 2px]]
+    #                outline:
+    #                    width: 0
+    #    airports:
+    #        filter: { aeroway: true }
+    #        draw:
+    #            lines:
+    #                color: '#f00'
+    #        taxiways:
+    #            filter: { aeroway: taxiway }
+    #            draw:
+    #                lines:
+    #                    width: [[13, 1px], [14, 2.0], [17, 5.0]]
+    #        runways:
+    #            filter: { aeroway: runway }
+    #            draw:
+    #                lines:
+    #                    color: [[13, '#FFE4B5'], [16, white]]
+    #                    width: [[11, 2.], [12, 3.], [13, 4.], [17, 8.]]
+    #                    order: 39
+    #                    cap: square
+    #                    outline:
+    #                        color: orange
+    #                        width: [[11, 0], [12, 1.], [17, 2.]]
 
-    poi_icons:
-        data: { source: osm, layer: pois }
-        filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
-        draw:
-            icons:
-                interactive: true
-                #offset: [0px, -15px]
-                size: 20px
-                priority: 5
-                collide: true
-                transition:
-                    [show, hide]:
-                        time: 1s
-                #size: [[13, 12px], [15, 18px]]
-                #interactive: true
+    #poi_icons:
+    #    data: { source: osm, layer: pois }
+    #    filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
+    #    draw:
+    #        icons:
+    #            interactive: true
+    #            #offset: [0px, -15px]
+    #            size: 20px
+    #            priority: 5
+    #            collide: true
+    #            transition:
+    #                [show, hide]:
+    #                    time: 1s
+    #            #size: [[13, 12px], [15, 18px]]
+    #            #interactive: true
 
-        # add generic icon at high zoom
-        generic:
-            filter: { $zoom: { min: 18 } }
-            draw:
-                icons:
-                    sprite: function() { return feature.kind; }
-                    sprite_default: info
-                    #sprite: info
+    #    # add generic icon at high zoom
+    #    generic:
+    #        filter: { $zoom: { min: 18 } }
+    #        draw:
+    #            icons:
+    #                sprite: function() { return feature.kind; }
+    #                sprite_default: info
+    #                #sprite: info
 
-        # examples of different icons mapped to feature properties
-        icons:
-            restaurant:
-                filter: { kind: [restaurant] }
-                draw: { icons: { sprite: restaurant } }
-            cafe:
-                filter: { kind: [cafe, convenience] }
-                draw: { icons: { sprite: cafe } }
-            bar:
-                filter: { kind: [bar, pub] }
-                draw: { icons: { sprite: bar } }
-            culture:
-                filter: { kind: [museum, library, church, place_of_worship, bank] }
-                draw: { icons: { sprite: museum } }
-            station:
-                filter: { kind: [station] }
-                draw: { icons: { sprite: train } }
-            hospital:
-                filter: { kind: [hospital, pharmacy] }
-                draw: { icons: { sprite: hospital } }
-            hotel:
-                filter: { kind: [hotel, hostel] }
-                draw: { icons: { sprite: hotel } }
-            bus_stop:
-                filter: { kind: [bus_stop] }
-                draw: { icons: { sprite: bus } }
-            bookstore:
-                filter: { kind: [bookstore] }
-                draw: { icons: { sprite: bookstore } }
+    #    # examples of different icons mapped to feature properties
+    #    icons:
+    #        restaurant:
+    #            filter: { kind: [restaurant] }
+    #            draw: { icons: { sprite: restaurant } }
+    #        cafe:
+    #            filter: { kind: [cafe, convenience] }
+    #            draw: { icons: { sprite: cafe } }
+    #        bar:
+    #            filter: { kind: [bar, pub] }
+    #            draw: { icons: { sprite: bar } }
+    #        culture:
+    #            filter: { kind: [museum, library, church, place_of_worship, bank] }
+    #            draw: { icons: { sprite: museum } }
+    #        station:
+    #            filter: { kind: [station] }
+    #            draw: { icons: { sprite: train } }
+    #        hospital:
+    #            filter: { kind: [hospital, pharmacy] }
+    #            draw: { icons: { sprite: hospital } }
+    #        hotel:
+    #            filter: { kind: [hotel, hostel] }
+    #            draw: { icons: { sprite: hotel } }
+    #        bus_stop:
+    #            filter: { kind: [bus_stop] }
+    #            draw: { icons: { sprite: bus } }
+    #        bookstore:
+    #            filter: { kind: [bookstore] }
+    #            draw: { icons: { sprite: bookstore } }
 
     buildings:
         data: { source: osm }
@@ -323,161 +323,161 @@ layers:
             draw:
                 polygons:
                     extrude: true
-                lines:
-                    style: heightglowline
-                    width: 1.0
-                    color: [.75, .75, .73]
-                    order: 52
-                    extrude: true
-        high-line:
-            filter: {roof_material: grass}
-            draw:
-                polygons:
-                    style: polygons
-                    color: '#bddec5'
-    poi_labels:
-        data: { source: osm, layer: pois }
-        filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
-        draw:
-            text:
-                interactive: true
-                #offset: [0, 12px]
-                align: right
-                text_wrap: 20
-                font:
-                    family: sans-serif
-                    weight: 400
-                    style: normal
-                    size: 1.2em
-                    fill: white
-    road_labels:
-        data: {source: osm, layer: roads}
-        filter: { name: true, aeroway: false, tunnel: false, railway: false, not: { kind: rail }, $zoom: { min: 10 } }
-        draw:
-            text:
-                interactive: true
-                visible: true
-                priority: 2
-                offset: [0, 8px]
-                transition:
-                    [show, hide]:
-                        time: 1s
-                offset: [[16, [0, 8px]], [18, [0, 120px]]]
-                font:
-                    family: sans-serif
-                    weight: 400
-                    style: normal
-                    size: 1.em
-                    fill: black
-                    stroke: { color: white, width: 2 }
-        highway:
-            filter: { kind: highway }
-            draw:
-                text:
-                    repeat_distance: 200px
-                    repeat_group: road_labels
-                    visible: true
-                    #offset: [0px, 5px]
-                    priority: 1
-                    transition:
-                        [show, hide]:
-                            time: 1s
-                    font:
-                        family: sans-serif
-                        weight: 400
-                        style: normal
-                        size: 25px
-                        fill: black
-                        transform: capitalize
-        major_road:
-            filter: { kind: major_road }
-            draw:
-                text:
-                    repeat_distance: 100px
-                    repeat_group: roads
-                    interactive: true
-                    visible: true
-                    priority: 3
-                    transition:
-                        [show, hide]:
-                            time: 1s
-                    font:
-                        family: sans-serif
-                        weight: 400
-                        style: normal
-                        size: 20.5pt
-    places:
-        data: { sources: osm }
-        filter:
-            name: true
-            not: { kind: [county, state, island] }
-            any:
-                - { $zoom: { min: 1 }, kind: ocean }
-                - { $zoom: { min: 2, max: 5 }, kind: continent }
-                #important contries
-                - { $zoom: { min: 4 }, name: ["United States of America", "Brasil", "Россия", "中华人民共和国"] }
-                # unimportant countries
-                - { $zoom: { min: 5 }, kind: country }
-                # this function matches the "cities" sublayer
-                #- function() {return (feature.scalerank * .75) <= ($zoom - 4); }
-        draw:
-            text:
-                text_source: [name:en, name, area, volume]
-                repeat_distance: 0
-                interactive: true
-                priority: 5
-                transition:
-                    [show, hide]:
-                        time: 1s
-                font:
-                    family: sans-serif
-                    weight: 400
-                    style: normal
-                    size: 15.5px
-                    fill: black
-        continents:
-            filter: { kind: continent }
-            draw: {}
-        countries:
-            filter: { kind: country }
-            draw: {}
-        oceans:
-            filter: { kind: ocean }
-            draw: {}
-        minor-places:
-            filter: { kind: [hamlet, village, town, neighbourhood, suburb, quarter], $zoom: { max: 13 } }
-            draw: {}
-            #visible: false
-        #cities:
-            # this filter shows lower scaleranks at higher zooms, starting at z4
-            #filter: function() { return (feature.scalerank * .75) <= ($zoom - 4); }
-    landuse_labels:
-        data: { source: osm, layer: [landuse_labels, pois] }
-        filter:
-            name: true
-            kind: [park, forest, cemetery, graveyard]
-            any:
-                # show labels for smaller landuse areas at higher zooms
-                - { $zoom: { min: 9 }, area: { min: 100000000 } }
-                - { $zoom: { min: 10 }, area: { min: 10000000 } }
-                - { $zoom: { min: 12 }, area: { min: 1000000 } }
-                - { $zoom: { min: 15 }, area: { min: 10000 } }
-                - { $zoom: { min: 18 } }
-        draw:
-            text:
-                interactive: true
-                priority: 0
-                transition:
-                    [show, hide]:
-                        time: 1s
-                font:
-                    family: sans-serif
-                    weight: 400
-                    style: normal
-                    size: 20px
-                    fill: darkgreen
+                #lines:
+                #    style: heightglowline
+                #    width: 1.0
+                #    color: [.75, .75, .73]
+                #    order: 52
+                #    extrude: true
+    #    high-line:
+    #        filter: {roof_material: grass}
+    #        draw:
+    #            polygons:
+    #                style: polygons
+    #                color: '#bddec5'
+    #poi_labels:
+    #    data: { source: osm, layer: pois }
+    #    filter: { name: true, not: { kind: [peak, viewpoint, bicycle_rental, car_sharing] }, $zoom: { min: 15 } }
+    #    draw:
+    #        text:
+    #            interactive: true
+    #            #offset: [0, 12px]
+    #            align: right
+    #            text_wrap: 20
+    #            font:
+    #                family: sans-serif
+    #                weight: 400
+    #                style: normal
+    #                size: 1.2em
+    #                fill: white
+    #road_labels:
+    #    data: {source: osm, layer: roads}
+    #    filter: { name: true, aeroway: false, tunnel: false, railway: false, not: { kind: rail }, $zoom: { min: 10 } }
+    #    draw:
+    #        text:
+    #            interactive: true
+    #            visible: true
+    #            priority: 2
+    #            offset: [0, 8px]
+    #            transition:
+    #                [show, hide]:
+    #                    time: 1s
+    #            offset: [[16, [0, 8px]], [18, [0, 120px]]]
+    #            font:
+    #                family: sans-serif
+    #                weight: 400
+    #                style: normal
+    #                size: 1.em
+    #                fill: black
+    #                stroke: { color: white, width: 2 }
+    #    highway:
+    #        filter: { kind: highway }
+    #        draw:
+    #            text:
+    #                repeat_distance: 200px
+    #                repeat_group: road_labels
+    #                visible: true
+    #                #offset: [0px, 5px]
+    #                priority: 1
+    #                transition:
+    #                    [show, hide]:
+    #                        time: 1s
+    #                font:
+    #                    family: sans-serif
+    #                    weight: 400
+    #                    style: normal
+    #                    size: 25px
+    #                    fill: black
+    #                    transform: capitalize
+    #    major_road:
+    #        filter: { kind: major_road }
+    #        draw:
+    #            text:
+    #                repeat_distance: 100px
+    #                repeat_group: roads
+    #                interactive: true
+    #                visible: true
+    #                priority: 3
+    #                transition:
+    #                    [show, hide]:
+    #                        time: 1s
+    #                font:
+    #                    family: sans-serif
+    #                    weight: 400
+    #                    style: normal
+    #                    size: 20.5pt
+    #places:
+    #    data: { sources: osm }
+    #    filter:
+    #        name: true
+    #        not: { kind: [county, state, island] }
+    #        any:
+    #            - { $zoom: { min: 1 }, kind: ocean }
+    #            - { $zoom: { min: 2, max: 5 }, kind: continent }
+    #            #important contries
+    #            - { $zoom: { min: 4 }, name: ["United States of America", "Brasil", "Россия", "中华人民共和国"] }
+    #            # unimportant countries
+    #            - { $zoom: { min: 5 }, kind: country }
+    #            # this function matches the "cities" sublayer
+    #            #- function() {return (feature.scalerank * .75) <= ($zoom - 4); }
+    #    draw:
+    #        text:
+    #            text_source: [name:en, name, area, volume]
+    #            repeat_distance: 0
+    #            interactive: true
+    #            priority: 5
+    #            transition:
+    #                [show, hide]:
+    #                    time: 1s
+    #            font:
+    #                family: sans-serif
+    #                weight: 400
+    #                style: normal
+    #                size: 15.5px
+    #                fill: black
+    #    continents:
+    #        filter: { kind: continent }
+    #        draw: {}
+    #    countries:
+    #        filter: { kind: country }
+    #        draw: {}
+    #    oceans:
+    #        filter: { kind: ocean }
+    #        draw: {}
+    #    minor-places:
+    #        filter: { kind: [hamlet, village, town, neighbourhood, suburb, quarter], $zoom: { max: 13 } }
+    #        draw: {}
+    #        #visible: false
+    #    #cities:
+    #        # this filter shows lower scaleranks at higher zooms, starting at z4
+    #        #filter: function() { return (feature.scalerank * .75) <= ($zoom - 4); }
+    #landuse_labels:
+    #    data: { source: osm, layer: [landuse_labels, pois] }
+    #    filter:
+    #        name: true
+    #        kind: [park, forest, cemetery, graveyard]
+    #        any:
+    #            # show labels for smaller landuse areas at higher zooms
+    #            - { $zoom: { min: 9 }, area: { min: 100000000 } }
+    #            - { $zoom: { min: 10 }, area: { min: 10000000 } }
+    #            - { $zoom: { min: 12 }, area: { min: 1000000 } }
+    #            - { $zoom: { min: 15 }, area: { min: 10000 } }
+    #            - { $zoom: { min: 18 } }
+    #    draw:
+    #        text:
+    #            interactive: true
+    #            priority: 0
+    #            transition:
+    #                [show, hide]:
+    #                    time: 1s
+    #            font:
+    #                family: sans-serif
+    #                weight: 400
+    #                style: normal
+    #                size: 20px
+    #                fill: darkgreen
 
-    pois:
-        data: { source: osm }
-        draw:
-            icons: {}
+    #pois:
+    #    data: { source: osm }
+    #    draw:
+    #        icons: {}

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -43,7 +43,7 @@ textures:
             hotel: [0, 259, 32, 32]
             bookstore: [0, 333, 32, 32]
     texture0:
-        url: img/cross.png
+        url: img/poi_icons_32.png
     texture1:
         url: img/sem.jpg
 

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -42,27 +42,20 @@ textures:
             info: [0, 1110, 32, 32]
             hotel: [0, 259, 32, 32]
             bookstore: [0, 333, 32, 32]
-    texture0:
-        url: img/poi_icons_32.png
-    texture1:
-        url: img/sem.jpg
 
 styles:
     flatcolor:
         base: polygons
+        lighting: false
     heightglow:
         base: polygons
-        #lighting: vertex
-        texcoords: true
+        lighting: vertex
         shaders:
-            uniforms:
-                u_test: [0.5, 0.5, 1.0, 0.5, 0.9]
-                u_textures: [texture0, texture1]
             blocks:
-                color: "color.rgb *= mix(texture2D(u_textures[1], v_texcoord).rgb, vec3(u_test[0], u_test[1], u_test[4]), 0.5);"
+                color: "color.rgb += vec3(position.z / 800.);"
     heightglowline:
         base: lines
-    #    mix: heightglow
+        mix: heightglow
     icons:
         base: points
         texture: pois
@@ -170,17 +163,17 @@ layers:
             draw:
                 lines:
                     cap: round
-        #rail:
-        #    filter: { kind: rail }
-        #    draw:
-        #       lines:
-        #          cap: butt
-        #          color: '#333'
-        #          width: 1.
-        #          order: 8
-        #          outline:
-        #            color: '#555'
-        #            width: 1.5
+        # rail:
+        #     filter: { kind: rail }
+        #     draw:
+        #        lines:
+        #           cap: butt
+        #           color: '#333'
+        #           width: 1.
+        #           order: 8
+        #           outline:
+        #             color: '#555'
+        #             width: 1.5
         routes:
             filter: { $zoom: { max: 10 } }
             draw:

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -51,8 +51,11 @@ styles:
         base: polygons
         lighting: vertex
         shaders:
+            uniforms:
+                u_test: [0.5, 0.5, 0.5, 0.5, 0.9]
+                #u_vec: [0.5, 0.5, 0.5]
             blocks:
-                color: "color.rgb += vec3(position.z / 800.);"
+                color: "color.rgb *= u_test[4];"
     heightglowline:
         base: lines
         mix: heightglow

--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -57,7 +57,7 @@ styles:
         shaders:
             uniforms:
                 u_test: [0.5, 0.5, 1.0, 0.5, 0.9]
-                u_textures: [texture0s, texture1]
+                u_textures: [texture0, texture1]
             blocks:
                 color: "color.rgb *= mix(texture2D(u_textures[1], v_texcoord).rgb, vec3(u_test[0], u_test[1], u_test[4]), 0.5);"
     heightglowline:

--- a/core/src/gl.h
+++ b/core/src/gl.h
@@ -267,6 +267,7 @@ typedef char            GLchar;
 #define GL_READ_WRITE                   0x88BA
 
 #define GL_MAX_TEXTURE_SIZE             0x0D33
+#define GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS 0x8B4D
 
 #ifdef PLATFORM_ANDROID
 #define GL_APICALL  __attribute__((visibility("default")))

--- a/core/src/gl/hardware.cpp
+++ b/core/src/gl/hardware.cpp
@@ -15,6 +15,7 @@ bool supportsVAOs = false;
 bool supportsTextureNPOT = false;
 
 uint32_t maxTextureSize = 0;
+uint32_t maxCombinedTextureUnits = 0;
 static char* s_glExtensions;
 
 bool isAvailable(std::string _extension) {
@@ -64,7 +65,11 @@ void loadCapabilities() {
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &val);
     maxTextureSize = val;
 
+    glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &val);
+    maxCombinedTextureUnits = val;
+
     LOG("Hardware max texture size %d", maxTextureSize);
+    LOG("Hardware max combined texture units %d", maxCombinedTextureUnits);
 }
 
 }

--- a/core/src/gl/hardware.h
+++ b/core/src/gl/hardware.h
@@ -9,6 +9,7 @@ extern bool supportsMapBuffer;
 extern bool supportsVAOs;
 extern bool supportsTextureNPOT;
 extern uint32_t maxTextureSize;
+extern uint32_t maxCombinedTextureUnits;
 
 void loadCapabilities();
 void loadExtensions();

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -2,6 +2,7 @@
 
 #include "platform.h"
 #include "vertexLayout.h"
+#include "gl/hardware.h"
 
 namespace Tangram {
 
@@ -35,10 +36,6 @@ namespace RenderState {
     ClearColor clearColor;
 
     GLuint getTextureUnit(GLuint _unit) {
-        if (_unit >= TANGRAM_MAX_TEXTURE_UNIT) {
-            LOGW("trying to access unavailable texture unit");
-        }
-
         return GL_TEXTURE0 + _unit;
     }
 
@@ -85,6 +82,11 @@ namespace RenderState {
     }
 
     int nextAvailableTextureUnit() {
+        if (s_textureUnit + 1 > Hardware::maxCombinedTextureUnits) {
+            LOGE("Too many combined texture units are being used");
+            LOGE("GPU supports %d combined texture units", Hardware::maxCombinedTextureUnits);
+        }
+
         return ++s_textureUnit;
     }
 

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -7,6 +7,7 @@ namespace Tangram {
 
  // Incremented when the GL context is invalidated
 static int s_validGeneration;
+static int s_textureUnit;
 
 namespace RenderState {
 
@@ -47,6 +48,7 @@ namespace RenderState {
     void bindTexture(GLenum _target, GLuint _textureId) { glBindTexture(_target, _textureId); }
 
     void configure() {
+        s_textureUnit = -1;
         s_validGeneration++;
         VertexLayout::clearCache();
 
@@ -63,13 +65,15 @@ namespace RenderState {
         glClearDepthf(1.0);
         glDepthRangef(0.0, 1.0);
 
+        static size_t max = std::numeric_limits<size_t>::max();
+
         clearColor.init(0.0, 0.0, 0.0, 0.0);
-        shaderProgram.init(std::numeric_limits<unsigned int>::max(), false);
-        vertexBuffer.init(std::numeric_limits<unsigned int>::max(), false);
-        indexBuffer.init(std::numeric_limits<unsigned int>::max(), false);
-        texture.init(GL_TEXTURE_2D, std::numeric_limits<unsigned int>::max(), false);
-        texture.init(GL_TEXTURE_CUBE_MAP, std::numeric_limits<unsigned int>::max(), false);
-        textureUnit.init(std::numeric_limits<unsigned int>::max(), false);
+        shaderProgram.init(max, false);
+        vertexBuffer.init(max, false);
+        indexBuffer.init(max, false);
+        texture.init(GL_TEXTURE_2D, max, false);
+        texture.init(GL_TEXTURE_CUBE_MAP, max, false);
+        textureUnit.init(max, false);
     }
 
     bool isValidGeneration(int _generation) {
@@ -80,6 +84,17 @@ namespace RenderState {
         return s_validGeneration;
     }
 
+    int nextAvailableTextureUnit() {
+        return ++s_textureUnit;
+    }
+
+    int currentTextureUnit() {
+        return s_textureUnit;
+    }
+
+    void resetTextureUnit() {
+        s_textureUnit = -1;
+    }
 }
 
 }

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -5,9 +5,6 @@
 #include <tuple>
 #include <limits>
 
-// Max texture units used at the same time by a shader
-#define TANGRAM_MAX_TEXTURE_UNIT 6
-
 namespace Tangram {
 
 namespace RenderState {

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -28,6 +28,12 @@ namespace RenderState {
     bool isValidGeneration(int _generation);
     int generation();
 
+    int currentTextureUnit();
+    /* Gives the immediately next available texture unit */
+    int nextAvailableTextureUnit();
+    /* Reset the currently used texture unit */
+    void resetTextureUnit();
+
     template <typename T>
     class State {
     public:

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -426,4 +426,13 @@ void ShaderProgram::setUniformMatrix4f(const UniformLocation& _loc, const glm::m
     }
 }
 
+void ShaderProgram::setUniformf(const UniformLocation& _loc, const UniformArray& _value) {
+    use();
+    GLint location = getUniformLocation(_loc);
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniform1fv(location, _value.size(), _value.data()); }
+    }
+}
+
 }

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -435,4 +435,13 @@ void ShaderProgram::setUniformf(const UniformLocation& _loc, const UniformArray&
     }
 }
 
+void ShaderProgram::setUniformi(const UniformLocation& _loc, const UniformTextureArray& _value) {
+    use();
+    GLint location = getUniformLocation(_loc);
+    if (location >= 0) {
+        bool cached = getFromCache(location, _value);
+        if (!cached) { glUniform1iv(location, _value.slots.size(), _value.slots.data()); }
+    }
+}
+
 }

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -80,6 +80,8 @@ public:
     void setUniformf(const UniformLocation& _loc, const glm::vec3& _value);
     void setUniformf(const UniformLocation& _loc, const glm::vec4& _value);
 
+    void setUniformf(const UniformLocation& _loc, const UniformArray& _value);
+
     /*
      * Ensures the program is bound and then sets the named uniform to the values
      * beginning at the pointer _value; 4 values are used for a 2x2 matrix, 9 values for a 3x3, etc.

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -81,6 +81,7 @@ public:
     void setUniformf(const UniformLocation& _loc, const glm::vec4& _value);
 
     void setUniformf(const UniformLocation& _loc, const UniformArray& _value);
+    void setUniformi(const UniformLocation& _loc, const UniformTextureArray& _value);
 
     /*
      * Ensures the program is bound and then sets the named uniform to the values

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -24,7 +24,7 @@ Texture::Texture(unsigned int _width, unsigned int _height, TextureOptions _opti
 }
 
 Texture::Texture(const std::string& _file, TextureOptions _options, bool _generateMipmaps)
-    : Texture(0, 0, _options, _generateMipmaps) {
+    : Texture(0u, 0u, _options, _generateMipmaps) {
 
     unsigned int size;
     unsigned char* data = bytesFromFile(_file.c_str(), PathType::resource, &size);
@@ -42,6 +42,19 @@ Texture::Texture(const std::string& _file, TextureOptions _options, bool _genera
     setData(reinterpret_cast<GLuint*>(pixels), width * height);
 
     free(data);
+    stbi_image_free(pixels);
+}
+
+Texture::Texture(const unsigned char* data, size_t dataSize, TextureOptions options, bool generateMipmaps)
+    : Texture(0u, 0u, options, generateMipmaps) {
+    unsigned char* pixels;
+    int width, height, comp;
+
+    pixels = stbi_load_from_memory(data, dataSize, &width, &height, &comp, STBI_rgb_alpha);
+
+    resize(width, height);
+    setData(reinterpret_cast<GLuint*>(pixels), width * height);
+
     stbi_image_free(pixels);
 }
 

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -27,30 +27,31 @@ Texture::Texture(const std::string& _file, TextureOptions _options, bool _genera
     : Texture(0u, 0u, _options, _generateMipmaps) {
 
     unsigned int size;
-    unsigned char* data = bytesFromFile(_file.c_str(), PathType::resource, &size);
-    unsigned char* pixels;
-    int width, height, comp;
+    unsigned char* data;
 
-    if (data == nullptr || size == 0) {
-        LOGE("Texture not found! '%s'", _file.c_str());
-        return;
-    }
+    data = bytesFromFile(_file.c_str(), PathType::resource, &size);
 
-    pixels = stbi_load_from_memory(data, size, &width, &height, &comp, STBI_rgb_alpha);
-
-    resize(width, height);
-    setData(reinterpret_cast<GLuint*>(pixels), width * height);
+    loadPNG(data, size);
 
     free(data);
-    stbi_image_free(pixels);
 }
 
 Texture::Texture(const unsigned char* data, size_t dataSize, TextureOptions options, bool generateMipmaps)
     : Texture(0u, 0u, options, generateMipmaps) {
+
+    loadPNG(data, dataSize);
+}
+
+void Texture::loadPNG(const unsigned char* blob, unsigned int size) {
+    if (blob == nullptr || size == 0) {
+        LOGE("Texture data is empty!");
+        return;
+    }
+
     unsigned char* pixels;
     int width, height, comp;
 
-    pixels = stbi_load_from_memory(data, dataSize, &width, &height, &comp, STBI_rgb_alpha);
+    pixels = stbi_load_from_memory(blob, size, &width, &height, &comp, STBI_rgb_alpha);
 
     resize(width, height);
     setData(reinterpret_cast<GLuint*>(pixels), width * height);

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -82,7 +82,10 @@ public:
 
     static bool isRepeatWrapping(TextureWrapping _wrapping);
 
+    void loadPNG(const unsigned char* blob, unsigned int size);
+
 protected:
+
     void generate(GLuint _textureUnit);
     void checkValidity();
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -25,18 +25,25 @@ struct TextureOptions {
     TextureWrapping wrapping;
 };
 
-#define TANGRAM_MAX_TEXTURE_UNIT    6
+#define DEFAULT_TEXTURE_OPTION \
+    {GL_ALPHA, GL_ALPHA, \
+    {GL_LINEAR, GL_LINEAR}, \
+    {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}
 
 class Texture {
 
 public:
 
     Texture(unsigned int _width, unsigned int _height,
-            TextureOptions _options = {GL_ALPHA, GL_ALPHA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}},
+            TextureOptions _options = DEFAULT_TEXTURE_OPTION},
+            bool _generateMipmaps = false);
+
+    Texture(const unsigned char* data, size_t dataSize,
+            TextureOptions _options = DEFAULT_TEXTURE_OPTION},
             bool _generateMipmaps = false);
 
     Texture(const std::string& _file,
-            TextureOptions _options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}},
+            TextureOptions _options = DEFAULT_TEXTURE_OPTION},
             bool _generateMipmaps = false);
 
     virtual ~Texture();

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -8,7 +8,7 @@
 
 namespace Tangram {
 
-TextureCube::TextureCube(std::string _file, TextureOptions _options) : Texture(0, 0, _options) {
+TextureCube::TextureCube(std::string _file, TextureOptions _options) : Texture(0u, 0u, _options) {
 
     m_target = GL_TEXTURE_CUBE_MAP;
     load(_file);

--- a/core/src/gl/uniform.h
+++ b/core/src/gl/uniform.h
@@ -5,15 +5,17 @@
 #include "glm/glm.hpp"
 
 #include <string>
+#include <vector>
 
 namespace Tangram {
 
 class ShaderProgram;
 
+using UniformArray = std::vector<float>;
 
 /* Style Block Uniform types */
 using UniformValue = variant<none_type, bool, std::string, float, int, glm::vec2, glm::vec3,
-      glm::vec4, glm::mat2, glm::mat3, glm::mat4>;
+      glm::vec4, glm::mat2, glm::mat3, glm::mat4, UniformArray>;
 
 
 class UniformLocation {

--- a/core/src/gl/uniform.h
+++ b/core/src/gl/uniform.h
@@ -3,7 +3,7 @@
 #include "util/variant.h"
 
 #include "glm/glm.hpp"
-
+#include "platform.h"
 #include <string>
 #include <vector>
 
@@ -15,8 +15,8 @@ struct UniformTextureArray {
     std::vector<std::string> names;
     std::vector<int> slots;
 
-    inline bool operator==(UniformTextureArray& uta) {
-        return uta.slots == slots;
+    inline bool operator==(const UniformTextureArray& uta) {
+        return uta.slots.size() == slots.size() && uta.slots == slots;
     };
 };
 

--- a/core/src/gl/uniform.h
+++ b/core/src/gl/uniform.h
@@ -11,11 +11,12 @@ namespace Tangram {
 
 class ShaderProgram;
 
+using UniformTextureArray = std::vector<std::string>;
 using UniformArray = std::vector<float>;
 
 /* Style Block Uniform types */
 using UniformValue = variant<none_type, bool, std::string, float, int, glm::vec2, glm::vec3,
-      glm::vec4, glm::mat2, glm::mat3, glm::mat4, UniformArray>;
+      glm::vec4, glm::mat2, glm::mat3, glm::mat4, UniformArray, UniformTextureArray>;
 
 
 class UniformLocation {

--- a/core/src/gl/uniform.h
+++ b/core/src/gl/uniform.h
@@ -11,7 +11,15 @@ namespace Tangram {
 
 class ShaderProgram;
 
-using UniformTextureArray = std::vector<std::string>;
+struct UniformTextureArray {
+    std::vector<std::string> names;
+    std::vector<int> slots;
+
+    inline bool operator==(UniformTextureArray& uta) {
+        return uta.slots == slots;
+    };
+};
+
 using UniformArray = std::vector<float>;
 
 /* Style Block Uniform types */

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -63,4 +63,16 @@ const Light* Scene::findLight(const std::string &_name) const {
     return nullptr;
 }
 
+bool Scene::texture(const std::string& textureName, std::shared_ptr<Texture>& texture) const {
+    auto texIt = m_textures.find(textureName);
+
+    if (texIt == m_textures.end()) {
+        return false;
+    }
+
+    texture = texIt->second;
+
+    return true;
+}
+
 }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -58,6 +58,8 @@ public:
     int addIdForName(const std::string& _name);
     int getIdForName(const std::string& _name) const;
 
+    bool texture(const std::string& textureName, std::shared_ptr<Texture>& texture) const;
+
     const int32_t id;
 
     glm::dvec2 startPosition = { 0, 0 };

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -215,7 +215,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
             } else if(styleUniform.value.is<UniformTextureArray>()) {
                 UniformTextureArray& textureArray = styleUniform.value.get<UniformTextureArray>();
                 shader.addSourceBlock("uniforms", "uniform " + styleUniform.type + " " + name +
-                    "[" + std::to_string(textureArray.size()) + "];");
+                    "[" + std::to_string(textureArray.names.size()) + "];");
             } else {
                 shader.addSourceBlock("uniforms", "uniform " + styleUniform.type + " " + name + ";");
             }
@@ -1015,12 +1015,12 @@ StyleUniform SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
         } catch (const BadConversion& e) { // array of strings (textures)
             // FIXME: don't base the fact that we should parse strings based on an exception
             UniformTextureArray textureArrayUniform;
-            textureArrayUniform.reserve(size);
+            textureArrayUniform.names.reserve(size);
             styleUniform.type = "sampler2D";
 
             for (const auto& strVal : value) {
                 auto textureName = strVal.as<std::string>();
-                textureArrayUniform.push_back(textureName);
+                textureArrayUniform.names.push_back(textureName);
                 auto texItr = scene.textures().find(textureName);
 
                 // TODO: remove, shouldn't load a texture 'name'

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1023,10 +1023,13 @@ StyleUniform SceneLoader::parseStyleUniforms(const Node& value, Scene& scene) {
                 textureArrayUniform.push_back(textureName);
                 auto texItr = scene.textures().find(textureName);
 
+                // TODO: remove, shouldn't load a texture 'name'
                 if (texItr == scene.textures().end()) {
                     loadTexture(textureName, scene);
                 }
             }
+
+            styleUniform.value = textureArrayUniform;
         }
     } else {
         LOGW("Expected a scalar or sequence value for uniforms");

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -28,7 +28,10 @@ struct MaterialTexture;
 struct Filter;
 
 // 0: type, 1: values
-using StyleUniforms = std::pair<std::string, std::vector<UniformValue>>;
+struct StyleUniform {
+    std::string type;
+    UniformValue value;
+};
 
 struct SceneLoader {
     using Node = YAML::Node;
@@ -61,7 +64,7 @@ struct SceneLoader {
                                  std::vector<StyleParam>& out);
     static void parseTransition(Node params, Scene& scene, std::vector<StyleParam>& out);
 
-    static StyleUniforms parseStyleUniforms(const Node& uniform, Scene& scene);
+    static StyleUniform parseStyleUniforms(const Node& uniform, Scene& scene);
 
     static bool loadStyle(const std::string& styleName, Node config, Scene& scene);
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -64,7 +64,7 @@ struct SceneLoader {
                                  std::vector<StyleParam>& out);
     static void parseTransition(Node params, Scene& scene, std::vector<StyleParam>& out);
 
-    static StyleUniform parseStyleUniforms(const Node& uniform, Scene& scene);
+    static bool parseStyleUniforms(const Node& value, Scene& scene, StyleUniform& styleUniform);
 
     static bool loadStyle(const std::string& styleName, Node config, Scene& scene);
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -56,7 +56,7 @@ struct SceneLoader {
     static Filter generateNoneFilter(Node filter, Scene& scene);
     static Filter generatePredicate(Node filter, std::string _key);
     /* loads a texture with default texture properties */
-    static void loadTexture(const std::string& url, Scene& scene);
+    static bool loadTexture(const std::string& url, Scene& scene);
 
     static MaterialTexture loadMaterialTexture(Node matCompNode, Scene& scene, Style& style);
 

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -3,6 +3,7 @@
 #include "platform.h"
 #include "gl/shaderProgram.h"
 #include "gl/texture.h"
+#include "gl/renderState.h"
 
 namespace Tangram {
 
@@ -168,9 +169,9 @@ void Material::setupProgram(MaterialUniforms& _uniforms) {
         u.shader.setUniformf(u.emission, m_emission);
 
         if (m_emission_texture.tex) {
-            m_emission_texture.tex->update(1);
-            m_emission_texture.tex->bind(1);
-            u.shader.setUniformi(u.emissionTexture, 1);
+            m_emission_texture.tex->update(RenderState::nextAvailableTextureUnit());
+            m_emission_texture.tex->bind(RenderState::currentTextureUnit());
+            u.shader.setUniformi(u.emissionTexture, RenderState::currentTextureUnit());
             u.shader.setUniformf(u.emissionScale, m_emission_texture.scale);
         }
     }
@@ -179,9 +180,9 @@ void Material::setupProgram(MaterialUniforms& _uniforms) {
         u.shader.setUniformf(u.ambient, m_ambient);
 
         if (m_ambient_texture.tex) {
-            m_ambient_texture.tex->update(2);
-            m_ambient_texture.tex->bind(2);
-            u.shader.setUniformi(u.ambientTexture, 2);
+            m_ambient_texture.tex->update(RenderState::nextAvailableTextureUnit());
+            m_ambient_texture.tex->bind(RenderState::currentTextureUnit());
+            u.shader.setUniformi(u.ambientTexture, RenderState::currentTextureUnit());
             u.shader.setUniformf(u.ambientScale, m_ambient_texture.scale);
         }
     }
@@ -190,9 +191,9 @@ void Material::setupProgram(MaterialUniforms& _uniforms) {
         u.shader.setUniformf(u.diffuse, m_diffuse);
 
         if (m_diffuse_texture.tex) {
-            m_diffuse_texture.tex->update(3);
-            m_diffuse_texture.tex->bind(3);
-            u.shader.setUniformi(u.diffuseTexture, 3);
+            m_diffuse_texture.tex->update(RenderState::nextAvailableTextureUnit());
+            m_diffuse_texture.tex->bind(RenderState::currentTextureUnit());
+            u.shader.setUniformi(u.diffuseTexture, RenderState::currentTextureUnit());
             u.shader.setUniformf(u.diffuseScale, m_diffuse_texture.scale);
         }
     }
@@ -202,17 +203,17 @@ void Material::setupProgram(MaterialUniforms& _uniforms) {
         u.shader.setUniformf(u.shininess, m_shininess);
 
         if (m_specular_texture.tex) {
-            m_specular_texture.tex->update(4);
-            m_specular_texture.tex->bind(4);
-            u.shader.setUniformi(u.specularTexture, 4);
+            m_specular_texture.tex->update(RenderState::nextAvailableTextureUnit());
+            m_specular_texture.tex->bind(RenderState::currentTextureUnit());
+            u.shader.setUniformi(u.specularTexture, RenderState::currentTextureUnit());
             u.shader.setUniformf(u.specularScale, m_specular_texture.scale);
         }
     }
 
     if (m_normal_texture.tex) {
-        m_normal_texture.tex->update(5);
-        m_normal_texture.tex->bind(5);
-        u.shader.setUniformi(u.normalTexture, 5);
+        m_normal_texture.tex->update(RenderState::nextAvailableTextureUnit());
+        m_normal_texture.tex->bind(RenderState::currentTextureUnit());
+        u.shader.setUniformi(u.normalTexture, RenderState::currentTextureUnit());
         u.shader.setUniformf(u.normalScale, m_normal_texture.scale);
         u.shader.setUniformf(u.normalAmount, m_normal_texture.amount);
     }

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -5,6 +5,7 @@
 #include "gl/shaderProgram.h"
 #include "gl/texture.h"
 #include "gl/vertexLayout.h"
+#include "gl/renderState.h"
 #include "labels/labelMesh.h"
 #include "labels/spriteLabel.h"
 #include "scene/drawRule.h"
@@ -53,18 +54,19 @@ void PointStyle::constructShaderProgram() {
     m_shaderProgram->addSourceBlock("defines", defines);
 }
 
-void PointStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit) {
+void PointStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
+    Style::onBeginDrawFrame(_view, _scene);
+
     if (m_spriteAtlas) {
-        m_spriteAtlas->bind(0);
+        m_spriteAtlas->bind(RenderState::nextAvailableTextureUnit());
     } else if (m_texture) {
-        m_texture->update(0);
-        m_texture->bind(0);
+        m_texture->update(RenderState::nextAvailableTextureUnit());
+        m_texture->bind(RenderState::currentTextureUnit());
     }
 
     m_shaderProgram->setUniformi(m_uTex, 0);
     m_shaderProgram->setUniformMatrix4f(m_uOrtho, _view.getOrthoViewportMatrix());
 
-    Style::onBeginDrawFrame(_view, _scene, 1);
 }
 
 struct PointStyleBuilder : public StyleBuilder {

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -28,7 +28,7 @@ public:
 
     PointStyle(std::string _name, Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES);
 
-    virtual void onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit = 0) override;
+    virtual void onBeginDrawFrame(const View& _view, Scene& _scene) override;
 
     void setSpriteAtlas(std::shared_ptr<SpriteAtlas> _spriteAtlas) { m_spriteAtlas = _spriteAtlas; }
     void setTexture(std::shared_ptr<Texture> _texture) { m_texture = _texture; }

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -108,6 +108,7 @@ void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
                 m_shaderProgram->setUniformf(name, value.get<UniformArray>());
             } else if (value.is<UniformTextureArray>()) {
                 UniformTextureArray& textureUniformArray = value.get<UniformTextureArray>();
+                textureUniformArray.slots.clear();
 
                 for (const auto& textureName : textureUniformArray.names) {
                     std::shared_ptr<Texture> texture = nullptr;

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -73,9 +73,9 @@ void Style::setLightingType(LightingType _type) {
 }
 
 void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
-    for (const auto& uniformPair : m_styleUniforms) {
+    for (auto& uniformPair : m_styleUniforms) {
         const auto& name = uniformPair.first;
-        const auto& value = uniformPair.second;
+        auto& value = uniformPair.second;
 
         if (value.is<std::string>()) {
             std::shared_ptr<Texture> texture = nullptr;
@@ -107,7 +107,7 @@ void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
             } else if (value.is<UniformArray>()) {
                 m_shaderProgram->setUniformf(name, value.get<UniformArray>());
             } else if (value.is<UniformTextureArray>()) {
-                auto& textureUniformArray = value.get<UniformTextureArray>();
+                UniformTextureArray& textureUniformArray = value.get<UniformTextureArray>();
 
                 for (const auto& textureName : textureUniformArray.names) {
                     std::shared_ptr<Texture> texture = nullptr;
@@ -120,6 +120,7 @@ void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
                     texture->update(_textureUnit);
                     texture->bind(_textureUnit);
 
+                    textureUniformArray.slots.push_back(_textureUnit);
                     _textureUnit++;
                 }
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -78,15 +78,23 @@ void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
         const auto& value = uniformPair.second;
 
         if (value.is<std::string>()) {
+            std::string textureName = value.get<std::string>();
+            auto texIt = _scene.textures().find(textureName);
 
-            auto& tex = _scene.textures()[value.get<std::string>()];
-            if (tex) {
-                tex->update(_textureUnit);
-                tex->bind(_textureUnit);
-
-                m_shaderProgram->setUniformi(name, _textureUnit);
-                _textureUnit++;
+            if (texIt == _scene.textures().end()) {
+                // TODO: LOG, would be nice to do have a notify-once-log not to overwhelm logging
+                continue;
             }
+
+            auto& texture = texIt->second;
+
+            texture->update(_textureUnit);
+            texture->bind(_textureUnit);
+
+            m_shaderProgram->setUniformi(name, _textureUnit);
+
+            // TODO: Bug, this might not be working properly since not a reference, move to renderstate
+            _textureUnit++;
         } else {
 
             if (value.is<bool>()) {
@@ -101,6 +109,8 @@ void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
                 m_shaderProgram->setUniformf(name, value.get<glm::vec4>());
             } else if (value.is<UniformArray>()) {
                 m_shaderProgram->setUniformf(name, value.get<UniformArray>());
+            } else if (value.is<UniformTextureArray>()) {
+
             } else {
                 // TODO: Throw away uniform on loading!
                 // none_type

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -99,6 +99,8 @@ void Style::setupShaderUniforms(int _textureUnit, Scene& _scene) {
                 m_shaderProgram->setUniformf(name, value.get<glm::vec3>());
             } else if(value.is<glm::vec4>()) {
                 m_shaderProgram->setUniformf(name, value.get<glm::vec4>());
+            } else if (value.is<UniformArray>()) {
+                m_shaderProgram->setUniformf(name, value.get<UniformArray>());
             } else {
                 // TODO: Throw away uniform on loading!
                 // none_type

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -129,9 +129,8 @@ protected:
     virtual void constructShaderProgram() = 0;
 
     /* Set uniform values when @_updateUniforms is true,
-     * and bind textures starting at @_textureUnit
      */
-    void setupShaderUniforms(int _textureUnit, Scene& _scene);
+    void setupShaderUniforms(Scene& _scene);
 
     UniformLocation m_uTime{"u_time"};
     // View uniforms
@@ -211,7 +210,7 @@ public:
     /* Perform any setup needed before drawing each frame
      * _textUnit is the next available texture unit
      */
-    virtual void onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit = 0);
+    virtual void onBeginDrawFrame(const View& _view, Scene& _scene);
 
     /* Perform any unsetup needed after drawing each frame */
     virtual void onEndDrawFrame() {}

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -5,6 +5,7 @@
 #include "text/fontContext.h"
 #include "tile/tile.h"
 #include "gl/shaderProgram.h"
+#include "gl/renderState.h"
 #include "gl/mesh.h"
 #include "view/view.h"
 #include "labels/textLabel.h"
@@ -60,15 +61,15 @@ void TextStyle::constructShaderProgram() {
     m_shaderProgram->addSourceBlock("defines", defines);
 }
 
-void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit) {
-    m_fontContext->bindAtlas(0);
+void TextStyle::onBeginDrawFrame(const View& _view, Scene& _scene) {
+    Style::onBeginDrawFrame(_view, _scene);
+
+    m_fontContext->bindAtlas(RenderState::nextAvailableTextureUnit());
+    m_shaderProgram->setUniformi(m_uTex, RenderState::currentTextureUnit());
 
     m_shaderProgram->setUniformf(m_uTexScaleFactor,
                                  1.0f / m_fontContext->getAtlasResolution());
-    m_shaderProgram->setUniformi(m_uTex, 0);
     m_shaderProgram->setUniformMatrix4f(m_uOrtho, _view.getOrthoViewportMatrix());
-
-    Style::onBeginDrawFrame(_view, _scene, 1);
 }
 
 struct TextStyleBuilder : public StyleBuilder {

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -44,7 +44,7 @@ public:
               Blending _blendMode = Blending::overlay,
               GLenum _drawMode = GL_TRIANGLES);
 
-    virtual void onBeginDrawFrame(const View& _view, Scene& _scene, int _textureUnit = 0) override;
+    virtual void onBeginDrawFrame(const View& _view, Scene& _scene) override;
 
     virtual ~TextStyle();
 

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -22,10 +22,9 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
         )END");
 
     auto uniformValues = SceneLoader::parseStyleUniforms(node["u_float"], scene);
-    REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<float>());
-    REQUIRE(uniformValues.second[0].get<float>() == 0.5);
-    REQUIRE(uniformValues.first == "float");
+    REQUIRE(uniformValues.value.is<float>());
+    REQUIRE(uniformValues.value.get<float>() == 0.5);
+    REQUIRE(uniformValues.type == "float");
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "[StyleUniforms][core][yaml]") {
@@ -36,16 +35,14 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
         )END");
 
     auto uniformValues = SceneLoader::parseStyleUniforms(node["u_true"], scene);
-    REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<bool>());
-    REQUIRE(uniformValues.second[0].get<bool>() == 1);
-    REQUIRE(uniformValues.first == "bool");
+    REQUIRE(uniformValues.value.is<bool>());
+    REQUIRE(uniformValues.value.get<bool>() == 1);
+    REQUIRE(uniformValues.type == "bool");
 
     uniformValues = SceneLoader::parseStyleUniforms(node["u_false"], scene);
-    REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<bool>());
-    REQUIRE(uniformValues.second[0].get<bool>() == 0);
-    REQUIRE(uniformValues.first == "bool");
+    REQUIRE(uniformValues.value.is<bool>());
+    REQUIRE(uniformValues.value.get<bool>() == 0);
+    REQUIRE(uniformValues.type == "bool");
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform value", "[StyleUniforms][core][yaml]") {
@@ -58,28 +55,25 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 
 
     auto uniformValues = SceneLoader::parseStyleUniforms(node["u_vec2"], scene);
-    REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<glm::vec2>());
-    REQUIRE(uniformValues.second[0].get<glm::vec2>().x == 0.1f);
-    REQUIRE(uniformValues.second[0].get<glm::vec2>().y == 0.2f);
-    REQUIRE(uniformValues.first == "vec2");
+    REQUIRE(uniformValues.value.is<glm::vec2>());
+    REQUIRE(uniformValues.value.get<glm::vec2>().x == 0.1f);
+    REQUIRE(uniformValues.value.get<glm::vec2>().y == 0.2f);
+    REQUIRE(uniformValues.type == "vec2");
 
     uniformValues = SceneLoader::parseStyleUniforms(node["u_vec3"], scene);
-    REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<glm::vec3>());
-    REQUIRE(uniformValues.second[0].get<glm::vec3>().x == 0.1f);
-    REQUIRE(uniformValues.second[0].get<glm::vec3>().y == 0.2f);
-    REQUIRE(uniformValues.second[0].get<glm::vec3>().z == 0.3f);
-    REQUIRE(uniformValues.first == "vec3");
+    REQUIRE(uniformValues.value.is<glm::vec3>());
+    REQUIRE(uniformValues.value.get<glm::vec3>().x == 0.1f);
+    REQUIRE(uniformValues.value.get<glm::vec3>().y == 0.2f);
+    REQUIRE(uniformValues.value.get<glm::vec3>().z == 0.3f);
+    REQUIRE(uniformValues.type == "vec3");
 
     uniformValues = SceneLoader::parseStyleUniforms(node["u_vec4"], scene);
-    REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<glm::vec4>());
-    REQUIRE(uniformValues.second[0].get<glm::vec4>().x == 0.1f);
-    REQUIRE(uniformValues.second[0].get<glm::vec4>().y == 0.2f);
-    REQUIRE(uniformValues.second[0].get<glm::vec4>().z == 0.3f);
-    REQUIRE(uniformValues.second[0].get<glm::vec4>().w == 0.4f);
-    REQUIRE(uniformValues.first == "vec4");
+    REQUIRE(uniformValues.value.is<glm::vec4>());
+    REQUIRE(uniformValues.value.get<glm::vec4>().x == 0.1f);
+    REQUIRE(uniformValues.value.get<glm::vec4>().y == 0.2f);
+    REQUIRE(uniformValues.value.get<glm::vec4>().z == 0.3f);
+    REQUIRE(uniformValues.value.get<glm::vec4>().w == 0.4f);
+    REQUIRE(uniformValues.type == "vec4");
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", "[StyleUniforms][core][yaml]") {
@@ -90,18 +84,15 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
         )END");
 
     auto uniformValues = SceneLoader::parseStyleUniforms(node["u_tex"], scene);
-    REQUIRE(uniformValues.second.size() == 1);
-    REQUIRE(uniformValues.second[0].is<std::string>());
-    REQUIRE(uniformValues.second[0].get<std::string>() == "texture1.png");
-    REQUIRE(uniformValues.first == "sampler2D");
+    REQUIRE(uniformValues.value.is<std::string>());
+    REQUIRE(uniformValues.value.get<std::string>() == "texture1.png");
+    REQUIRE(uniformValues.type == "sampler2D");
 
     uniformValues = SceneLoader::parseStyleUniforms(node["u_tex2"], scene);
-    REQUIRE(uniformValues.second.size() == 3);
-    REQUIRE(uniformValues.second[0].is<std::string>());
-    REQUIRE(uniformValues.second[1].is<std::string>());
-    REQUIRE(uniformValues.second[2].is<std::string>());
-    REQUIRE(uniformValues.second[0].get<std::string>() == "texture2.png");
-    REQUIRE(uniformValues.second[1].get<std::string>() == "texture3.png");
-    REQUIRE(uniformValues.second[2].get<std::string>() == "texture4.png");
+    REQUIRE(uniformValues.value.is<UniformTextureArray>());
+    REQUIRE(uniformValues.value.get<UniformTextureArray>().names.size() == 3);
+    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[0] == "texture2.png");
+    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[1] == "texture3.png");
+    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[2] == "texture4.png");
 }
 

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -51,6 +51,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
         u_vec2: [0.1, 0.2]
         u_vec3: [0.1, 0.2, 0.3]
         u_vec4: [0.1, 0.2, 0.3, 0.4]
+        u_array: [0.1, 0.2, 0.3, 0.4, 0.5]
         )END");
 
 
@@ -74,6 +75,14 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
     REQUIRE(uniformValues.value.get<glm::vec4>().z == 0.3f);
     REQUIRE(uniformValues.value.get<glm::vec4>().w == 0.4f);
     REQUIRE(uniformValues.type == "vec4");
+
+    uniformValues = SceneLoader::parseStyleUniforms(node["u_array"], scene);
+    REQUIRE(uniformValues.value.is<UniformArray>());
+    REQUIRE(uniformValues.value.get<UniformArray>()[0] == 0.1f);
+    REQUIRE(uniformValues.value.get<UniformArray>()[1] == 0.2f);
+    REQUIRE(uniformValues.value.get<UniformArray>()[2] == 0.3f);
+    REQUIRE(uniformValues.value.get<UniformArray>()[3] == 0.4f);
+    REQUIRE(uniformValues.value.get<UniformArray>()[4] == 0.5f);
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", "[StyleUniforms][core][yaml]") {

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -21,7 +21,9 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
         u_float: 0.5
         )END");
 
-    auto uniformValues = SceneLoader::parseStyleUniforms(node["u_float"], scene);
+    StyleUniform uniformValues;
+
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_float"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<float>());
     REQUIRE(uniformValues.value.get<float>() == 0.5);
     REQUIRE(uniformValues.type == "float");
@@ -34,12 +36,14 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
         u_false: false
         )END");
 
-    auto uniformValues = SceneLoader::parseStyleUniforms(node["u_true"], scene);
+    StyleUniform uniformValues;
+
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_true"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 1);
     REQUIRE(uniformValues.type == "bool");
 
-    uniformValues = SceneLoader::parseStyleUniforms(node["u_false"], scene);
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_false"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 0);
     REQUIRE(uniformValues.type == "bool");
@@ -54,21 +58,22 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
         u_array: [0.1, 0.2, 0.3, 0.4, 0.5]
         )END");
 
+    StyleUniform uniformValues;
 
-    auto uniformValues = SceneLoader::parseStyleUniforms(node["u_vec2"], scene);
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec2"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec2>());
     REQUIRE(uniformValues.value.get<glm::vec2>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec2>().y == 0.2f);
     REQUIRE(uniformValues.type == "vec2");
 
-    uniformValues = SceneLoader::parseStyleUniforms(node["u_vec3"], scene);
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec3"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec3>());
     REQUIRE(uniformValues.value.get<glm::vec3>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec3>().y == 0.2f);
     REQUIRE(uniformValues.value.get<glm::vec3>().z == 0.3f);
     REQUIRE(uniformValues.type == "vec3");
 
-    uniformValues = SceneLoader::parseStyleUniforms(node["u_vec4"], scene);
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec4"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec4>());
     REQUIRE(uniformValues.value.get<glm::vec4>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec4>().y == 0.2f);
@@ -76,7 +81,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
     REQUIRE(uniformValues.value.get<glm::vec4>().w == 0.4f);
     REQUIRE(uniformValues.type == "vec4");
 
-    uniformValues = SceneLoader::parseStyleUniforms(node["u_array"], scene);
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_array"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<UniformArray>());
     REQUIRE(uniformValues.value.get<UniformArray>()[0] == 0.1f);
     REQUIRE(uniformValues.value.get<UniformArray>()[1] == 0.2f);
@@ -88,20 +93,22 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", "[StyleUniforms][core][yaml]") {
 
     Node node = YAML::Load(R"END(
-        u_tex : texture1.png
-        u_tex2 : [texture2.png, texture3.png, texture4.png]
+        u_tex : img/cross.png
+        u_tex2 : [img/cross.png, img/normal_map.png, img/sem.jpg]
         )END");
 
-    auto uniformValues = SceneLoader::parseStyleUniforms(node["u_tex"], scene);
+    StyleUniform uniformValues;
+
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<std::string>());
-    REQUIRE(uniformValues.value.get<std::string>() == "texture1.png");
+    REQUIRE(uniformValues.value.get<std::string>() == "img/cross.png");
     REQUIRE(uniformValues.type == "sampler2D");
 
-    uniformValues = SceneLoader::parseStyleUniforms(node["u_tex2"], scene);
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex2"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<UniformTextureArray>());
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names.size() == 3);
-    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[0] == "texture2.png");
-    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[1] == "texture3.png");
-    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[2] == "texture4.png");
+    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[0] == "img/cross.png");
+    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[1] == "img/normal_map.png");
+    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[2] == "img/sem.jpg");
 }
 

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -94,7 +94,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
 
     Node node = YAML::Load(R"END(
         u_tex : img/cross.png
-        u_tex2 : [img/cross.png, img/normal_map.png, img/sem.jpg]
+        u_tex2 : [img/cross.png, img/normals.jpg, img/sem.jpg]
         )END");
 
     StyleUniform uniformValues;
@@ -108,7 +108,24 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
     REQUIRE(uniformValues.value.is<UniformTextureArray>());
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names.size() == 3);
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names[0] == "img/cross.png");
-    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[1] == "img/normal_map.png");
+    REQUIRE(uniformValues.value.get<UniformTextureArray>().names[1] == "img/normals.jpg");
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names[2] == "img/sem.jpg");
+}
+
+TEST_CASE( "Style Uniforms Parsing failure Tests: textures uniform value", "[StyleUniforms][core][yaml]") {
+
+    Node node = YAML::Load(R"END(
+        u_tex : not_a_texture
+        u_tex2 : [not_a_texture_path2, not_a_texture_path_1]
+        u_uniform_float0: 0.5f
+        u_uniform_float1: 0s.5
+        )END");
+
+    StyleUniform uniformValues;
+
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex"], scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex2"], scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float0"], scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float1"], scene, uniformValues));
 }
 


### PR DESCRIPTION
Fixes https://github.com/tangrams/tangram-es/issues/548 

Add possibility to use uniform arrays, this part is partially documented but will complete the docs more consistently.

Comparing with the -js behavior, this adds the possibility to write the following:

```yaml
textures:
    texture0:
        url: img/poi_icons_32.png
    texture1:
        url: img/sem.jpg
styles:
    heightglow:
        base: polygons
        texcoords: true
        shaders:
            uniforms:
                u_test: [0.5, 0.5, 1.0, 0.5, 0.9]
                u_textures: [texture0, texture1]
            blocks:
                color: |
                    color.rgb *= mix(texture2D(u_textures[1], v_texcoord).rgb, vec3(u_test[0], u_test[1], u_test[4]), 0.5);
```

- Refactor uniform block scene loading
- Fix a bug in the way texture unit were used (now next available texture unit is tracked within the render states, https://github.com/tangrams/tangram-es/commit/ed29ad6bdd8df72d45f3d2a83ef2f1ccb84dbbd5 but could be a separate PR if needed)