### PR TITLE
Enable subclassing MapController and MapView

### DIFF
--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -57,7 +57,7 @@ public class MapController implements Renderer {
      * must contain all the local files that the map will need
      * @param sceneFilePath Location of the YAML scene file within the assets directory
      */
-    MapController(Context context, String sceneFilePath) {
+    protected MapController(Context context, String sceneFilePath) {
 
         scenePath = sceneFilePath;
 
@@ -74,6 +74,10 @@ public class MapController implements Renderer {
 
         nativeInit(this, assetManager, scenePath);
 
+    }
+
+    static MapController getInstance(Context context, String sceneFilePath) {
+        return new MapController(context, sceneFilePath);
     }
 
     /**

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -60,8 +60,9 @@ public class MapView extends FrameLayout {
         getMapTask = new AsyncTask<Void, Void, MapController>() {
 
             @Override
+            @SuppressWarnings("WrongThread")
             protected MapController doInBackground(Void... params) {
-                return new MapController(context, sceneFilePath);
+                return getMapInstance(context, sceneFilePath);
             }
 
             @Override
@@ -73,6 +74,10 @@ public class MapView extends FrameLayout {
 
         }.execute();
 
+    }
+
+    protected MapController getMapInstance(Context context, String sceneFilePath) {
+        return MapController.getInstance(context, sceneFilePath);
     }
 
     protected void configureGLSurfaceView() {


### PR DESCRIPTION
`MapController` and `MapView` subclasses should implement `MapController$getInstance` and `MapView$getMapInstance`.

I had to suppress a warning in our `AsyncTask` because Android thinks that every method on a subclass of `View` can only be run on the UI thread, even though `getMapInstance` is perfectly safe to call from a worker thread. 