### PR TITLE
Refactor Android feature pick callbacks

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -8,7 +8,7 @@ import android.widget.Toast;
 import com.mapzen.tangram.HttpHandler;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
-import com.mapzen.tangram.MapController.FeatureTouchListener;
+import com.mapzen.tangram.MapController.FeaturePickListener;
 import com.mapzen.tangram.MapData;
 import com.mapzen.tangram.MapView;
 import com.mapzen.tangram.MapView.OnMapReadyCallback;
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 public class MainActivity extends Activity implements OnMapReadyCallback, TapResponder,
-        DoubleTapResponder, LongPressResponder, FeatureTouchListener {
+        DoubleTapResponder, LongPressResponder, FeaturePickListener {
 
     MapController map;
     MapView view;
@@ -80,7 +80,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
         map.setTapResponder(this);
         map.setDoubleTapResponder(this);
         map.setLongPressResponder(this);
-        map.setFeatureTouchListener(this);
+        map.setFeaturePickListener(this);
 
         markers = new MapData("touch");
         markers.addToMap(map);
@@ -165,7 +165,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     }
 
     @Override
-    public void onTouch(Map<String, String> properties, float positionX, float positionY) {
+    public void onFeaturePick(Map<String, String> properties, float positionX, float positionY) {
         String name = properties.get("name");
         if (name.isEmpty()) {
             name = "unnamed";

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -139,10 +139,10 @@ extern "C" {
         onUrlFailure(jniEnv, callbackPtr);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_pickFeature(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickFeature(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jobject listener) {
         auto& items = Tangram::pickFeaturesAt(posX, posY);
         if (!items.empty()) {
-            featureSelectionCallback(jniEnv, items);
+            featurePickCallback(jniEnv, listener, items);
         }
     }
 

--- a/android/tangram/jni/platform_android.h
+++ b/android/tangram/jni/platform_android.h
@@ -13,6 +13,6 @@ namespace Tangram {
 struct TouchItem;
 }
 
-void featureSelectionCallback(JNIEnv* jniEnv, const std::vector<Tangram::TouchItem>& items);
+void featurePickCallback(JNIEnv* jniEnv, jobject listener, const std::vector<Tangram::TouchItem>& items);
 
 std::string stringFromJString(JNIEnv* jniEnv, jstring string);


### PR DESCRIPTION
- Rename `FeatureTouchListener` and `onTouch` to `FeaturePickListener` and `onFeaturePick`
- Simplify callback cycle; if a listener is provided, the native function makes the callback directly