### PR TITLE
osx: cancel download tasks when exiting mainloop

### DIFF
--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -381,6 +381,8 @@ int main(int argc, char* argv[]) {
 
     }
 
+    finishUrlRequests();
+
     glfwTerminate();
     return 0;
 }

--- a/osx/src/platform_osx.h
+++ b/osx/src/platform_osx.h
@@ -6,3 +6,5 @@
 #include <GLFW/glfw3.h>
 
 void NSurlInit();
+
+void finishUrlRequests();

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -174,6 +174,15 @@ void cancelUrlRequest(const std::string& _url) {
     }];
 }
 
+void finishUrlRequests() {
+
+    [defaultSession getTasksWithCompletionHandler:^(NSArray* dataTasks, NSArray* uploadTasks, NSArray* downloadTasks) {
+        for(NSURLSessionTask* task in dataTasks) {
+            [task cancel];
+        }
+    }];
+}
+
 void setCurrentThreadPriority(int priority) {
     int tid = syscall(SYS_gettid);
     setpriority(PRIO_PROCESS, tid, priority);


### PR DESCRIPTION
This is analog to how it works for glfw/linux. I'm not sure if one has to check the cancel state in the completionHandler. 