### PR TITLE
Make Android map initialization asynchronous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
               sources: [ 'kubuntu-backports', 'george-edison55-precise-backports' ]
               packages: [ 'cmake', 'lib32z1-dev', 'lib32stdc++6', 's3cmd' ]
           android:
-            components: [ 'build-tools-21.1.2', 'android-22' ]
+            components: [ 'build-tools-21.1.2', 'extra-android-m2repository', 'android-23' ]
 
 before_install:
     - git submodule update --init --recursive

--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -7,12 +7,12 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 22
+  compileSdkVersion 23
   buildToolsVersion "21.1.2"
 
   defaultConfig {
     minSdkVersion 15
-    targetSdkVersion 22
+    targetSdkVersion 23
   }
 
   sourceSets.main {

--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -8,25 +8,31 @@ import android.widget.Toast;
 import com.mapzen.tangram.HttpHandler;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
+import com.mapzen.tangram.MapController.FeatureTouchListener;
 import com.mapzen.tangram.MapData;
 import com.mapzen.tangram.MapView;
-import com.mapzen.tangram.TouchInput;
+import com.mapzen.tangram.MapView.OnMapReadyCallback;
+import com.mapzen.tangram.TouchInput.DoubleTapResponder;
+import com.mapzen.tangram.TouchInput.LongPressResponder;
+import com.mapzen.tangram.TouchInput.TapResponder;
 import com.squareup.okhttp.Callback;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-public class MainActivity extends Activity {
+public class MainActivity extends Activity implements OnMapReadyCallback, TapResponder,
+        DoubleTapResponder, LongPressResponder, FeatureTouchListener {
 
-    MapController mapController;
-    MapView mapView;
-    MapData touchMarkers;
+    MapController map;
+    MapView view;
+    LngLat lastTappedPoint;
+    MapData markers;
+    boolean showTileInfo = false;
 
-    boolean tileInfo;
-
-    String tileApiKey = "?api_key=vector-tiles-tyHL4AY";
+    final static String tileApiKey = "?api_key=vector-tiles-tyHL4AY";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -36,95 +42,25 @@ public class MainActivity extends Activity {
 
         setContentView(R.layout.main);
 
-        mapView = (MapView)findViewById(R.id.map);
-        mapController = new MapController(this, mapView);
-        mapController.setMapZoom(16);
-        mapController.setMapPosition(-74.00976419448854, 40.70532700869127);
+        view = (MapView)findViewById(R.id.map);
+        view.getMapAsync(this, "scene.yaml");
+    }
 
-        touchMarkers = new MapData("touch");
-        touchMarkers.addToMap(mapController);
+    @Override
+    public void onMapReady(MapController mapController) {
+        map = mapController;
+        map.setMapZoom(16);
+        map.setMapPosition(-74.00976419448854, 40.70532700869127);
+        map.setHttpHandler(getHttpHandler());
+        map.setTapResponder(this);
+        map.setDoubleTapResponder(this);
+        map.setLongPressResponder(this);
 
-        final LngLat lastTappedPoint = new LngLat();
-        final String colors[] = {"blue", "red", "green"};
-        final LngLat zeroCoord = new LngLat();
-        final ArrayList<LngLat> line = new ArrayList<>();
+        markers = new MapData("touch");
+        markers.addToMap(map);
+    }
 
-        mapController.setTapResponder(new TouchInput.TapResponder() {
-            @Override
-            public boolean onSingleTapUp(float x, float y) {
-                return false;
-            }
-
-            @Override
-            public boolean onSingleTapConfirmed(float x, float y) {
-                LngLat tapPoint = mapController.coordinatesAtScreenPosition(x, y);
-
-                if (!lastTappedPoint.equals(zeroCoord)) {
-                    Map<String, String> props = new HashMap<>();
-                    props.put("type", "line");
-                    props.put("color", colors[(int) (Math.random() * 2.0 + 0.5)]);
-
-                    line.clear();
-                    line.add(new LngLat(tapPoint));
-                    line.add(new LngLat(lastTappedPoint));
-                    touchMarkers.addPolyline(line, props);
-
-                    props = new HashMap<>();
-                    props.put("type", "point");
-                    touchMarkers.addPoint(lastTappedPoint, props);
-
-                    touchMarkers.syncWithMap();
-                }
-                lastTappedPoint.set(tapPoint);
-
-                mapController.pickFeature(x, y);
-
-                mapController.setMapPosition(tapPoint.longitude, tapPoint.latitude, 1);
-
-                return true;
-            }
-        });
-
-        mapController.setDoubleTapResponder(new TouchInput.DoubleTapResponder() {
-            @Override
-            public boolean onDoubleTap(float x, float y) {
-                mapController.setMapZoom(mapController.getMapZoom() + 1.f, .5f);
-                LngLat tapped = mapController.coordinatesAtScreenPosition(x, y);
-                LngLat current = mapController.getMapPosition();
-                mapController.setMapPosition(
-                        .5 * (tapped.longitude + current.longitude),
-                        .5 * (tapped.latitude + current.latitude),
-                        .5f
-                );
-                return true;
-            }
-        });
-
-        mapController.setLongPressResponder(new TouchInput.LongPressResponder() {
-            @Override
-            public void onLongPress(float x, float y) {
-                if (touchMarkers != null) {
-                    touchMarkers.clear().syncWithMap();
-                }
-                tileInfo = !tileInfo;
-                mapController.setDebugFlag(MapController.DebugFlag.TILE_BOUNDS, tileInfo);
-                mapController.setDebugFlag(MapController.DebugFlag.TILE_INFOS, tileInfo);
-            }
-        });
-
-        mapController.setFeatureTouchListener(new MapController.FeatureTouchListener() {
-            @Override
-            public void onTouch(Map<String, String> properties, float positionX, float positionY) {
-                String name = properties.get("name");
-                if (name != null) {
-                    name = "unnamed...";
-                }
-                Toast.makeText(getApplicationContext(),
-                        "Selected: " + name + " at: " + positionX + ", " + positionY,
-                        Toast.LENGTH_SHORT).show();
-            }
-        });
-
+    HttpHandler getHttpHandler() {
         HttpHandler handler = new HttpHandler() {
             @Override
             public boolean onRequest(String url, Callback cb) {
@@ -139,16 +75,78 @@ public class MainActivity extends Activity {
             }
         };
 
-        try {
-            File httpCache = new File(getExternalCacheDir().getAbsolutePath() + "/tile_cache");
-            handler.setCache(httpCache, 30 * 1024 * 1024);
-        } catch (Exception e) {
-            e.printStackTrace();
+        File cacheDir = getExternalCacheDir();
+        if (cacheDir != null && cacheDir.exists()) {
+            handler.setCache(new File(cacheDir, "tile_cache"), 30 * 1024 * 1024);
         }
 
-        mapController.setHttpHandler(handler);
-
+        return handler;
     }
 
+    @Override
+    public boolean onSingleTapUp(float x, float y) {
+        return false;
+    }
+
+    @Override
+    public boolean onSingleTapConfirmed(float x, float y) {
+        LngLat tappedPoint = map.coordinatesAtScreenPosition(x, y);
+
+        if (lastTappedPoint != null) {
+            Map<String, String> props = new HashMap<>();
+            props.put("type", "line");
+            props.put("color", "#D2655F");
+
+            List<LngLat> line = new ArrayList<>();
+            line.add(lastTappedPoint);
+            line.add(tappedPoint);
+            markers.addPolyline(line, props);
+
+            props = new HashMap<>();
+            props.put("type", "point");
+            markers.addPoint(tappedPoint, props);
+
+            markers.syncWithMap();
+        }
+
+        lastTappedPoint = tappedPoint;
+
+        map.pickFeature(x, y);
+
+        map.setMapPosition(tappedPoint.longitude, tappedPoint.latitude, 1.f);
+
+        return true;
+    }
+
+    @Override
+    public boolean onDoubleTap(float x, float y) {
+        map.setMapZoom(map.getMapZoom() + 1.f, .5f);
+        LngLat tapped = map.coordinatesAtScreenPosition(x, y);
+        LngLat current = map.getMapPosition();
+        map.setMapPosition(
+                .5 * (tapped.longitude + current.longitude),
+                .5 * (tapped.latitude + current.latitude),
+                .5f
+        );
+        return true;
+    }
+
+    @Override
+    public void onLongPress(float x, float y) {
+        markers.clear().syncWithMap();
+        showTileInfo = !showTileInfo;
+        map.setDebugFlag(MapController.DebugFlag.TILE_INFOS, showTileInfo);
+    }
+
+    @Override
+    public void onTouch(Map<String, String> properties, float positionX, float positionY) {
+        String name = properties.get("name");
+        if (name.isEmpty()) {
+            name = "unnamed";
+        }
+        Toast.makeText(getApplicationContext(),
+                "Selected: " + name + " at: " + positionX + ", " + positionY,
+                Toast.LENGTH_SHORT).show();
+    }
 }
 

--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -43,7 +43,32 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
         setContentView(R.layout.main);
 
         view = (MapView)findViewById(R.id.map);
+        view.onCreate(savedInstanceState);
         view.getMapAsync(this, "scene.yaml");
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        view.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        view.onPause();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        view.onDestroy();
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        view.onLowMemory();
     }
 
     @Override

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -12,7 +12,7 @@ group = GROUP
 version = VERSION_NAME
 
 android {
-  compileSdkVersion 22
+  compileSdkVersion 23
 
   /*
    * Ubuntu can't run the aapt on 64 bit before installing this packages
@@ -24,7 +24,7 @@ android {
 
   defaultConfig {
     minSdkVersion 15
-    targetSdkVersion 22
+    targetSdkVersion 23
   }
 
   sourceSets.main {
@@ -48,6 +48,7 @@ afterEvaluate {
 dependencies {
   compile 'com.squareup.okhttp:okhttp:2.5.0'
   compile 'xmlpull:xmlpull:1.1.3.1'
+  compile 'com.android.support:support-annotations:23.1.1'
 }
 
 apply from: file('gradle-mvn-push.gradle')

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -60,7 +60,7 @@ public class MapController implements Renderer {
      * must contain all the local files that the map will need
      * @param sceneFilePath Location of the YAML scene file within the assets directory
      */
-    public MapController(Context context, String sceneFilePath) {
+    MapController(Context context, String sceneFilePath) {
 
         scenePath = sceneFilePath;
 
@@ -81,7 +81,7 @@ public class MapController implements Renderer {
      * @param view GLSurfaceView where the map will be displayed; input events from this view will
      * be handled by the resulting MapController
      */
-    public void setView(GLSurfaceView view) {
+    void setView(GLSurfaceView view) {
         touchInput = new TouchInput(view.getContext());
         setPanResponder(null);
         setScaleResponder(null);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -1,11 +1,12 @@
 package com.mapzen.tangram;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.res.AssetManager;
 import android.opengl.GLSurfaceView;
 import android.opengl.GLSurfaceView.Renderer;
 import android.util.DisplayMetrics;
 
+import com.mapzen.tangram.TouchInput.Gestures;
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
@@ -17,8 +18,6 @@ import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
 import okio.BufferedSource;
-
-import com.mapzen.tangram.TouchInput.Gestures;
 
 public class MapController implements Renderer {
 
@@ -56,34 +55,34 @@ public class MapController implements Renderer {
     }
 
     /**
-     * Construct a MapController using the default scene file
-     * @param mainApp Activity in which the map will function; the asset bundle for this activity must contain all
-     * the local files that the map will need
-     * @param view MapView where the map will be displayed; input events from this view will be handled by the
-     * resulting MapController
-     */
-    public MapController(Activity mainApp, MapView view) {
-
-        this(mainApp, view, "scene.yaml");
-    }
-
-    /**
      * Construct a MapController using a custom scene file
-     * @param mainApp Activity in which the map will function; the asset bundle for this activity must contain all
-     * the local files that the map will need
-     * @param view MapView where the map will be displayed; input events from this view will be handled by the
-     * resulting MapController
+     * @param context Context in which the map will function; the asset bundle for this activity
+     * must contain all the local files that the map will need
      * @param sceneFilePath Location of the YAML scene file within the assets directory
      */
-    public MapController(Activity mainApp, MapView view, String sceneFilePath) {
+    public MapController(Context context, String sceneFilePath) {
 
         scenePath = sceneFilePath;
 
         // Get configuration info from application
-        mainApp.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
-        assetManager = mainApp.getAssets();
+        displayMetrics = context.getResources().getDisplayMetrics();
+        assetManager = context.getAssets();
 
-        touchInput = new TouchInput(mainApp);
+        // Load the fonts
+        fontFileParser = new FontFileParser();
+        fontFileParser.parse("/system/etc/fonts.xml");
+
+        init(this, assetManager, scenePath);
+
+    }
+
+    /**
+     * Set the view in which the map will be drawn
+     * @param view GLSurfaceView where the map will be displayed; input events from this view will
+     * be handled by the resulting MapController
+     */
+    public void setView(GLSurfaceView view) {
+        touchInput = new TouchInput(view.getContext());
         setPanResponder(null);
         setScaleResponder(null);
         setRotateResponder(null);
@@ -100,13 +99,6 @@ public class MapController implements Renderer {
         view.setOnTouchListener(touchInput);
         view.setRenderer(this);
         view.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
-
-        // Load the fonts
-        fontFileParser = new FontFileParser();
-        fontFileParser.parse("/system/etc/fonts.xml");
-
-        init(this, assetManager, scenePath);
-
     }
 
     /**
@@ -564,7 +556,7 @@ public class MapController implements Renderer {
 
     private String scenePath;
     private long time = System.nanoTime();
-    private MapView mapView;
+    private GLSurfaceView mapView;
     private AssetManager assetManager;
     private TouchInput touchInput;
     private FontFileParser fontFileParser;

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -51,6 +51,10 @@ public class MapView extends FrameLayout {
 
         final Context context = getContext();
 
+        if (getMapTask != null) {
+            getMapTask.cancel(true);
+        }
+
         getMapTask = new AsyncTask<Void, Void, MapController>() {
 
             @Override

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -28,19 +28,26 @@ public class MapView extends FrameLayout {
 
     }
 
+    /**
+     * Interface for receiving a {@code MapController} once it is ready to be used
+     */
     public interface OnMapReadyCallback {
 
+        /**
+         * Called when the map is ready to be used
+         * @param mapController A non-null {@code MapController} instance for this {@code MapView}
+         */
         void onMapReady(MapController mapController);
 
     }
 
     /**
-     * Construct a MapController asynchronously; may only be called from the UI thread
-     * @param listener The object to receive the resulting MapController in a callback;
+     * Construct a {@code MapController} asynchronously; may only be called from the UI thread
+     * @param callback The object to receive the resulting MapController in a callback;
      * the callback will be made on the UI thread
      * @param sceneFilePath Location of the YAML scene file within the asset bundle
      */
-    public void getMapAsync(final OnMapReadyCallback listener, final String sceneFilePath) {
+    public void getMapAsync(final OnMapReadyCallback callback, final String sceneFilePath) {
 
         final Context context = getContext();
 
@@ -55,7 +62,7 @@ public class MapView extends FrameLayout {
             protected void onPostExecute(MapController map) {
                 map.setView(glSurfaceView);
                 addView(glSurfaceView);
-                listener.onMapReady(map);
+                callback.onMapReady(map);
             }
 
         }.execute();
@@ -71,18 +78,30 @@ public class MapView extends FrameLayout {
 
     }
 
+    /**
+     * You must call this method from the parent Activity/Fragment's corresponding method.
+     */
     public void onCreate(Bundle savedInstanceState) {
 
     }
 
+    /**
+     * You must call this method from the parent Activity/Fragment's corresponding method.
+     */
     public void onResume() {
 
     }
 
+    /**
+     * You must call this method from the parent Activity/Fragment's corresponding method.
+     */
     public void onPause() {
 
     }
 
+    /**
+     * You must call this method from the parent Activity/Fragment's corresponding method.
+     */
     public void onDestroy() {
 
         if (getMapTask != null) {
@@ -91,6 +110,9 @@ public class MapView extends FrameLayout {
 
     }
 
+    /**
+     * You must call this method from the parent Activity/Fragment's corresponding method.
+     */
     public void onLowMemory() {
 
     }

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -3,12 +3,14 @@ package com.mapzen.tangram;
 import android.content.Context;
 import android.opengl.GLSurfaceView;
 import android.os.AsyncTask;
+import android.os.Bundle;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 
 public class MapView extends FrameLayout {
 
     protected GLSurfaceView glSurfaceView;
+    protected AsyncTask<Void, Void, MapController> getMapTask;
 
     public MapView(Context context) {
 
@@ -42,7 +44,7 @@ public class MapView extends FrameLayout {
 
         final Context context = getContext();
 
-        new AsyncTask<Void, Void, MapController>() {
+        getMapTask = new AsyncTask<Void, Void, MapController>() {
 
             @Override
             protected MapController doInBackground(Void... params) {
@@ -69,5 +71,28 @@ public class MapView extends FrameLayout {
 
     }
 
+    public void onCreate(Bundle savedInstanceState) {
+
+    }
+
+    public void onResume() {
+
+    }
+
+    public void onPause() {
+
+    }
+
+    public void onDestroy() {
+
+        if (getMapTask != null) {
+            getMapTask.cancel(true);
+        }
+
+    }
+
+    public void onLowMemory() {
+
+    }
 
 }

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.opengl.GLSurfaceView;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 
@@ -47,7 +48,8 @@ public class MapView extends FrameLayout {
      * the callback will be made on the UI thread
      * @param sceneFilePath Location of the YAML scene file within the asset bundle
      */
-    public void getMapAsync(final OnMapReadyCallback callback, final String sceneFilePath) {
+    public void getMapAsync(@NonNull final OnMapReadyCallback callback,
+                            @NonNull final String sceneFilePath) {
 
         final Context context = getContext();
 

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -2,9 +2,13 @@ package com.mapzen.tangram;
 
 import android.content.Context;
 import android.opengl.GLSurfaceView;
+import android.os.AsyncTask;
 import android.util.AttributeSet;
+import android.widget.FrameLayout;
 
-public class MapView extends GLSurfaceView {
+public class MapView extends FrameLayout {
+
+    protected GLSurfaceView glSurfaceView;
 
     public MapView(Context context) {
 
@@ -22,11 +26,46 @@ public class MapView extends GLSurfaceView {
 
     }
 
-    private void configureGLSurfaceView() {
+    public interface OnMapReadyCallback {
 
-        setEGLContextClientVersion(2);
-        setPreserveEGLContextOnPause(true);
-        setEGLConfigChooser(new ConfigChooser(8, 8, 8, 0, 16, 0));
+        void onMapReady(MapController mapController);
+
+    }
+
+    /**
+     * Construct a MapController asynchronously; may only be called from the UI thread
+     * @param listener The object to receive the resulting MapController in a callback;
+     * the callback will be made on the UI thread
+     * @param sceneFilePath Location of the YAML scene file within the asset bundle
+     */
+    public void getMapAsync(final OnMapReadyCallback listener, final String sceneFilePath) {
+
+        final Context context = getContext();
+
+        new AsyncTask<Void, Void, MapController>() {
+
+            @Override
+            protected MapController doInBackground(Void... params) {
+                return new MapController(context, sceneFilePath);
+            }
+
+            @Override
+            protected void onPostExecute(MapController map) {
+                map.setView(glSurfaceView);
+                addView(glSurfaceView);
+                listener.onMapReady(map);
+            }
+
+        }.execute();
+
+    }
+
+    protected void configureGLSurfaceView() {
+
+        glSurfaceView = new GLSurfaceView(getContext());
+        glSurfaceView.setEGLContextClientVersion(2);
+        glSurfaceView.setPreserveEGLContextOnPause(true);
+        glSurfaceView.setEGLConfigChooser(new ConfigChooser(8, 8, 8, 0, 16, 0));
 
     }
 


### PR DESCRIPTION
Resolves #558 

With this change, the primary means of initializing a tangram map on android is with the method `getMapAsync()` on `MapView`. This is very similar to the way a Google Map is initialized, the main difference being that our initializer takes a string argument to specify the scene file that should be loaded. There are a few advantages to this:

 - Loading large scene files will no longer block the UI thread
 - Client apps no longer need to provide an `Activity` or `Context`, (we get a `Context` from the `MapView` itself)
 - Similarity to a widely-adopted API should make it easier for new users to understand. 

This PR also _heavily_ refactors the `MainActivity` in the Android demo. It was rather messy and I had to do a bit of cleaning for the new async initializer anyway.