### PR TITLE
`color` and `normal` blocks are executed regardless of lighting mode

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -52,7 +52,7 @@ styles:
         lighting: vertex
         shaders:
             blocks:
-                color: "color.rgb += vec3(position.z / 800.);"
+                color: "color.rgb += vec3(worldPosition().z / 800.);"
     heightglowline:
         base: lines
         mix: heightglow

--- a/core/resources/shaders/polygon.fs
+++ b/core/resources/shaders/polygon.fs
@@ -37,6 +37,10 @@ varying vec3 v_normal;
 #pragma tangram: lighting
 #pragma tangram: global
 
+vec4 worldPosition() {
+    return v_world_position;
+}
+
 vec3 worldNormal() {
     return normalize(u_inverse_normal_matrix * v_normal);
 }
@@ -57,20 +61,18 @@ void main(void) {
         calculateNormal(normal);
     #endif
 
-    // Modify normal before lighting
-    #pragma tangram: normal
-
-    // Modify color and material properties before lighting
-    #ifndef TANGRAM_LIGHTING_VERTEX
-        #pragma tangram: color
+    // Modify normal before lighting if not already modified in vertex shader
+    #if !defined(TANGRAM_LIGHTING_VERTEX)
+        #pragma tangram: normal
     #endif
 
-    #ifdef TANGRAM_LIGHTING_FRAGMENT
+    // Modify color before lighting is applied
+    #pragma tangram: color
+
+    #if defined(TANGRAM_LIGHTING_FRAGMENT)
         color = calculateLighting(v_position.xyz, normal, color);
-    #else
-        #ifdef TANGRAM_LIGHTING_VERTEX
-            color = v_lighting;
-        #endif
+    #elif defined(TANGRAM_LIGHTING_VERTEX)
+        color *= v_lighting;
     #endif
 
     // Modify color after lighting (filter-like effects that don't require a additional render passes)

--- a/core/resources/shaders/polygon.vs
+++ b/core/resources/shaders/polygon.vs
@@ -87,19 +87,12 @@ void main() {
     // Set position varying to the camera-space vertex position
     v_position = u_view * position;
 
-    #ifdef TANGRAM_LIGHTING_VERTEX
-        vec4 color = v_color;
-        vec3 normal = v_normal;
-
+    #if defined(TANGRAM_LIGHTING_VERTEX)
         // Modify normal before lighting
+        vec3 normal = v_normal;
         #pragma tangram: normal
 
-        // Modify color and material properties before lighting
-        #pragma tangram: color
-
-        v_lighting = calculateLighting(v_position.xyz, normal, color);
-        v_color = color;
-        v_normal = normal;
+        v_lighting = calculateLighting(v_position.xyz, normal, vec4(1.));
     #endif
 
     gl_Position = u_proj * v_position;

--- a/core/resources/shaders/polyline.fs
+++ b/core/resources/shaders/polyline.fs
@@ -33,6 +33,10 @@ varying vec3 v_normal;
     varying vec4 v_lighting;
 #endif
 
+vec4 worldPosition() {
+    return v_world_position;
+}
+
 vec3 worldNormal() {
     return normalize(u_inverse_normal_matrix * v_normal);
 }
@@ -57,20 +61,18 @@ void main(void) {
         calculateNormal(normal);
     #endif
 
-    // Modify normal before lighting
-    #pragma tangram: normal
-
-    // Modify color and material properties before lighting
-    #ifndef TANGRAM_LIGHTING_VERTEX
-        #pragma tangram: color
+    // Modify normal before lighting if not already modified in vertex shader
+    #if !defined(TANGRAM_LIGHTING_VERTEX)
+        #pragma tangram: normal
     #endif
 
-    #ifdef TANGRAM_LIGHTING_FRAGMENT
+    // Modify color before lighting is applied
+    #pragma tangram: color
+
+    #if defined(TANGRAM_LIGHTING_FRAGMENT)
         color = calculateLighting(v_position.xyz, normal, color);
-    #else
-        #ifdef TANGRAM_LIGHTING_VERTEX
-            color = v_lighting;
-        #endif
+    #elif defined(TANGRAM_LIGHTING_VERTEX)
+        color *= v_lighting;
     #endif
 
     // Modify color after lighting (filter-like effects that don't require a additional render passes)

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -106,18 +106,11 @@ void main() {
     v_position = u_view * position;
 
     #ifdef TANGRAM_LIGHTING_VERTEX
-        vec4 color = v_color;
-        vec3 normal = v_normal;
-
         // Modify normal before lighting
+        vec3 normal = v_normal;
         #pragma tangram: normal
 
-        // Modify color and material properties before lighting
-        #pragma tangram: color
-
-        v_lighting = calculateLighting(v_position.xyz, normal, color);
-        v_color = color;
-        v_normal = normal;
+        v_lighting = calculateLighting(v_position.xyz, normal, vec4(1.));
     #endif
 
     gl_Position = u_proj * v_position;


### PR DESCRIPTION
This follows the behavior described here https://github.com/tangrams/tangram/pull/271