### PR TITLE
Yet Another Refactor of MapData usage

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -82,8 +82,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
         map.setLongPressResponder(this);
         map.setFeaturePickListener(this);
 
-        markers = new MapData("touch");
-        markers.addToMap(map);
+        markers = map.addDataLayer("touch");
     }
 
     HttpHandler getHttpHandler() {
@@ -131,8 +130,6 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
             props = new HashMap<>();
             props.put("type", "point");
             markers.addPoint(tappedPoint, props);
-
-            markers.syncWithMap();
         }
 
         lastTappedPoint = tappedPoint;
@@ -159,7 +156,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
     @Override
     public void onLongPress(float x, float y) {
-        markers.clear().syncWithMap();
+        markers.clear();
         showTileInfo = !showTileInfo;
         map.setDebugFlag(MapController.DebugFlag.TILE_INFOS, showTileInfo);
     }


### PR DESCRIPTION
 - `MapData` can only be instantiated through a `MapController`, so now they are always associated with a non-null map
 - You no longer need to call `syncWithMap` after modifying a `MapData`, synchronization is automatic
 - To prevent native data sources becoming unreachable from Java code, `MapController` keeps a static collection of all `MapData` instances