### PR TITLE
Consistently prefix native methods with 'native'

### DIFF
--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -6,136 +6,136 @@
 
 extern "C" {
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setPosition(JNIEnv* jniEnv, jobject obj, jdouble lon, jdouble lat) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPosition(JNIEnv* jniEnv, jobject obj, jdouble lon, jdouble lat) {
         Tangram::setPosition(lon, lat);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setPositionEased(JNIEnv* jniEnv, jobject obj, jdouble lon, jdouble lat, jfloat duration, jint ease) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPositionEased(JNIEnv* jniEnv, jobject obj, jdouble lon, jdouble lat, jfloat duration, jint ease) {
         Tangram::setPosition(lon, lat, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_getPosition(JNIEnv* jniEnv, jobject obj, jdoubleArray lonLat) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeGetPosition(JNIEnv* jniEnv, jobject obj, jdoubleArray lonLat) {
         jdouble* arr = jniEnv->GetDoubleArrayElements(lonLat, NULL);
         Tangram::getPosition(arr[0], arr[1]);
         jniEnv->ReleaseDoubleArrayElements(lonLat, arr, 0);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setZoom(JNIEnv* jniEnv, jobject obj, jfloat zoom) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetZoom(JNIEnv* jniEnv, jobject obj, jfloat zoom) {
         Tangram::setZoom(zoom);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setZoomEased(JNIEnv* jniEnv, jobject obj, jfloat zoom, jfloat duration, jint ease) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetZoomEased(JNIEnv* jniEnv, jobject obj, jfloat zoom, jfloat duration, jint ease) {
         Tangram::setZoom(zoom, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_getZoom(JNIEnv* jniEnv, jobject obj) {
+    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetZoom(JNIEnv* jniEnv, jobject obj) {
         return Tangram::getZoom();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setRotation(JNIEnv* jniEnv, jobject obj, jfloat radians) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetRotation(JNIEnv* jniEnv, jobject obj, jfloat radians) {
         Tangram::setRotation(radians);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setRotationEased(JNIEnv* jniEnv, jobject obj, jfloat radians, jfloat duration, jint ease) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetRotationEased(JNIEnv* jniEnv, jobject obj, jfloat radians, jfloat duration, jint ease) {
         Tangram::setRotation(radians, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_getRotation(JNIEnv* jniEnv, jobject obj) {
+    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetRotation(JNIEnv* jniEnv, jobject obj) {
         return Tangram::getRotation();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setTilt(JNIEnv* jniEnv, jobject obj, jfloat radians) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetTilt(JNIEnv* jniEnv, jobject obj, jfloat radians) {
         Tangram::setTilt(radians);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setTiltEased(JNIEnv* jniEnv, jobject obj, jfloat radians, jfloat duration, jint ease) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetTiltEased(JNIEnv* jniEnv, jobject obj, jfloat radians, jfloat duration, jint ease) {
         Tangram::setTilt(radians, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_getTilt(JNIEnv* jniEnv, jobject obj) {
+    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetTilt(JNIEnv* jniEnv, jobject obj) {
         return Tangram::getTilt();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_screenToWorldCoordinates(JNIEnv* jniEnv, jobject obj, jdoubleArray screenPos) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeScreenToWorldCoordinates(JNIEnv* jniEnv, jobject obj, jdoubleArray screenPos) {
         jdouble* arr = jniEnv->GetDoubleArrayElements(screenPos, NULL);
         Tangram::screenToWorldCoordinates(arr[0], arr[1]);
         jniEnv->ReleaseDoubleArrayElements(screenPos, arr, 0);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_init(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager, jstring stylePath) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager, jstring stylePath) {
         setupJniEnv(jniEnv, tangramInstance, assetManager);
         const char* cStylePath = jniEnv->GetStringUTFChars(stylePath, NULL);
         Tangram::initialize(cStylePath);
         jniEnv->ReleaseStringUTFChars(stylePath, cStylePath);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_loadScene(JNIEnv* jniEnv, jobject obj, jstring path) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jstring path) {
         const char* cPath = jniEnv->GetStringUTFChars(path, NULL);
         Tangram::loadScene(cPath);
         jniEnv->ReleaseStringUTFChars(path, cPath);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_resize(JNIEnv* jniEnv, jobject obj, jint width, jint height) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeResize(JNIEnv* jniEnv, jobject obj, jint width, jint height) {
         Tangram::resize(width, height);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_update(JNIEnv* jniEnv, jobject obj, jfloat dt) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeUpdate(JNIEnv* jniEnv, jobject obj, jfloat dt) {
         Tangram::update(dt);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_render(JNIEnv* jniEnv, jobject obj) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeRender(JNIEnv* jniEnv, jobject obj) {
         Tangram::render();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setupGL(JNIEnv* jniEnv, jobject obj) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetupGL(JNIEnv* jniEnv, jobject obj) {
         Tangram::setupGL();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setPixelScale(JNIEnv* jniEnv, jobject obj, jfloat scale) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPixelScale(JNIEnv* jniEnv, jobject obj, jfloat scale) {
         Tangram::setPixelScale(scale);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_setCameraType(JNIEnv* jniEnv, jobject obj, jint cameraType) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetCameraType(JNIEnv* jniEnv, jobject obj, jint cameraType) {
         Tangram::setCameraType(cameraType);
     }
 
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_getCameraType(JNIEnv* jniEnv, jobject obj) {
+    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeGetCameraType(JNIEnv* jniEnv, jobject obj) {
         return Tangram::getCameraType();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_handleTapGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleTapGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
         Tangram::handleTapGesture(posX, posY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_handleDoubleTapGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleDoubleTapGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
         Tangram::handleDoubleTapGesture(posX, posY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_handlePanGesture(JNIEnv* jniEnv, jobject obj, jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandlePanGesture(JNIEnv* jniEnv, jobject obj, jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
         Tangram::handlePanGesture(startX, startY, endX, endY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_handleFlingGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat velocityX, jfloat velocityY) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleFlingGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat velocityX, jfloat velocityY) {
         Tangram::handleFlingGesture(posX, posY, velocityX, velocityY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_handlePinchGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat scale, jfloat velocity) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandlePinchGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat scale, jfloat velocity) {
         Tangram::handlePinchGesture(posX, posY, scale, velocity);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_handleRotateGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat rotation) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleRotateGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat rotation) {
         Tangram::handleRotateGesture(posX, posY, rotation);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_handleShoveGesture(JNIEnv* jniEnv, jobject obj, jfloat distance) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleShoveGesture(JNIEnv* jniEnv, jobject obj, jfloat distance) {
         Tangram::handleShoveGesture(distance);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_onUrlSuccess(JNIEnv* jniEnv, jobject obj, jbyteArray fetchedBytes, jlong callbackPtr) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeOnUrlSuccess(JNIEnv* jniEnv, jobject obj, jbyteArray fetchedBytes, jlong callbackPtr) {
         onUrlSuccess(jniEnv, fetchedBytes, callbackPtr);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_onUrlFailure(JNIEnv* jniEnv, jobject obj, jlong callbackPtr) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeOnUrlFailure(JNIEnv* jniEnv, jobject obj, jlong callbackPtr) {
         onUrlFailure(jniEnv, callbackPtr);
     }
 

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -72,7 +72,7 @@ public class MapController implements Renderer {
         fontFileParser = new FontFileParser();
         fontFileParser.parse("/system/etc/fonts.xml");
 
-        init(this, assetManager, scenePath);
+        nativeInit(this, assetManager, scenePath);
 
     }
 
@@ -107,7 +107,7 @@ public class MapController implements Renderer {
      */
     public void loadSceneFile(String path) {
         scenePath = path;
-        loadScene(path);
+        nativeLoadScene(path);
         requestRender();
     }
 
@@ -134,7 +134,7 @@ public class MapController implements Renderer {
      * @param lat Degrees latitude of the position to set
      */
     public void setMapPosition(double lng, double lat) {
-        setPosition(lng, lat);
+        nativeSetPosition(lng, lat);
     }
 
     /**
@@ -144,7 +144,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to the given position
      */
     public void setMapPosition(double lng, double lat, float duration) {
-        setPositionEased(lng, lat, duration, EaseType.QUINT.ordinal());
+        nativeSetPositionEased(lng, lat, duration, EaseType.QUINT.ordinal());
     }
 
     /**
@@ -155,7 +155,7 @@ public class MapController implements Renderer {
      * @param ease Type of easing to use
      */
     public void setMapPosition(double lng, double lat, float duration, EaseType ease) {
-        setPositionEased(lng, lat, duration, ease.ordinal());
+        nativeSetPositionEased(lng, lat, duration, ease.ordinal());
     }
 
     /**
@@ -173,7 +173,7 @@ public class MapController implements Renderer {
      */
     public LngLat getMapPosition(LngLat out) {
         double[] tmp = { 0, 0 };
-        getPosition(tmp);
+        nativeGetPosition(tmp);
         return out.set(tmp[0], tmp[1]);
     }
 
@@ -182,7 +182,7 @@ public class MapController implements Renderer {
      * @param zoom Fractional zoom level
      */
     public void setMapZoom(float zoom) {
-        setZoom(zoom);
+        nativeSetZoom(zoom);
     }
 
     /**
@@ -191,7 +191,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to given zoom
      */
     public void setMapZoom(float zoom, float duration) {
-        setZoomEased(zoom, duration, EaseType.QUINT.ordinal());
+        nativeSetZoomEased(zoom, duration, EaseType.QUINT.ordinal());
     }
 
     /**
@@ -201,7 +201,7 @@ public class MapController implements Renderer {
      * @param ease Type of easing to use
      */
     public void setMapZoom(float zoom, float duration, EaseType ease) {
-        setZoomEased(zoom, duration, ease.ordinal());
+        nativeSetZoomEased(zoom, duration, ease.ordinal());
     }
 
     /**
@@ -209,7 +209,7 @@ public class MapController implements Renderer {
      * @return Fractional zoom level
      */
     public float getMapZoom() {
-        return getZoom();
+        return nativeGetZoom();
     }
 
     /**
@@ -217,7 +217,7 @@ public class MapController implements Renderer {
      * @param radians Rotation in radians
      */
     public void setMapRotation(float radians) {
-        setRotation(radians);
+        nativeSetRotation(radians);
     }
 
     /**
@@ -226,7 +226,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to the given rotation
      */
     public void setMapRotation(float radians, float duration) {
-        setRotationEased(radians, duration, EaseType.QUINT.ordinal());
+        nativeSetRotationEased(radians, duration, EaseType.QUINT.ordinal());
     }
 
     /**
@@ -236,7 +236,7 @@ public class MapController implements Renderer {
      * @param ease Type of easing to use
      */
     public void setMapRotation(float radians, float duration, EaseType ease) {
-        setRotationEased(radians, duration, ease.ordinal());
+        nativeSetRotationEased(radians, duration, ease.ordinal());
     }
 
     /**
@@ -244,7 +244,7 @@ public class MapController implements Renderer {
      * @return Rotation in radians
      */
     public float getMapRotation() {
-        return getRotation();
+        return nativeGetRotation();
     }
 
     /**
@@ -252,7 +252,7 @@ public class MapController implements Renderer {
      * @param radians Tilt angle in radians
      */
     public void setMapTilt(float radians) {
-        setTilt(radians);
+        nativeSetTilt(radians);
     }
 
     /**
@@ -261,7 +261,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to the given tilt
      */
     public void setMapTilt(float radians, float duration) {
-        setTiltEased(radians, duration, EaseType.QUINT.ordinal());
+        nativeSetTiltEased(radians, duration, EaseType.QUINT.ordinal());
     }
 
     /**
@@ -271,7 +271,7 @@ public class MapController implements Renderer {
      * @param ease Type of easing to use
      */
     public void setMapTilt(float radians, float duration, EaseType ease) {
-        setTiltEased(radians, duration, ease.ordinal());
+        nativeSetTiltEased(radians, duration, ease.ordinal());
     }
 
     /**
@@ -279,7 +279,7 @@ public class MapController implements Renderer {
      * @return Tilt angle in radians
      */
     public float getMapTilt() {
-        return getTilt();
+        return nativeGetTilt();
     }
 
     /**
@@ -287,7 +287,7 @@ public class MapController implements Renderer {
      * @param type A CameraType
      */
     public void setMapCameraType(CameraType type) {
-        setCameraType(type.ordinal());
+        nativeSetCameraType(type.ordinal());
         requestRender();
     }
 
@@ -296,7 +296,7 @@ public class MapController implements Renderer {
      * @return The current CameraType
      */
     public CameraType getMapCameraType() {
-        return CameraType.values()[getCameraType()];
+        return CameraType.values()[nativeGetCameraType()];
     }
 
     /**
@@ -307,7 +307,7 @@ public class MapController implements Renderer {
      */
     public LngLat coordinatesAtScreenPosition(double screenX, double screenY) {
         double[] tmp = { screenX, screenY };
-        screenToWorldCoordinates(tmp);
+        nativeScreenToWorldCoordinates(tmp);
         return new LngLat(tmp[0], tmp[1]);
     }
 
@@ -386,7 +386,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onPan(float startX, float startY, float endX, float endY) {
                 if (responder == null || !responder.onPan(startX, startY, endX, endY)) {
-                    handlePanGesture(startX, startY, endX, endY);
+                    nativeHandlePanGesture(startX, startY, endX, endY);
                 }
                 return true;
             }
@@ -394,7 +394,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onFling(float posX, float posY, float velocityX, float velocityY) {
                 if (responder == null || !responder.onFling(posX, posY, velocityX, velocityY)) {
-                    handleFlingGesture(posX, posY, velocityX, velocityY);
+                    nativeHandleFlingGesture(posX, posY, velocityX, velocityY);
                 }
                 return true;
             }
@@ -410,7 +410,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onRotate(float x, float y, float rotation) {
                 if (responder == null || !responder.onRotate(x, y, rotation)) {
-                    handleRotateGesture(x, y, rotation);
+                    nativeHandleRotateGesture(x, y, rotation);
                 }
                 return true;
             }
@@ -426,7 +426,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onScale(float x, float y, float scale, float velocity) {
                 if (responder == null || !responder.onScale(x, y, scale, velocity)) {
-                    handlePinchGesture(x, y, scale, velocity);
+                    nativeHandlePinchGesture(x, y, scale, velocity);
                 }
                 return true;
             }
@@ -442,7 +442,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onShove(float distance) {
                 if (responder == null || !responder.onShove(distance)) {
-                    handleShoveGesture(distance);
+                    nativeHandleShoveGesture(distance);
                 }
                 return true;
             }
@@ -514,40 +514,40 @@ public class MapController implements Renderer {
         System.loadLibrary("tangram");
     }
 
-    private synchronized native void init(MapController instance, AssetManager assetManager, String stylePath);
-    private synchronized native void loadScene(String path);
-    private synchronized native void setupGL();
-    private synchronized native void resize(int width, int height);
-    private synchronized native void update(float dt);
-    private synchronized native void render();
-    private synchronized native void setPosition(double lon, double lat);
-    private synchronized native void setPositionEased(double lon, double lat, float duration, int ease);
-    private synchronized native void getPosition(double[] lonLatOut);
-    private synchronized native void setZoom(float zoom);
-    private synchronized native void setZoomEased(float zoom, float duration, int ease);
-    private synchronized native float getZoom();
-    private synchronized native void setRotation(float radians);
-    private synchronized native void setRotationEased(float radians, float duration, int ease);
-    private synchronized native float getRotation();
-    private synchronized native void setTilt(float radians);
-    private synchronized native void setTiltEased(float radians, float duration, int ease);
-    private synchronized native float getTilt();
-    private synchronized native void screenToWorldCoordinates(double[] screenCoords);
-    private synchronized native void setPixelScale(float scale);
-    private synchronized native void setCameraType(int cameraType);
-    private synchronized native int getCameraType();
-    private synchronized native void handleTapGesture(float posX, float posY);
-    private synchronized native void handleDoubleTapGesture(float posX, float posY);
-    private synchronized native void handlePanGesture(float startX, float startY, float endX, float endY);
-    private synchronized native void handleFlingGesture(float posX, float posY, float velocityX, float velocityY);
-    private synchronized native void handlePinchGesture(float posX, float posY, float scale, float velocity);
-    private synchronized native void handleRotateGesture(float posX, float posY, float rotation);
-    private synchronized native void handleShoveGesture(float distance);
+    private synchronized native void nativeInit(MapController instance, AssetManager assetManager, String stylePath);
+    private synchronized native void nativeLoadScene(String path);
+    private synchronized native void nativeSetupGL();
+    private synchronized native void nativeResize(int width, int height);
+    private synchronized native void nativeUpdate(float dt);
+    private synchronized native void nativeRender();
+    private synchronized native void nativeSetPosition(double lon, double lat);
+    private synchronized native void nativeSetPositionEased(double lon, double lat, float duration, int ease);
+    private synchronized native void nativeGetPosition(double[] lonLatOut);
+    private synchronized native void nativeSetZoom(float zoom);
+    private synchronized native void nativeSetZoomEased(float zoom, float duration, int ease);
+    private synchronized native float nativeGetZoom();
+    private synchronized native void nativeSetRotation(float radians);
+    private synchronized native void nativeSetRotationEased(float radians, float duration, int ease);
+    private synchronized native float nativeGetRotation();
+    private synchronized native void nativeSetTilt(float radians);
+    private synchronized native void nativeSetTiltEased(float radians, float duration, int ease);
+    private synchronized native float nativeGetTilt();
+    private synchronized native void nativeScreenToWorldCoordinates(double[] screenCoords);
+    private synchronized native void nativeSetPixelScale(float scale);
+    private synchronized native void nativeSetCameraType(int cameraType);
+    private synchronized native int nativeGetCameraType();
+    private synchronized native void nativeHandleTapGesture(float posX, float posY);
+    private synchronized native void nativeHandleDoubleTapGesture(float posX, float posY);
+    private synchronized native void nativeHandlePanGesture(float startX, float startY, float endX, float endY);
+    private synchronized native void nativeHandleFlingGesture(float posX, float posY, float velocityX, float velocityY);
+    private synchronized native void nativeHandlePinchGesture(float posX, float posY, float scale, float velocity);
+    private synchronized native void nativeHandleRotateGesture(float posX, float posY, float rotation);
+    private synchronized native void nativeHandleShoveGesture(float distance);
 
     public synchronized native void nativePickFeature(float posX, float posY, FeaturePickListener listener);
 
-    private native void onUrlSuccess(byte[] rawDataBytes, long callbackPtr);
-    private native void onUrlFailure(long callbackPtr);
+    private native void nativeOnUrlSuccess(byte[] rawDataBytes, long callbackPtr);
+    private native void nativeOnUrlFailure(long callbackPtr);
 
     native long nativeAddDataSource(String name);
     native void nativeRemoveDataSource(long pointer);
@@ -579,22 +579,22 @@ public class MapController implements Renderer {
         float delta = (newTime - time) / 1000000000.0f;
         time = newTime;
 
-        update(delta);
-        render();
+        nativeUpdate(delta);
+        nativeRender();
     }
 
     @Override
     public void onSurfaceChanged(GL10 gl, int width, int height) {
-        setPixelScale(displayMetrics.density);
-        resize(width, height);
+        nativeSetPixelScale(displayMetrics.density);
+        nativeResize(width, height);
     }
 
     @Override
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
-        init(this, assetManager, scenePath);
-        // init() is safe to call twice, this invocation ensures that the jni
+        nativeInit(this, assetManager, scenePath);
+        // nativeInit() is safe to call twice, this invocation ensures that the jni
         // environment is attached to the rendering thread
-        setupGL();
+        nativeSetupGL();
     }
 
     // Networking methods
@@ -614,19 +614,19 @@ public class MapController implements Renderer {
         httpHandler.onRequest(url, new Callback() {
             @Override
             public void onFailure(Request request, IOException e) {
-                onUrlFailure(callbackPtr);
+                nativeOnUrlFailure(callbackPtr);
                 //e.printStackTrace();
             }
 
             @Override
             public void onResponse(Response response) throws IOException {
                 if (!response.isSuccessful()) {
-                    onUrlFailure(callbackPtr);
+                    nativeOnUrlFailure(callbackPtr);
                     throw new IOException("Unexpected response code: " + response);
                 }
                 BufferedSource source = response.body().source();
                 byte[] bytes = source.readByteArray();
-                onUrlSuccess(bytes, callbackPtr);
+                nativeOnUrlSuccess(bytes, callbackPtr);
             }
         });
         return true;


### PR DESCRIPTION
This is a pretty typical practice for code that uses JNI. For us it means that 1) we can immediately tell when JNI is and is not being invoked in our Java classes and 2) we'll have less trouble with method name collisions (e.g. `setMapPosition` could just be called `setPosition` now).