### PR TITLE
Clean up camera-related code in Android SDK

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -74,8 +74,8 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     @Override
     public void onMapReady(MapController mapController) {
         map = mapController;
-        map.setMapZoom(16);
-        map.setMapPosition(-74.00976419448854, 40.70532700869127);
+        map.setZoom(16);
+        map.setPosition(new LngLat(-74.00976419448854, 40.70532700869127));
         map.setHttpHandler(getHttpHandler());
         map.setTapResponder(this);
         map.setDoubleTapResponder(this);
@@ -136,21 +136,20 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
         map.pickFeature(x, y);
 
-        map.setMapPosition(tappedPoint.longitude, tappedPoint.latitude, 1.f);
+        map.setPosition(tappedPoint, 1.f);
 
         return true;
     }
 
     @Override
     public boolean onDoubleTap(float x, float y) {
-        map.setMapZoom(map.getMapZoom() + 1.f, .5f);
+        map.setZoom(map.getZoom() + 1.f, .5f);
         LngLat tapped = map.coordinatesAtScreenPosition(x, y);
-        LngLat current = map.getMapPosition();
-        map.setMapPosition(
+        LngLat current = map.getPosition();
+        LngLat next = new LngLat(
                 .5 * (tapped.longitude + current.longitude),
-                .5 * (tapped.latitude + current.latitude),
-                .5f
-        );
+                .5 * (tapped.latitude + current.latitude));
+        map.setPosition(next, .5f);
         return true;
     }
 

--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -136,20 +136,20 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
         map.pickFeature(x, y);
 
-        map.setPosition(tappedPoint, 1.f);
+        map.setPosition(tappedPoint, 1000);
 
         return true;
     }
 
     @Override
     public boolean onDoubleTap(float x, float y) {
-        map.setZoom(map.getZoom() + 1.f, .5f);
+        map.setZoom(map.getZoom() + 1.f, 500);
         LngLat tapped = map.coordinatesAtScreenPosition(x, y);
         LngLat current = map.getPosition();
         LngLat next = new LngLat(
                 .5 * (tapped.longitude + current.longitude),
                 .5 * (tapped.latitude + current.latitude));
-        map.setPosition(next, .5f);
+        map.setPosition(next, 500);
         return true;
     }
 

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -95,14 +95,6 @@ extern "C" {
         Tangram::setPixelScale(scale);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetCameraType(JNIEnv* jniEnv, jobject obj, jint cameraType) {
-        Tangram::setCameraType(cameraType);
-    }
-
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeGetCameraType(JNIEnv* jniEnv, jobject obj) {
-        return Tangram::getCameraType();
-    }
-
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleTapGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
         Tangram::handleTapGesture(posX, posY);
     }

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -31,12 +31,6 @@ public class MapController implements Renderer {
 
     protected static EaseType DEFAULT_EASE_TYPE = EaseType.CUBIC;
 
-    public enum CameraType {
-        PERSPECTIVE,
-        ISOMETRIC,
-        FLAT,
-    }
-
     public enum DebugFlag {
         FREEZE_TILES,
         PROXY_COLORS,
@@ -276,23 +270,6 @@ public class MapController implements Renderer {
      */
     public float getTilt() {
         return nativeGetTilt();
-    }
-
-    /**
-     * Set the camera type for the map view
-     * @param type A CameraType
-     */
-    public void setMapCameraType(CameraType type) {
-        nativeSetCameraType(type.ordinal());
-        requestRender();
-    }
-
-    /**
-     * Get the camera type currently in use for the map view
-     * @return The current CameraType
-     */
-    public CameraType getMapCameraType() {
-        return CameraType.values()[nativeGetCameraType()];
     }
 
     /**
@@ -577,8 +554,6 @@ public class MapController implements Renderer {
     private synchronized native float nativeGetTilt();
     private synchronized native void nativeScreenToWorldCoordinates(double[] screenCoords);
     private synchronized native void nativeSetPixelScale(float scale);
-    private synchronized native void nativeSetCameraType(int cameraType);
-    private synchronized native int nativeGetCameraType();
     private synchronized native void nativeHandleTapGesture(float posX, float posY);
     private synchronized native void nativeHandleDoubleTapGesture(float posX, float posY);
     private synchronized native void nativeHandlePanGesture(float startX, float startY, float endX, float endY);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -29,6 +29,8 @@ public class MapController implements Renderer {
         SINE,
     }
 
+    protected static EaseType DEFAULT_EASE_TYPE = EaseType.CUBIC;
+
     public enum CameraType {
         PERSPECTIVE,
         ISOMETRIC,
@@ -135,7 +137,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to the given position
      */
     public void setPosition(LngLat position, float duration) {
-        nativeSetPositionEased(position.longitude, position.latitude, duration, EaseType.QUINT.ordinal());
+        setPosition(position, duration, DEFAULT_EASE_TYPE);
     }
 
     /**
@@ -181,7 +183,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to given zoom
      */
     public void setZoom(float zoom, float duration) {
-        nativeSetZoomEased(zoom, duration, EaseType.QUINT.ordinal());
+        setZoom(zoom, duration, DEFAULT_EASE_TYPE);
     }
 
     /**
@@ -216,7 +218,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to the given rotation
      */
     public void setRotation(float radians, float duration) {
-        nativeSetRotationEased(radians, duration, EaseType.QUINT.ordinal());
+        setRotation(radians, duration, DEFAULT_EASE_TYPE);
     }
 
     /**
@@ -251,7 +253,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to the given tilt
      */
     public void setTilt(float radians, float duration) {
-        nativeSetTiltEased(radians, duration, EaseType.QUINT.ordinal());
+        setTilt(radians, duration, DEFAULT_EASE_TYPE);
     }
 
     /**

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -134,20 +134,21 @@ public class MapController implements Renderer {
     /**
      * Set the geographic position of the center of the map view
      * @param position LngLat of the position to set
-     * @param duration Time in seconds to ease to the given position
+     * @param duration Time in milliseconds to ease to the given position
      */
-    public void setPosition(LngLat position, float duration) {
+    public void setPosition(LngLat position, int duration) {
         setPosition(position, duration, DEFAULT_EASE_TYPE);
     }
 
     /**
      * Set the geographic position of the center of the map view
      * @param position LngLat of the position to set
-     * @param duration Time in seconds to ease to the given position
+     * @param duration Time in milliseconds to ease to the given position
      * @param ease Type of easing to use
      */
-    public void setPosition(LngLat position, float duration, EaseType ease) {
-        nativeSetPositionEased(position.longitude, position.latitude, duration, ease.ordinal());
+    public void setPosition(LngLat position, int duration, EaseType ease) {
+        float seconds = duration / 1000.f;
+        nativeSetPositionEased(position.longitude, position.latitude, seconds, ease.ordinal());
     }
 
     /**
@@ -180,20 +181,21 @@ public class MapController implements Renderer {
     /**
      * Set the zoom level of the map view
      * @param zoom Fractional zoom level
-     * @param duration Time in seconds to ease to given zoom
+     * @param duration Time in milliseconds to ease to given zoom
      */
-    public void setZoom(float zoom, float duration) {
+    public void setZoom(float zoom, int duration) {
         setZoom(zoom, duration, DEFAULT_EASE_TYPE);
     }
 
     /**
      * Set the zoom level of the map view
      * @param zoom Fractional zoom level
-     * @param duration Time in seconds to ease to given zoom
+     * @param duration Time in milliseconds to ease to given zoom
      * @param ease Type of easing to use
      */
-    public void setZoom(float zoom, float duration, EaseType ease) {
-        nativeSetZoomEased(zoom, duration, ease.ordinal());
+    public void setZoom(float zoom, int duration, EaseType ease) {
+        float seconds = duration / 1000.f;
+        nativeSetZoomEased(zoom, seconds, ease.ordinal());
     }
 
     /**
@@ -215,20 +217,21 @@ public class MapController implements Renderer {
     /**
      * Set the counter-clockwise rotation of the view in radians; 0 corresponds to North pointing up
      * @param radians Rotation in radians
-     * @param duration Time in seconds to ease to the given rotation
+     * @param duration Time in milliseconds to ease to the given rotation
      */
-    public void setRotation(float radians, float duration) {
+    public void setRotation(float radians, int duration) {
         setRotation(radians, duration, DEFAULT_EASE_TYPE);
     }
 
     /**
      * Set the counter-clockwise rotation of the view in radians; 0 corresponds to North pointing up
      * @param radians Rotation in radians
-     * @param duration Time in seconds to ease to the given rotation
+     * @param duration Time in milliseconds to ease to the given rotation
      * @param ease Type of easing to use
      */
-    public void setRotation(float radians, float duration, EaseType ease) {
-        nativeSetRotationEased(radians, duration, ease.ordinal());
+    public void setRotation(float radians, int duration, EaseType ease) {
+        float seconds = duration / 1000.f;
+        nativeSetRotationEased(radians, seconds, ease.ordinal());
     }
 
     /**
@@ -250,20 +253,21 @@ public class MapController implements Renderer {
     /**
      * Set the tilt angle of the view in radians; 0 corresponds to straight down
      * @param radians Tilt angle in radians
-     * @param duration Time in seconds to ease to the given tilt
+     * @param duration Time in milliseconds to ease to the given tilt
      */
-    public void setTilt(float radians, float duration) {
+    public void setTilt(float radians, int duration) {
         setTilt(radians, duration, DEFAULT_EASE_TYPE);
     }
 
     /**
      * Set the tilt angle of the view in radians; 0 corresponds to straight down
      * @param radians Tilt angle in radians
-     * @param duration Time in seconds to ease to the given tilt
+     * @param duration Time in milliseconds to ease to the given tilt
      * @param ease Type of easing to use
      */
-    public void setTilt(float radians, float duration, EaseType ease) {
-        nativeSetTiltEased(radians, duration, ease.ordinal());
+    public void setTilt(float radians, int duration, EaseType ease) {
+        float seconds = duration / 1000.f;
+        nativeSetTiltEased(radians, seconds, ease.ordinal());
     }
 
     /**
@@ -560,16 +564,16 @@ public class MapController implements Renderer {
     private synchronized native void nativeUpdate(float dt);
     private synchronized native void nativeRender();
     private synchronized native void nativeSetPosition(double lon, double lat);
-    private synchronized native void nativeSetPositionEased(double lon, double lat, float duration, int ease);
+    private synchronized native void nativeSetPositionEased(double lon, double lat, float seconds, int ease);
     private synchronized native void nativeGetPosition(double[] lonLatOut);
     private synchronized native void nativeSetZoom(float zoom);
-    private synchronized native void nativeSetZoomEased(float zoom, float duration, int ease);
+    private synchronized native void nativeSetZoomEased(float zoom, float seconds, int ease);
     private synchronized native float nativeGetZoom();
     private synchronized native void nativeSetRotation(float radians);
-    private synchronized native void nativeSetRotationEased(float radians, float duration, int ease);
+    private synchronized native void nativeSetRotationEased(float radians, float seconds, int ease);
     private synchronized native float nativeGetRotation();
     private synchronized native void nativeSetTilt(float radians);
-    private synchronized native void nativeSetTiltEased(float radians, float duration, int ease);
+    private synchronized native void nativeSetTiltEased(float radians, float seconds, int ease);
     private synchronized native float nativeGetTilt();
     private synchronized native void nativeScreenToWorldCoordinates(double[] screenCoords);
     private synchronized native void nativeSetPixelScale(float scale);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -125,46 +125,35 @@ public class MapController implements Renderer {
      * Set the geographic position of the center of the map view
      * @param position LngLat of the position to set
      */
-    public void setMapPosition(LngLat position) {
-        setMapPosition(position.longitude, position.latitude);
+    public void setPosition(LngLat position) {
+        nativeSetPosition(position.longitude, position.latitude);
     }
 
     /**
      * Set the geographic position of the center of the map view
-     * @param lng Degrees longitude of the position to set
-     * @param lat Degrees latitude of the position to set
-     */
-    public void setMapPosition(double lng, double lat) {
-        nativeSetPosition(lng, lat);
-    }
-
-    /**
-     * Set the geographic position of the center of the map view
-     * @param lng Degrees longitude of the position to set
-     * @param lat Degrees latitude of the position to set
+     * @param position LngLat of the position to set
      * @param duration Time in seconds to ease to the given position
      */
-    public void setMapPosition(double lng, double lat, float duration) {
-        nativeSetPositionEased(lng, lat, duration, EaseType.QUINT.ordinal());
+    public void setPosition(LngLat position, float duration) {
+        nativeSetPositionEased(position.longitude, position.latitude, duration, EaseType.QUINT.ordinal());
     }
 
     /**
      * Set the geographic position of the center of the map view
-     * @param lng Degrees longitude of the position to set
-     * @param lat Degrees latitude of the position to set
+     * @param position LngLat of the position to set
      * @param duration Time in seconds to ease to the given position
      * @param ease Type of easing to use
      */
-    public void setMapPosition(double lng, double lat, float duration, EaseType ease) {
-        nativeSetPositionEased(lng, lat, duration, ease.ordinal());
+    public void setPosition(LngLat position, float duration, EaseType ease) {
+        nativeSetPositionEased(position.longitude, position.latitude, duration, ease.ordinal());
     }
 
     /**
      * Get the geographic position of the center of the map view
      * @return The current map position in a LngLat
      */
-    public LngLat getMapPosition() {
-        return getMapPosition(new LngLat());
+    public LngLat getPosition() {
+        return getPosition(new LngLat());
     }
 
     /**
@@ -172,7 +161,7 @@ public class MapController implements Renderer {
      * @param out LngLat to be reused as the output
      * @return Degrees longitude and latitude of the current map position, in a two-element array
      */
-    public LngLat getMapPosition(LngLat out) {
+    public LngLat getPosition(LngLat out) {
         double[] tmp = { 0, 0 };
         nativeGetPosition(tmp);
         return out.set(tmp[0], tmp[1]);
@@ -182,7 +171,7 @@ public class MapController implements Renderer {
      * Set the zoom level of the map view
      * @param zoom Fractional zoom level
      */
-    public void setMapZoom(float zoom) {
+    public void setZoom(float zoom) {
         nativeSetZoom(zoom);
     }
 
@@ -191,7 +180,7 @@ public class MapController implements Renderer {
      * @param zoom Fractional zoom level
      * @param duration Time in seconds to ease to given zoom
      */
-    public void setMapZoom(float zoom, float duration) {
+    public void setZoom(float zoom, float duration) {
         nativeSetZoomEased(zoom, duration, EaseType.QUINT.ordinal());
     }
 
@@ -201,7 +190,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to given zoom
      * @param ease Type of easing to use
      */
-    public void setMapZoom(float zoom, float duration, EaseType ease) {
+    public void setZoom(float zoom, float duration, EaseType ease) {
         nativeSetZoomEased(zoom, duration, ease.ordinal());
     }
 
@@ -209,7 +198,7 @@ public class MapController implements Renderer {
      * Get the zoom level of the map view
      * @return Fractional zoom level
      */
-    public float getMapZoom() {
+    public float getZoom() {
         return nativeGetZoom();
     }
 
@@ -217,7 +206,7 @@ public class MapController implements Renderer {
      * Set the counter-clockwise rotation of the view in radians; 0 corresponds to North pointing up
      * @param radians Rotation in radians
      */
-    public void setMapRotation(float radians) {
+    public void setRotation(float radians) {
         nativeSetRotation(radians);
     }
 
@@ -226,7 +215,7 @@ public class MapController implements Renderer {
      * @param radians Rotation in radians
      * @param duration Time in seconds to ease to the given rotation
      */
-    public void setMapRotation(float radians, float duration) {
+    public void setRotation(float radians, float duration) {
         nativeSetRotationEased(radians, duration, EaseType.QUINT.ordinal());
     }
 
@@ -236,7 +225,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to the given rotation
      * @param ease Type of easing to use
      */
-    public void setMapRotation(float radians, float duration, EaseType ease) {
+    public void setRotation(float radians, float duration, EaseType ease) {
         nativeSetRotationEased(radians, duration, ease.ordinal());
     }
 
@@ -244,7 +233,7 @@ public class MapController implements Renderer {
      * Get the counter-clockwise rotation of the view in radians; 0 corresponds to North pointing up
      * @return Rotation in radians
      */
-    public float getMapRotation() {
+    public float getRotation() {
         return nativeGetRotation();
     }
 
@@ -252,7 +241,7 @@ public class MapController implements Renderer {
      * Set the tilt angle of the view in radians; 0 corresponds to straight down
      * @param radians Tilt angle in radians
      */
-    public void setMapTilt(float radians) {
+    public void setTilt(float radians) {
         nativeSetTilt(radians);
     }
 
@@ -261,7 +250,7 @@ public class MapController implements Renderer {
      * @param radians Tilt angle in radians
      * @param duration Time in seconds to ease to the given tilt
      */
-    public void setMapTilt(float radians, float duration) {
+    public void setTilt(float radians, float duration) {
         nativeSetTiltEased(radians, duration, EaseType.QUINT.ordinal());
     }
 
@@ -271,7 +260,7 @@ public class MapController implements Renderer {
      * @param duration Time in seconds to ease to the given tilt
      * @param ease Type of easing to use
      */
-    public void setMapTilt(float radians, float duration, EaseType ease) {
+    public void setTilt(float radians, float duration, EaseType ease) {
         nativeSetTiltEased(radians, duration, ease.ordinal());
     }
 
@@ -279,7 +268,7 @@ public class MapController implements Renderer {
      * Get the tilt angle of the view in radians; 0 corresponds to straight down
      * @return Tilt angle in radians
      */
-    public float getMapTilt() {
+    public float getTilt() {
         return nativeGetTilt();
     }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -390,17 +390,6 @@ void setPixelScale(float _pixelsPerPoint) {
     }
 }
 
-void setCameraType(uint8_t _cameraType) {
-
-    if (m_view) {
-        m_view->setCameraType(static_cast<CameraType>(_cameraType));
-    }
-}
-
-uint8_t getCameraType() {
-    return static_cast<uint8_t>(m_view->cameraType());
-}
-
 void addDataSource(std::shared_ptr<DataSource> _source) {
     if (!m_tileManager) { return; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -78,12 +78,6 @@ void screenToWorldCoordinates(double& _x, double& _y);
 // Set the ratio of hardware pixels to logical pixels (defaults to 1.0)
 void setPixelScale(float _pixelsPerPoint);
 
-// Set the CameraType based on the _cameraType value
-void setCameraType(uint8_t _cameraType);
-
-// Get the current CameraType of the view
-uint8_t getCameraType();
-
 // Add a data source for adding drawable map data, which will be styled
 // according to the scene file using the provided data source name;
 void addDataSource(std::shared_ptr<DataSource> _source);


### PR DESCRIPTION
Consider this a prelude to more substantial changes that will bring the "camera" interface closer to that of gmaps. Notable changes here:

 - `setMapThing` -> `setThing` in `MapController`
 - Eased setters in `MapController` now take duration values in milliseconds instead of seconds
 - Positions are always represented as a `LngLat` in `MapController` (a method that takes two `double` arguments makes it too easy to put them in the wrong order)
 - Removed the methods to get/set camera type (this can now be done with scene component updates)