### PR TITLE
Polyline texture coordinates grow linearly with path distance

### DIFF
--- a/core/resources/scene.yaml
+++ b/core/resources/scene.yaml
@@ -61,6 +61,12 @@ styles:
     icons:
         base: points
         texture: pois
+    stripeline:
+        base: lines
+        texcoords: true
+        shaders:
+            blocks:
+                filter: "color.rgb -= .1 * floor(2. * fract(v_texcoord.y / 2.));"
 
 sources:
     osm:
@@ -222,6 +228,11 @@ layers:
                     width: [[15, 1px], [17, 2px]]
                     outline:
                         width: 0
+        ferries:
+            filter: { kind: ferry }
+            draw:
+                lines:
+                    style: stripeline
         airports:
             filter: { aeroway: true }
             draw:

--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -41,6 +41,7 @@ varying vec3 v_normal;
 #define UNPACK_POSITION(x) (x / 8192.0)
 #define UNPACK_EXTRUSION(x) (x / 4096.0)
 #define UNPACK_ORDER(x) (x / 2.0)
+#define UNPACK_TEXCOORD(x) (x / 8192.0)
 
 vec4 modelPosition() {
     return vec4(UNPACK_POSITION(a_position.xyz) * exp2(u_tile_origin.z - u_tile_origin.w), 1.0);
@@ -68,7 +69,7 @@ void main() {
     v_color = a_color;
 
     #ifdef TANGRAM_USE_TEX_COORDS
-        v_texcoord = a_texcoord;
+        v_texcoord = UNPACK_TEXCOORD(a_texcoord);
     #endif
 
     v_normal = u_normal_matrix * vec3(0.,0.,1.);
@@ -87,6 +88,10 @@ void main() {
         #pragma tangram: width
 
         position.xy += extrude.xy * width;
+
+        #ifdef TANGRAM_USE_TEX_COORDS
+            v_texcoord.y /= 2. * width;
+        #endif
     }
 
     // Transform position into meters relative to map center

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -17,7 +17,7 @@
 
 constexpr float extrusion_scale = 4096.0f;
 constexpr float position_scale = 8192.0f;
-constexpr float texture_scale = 65535.0f;
+constexpr float texture_scale = 8192.0f;
 constexpr float order_scale = 2.0f;
 
 namespace Tangram {
@@ -64,7 +64,7 @@ void PolylineStyle::constructVertexLayout() {
             {"a_position", 4, GL_SHORT, false, 0},
             {"a_extrude", 4, GL_SHORT, false, 0},
             {"a_color", 4, GL_UNSIGNED_BYTE, true, 0},
-            {"a_texcoord", 2, GL_UNSIGNED_SHORT, true, 0},
+            {"a_texcoord", 2, GL_UNSIGNED_SHORT, false, 0},
         }));
     } else {
         m_vertexLayout = std::shared_ptr<VertexLayout>(new VertexLayout({


### PR DESCRIPTION
Resolves #678 

Before:
<img width="912" alt="screen shot 2016-04-21 at 1 05 39 am" src="https://cloud.githubusercontent.com/assets/3371850/14698486/57a90f9e-075d-11e6-98e2-2b809273358d.png">

After:
<img width="912" alt="screen shot 2016-04-21 at 1 01 59 am" src="https://cloud.githubusercontent.com/assets/3371850/14698490/632b9de6-075d-11e6-8ca7-9564abf63d06.png">

There's currently no special logic for the texture coordinates of caps or joins. I haven't noticed significant visual impact from these, but they can be addressed incrementally as we see fit. 
