### PR TITLE
Descriptive mesh drawing failure errors

### DIFF
--- a/core/src/gl/dynamicQuadMesh.h
+++ b/core/src/gl/dynamicQuadMesh.h
@@ -41,7 +41,7 @@ public:
         QuadIndices::unref();
     }
 
-    void draw(ShaderProgram& _shader) override;
+    bool draw(ShaderProgram& _shader) override;
 
     size_t bufferSize() const override {
         return MeshBase::bufferSize();
@@ -91,16 +91,18 @@ void DynamicQuadMesh<T>::upload() {
 }
 
 template<class T>
-void DynamicQuadMesh<T>::draw(ShaderProgram& _shader) {
+bool DynamicQuadMesh<T>::draw(ShaderProgram& _shader) {
 
-    if (m_nVertices == 0) { return; }
+    if (m_nVertices == 0) { return false; }
 
     // Bind buffers for drawing
     RenderState::vertexBuffer(m_glVertexBuffer);
     QuadIndices::load();
 
     // Enable shader program
-    _shader.use();
+    if (!_shader.use()) {
+        return false;
+    }
 
     size_t vertexOffset = 0;
 
@@ -118,6 +120,8 @@ void DynamicQuadMesh<T>::draw(ShaderProgram& _shader) {
 
         vertexOffset += nVertices;
     }
+
+    return true;
 }
 
 }

--- a/core/src/gl/mesh.cpp
+++ b/core/src/gl/mesh.cpp
@@ -151,16 +151,16 @@ void MeshBase::upload() {
     m_isUploaded = true;
 }
 
-void MeshBase::draw(ShaderProgram& _shader) {
+bool MeshBase::draw(ShaderProgram& _shader) {
 
     checkValidity();
 
-    if (!m_isCompiled) { return; }
-    if (m_nVertices == 0) { return; }
+    if (!m_isCompiled) { return false; }
+    if (m_nVertices == 0) { return false; }
 
     // Enable shader program
     if (!_shader.use()) {
-        return;
+        return false;
     }
 
     // Ensure that geometry is buffered into GPU
@@ -217,6 +217,8 @@ void MeshBase::draw(ShaderProgram& _shader) {
     if (Hardware::supportsVAOs) {
         m_vaos->unbind();
     }
+
+    return true;
 }
 
 bool MeshBase::checkValidity() {

--- a/core/src/gl/mesh.h
+++ b/core/src/gl/mesh.h
@@ -62,7 +62,7 @@ public:
      * Renders the geometry in this mesh using the ShaderProgram _shader; if
      * geometry has not already been uploaded it will be uploaded at this point
      */
-    void draw(ShaderProgram& _shader);
+    bool draw(ShaderProgram& _shader);
 
     size_t bufferSize() const;
 
@@ -142,8 +142,8 @@ public:
         return MeshBase::bufferSize();
     }
 
-    void draw(ShaderProgram& _shader) override {
-        MeshBase::draw(_shader);
+    bool draw(ShaderProgram& _shader) override {
+        return MeshBase::draw(_shader);
     }
 
     void compile(const std::vector<MeshData<T>>& _meshes);

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -319,7 +319,7 @@ std::string ShaderProgram::getExtensionDeclaration(const std::string& _extension
 }
 
 void ShaderProgram::setUniformi(const UniformLocation& _loc, int _value) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
@@ -328,7 +328,7 @@ void ShaderProgram::setUniformi(const UniformLocation& _loc, int _value) {
 }
 
 void ShaderProgram::setUniformi(const UniformLocation& _loc, int _value0, int _value1) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, glm::vec2(_value0, _value1));
@@ -337,7 +337,7 @@ void ShaderProgram::setUniformi(const UniformLocation& _loc, int _value0, int _v
 }
 
 void ShaderProgram::setUniformi(const UniformLocation& _loc, int _value0, int _value1, int _value2) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, glm::vec3(_value0, _value1, _value2));
@@ -346,7 +346,7 @@ void ShaderProgram::setUniformi(const UniformLocation& _loc, int _value0, int _v
 }
 
 void ShaderProgram::setUniformi(const UniformLocation& _loc, int _value0, int _value1, int _value2, int _value3) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, glm::vec4(_value0, _value1, _value2, _value3));
@@ -355,7 +355,7 @@ void ShaderProgram::setUniformi(const UniformLocation& _loc, int _value0, int _v
 }
 
 void ShaderProgram::setUniformf(const UniformLocation& _loc, float _value) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
@@ -376,7 +376,7 @@ void ShaderProgram::setUniformf(const UniformLocation& _loc, float _value0, floa
 }
 
 void ShaderProgram::setUniformf(const UniformLocation& _loc, const glm::vec2& _value) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
@@ -385,7 +385,7 @@ void ShaderProgram::setUniformf(const UniformLocation& _loc, const glm::vec2& _v
 }
 
 void ShaderProgram::setUniformf(const UniformLocation& _loc, const glm::vec3& _value) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
@@ -394,7 +394,7 @@ void ShaderProgram::setUniformf(const UniformLocation& _loc, const glm::vec3& _v
 }
 
 void ShaderProgram::setUniformf(const UniformLocation& _loc, const glm::vec4& _value) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
@@ -403,7 +403,7 @@ void ShaderProgram::setUniformf(const UniformLocation& _loc, const glm::vec4& _v
 }
 
 void ShaderProgram::setUniformMatrix2f(const UniformLocation& _loc, const glm::mat2& _value, bool _transpose) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = !_transpose && getFromCache(location, _value);
@@ -412,7 +412,7 @@ void ShaderProgram::setUniformMatrix2f(const UniformLocation& _loc, const glm::m
 }
 
 void ShaderProgram::setUniformMatrix3f(const UniformLocation& _loc, const glm::mat3& _value, bool _transpose) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = !_transpose && getFromCache(location, _value);
@@ -421,7 +421,7 @@ void ShaderProgram::setUniformMatrix3f(const UniformLocation& _loc, const glm::m
 }
 
 void ShaderProgram::setUniformMatrix4f(const UniformLocation& _loc, const glm::mat4& _value, bool _transpose) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = !_transpose && getFromCache(location, _value);
@@ -430,7 +430,7 @@ void ShaderProgram::setUniformMatrix4f(const UniformLocation& _loc, const glm::m
 }
 
 void ShaderProgram::setUniformf(const UniformLocation& _loc, const UniformArray& _value) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);
@@ -439,7 +439,7 @@ void ShaderProgram::setUniformf(const UniformLocation& _loc, const UniformArray&
 }
 
 void ShaderProgram::setUniformi(const UniformLocation& _loc, const UniformTextureArray& _value) {
-    use();
+    if (!use()) { return; }
     GLint location = getUniformLocation(_loc);
     if (location >= 0) {
         bool cached = getFromCache(location, _value);

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -20,6 +20,7 @@ ShaderProgram::ShaderProgram() {
     m_needsBuild = true;
     m_generation = -1;
     m_invalidShaderSource = false;
+    m_description = "";
 }
 
 ShaderProgram::~ShaderProgram() {
@@ -102,7 +103,7 @@ bool ShaderProgram::use() {
     checkValidity();
 
     if (m_needsBuild) {
-        valid |= build();
+        build();
     }
 
     valid &= (m_glProgram != 0);
@@ -212,7 +213,8 @@ GLuint ShaderProgram::makeCompiledShader(const std::string& _src, GLenum _type) 
         if (infoLength > 1) {
             std::vector<GLchar> infoLog(infoLength);
             glGetShaderInfoLog(shader, infoLength, NULL, &infoLog[0]);
-            LOGE("Compiling shader:\n%s", &infoLog[0]);
+            LOGE("Shader compilation failed %s", m_description.c_str());
+            LOGE("%s", &infoLog[0]);
             //logMsg("\n%s\n", source);
         }
         glDeleteShader(shader);

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -97,18 +97,21 @@ GLint ShaderProgram::getUniformLocation(const UniformLocation& _uniform) {
 }
 
 bool ShaderProgram::use() {
+    bool valid = true;
 
     checkValidity();
 
     if (m_needsBuild) {
-        build();
+        valid |= build();
     }
 
-    if (m_glProgram != 0) {
+    valid &= (m_glProgram != 0);
+
+    if (valid) {
         RenderState::shaderProgram(m_glProgram);
-        return true;
     }
-    return false;
+
+    return valid;
 }
 
 bool ShaderProgram::build() {

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -102,6 +102,8 @@ public:
 
     auto getSourceBlocks() const { return  m_sourceBlocks; }
 
+    void setDescription(std::string _description) { m_description = _description; }
+
 private:
 
     struct ShaderLocation {
@@ -142,6 +144,9 @@ private:
 
     std::string m_fragmentShaderSource;
     std::string m_vertexShaderSource;
+
+    // An optionnal shader description printed on compile failure
+    std::string m_description;
 
     std::map<std::string, std::vector<std::string>> m_sourceBlocks;
 

--- a/core/src/labels/labelSet.h
+++ b/core/src/labels/labelSet.h
@@ -15,7 +15,7 @@ public:
 
     virtual ~LabelSet();
 
-    void draw(ShaderProgram& _shader) override {}
+    bool draw(ShaderProgram& _shader) override { return true; }
 
     size_t bufferSize() const override { return 0; }
 

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -79,7 +79,14 @@ std::string systemFontFallbackPath(int _importance, int _weightHint);
 
 void initGLExtensions();
 
-/* Log utilities */
+/* 
+ * Log utilities:
+ * LOGD: Debug log, level >= 3
+ * LOGW: Warning log, level >= 2
+ * LOGE: Error log, level >= 1
+ * LOGN: Notification log (displayed once), level >= 0
+ * LOG: Default log, level >= 0
+ */
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #define TANGRAM_MAX_BUFFER_LOG_SIZE 99999
@@ -103,7 +110,7 @@ void initGLExtensions();
 #endif
 
 #if LOG_LEVEL >= 0
-#define NOTIFY(fmt, ...) do {                                                       \
+#define LOGN(fmt, ...) do {                                                         \
     static std::vector<std::string> logs;                                           \
     static char buffer[TANGRAM_MAX_BUFFER_LOG_SIZE];                                \
     snprintf(buffer, TANGRAM_MAX_BUFFER_LOG_SIZE - 1, fmt, ## __VA_ARGS__);         \
@@ -115,7 +122,7 @@ void initGLExtensions();
 } while (0)
 #define LOG(fmt, ...) do { logMsg("TANGRAM %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
 #else
-#define NOTIFY(fmt, ...)
+#define LOGN(fmt, ...)
 #define LOG(fmt, ...)
 #endif
 

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -3,7 +3,9 @@
 #include <string>
 #include <cstring>
 #include <vector>
+#include <algorithm>
 #include <functional>
+#include <cstdio>
 
 /* Print a formatted message to the console
  *
@@ -80,6 +82,7 @@ void initGLExtensions();
 /* Log utilities */
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define TANGRAM_MAX_BUFFER_LOG_SIZE 99999
 
 #if LOG_LEVEL >= 3
 #define LOGD(fmt, ...) do { logMsg("DEBUG %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
@@ -100,8 +103,19 @@ void initGLExtensions();
 #endif
 
 #if LOG_LEVEL >= 0
+#define NOTIFY(fmt, ...) do {                                                       \
+    static std::vector<std::string> logs;                                           \
+    static char buffer[TANGRAM_MAX_BUFFER_LOG_SIZE];                                \
+    snprintf(buffer, TANGRAM_MAX_BUFFER_LOG_SIZE - 1, fmt, ## __VA_ARGS__);         \
+    std::string log(buffer);                                                        \
+    if (std::find(logs.begin(), logs.end(), log) == logs.end()) {                   \
+        logs.push_back(log);                                                        \
+        logMsg("NOTIFY %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__);  \
+    }                                                                               \
+} while (0)
 #define LOG(fmt, ...) do { logMsg("TANGRAM %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
 #else
+#define NOTIFY(fmt, ...)
 #define LOG(fmt, ...)
 #endif
 

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -81,30 +81,34 @@ void initGLExtensions();
 
 /* 
  * Log utilities:
- * LOGD: Debug log, level >= 3
- * LOGW: Warning log, level >= 2
- * LOGE: Error log, level >= 1
- * LOGN: Notification log (displayed once), level >= 0
- * LOG: Default log, level >= 0
+ * LOGD: Debug log, LOG_LEVEL >= 3
+ * LOGW: Warning log, LOG_LEVEL >= 2
+ * LOGE: Error log, LOG_LEVEL >= 1
+ * LOGN: Notification log (displayed once), LOG_LEVEL >= 0
+ * LOG: Default log, LOG_LEVEL >= 0
+ * LOGS: Screen log, no LOG_LEVEL
  */
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #define TANGRAM_MAX_BUFFER_LOG_SIZE 99999
 
 #if LOG_LEVEL >= 3
-#define LOGD(fmt, ...) do { logMsg("DEBUG %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
+#define LOGD(fmt, ...) \
+do { logMsg("DEBUG %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
 #else
 #define LOGD(fmt, ...)
 #endif
 
 #if LOG_LEVEL >= 2
-#define LOGW(fmt, ...) do { logMsg("WARNING %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
+#define LOGW(fmt, ...) \
+do { logMsg("WARNING %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
 #else
 #define LOGW(fmt, ...)
 #endif
 
 #if LOG_LEVEL >= 1
-#define LOGE(fmt, ...) do { logMsg("ERROR %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
+#define LOGE(fmt, ...) \
+do { logMsg("ERROR %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
 #else
 #define LOGE(fmt, ...)
 #endif
@@ -113,17 +117,20 @@ void initGLExtensions();
 #define LOGN(fmt, ...) do {                                                         \
     static std::vector<std::string> logs;                                           \
     static char buffer[TANGRAM_MAX_BUFFER_LOG_SIZE];                                \
-    snprintf(buffer, TANGRAM_MAX_BUFFER_LOG_SIZE - 1, fmt, ## __VA_ARGS__);         \
+    snprintf(buffer, TANGRAM_MAX_BUFFER_LOG_SIZE - 1, "%s:%d:" fmt, __FILENAME__,   \
+        __LINE__, ## __VA_ARGS__);                                                  \
     std::string log(buffer);                                                        \
     if (std::find(logs.begin(), logs.end(), log) == logs.end()) {                   \
         logs.push_back(log);                                                        \
         logMsg("NOTIFY %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__);  \
     }                                                                               \
 } while (0)
-#define LOG(fmt, ...) do { logMsg("TANGRAM %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
+#define LOG(fmt, ...) \
+do { logMsg("TANGRAM %s:%d: " fmt "\n", __FILENAME__, __LINE__, ## __VA_ARGS__); } while(0)
 #else
 #define LOGN(fmt, ...)
 #define LOG(fmt, ...)
 #endif
 
-#define LOGS(fmt, ...) do { TextDisplay::Instance().log(fmt, ## __VA_ARGS__); } while(0)
+#define LOGS(fmt, ...) \
+do { TextDisplay::Instance().log(fmt, ## __VA_ARGS__); } while(0)

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -38,6 +38,8 @@ void Style::build(const std::vector<std::unique_ptr<Light>>& _lights) {
     constructVertexLayout();
     constructShaderProgram();
 
+    m_shaderProgram->setDescription("{style:" + m_name + "}");
+
     switch (m_lightingType) {
         case LightingType::vertex:
             m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_LIGHTING_VERTEX\n", false);

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -84,7 +84,7 @@ void Style::setupShaderUniforms(Scene& _scene) {
             std::string textureName = value.get<std::string>();
 
             if (!_scene.texture(textureName, texture) || !texture) {
-                NOTIFY("Texture with texture name %s is not available to be sent as uniform",
+                LOGN("Texture with texture name %s is not available to be sent as uniform",
                     textureName.c_str());
                 continue;
             }
@@ -115,7 +115,7 @@ void Style::setupShaderUniforms(Scene& _scene) {
                     std::shared_ptr<Texture> texture = nullptr;
 
                     if (!_scene.texture(textureName, texture) || !texture) {
-                        NOTIFY("Texture with texture name %s is not available to be sent as uniform",
+                        LOGN("Texture with texture name %s is not available to be sent as uniform",
                             textureName.c_str());
                         continue;
                     }
@@ -216,7 +216,7 @@ void Style::draw(const Tile& _tile) {
                                      _tile.getID().z);
 
         if (!styleMesh->draw(*m_shaderProgram)) {
-            NOTIFY("Mesh built by style %s cannot be drawn", m_name.c_str());
+            LOGN("Mesh built by style %s cannot be drawn", m_name.c_str());
         }
     }
 }

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -79,9 +79,11 @@ void Style::setupShaderUniforms(Scene& _scene) {
 
         if (value.is<std::string>()) {
             std::shared_ptr<Texture> texture = nullptr;
+            std::string textureName = value.get<std::string>();
 
-            if (!_scene.texture(value.get<std::string>(), texture) || !texture) {
-                // TODO: LOG, would be nice to do have a notify-once-log not to overwhelm logging
+            if (!_scene.texture(textureName, texture) || !texture) {
+                NOTIFY("Texture with texture name %s is not available to be sent as uniform",
+                    textureName.c_str());
                 continue;
             }
 
@@ -111,7 +113,8 @@ void Style::setupShaderUniforms(Scene& _scene) {
                     std::shared_ptr<Texture> texture = nullptr;
 
                     if (!_scene.texture(textureName, texture) || !texture) {
-                        // TODO: LOG, would be nice to do have a notify-once-log not to overwhelm logging
+                        NOTIFY("Texture with texture name %s is not available to be sent as uniform",
+                            textureName.c_str());
                         continue;
                     }
 
@@ -122,9 +125,6 @@ void Style::setupShaderUniforms(Scene& _scene) {
                 }
 
                 m_shaderProgram->setUniformi(name, textureUniformArray);
-            } else {
-                // TODO: Throw away uniform on loading!
-                // none_type
             }
         }
     }
@@ -213,7 +213,9 @@ void Style::draw(const Tile& _tile) {
                                      _tile.getID().s,
                                      _tile.getID().z);
 
-        styleMesh->draw(*m_shaderProgram);
+        if (!styleMesh->draw(*m_shaderProgram)) {
+            NOTIFY("Mesh built by style %s cannot be drawn", m_name.c_str());
+        }
     }
 }
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -38,7 +38,7 @@ enum class Blending : int8_t {
 };
 
 struct StyledMesh {
-    virtual void draw(ShaderProgram& _shader) = 0;
+    virtual bool draw(ShaderProgram& _shader) = 0;
     virtual size_t bufferSize() const = 0;
 
     virtual ~StyledMesh() {}

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -297,8 +297,7 @@ bool TextStyleBuilder::prepareLabel(TextStyle::Parameters& _params, Label::Type 
 
     uint32_t strokeAttrib = std::max(_params.strokeWidth / ctx->maxStrokeWidth() * 255.f, 0.f);
     if (strokeAttrib > 255) {
-        // FIXME: This warning should not be logged for every label
-        // LOGW("stroke_width too large: %f / %f", _params.strokeWidth, strokeAttrib/255.f);
+        LOGN("stroke_width too large: %f / %f", _params.strokeWidth, strokeAttrib/255.f);
         strokeAttrib = 255;
     }
     m_attributes.stroke = (_params.strokeColor & 0x00ffffff) + (strokeAttrib << 24);


### PR DESCRIPTION
When the mesh is not able to draw, our logs give no information about the style/shader it is coming from. This mesh will also keep drawing and trying to send uniform to uncompiled shader which leads to GL errors.
- Add a `NOTIFY` macro to send messages once to the log (can be renamed to `LOGN` for consistency with others) 
- Uniforms of uncompiled shader are not anymore asked for their location
- If a shader fails to compile, the style to which this mesh is associated will be notified on the log