### PR TITLE
Upgrade Gradle to 2.0

### DIFF
--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.2.3'
+    classpath 'com.android.tools.build:gradle:2.0.0'
   }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Thu Apr 07 21:50:30 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.2.3'
-    classpath 'com.github.dcendents:android-maven-plugin:1.2'
+    classpath 'com.android.tools.build:gradle:2.0.0'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
   }
 }
 


### PR DESCRIPTION
Updates our Gradle wrapper and the android-maven-gradle plugin.

This upgrade was "strongly recommended" by the latest update to Android Studio. Seems alright so far!