### PR TITLE
Scene update tweaks

### DIFF
--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -48,8 +48,8 @@ struct TestContext {
             LOGE("Parsing scene config '%s'", e.what());
             return;
         }
-        scene = std::make_shared<Scene>("");
-        SceneLoader::loadScene(sceneNode, *scene);
+        scene = std::make_shared<Scene>();
+        SceneLoader::applyConfig(sceneNode, *scene);
 
         styleContext.initFunctions(*scene);
         styleContext.setKeywordZoom(0);

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -21,16 +21,14 @@ namespace Tangram {
 
 static std::atomic<int32_t> s_serial;
 
-Scene::Scene(std::string scene) : id(s_serial++), m_scene(scene) {
+Scene::Scene() : id(s_serial++) {
     m_view = std::make_shared<View>();
     // For now we only have one projection..
     // TODO how to share projection with view?
     m_mapProjection.reset(new MercatorProjection());
 }
 
-Scene::Scene(std::vector<UpdateValue> updates, std::string scene) :
-    Scene(scene)
-{
+Scene::Scene(std::vector<Update> updates) : Scene() {
     m_updates = updates;
 }
 
@@ -82,7 +80,7 @@ bool Scene::texture(const std::string& textureName, std::shared_ptr<Texture>& te
     return true;
 }
 
-void Scene::queueComponentUpdate(std::string componentPath, std::string value) {
+void Scene::queueUpdate(std::string componentPath, std::string value) {
     std::vector<std::string> splitPath = splitString(componentPath, COMPONENT_PATH_DELIMITER);
     m_updates.push_back({ splitPath, value });
 }

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -28,8 +28,11 @@ Scene::Scene() : id(s_serial++) {
     m_mapProjection.reset(new MercatorProjection());
 }
 
-Scene::Scene(std::vector<Update> updates) : Scene() {
-    m_updates = updates;
+Scene::Scene(const Scene& _other) : Scene() {
+    m_config = _other.m_config;
+    m_updates = _other.m_updates;
+    m_clientDataSources = _other.m_clientDataSources;
+    m_view = _other.m_view;
 }
 
 Scene::~Scene() {}
@@ -83,6 +86,22 @@ bool Scene::texture(const std::string& textureName, std::shared_ptr<Texture>& te
 void Scene::queueUpdate(std::string componentPath, std::string value) {
     std::vector<std::string> splitPath = splitString(componentPath, COMPONENT_PATH_DELIMITER);
     m_updates.push_back({ splitPath, value });
+}
+
+void Scene::addClientDataSource(std::shared_ptr<DataSource> _source) {
+    m_clientDataSources.push_back(_source);
+}
+
+void Scene::removeClientDataSource(DataSource& _source) {
+    auto it = std::remove_if(m_clientDataSources.begin(), m_clientDataSources.end(),
+        [&](auto& s) { return s.get() == &_source; });
+    m_clientDataSources.erase(it, m_clientDataSources.end());
+}
+
+const std::vector<std::shared_ptr<DataSource>> Scene::getAllDataSources() const {
+    auto sources = m_dataSources;
+    sources.insert(sources.end(), m_clientDataSources.begin(), m_clientDataSources.end());
+    return sources;
 }
 
 }

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -83,9 +83,9 @@ bool Scene::texture(const std::string& textureName, std::shared_ptr<Texture>& te
     return true;
 }
 
-void Scene::queueUpdate(std::string componentPath, std::string value) {
-    std::vector<std::string> splitPath = splitString(componentPath, COMPONENT_PATH_DELIMITER);
-    m_updates.push_back({ splitPath, value });
+void Scene::queueUpdate(std::string path, std::string value) {
+    auto keys = splitString(path, COMPONENT_PATH_DELIMITER);
+    m_updates.push_back({ keys, value });
 }
 
 void Scene::addClientDataSource(std::shared_ptr<DataSource> _source) {

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -56,7 +56,6 @@ public:
     auto& background() { return m_background; }
     auto& fontContext() { return m_fontContext; }
     auto& globals() { return m_globals; }
-    auto& updates() { return m_updates; }
 
     const auto& config() const { return m_config; }
     const auto& dataSources() const { return m_dataSources; };
@@ -85,7 +84,7 @@ public:
     void animated(bool animated) { m_animated = animated ? yes : no; }
     animate animated() const { return m_animated; }
 
-    void queueUpdate(std::string componentName, std::string value);
+    void queueUpdate(std::string path, std::string value);
 
     void clearUpdates() { m_updates.clear(); }
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -31,7 +31,7 @@ struct Stops;
 class Scene {
 public:
     struct Update {
-        std::vector<std::string> splitPath;
+        std::vector<std::string> keys;
         std::string value;
     };
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -30,7 +30,7 @@ struct Stops;
 
 class Scene {
 public:
-    struct UpdateValue {
+    struct Update {
         std::vector<std::string> splitPath;
         std::string value;
     };
@@ -39,8 +39,8 @@ public:
         yes, no, none
     };
 
-    Scene(std::string scene = "");
-    Scene(std::vector<UpdateValue> updates, std::string scene);
+    Scene();
+    Scene(std::vector<Update> updates);
     ~Scene();
 
     auto& view() { return m_view; }
@@ -81,17 +81,18 @@ public:
     void animated(bool animated) { m_animated = animated ? yes : no; }
     animate animated() const { return m_animated; }
 
-    void queueComponentUpdate(std::string componentName, std::string value);
+    void queueUpdate(std::string componentName, std::string value);
 
-    void scene(const std::string& scene) { m_scene = scene; }
-    const std::string& scene() const { return m_scene; }
-
-
-    const std::vector<UpdateValue>& updates() const { return m_updates; }
+    const std::vector<Update>& updates() const { return m_updates; }
 
     void clearUpdates() { m_updates.clear(); }
 
+    YAML::Node& config() { return m_config; }
+
 private:
+
+    // The root node of the YAML scene configuration
+    YAML::Node m_config;
 
     std::unique_ptr<MapProjection> m_mapProjection;
     std::shared_ptr<View> m_view;
@@ -104,9 +105,7 @@ private:
     std::unordered_map<std::string, std::shared_ptr<SpriteAtlas>> m_spriteAtlases;
     std::unordered_map<std::string, YAML::Node> m_globals;
 
-    std::vector<UpdateValue> m_updates;
-
-    std::string m_scene;
+    std::vector<Update> m_updates;
 
     // Container of all strings used in styling rules; these need to be
     // copied and compared frequently when applying styling, so rules use

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -40,9 +40,10 @@ public:
     };
 
     Scene();
-    Scene(std::vector<Update> updates);
+    Scene(const Scene& _other);
     ~Scene();
 
+    auto& config() { return m_config; }
     auto& view() { return m_view; }
     auto& dataSources() { return m_dataSources; };
     auto& layers() { return m_layers; };
@@ -55,7 +56,9 @@ public:
     auto& background() { return m_background; }
     auto& fontContext() { return m_fontContext; }
     auto& globals() { return m_globals; }
+    auto& updates() { return m_updates; }
 
+    const auto& config() const { return m_config; }
     const auto& dataSources() const { return m_dataSources; };
     const auto& layers() const { return m_layers; };
     const auto& styles() const { return m_styles; };
@@ -64,6 +67,7 @@ public:
     const auto& mapProjection() const { return m_mapProjection; };
     const auto& fontContext() const { return m_fontContext; }
     const auto& globals() const { return m_globals; }
+    const auto& updates() const { return m_updates; }
 
     const Style* findStyle(const std::string& _name) const;
     const Light* findLight(const std::string& _name) const;
@@ -83,11 +87,12 @@ public:
 
     void queueUpdate(std::string componentName, std::string value);
 
-    const std::vector<Update>& updates() const { return m_updates; }
-
     void clearUpdates() { m_updates.clear(); }
 
-    YAML::Node& config() { return m_config; }
+    void addClientDataSource(std::shared_ptr<DataSource> _source);
+    void removeClientDataSource(DataSource& _source);
+
+    const std::vector<std::shared_ptr<DataSource>> getAllDataSources() const;
 
 private:
 
@@ -99,6 +104,7 @@ private:
 
     std::vector<DataLayer> m_layers;
     std::vector<std::shared_ptr<DataSource>> m_dataSources;
+    std::vector<std::shared_ptr<DataSource>> m_clientDataSources;
     std::vector<std::unique_ptr<Style>> m_styles;
     std::vector<std::unique_ptr<Light>> m_lights;
     std::unordered_map<std::string, std::shared_ptr<Texture>> m_textures;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -47,13 +47,21 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
 
     Node& root = _scene.config();
 
+    if (loadConfig(_sceneString, root)) {
+        applyConfig(root, _scene);
+        return true;
+    }
+    return false;
+}
+
+bool SceneLoader::loadConfig(const std::string& _sceneString, Node& root) {
+
     try { root = YAML::Load(_sceneString); }
     catch (YAML::ParserException e) {
         LOGE("Parsing scene config '%s'", e.what());
         return false;
     }
-
-    return applyConfig(root, _scene);
+    return true;
 }
 
 void SceneLoader::applyUpdates(Node& root, const std::vector<Scene::Update>& updates) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -44,7 +44,9 @@ const std::string DELIMITER = ":";
 // TODO: make this configurable: 16MB default in-memory DataSource cache:
 constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
-bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene, Node& root, bool _applyUpdates) {
+bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
+
+    Node& root = _scene.config();
 
     try { root = YAML::Load(_sceneString); }
     catch (YAML::ParserException e) {
@@ -52,17 +54,12 @@ bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene, Node
         return false;
     }
 
-    if (_applyUpdates) {
-        processUpdates(root, _scene);
-    }
-
-    return loadScene(root, _scene);
+    return applyConfig(root, _scene);
 }
 
-void SceneLoader::processUpdates(Node root, Scene& scene) {
-    auto& updates = scene.updates();
+void SceneLoader::applyUpdates(Node& root, const std::vector<Scene::Update>& updates) {
 
-    for (const Scene::UpdateValue& update : updates) {
+    for (const Scene::Update& update : updates) {
 
         std::vector<Node> stack;
         stack.push_back(root);
@@ -157,7 +154,7 @@ void SceneLoader::parseGlobals(const Node& node, Scene& scene, const std::string
     }
 }
 
-bool SceneLoader::loadScene(Node& config, Scene& _scene) {
+bool SceneLoader::applyConfig(Node& config, Scene& _scene) {
 
     // Instantiate built-in styles
     _scene.styles().emplace_back(new PolygonStyle("polygons"));

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -37,8 +37,9 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static bool loadScene(const std::string& _sceneString, Scene& _scene, Node& _root, bool _applyUserUpdates = false);
-    static bool loadScene(Node& config, Scene& _scene);
+    static bool loadScene(const std::string& _sceneString, Scene& _scene);
+    static bool applyConfig(Node& config, Scene& scene);
+    static void applyUpdates(Node& root, const std::vector<Scene::Update>& updates);
     static void applyGlobalProperties(Node& node, Scene& scene);
 
     /*** all public for testing ***/
@@ -59,8 +60,6 @@ struct SceneLoader {
     static Filter generatePredicate(Node filter, std::string _key);
     /* loads a texture with default texture properties */
     static bool loadTexture(const std::string& url, Scene& scene);
-
-    static void processUpdates(Node root, Scene& scene);
 
     static MaterialTexture loadMaterialTexture(Node matCompNode, Scene& scene, Style& style);
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gl/uniform.h"
+#include "scene/scene.h"
 
 #include <string>
 #include <vector>
@@ -16,7 +17,6 @@
 
 namespace Tangram {
 
-class Scene;
 class TileManager;
 class SceneLayer;
 class View;

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -38,6 +38,7 @@ struct SceneLoader {
     using Node = YAML::Node;
 
     static bool loadScene(const std::string& _sceneString, Scene& _scene);
+    static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, Scene& scene);
     static void applyUpdates(Node& root, const std::vector<Scene::Update>& updates);
     static void applyGlobalProperties(Node& node, Scene& scene);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -116,9 +116,8 @@ void loadScene(const char* _scenePath) {
     }
 }
 
-void queueSceneUpdate(const char* componentName, const char* value) {
-
-    return m_scene->queueUpdate(componentName, value);
+void queueSceneUpdate(const char* _path, const char* _value) {
+    return m_scene->queueUpdate(_path, _value);
 }
 
 void applySceneUpdates() {

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -20,7 +20,7 @@ class DataSource;
 // given resource path
 void initialize(const char* _scenePath);
 
-void loadScene(const char* _scenePath, bool _setPositionFromScene = false);
+void loadScene(const char* _scenePath);
 
 void queueSceneUpdate(const char* componentName, const char* value);
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -20,6 +20,12 @@ class DataSource;
 // given resource path
 void initialize(const char* _scenePath);
 
+void loadScene(const char* _scenePath, bool _setPositionFromScene = false);
+
+void queueSceneUpdate(const char* componentName, const char* value);
+
+void applySceneUpdates();
+
 // Initialize graphics resources; OpenGL context must be created prior to calling this
 void setupGL();
 
@@ -129,13 +135,7 @@ bool getDebugFlag(DebugFlags _flag);
 // Toggle the boolean state of a debug feature (see debug.h)
 void toggleDebugFlag(DebugFlags _flag);
 
-void loadScene(const char* _scenePath, bool _setPositionFromScene = false);
-
 void runOnMainLoop(std::function<void()> _task);
-
-void queueSceneUpdate(const char* componentName, const char* value);
-
-void applySceneUpdates(bool _setPositionFromScene = false);
 
 struct TouchItem {
     std::shared_ptr<Properties> properties;

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -20,10 +20,15 @@ class DataSource;
 // given resource path
 void initialize(const char* _scenePath);
 
+// Load the scene at the given absolute file path
 void loadScene(const char* _scenePath);
 
-void queueSceneUpdate(const char* componentName, const char* value);
+// Request an update to the scene configuration; the path is a series of yaml keys
+// separated by a '.' and the value is a string of yaml to replace the current value
+// at the given path in the scene
+void queueSceneUpdate(const char* _path, const char* _value);
 
+// Apply all previously requested scene updates
 void applySceneUpdates();
 
 // Initialize graphics resources; OpenGL context must be created prior to calling this

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -221,6 +221,14 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 Tangram::setPixelScale(pixel_scale);
 
                 break;
+            case GLFW_KEY_P:
+                Tangram::queueSceneUpdate("cameras", "{ main_camera: { type: perspective } }");
+                Tangram::applySceneUpdates();
+                break;
+            case GLFW_KEY_I:
+                Tangram::queueSceneUpdate("cameras", "{ main_camera: { type: isometric } }");
+                Tangram::applySceneUpdates();
+                break;
             case GLFW_KEY_ESCAPE:
                 glfwSetWindowShouldClose(main_window, true);
                 break;

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -216,6 +216,14 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 Tangram::loadScene(sceneFile.c_str());
                 Tangram::setPixelScale(pixel_scale);
                 break;
+            case GLFW_KEY_P:
+                Tangram::queueSceneUpdate("cameras", "{ main_camera: { type: perspective } }");
+                Tangram::applySceneUpdates();
+                break;
+            case GLFW_KEY_I:
+                Tangram::queueSceneUpdate("cameras", "{ main_camera: { type: isometric } }");
+                Tangram::applySceneUpdates();
+                break;
             case GLFW_KEY_G:
                 static bool geoJSON = false;
                 if (!geoJSON) {

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -218,7 +218,7 @@ TEST_CASE( "Test evalStyleFn - StyleParamKey::extrude", "[Duktape][evalStyleFn]"
 }
 
 TEST_CASE( "Test evalFilter - Init filter function from yaml", "[Duktape][evalFilter]") {
-    Scene scene("");
+    Scene scene;
     YAML::Node n0 = YAML::Load(R"(filter: function() { return feature.sort_key === 2; })");
     YAML::Node n1 = YAML::Load(R"(filter: function() { return feature.name === 'test'; })");
 
@@ -260,7 +260,7 @@ TEST_CASE( "Test evalFilter - Init filter function from yaml", "[Duktape][evalFi
 }
 
 TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][evalStyle]") {
-    Scene scene("");
+    Scene scene;
     YAML::Node n0 = YAML::Load(R"(
             draw:
                 color: function() { return '#ffff00ff'; }
@@ -308,7 +308,7 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
 }
 
 TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
-    Scene scene("");
+    Scene scene;
     YAML::Node n0 = YAML::Load(R"(
             global:
                 width: 2

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -52,8 +52,7 @@ TEST_CASE("Scene update tests") {
 
     REQUIRE(!sceneString.empty());
 
-    Node root;
-    REQUIRE(SceneLoader::loadScene(sceneString, scene));
+    REQUIRE(SceneLoader::loadConfig(sceneString, scene.config()));
 
     // Update
     scene.queueUpdate("lights.light1.ambient", "0.9");
@@ -68,15 +67,16 @@ TEST_CASE("Scene update tests") {
     scene.queueUpdate("global.non_existing_property1.non_existing_property_deep", "true");
 
     // Tangram apply scene updates, reload the scene
-    REQUIRE(SceneLoader::loadScene(sceneString, scene));
+    SceneLoader::applyUpdates(scene.config(), scene.updates());
     scene.clearUpdates();
+
+    const Node& root = scene.config();
 
     REQUIRE(root["lights"]["light1"]["ambient"].Scalar() == "0.9");
     REQUIRE(root["lights"]["light1"]["type"].Scalar() == "spotlight");
     REQUIRE(root["lights"]["light1"]["origin"].Scalar() == "ground");
     REQUIRE(root["layers"]["poi_icons"]["draw"]["icons"]["interactive"].Scalar() == "false");
     REQUIRE(root["styles"]["heightglow"]["shaders"]["uniforms"]["u_time_expand"].Scalar() == "5.0");
-    REQUIRE(root["styles"]["heightglowline"]["shaders"]["uniforms"]["u_time_expand"].Scalar() == "5.0");
     REQUIRE(root["cameras"]["iso-camera"]["active"].Scalar() == "true");
     REQUIRE(root["cameras"]["iso-camera"]["type"].Scalar() == "perspective");
     REQUIRE(root["global"]["default_order"].Scalar() == "function() { return 0.0; }");
@@ -89,8 +89,7 @@ TEST_CASE("Scene update tests, ensure update ordering is preserved") {
 
     REQUIRE(!sceneString.empty());
 
-    Node root;
-    REQUIRE(SceneLoader::loadScene(sceneString, scene));
+    REQUIRE(SceneLoader::loadConfig(sceneString, scene.config()));
 
     // Update
     scene.queueUpdate("lights.light1.ambient", "0.9");
@@ -101,8 +100,10 @@ TEST_CASE("Scene update tests, ensure update ordering is preserved") {
     scene.queueUpdate("lights.light2.ambient", "0.0");
 
     // Tangram apply scene updates, reload the scene
-    REQUIRE(SceneLoader::loadScene(sceneString, scene));
+    SceneLoader::applyUpdates(scene.config(), scene.updates());
     scene.clearUpdates();
+
+    const Node& root = scene.config();
 
     REQUIRE(!root["lights"]["light1"]);
     REQUIRE(!root["lights"]["light2"]);

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -53,22 +53,22 @@ TEST_CASE("Scene update tests") {
     REQUIRE(!sceneString.empty());
 
     Node root;
-    REQUIRE(SceneLoader::loadScene(sceneString, scene, root, true));
+    REQUIRE(SceneLoader::loadScene(sceneString, scene));
 
     // Update
-    scene.queueComponentUpdate("lights.light1.ambient", "0.9");
-    scene.queueComponentUpdate("lights.light1.type", "spotlight");
-    scene.queueComponentUpdate("lights.light1.origin", "ground");
-    scene.queueComponentUpdate("layers.poi_icons.draw.icons.interactive", "false");
-    scene.queueComponentUpdate("styles.heightglow.shaders.uniforms.u_time_expand", "5.0");
-    scene.queueComponentUpdate("cameras.iso-camera.active", "true");
-    scene.queueComponentUpdate("cameras.iso-camera.type", "perspective");
-    scene.queueComponentUpdate("global.default_order", "function() { return 0.0; }");
-    scene.queueComponentUpdate("global.non_existing_property0", "true");
-    scene.queueComponentUpdate("global.non_existing_property1.non_existing_property_deep", "true");
+    scene.queueUpdate("lights.light1.ambient", "0.9");
+    scene.queueUpdate("lights.light1.type", "spotlight");
+    scene.queueUpdate("lights.light1.origin", "ground");
+    scene.queueUpdate("layers.poi_icons.draw.icons.interactive", "false");
+    scene.queueUpdate("styles.heightglow.shaders.uniforms.u_time_expand", "5.0");
+    scene.queueUpdate("cameras.iso-camera.active", "true");
+    scene.queueUpdate("cameras.iso-camera.type", "perspective");
+    scene.queueUpdate("global.default_order", "function() { return 0.0; }");
+    scene.queueUpdate("global.non_existing_property0", "true");
+    scene.queueUpdate("global.non_existing_property1.non_existing_property_deep", "true");
 
     // Tangram apply scene updates, reload the scene
-    REQUIRE(SceneLoader::loadScene(sceneString, scene, root, true));
+    REQUIRE(SceneLoader::loadScene(sceneString, scene));
     scene.clearUpdates();
 
     REQUIRE(root["lights"]["light1"]["ambient"].Scalar() == "0.9");
@@ -90,18 +90,18 @@ TEST_CASE("Scene update tests, ensure update ordering is preserved") {
     REQUIRE(!sceneString.empty());
 
     Node root;
-    REQUIRE(SceneLoader::loadScene(sceneString, scene, root, true));
+    REQUIRE(SceneLoader::loadScene(sceneString, scene));
 
     // Update
-    scene.queueComponentUpdate("lights.light1.ambient", "0.9");
-    scene.queueComponentUpdate("lights.light2.ambient", "0.0");
+    scene.queueUpdate("lights.light1.ambient", "0.9");
+    scene.queueUpdate("lights.light2.ambient", "0.0");
 
     // Delete lights
-    scene.queueComponentUpdate("lights", "null");
-    scene.queueComponentUpdate("lights.light2.ambient", "0.0");
+    scene.queueUpdate("lights", "null");
+    scene.queueUpdate("lights.light2.ambient", "0.0");
 
     // Tangram apply scene updates, reload the scene
-    REQUIRE(SceneLoader::loadScene(sceneString, scene, root, true));
+    REQUIRE(SceneLoader::loadScene(sceneString, scene));
     scene.clearUpdates();
 
     REQUIRE(!root["lights"]["light1"]);


### PR DESCRIPTION
Two major updates here:

 - Instead of retaining a string containing the yaml scene configuration, the scene object retains the parsed yaml scene representation, so that we don't have to re-parse the unchanged text. 
 - Data sources added dynamically were dropped whenever a scene was loaded (and, by extension, whenever a scene component was updated). These dynamic "client" sources are now stored separately in the scene object in order to preserve them across scene loads. 

Aside from that there's a good bit of refactoring for clarity and succinctness. 