### PR TITLE
Add vanishing_point perspective camera property

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -13,7 +13,6 @@ cameras:
         position: [-74.00976419448854, 40.70532700869127, 16]
         type: perspective
         fov: 45
-        vanishing_point: [-250, -250] # currently ignored
         active: true
 
 lights:

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -744,7 +744,12 @@ void SceneLoader::loadCameras(Node _cameras, Scene& _scene) {
             }
 
             if (Node vanishing = camera["vanishing_point"]) {
-                // TODO
+                if (vanishing.IsSequence() && vanishing.size() >= 2) {
+                    // Values are pixels, unit strings are ignored.
+                    float x = std::stof(vanishing[0].Scalar());
+                    float y = std::stof(vanishing[1].Scalar());
+                    view->setVanishingPoint(x, y);
+                }
             }
         } else if (type == "isometric") {
 

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -329,6 +329,9 @@ void View::updateMatrices() {
             far = 2. * m_pos.z / std::max(0., cos(m_pitch + 0.5 * fovy));
             far = std::min(far, maxTileDistance);
             m_proj = glm::perspective(fovy, m_aspect, near, far);
+            // Adjust for vanishing point.
+            m_proj[2][0] -= m_vanishingPoint.x / getWidth();
+            m_proj[2][1] -= m_vanishingPoint.y / getHeight();
             break;
         case CameraType::isometric:
         case CameraType::flat:

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -47,6 +47,9 @@ public:
     void setObliqueAxis(float _x, float _y) { m_obliqueAxis = { _x, _y}; }
     auto obliqueAxis() const { return m_obliqueAxis; }
 
+    void setVanishingPoint(float x, float y) { m_vanishingPoint = { x, y }; }
+    auto vanishingPoint() const { return m_vanishingPoint; }
+
     // Set the vertical field-of-view angle, in radians.
     void setFieldOfView(float radians);
 
@@ -183,6 +186,7 @@ protected:
     glm::dvec3 m_pos;
     glm::vec3 m_eye;
     glm::vec2 m_obliqueAxis;
+    glm::vec2 m_vanishingPoint;
 
     glm::mat4 m_view;
     glm::mat4 m_orthoViewport;


### PR DESCRIPTION
Resolves #541 

`vanishing_point` now has the same behavior as it does in tangram-js for top-down views. There is a known issue that for very large `vanishing_point` vectors, a top-down view may show reduced-level-of-detail tiles. This is not the intended LOD behavior, but I think it's an acceptably small degradation of quality, given the rarity of its occurrence.