### PR TITLE
Camera field of view and focal length are configurable from scene file

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -11,8 +11,8 @@ cameras:
     perspective-camera:
         # Manhattan
         position: [-74.00976419448854, 40.70532700869127, 16]
-        type: perspective #currently ignored
-        focal_length: [[16, 2], [20, 6]] # currently ignored
+        type: perspective
+        fov: 45
         vanishing_point: [-250, -250] # currently ignored
         active: true
 

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -181,6 +181,29 @@ auto Stops::Widths(const YAML::Node& _node, const MapProjection& _projection, co
     return stops;
 }
 
+auto Stops::Numbers(const YAML::Node& node) -> Stops {
+    Stops stops;
+    if (!node.IsSequence()) { return stops; }
+
+    float lastKey = 0;
+
+    for (const auto frameNode : node) {
+        if (!frameNode.IsSequence() || frameNode.size() != 2) { continue; }
+
+        float key = frameNode[0].as<float>();
+        if (lastKey > key) {
+            LOGW("Invalid stop order: key %f > %f\n", lastKey, key);
+            continue;
+        }
+        lastKey = key;
+
+        float value = frameNode[1].as<float>();
+        stops.frames.emplace_back(key, value);
+    }
+
+    return stops;
+}
+
 auto Stops::evalWidth(float _key) const -> float {
     if (frames.empty()) { return 0; }
 

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -31,8 +31,10 @@ struct Stops {
     static Stops Widths(const YAML::Node& _node, const MapProjection& _projection, const std::vector<Unit>& _units);
     static Stops FontSize(const YAML::Node& _node);
     static Stops Offsets(const YAML::Node& _node, const std::vector<Unit>& _units);
+    static Stops Numbers(const YAML::Node& node);
 
     Stops(const std::vector<Frame>& _frames) : frames(_frames) {}
+    Stops(const Stops& rhs) = default;
     Stops() {}
 
     auto evalFloat(float _key) const -> float;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -19,6 +19,8 @@ enum class CameraType : uint8_t {
     flat,
 };
 
+struct Stops;
+
 /* View
  * 1. Stores a representation of the current view into the map world
  * 2. Determines which tiles are visible in the current view
@@ -44,6 +46,27 @@ public:
 
     void setObliqueAxis(float _x, float _y) { m_obliqueAxis = { _x, _y}; }
     auto obliqueAxis() const { return m_obliqueAxis; }
+
+    // Set the vertical field-of-view angle, in radians.
+    void setFieldOfView(float radians);
+
+    // Set the vertical field-of-view angle as a series of stops over zooms.
+    void setFieldOfViewStops(std::shared_ptr<Stops> stops);
+
+    // Get the vertical field-of-view angle, in radians.
+    float getFieldOfView() const;
+
+    // Set the vertical field-of-view angle to a value that corresponds to the
+    // given focal length.
+    void setFocalLength(float length);
+
+    // Set the vertical field-of-view angle according to focal length as a
+    // series of stops over zooms.
+    void setFocalLengthStops(std::shared_ptr<Stops> stops);
+
+    // Get the focal length that corresponds to the current vertical
+    // field-of-view angle.
+    float getFocalLength() const;
 
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
      * If unset, default is 1.0
@@ -143,12 +166,16 @@ public:
     float pixelScale() const { return m_pixelScale; }
     float pixelsPerMeter() const;
 
+    static float focalLengthToFieldOfView(float length);
+    static float fieldOfViewToFocalLength(float radians);
+
 protected:
 
     void updateMatrices();
     void updateTiles();
 
     std::shared_ptr<MapProjection> m_projection;
+    std::shared_ptr<Stops> m_fovStops;
     std::set<TileID> m_visibleTiles;
 
     ViewConstraint m_constraint;
@@ -177,6 +204,7 @@ protected:
     int m_vpHeight;
     float m_aspect;
     float m_pixelScale = 1.0f;
+    float m_fov = 0.25 * PI;
 
     CameraType m_type;
 


### PR DESCRIPTION
Resolves #540 

This was a pretty straightforward set of changes. 

I shouldn't have needed to add code to `Stops` to complete this, but the current implementation of `Stops` is a bit silly. I'd like to revise it to be more naturally extensible, but that's for another time.