### PR TITLE
Gl check errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,20 @@ cd build/rpi/bin
 
 You can also move the map with `w`, `a`, `s`, and `z`, zoom in and out with `-` and `=`, and quit with `q`.
 
+## debug ##
+
+To build in `RELEASE` or `DEBUG` run the following:
+
+```sh
+make [platform] DEBUG=1
+```
+or
+```sh
+make [platform] RELEASE=1
+```
+
 Code Style
-=====
+==========
 In general, code changes should follow the style of the surrounding code.
 
 When in doubt, you can use the provided clang-format style file for automatic styling.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CORE_LIBRARY core CACHE INTERNAL "core library name" FORCE)
 
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
+  add_definitions(-DDEBUG)
   add_definitions(-DLOG_LEVEL=3)
 else()
   add_definitions(-DLOG_LEVEL=2)

--- a/core/src/debug/frameInfo.cpp
+++ b/core/src/debug/frameInfo.cpp
@@ -7,6 +7,7 @@
 #include "tile/tileCache.h"
 #include "view/view.h"
 #include "gl.h"
+#include "gl/error.h"
 
 #include <ctime>
 
@@ -58,7 +59,7 @@ void FrameInfo::draw(const View& _view, TileManager& _tileManager) {
         timeCpu[cpt] = TIME_TO_MS(s_startFrameTime, endCpu);
 
         // Force opengl to finish commands (for accurate frame time)
-        glFinish();
+        GL_CHECK(glFinish());
 
         s_endFrameTime = clock();
         timeRender[cpt] = TIME_TO_MS(s_startFrameTime, s_endFrameTime);

--- a/core/src/debug/textDisplay.cpp
+++ b/core/src/debug/textDisplay.cpp
@@ -95,7 +95,7 @@ void TextDisplay::draw(const std::string& _text, int _posx, int _posy) {
     }
     vertexLayout.enable(*m_shader, 0, (void*)vertices.data());
 
-    glDrawArrays(GL_TRIANGLES, 0, nquads * 6);
+    GL_CHECK(glDrawArrays(GL_TRIANGLES, 0, nquads * 6));
 }
 
 void TextDisplay::draw(const std::vector<std::string>& _infos) {
@@ -106,7 +106,7 @@ void TextDisplay::draw(const std::vector<std::string>& _infos) {
     RenderState::depthTest(GL_FALSE);
     RenderState::depthWrite(GL_FALSE);
 
-    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, (GLint*) &boundbuffer);
+    GL_CHECK(glGetIntegerv(GL_ARRAY_BUFFER_BINDING, (GLint*) &boundbuffer));
     RenderState::vertexBuffer(0);
 
     m_shader->use();

--- a/core/src/gl.h
+++ b/core/src/gl.h
@@ -96,6 +96,7 @@ typedef char            GLchar;
 #define GL_INVALID_VALUE                0x0501
 #define GL_INVALID_OPERATION            0x0502
 #define GL_OUT_OF_MEMORY                0x0505
+#define GL_INVALID_FRAMEBUFFER_OPERATION  0x0506
 
 /* Data types */
 #define GL_BYTE                         0x1400

--- a/core/src/gl/dynamicQuadMesh.cpp
+++ b/core/src/gl/dynamicQuadMesh.cpp
@@ -22,7 +22,7 @@ void QuadIndices::unref() {
         if (RenderState::indexBuffer.compare(quadIndexBuffer)) {
             RenderState::indexBuffer.init(0, false);
         }
-        glDeleteBuffers(1, &quadIndexBuffer);
+        GL_CHECK(glDeleteBuffers(1, &quadIndexBuffer));
         quadIndexBuffer = 0;
         quadGeneration = -1;
     }
@@ -49,10 +49,10 @@ void QuadIndices::load() {
         indices.push_back(i + 2);
     }
 
-    glGenBuffers(1, &quadIndexBuffer);
+    GL_CHECK(glGenBuffers(1, &quadIndexBuffer));
     RenderState::indexBuffer(quadIndexBuffer);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(GLushort),
-                 reinterpret_cast<GLbyte*>(indices.data()), GL_STATIC_DRAW);
+    GL_CHECK(glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(GLushort),
+                 reinterpret_cast<GLbyte*>(indices.data()), GL_STATIC_DRAW));
 }
 
 }

--- a/core/src/gl/dynamicQuadMesh.h
+++ b/core/src/gl/dynamicQuadMesh.h
@@ -82,7 +82,7 @@ void DynamicQuadMesh<T>::upload() {
 
     // Generate vertex buffer, if needed
     if (m_glVertexBuffer == 0) {
-        glGenBuffers(1, &m_glVertexBuffer);
+        GL_CHECK(glGenBuffers(1, &m_glVertexBuffer));
     }
 
     MeshBase::subDataUpload(reinterpret_cast<GLbyte*>(m_vertices.data()));
@@ -116,7 +116,7 @@ bool DynamicQuadMesh<T>::draw(ShaderProgram& _shader) {
 
         m_vertexLayout->enable(_shader, byteOffset);
 
-        glDrawElements(m_drawMode, nVertices * 6 / 4, GL_UNSIGNED_SHORT, 0);
+        GL_CHECK(glDrawElements(m_drawMode, nVertices * 6 / 4, GL_UNSIGNED_SHORT, 0));
 
         vertexOffset += nVertices;
     }

--- a/core/src/gl/error.cpp
+++ b/core/src/gl/error.cpp
@@ -7,7 +7,8 @@ std::unordered_map<GLenum, std::string> Error::s_GlErrorCodesToStrings = {
         {GL_INVALID_ENUM, "GL_INVALID_ENUM"},
         {GL_INVALID_VALUE, "GL_INVALID_VALUE"},
         {GL_INVALID_OPERATION, "GL_INVALID_OPERATION"},
-        {GL_OUT_OF_MEMORY, "GL_OUT_OF_MEMORY"}
+        {GL_OUT_OF_MEMORY, "GL_OUT_OF_MEMORY"},
+        {GL_INVALID_FRAMEBUFFER_OPERATION, "GL_INVALID_FRAMEBUFFER_OPERATION"}
     };
 
 bool Error::hadGlError(const std::string& _locationTag) {
@@ -29,10 +30,14 @@ bool Error::hadGlError(const std::string& _locationTag) {
 void Error::glError(const char* stmt, const char* fname, int line) {
     GLenum err = glGetError();
 
-    auto it = s_GlErrorCodesToStrings.find(err);
+    while (err != GL_NO_ERROR) {
+        auto it = s_GlErrorCodesToStrings.find(err);
 
-    if (it != s_GlErrorCodesToStrings.end() && err != GL_NO_ERROR) {
-        LOGE("OpenGL error %s, at %s:%i - for %s\n", it->second.c_str(), fname, line, stmt);
+        if (it != s_GlErrorCodesToStrings.end()) {
+            LOGE("OpenGL error %s, at %s:%i - for %s\n", it->second.c_str(), fname, line, stmt);
+        }
+
+        err = glGetError();
     }
 }
 

--- a/core/src/gl/error.cpp
+++ b/core/src/gl/error.cpp
@@ -26,4 +26,14 @@ bool Error::hadGlError(const std::string& _locationTag) {
     return false;
 }
 
+void Error::glError(const char* stmt, const char* fname, int line) {
+    GLenum err = glGetError();
+
+    auto it = s_GlErrorCodesToStrings.find(err);
+
+    if (it != s_GlErrorCodesToStrings.end() && err != GL_NO_ERROR) {
+        LOGE("OpenGL error %s, at %s:%i - for %s\n", it->second.c_str(), fname, line, stmt);
+    }
+}
+
 }

--- a/core/src/gl/error.h
+++ b/core/src/gl/error.h
@@ -18,10 +18,18 @@ public:
      */
     static bool hadGlError(const std::string& _locationTag);
 
+    static void glError(const char* stmt, const char* fname, int line);
+
 private:
 
     static std::unordered_map<GLenum, std::string> s_GlErrorCodesToStrings;
 
 };
+
+#ifdef TANGRAM_DEBUG
+#define GL_CHECK(STMT) do { STMT; Tangram::Error::glError(#STMT, __FILE__, __LINE__); } while (0)
+#else
+#define GL_CHECK(STMT) STMT;
+#endif
 
 }

--- a/core/src/gl/error.h
+++ b/core/src/gl/error.h
@@ -26,7 +26,7 @@ private:
 
 };
 
-#ifdef TANGRAM_DEBUG
+#ifdef DEBUG
 #define GL_CHECK(STMT) do { STMT; Tangram::Error::glError(#STMT, __FILE__, __LINE__); } while (0)
 #else
 #define GL_CHECK(STMT) STMT;

--- a/core/src/gl/hardware.cpp
+++ b/core/src/gl/hardware.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <iterator>
 #include "platform.h"
+#include "gl/error.h"
 #include "gl.h"
 
 namespace Tangram {
@@ -62,10 +63,10 @@ void loadExtensions() {
 
 void loadCapabilities() {
     int val;
-    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &val);
+    GL_CHECK(glGetIntegerv(GL_MAX_TEXTURE_SIZE, &val));
     maxTextureSize = val;
 
-    glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &val);
+    GL_CHECK(glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &val));
     maxCombinedTextureUnits = val;
 
     LOG("Hardware max texture size %d", maxTextureSize);

--- a/core/src/gl/mesh.cpp
+++ b/core/src/gl/mesh.cpp
@@ -41,13 +41,13 @@ MeshBase::~MeshBase() {
         if (RenderState::vertexBuffer.compare(m_glVertexBuffer)) {
             RenderState::vertexBuffer.init(0, false);
         }
-        glDeleteBuffers(1, &m_glVertexBuffer);
+        GL_CHECK(glDeleteBuffers(1, &m_glVertexBuffer));
     }
     if (m_glIndexBuffer) {
         if (RenderState::indexBuffer.compare(m_glIndexBuffer)) {
             RenderState::indexBuffer.init(0, false);
         }
-        glDeleteBuffers(1, &m_glIndexBuffer);
+        GL_CHECK(glDeleteBuffers(1, &m_glIndexBuffer));
     }
 
     if (m_glVertexData) {
@@ -96,20 +96,21 @@ void MeshBase::subDataUpload(GLbyte* _data) {
     long vertexBytes = m_nVertices * m_vertexLayout->getStride();
 
     // invalidate/orphane the data store on the driver
-    glBufferData(GL_ARRAY_BUFFER, vertexBytes, NULL, m_hint);
+    GL_CHECK(glBufferData(GL_ARRAY_BUFFER, vertexBytes, NULL, m_hint));
 
     if (Hardware::supportsMapBuffer) {
         GLvoid* dataStore = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        GL_CHECK(void(0));
 
         // write memory client side
         std::memcpy(dataStore, data, vertexBytes);
 
-        glUnmapBuffer(GL_ARRAY_BUFFER);
+        GL_CHECK(glUnmapBuffer(GL_ARRAY_BUFFER));
     } else {
 
         // if this buffer is still used by gpu on current frame this call will not wait
         // for the frame to finish using the vbo but "directly" send command to upload the data
-        glBufferData(GL_ARRAY_BUFFER, vertexBytes, data, m_hint);
+        GL_CHECK(glBufferData(GL_ARRAY_BUFFER, vertexBytes, data, m_hint));
     }
 
     m_dirty = false;
@@ -119,14 +120,14 @@ void MeshBase::upload() {
 
     // Generate vertex buffer, if needed
     if (m_glVertexBuffer == 0) {
-        glGenBuffers(1, &m_glVertexBuffer);
+        GL_CHECK(glGenBuffers(1, &m_glVertexBuffer));
     }
 
     // Buffer vertex data
     int vertexBytes = m_nVertices * m_vertexLayout->getStride();
 
     RenderState::vertexBuffer(m_glVertexBuffer);
-    glBufferData(GL_ARRAY_BUFFER, vertexBytes, m_glVertexData, m_hint);
+    GL_CHECK(glBufferData(GL_ARRAY_BUFFER, vertexBytes, m_glVertexData, m_hint));
 
     delete[] m_glVertexData;
     m_glVertexData = nullptr;
@@ -134,13 +135,13 @@ void MeshBase::upload() {
     if (m_glIndexData) {
 
         if (m_glIndexBuffer == 0) {
-            glGenBuffers(1, &m_glIndexBuffer);
+            GL_CHECK(glGenBuffers(1, &m_glIndexBuffer));
         }
 
         // Buffer element index data
         RenderState::indexBuffer(m_glIndexBuffer);
 
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_nIndices * sizeof(GLushort), m_glIndexData, m_hint);
+        GL_CHECK(glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_nIndices * sizeof(GLushort), m_glIndexData, m_hint));
 
         delete[] m_glIndexData;
         m_glIndexData = nullptr;
@@ -205,9 +206,10 @@ bool MeshBase::draw(ShaderProgram& _shader) {
 
         // Draw as elements or arrays
         if (nIndices > 0) {
-            glDrawElements(m_drawMode, nIndices, GL_UNSIGNED_SHORT, (void*)(indiceOffset * sizeof(GLushort)));
+            GL_CHECK(glDrawElements(m_drawMode, nIndices, GL_UNSIGNED_SHORT,
+                (void*)(indiceOffset * sizeof(GLushort))));
         } else if (nVertices > 0) {
-            glDrawArrays(m_drawMode, 0, nVertices);
+            GL_CHECK(glDrawArrays(m_drawMode, 0, nVertices));
         }
 
         vertexOffset += nVertices;

--- a/core/src/gl/mesh.cpp
+++ b/core/src/gl/mesh.cpp
@@ -100,7 +100,7 @@ void MeshBase::subDataUpload(GLbyte* _data) {
 
     if (Hardware::supportsMapBuffer) {
         GLvoid* dataStore = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
-        GL_CHECK(void(0));
+        GL_CHECK();
 
         // write memory client side
         std::memcpy(dataStore, data, vertexBytes);

--- a/core/src/gl/primitives.cpp
+++ b/core/src/gl/primitives.cpp
@@ -37,13 +37,13 @@ void init() {
         }));
 
         s_initialized = true;
-        glLineWidth(1.5f);
+        GL_CHECK(glLineWidth(1.5f));
     }
 }
 
 void saveState() {
     // save the current gl state
-    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, (GLint*) &s_boundBuffer);
+    GL_CHECK(glGetIntegerv(GL_ARRAY_BUFFER_BINDING, (GLint*) &s_boundBuffer));
     RenderState::depthTest(GL_FALSE);
     RenderState::vertexBuffer(0);
 }
@@ -69,7 +69,7 @@ void drawLine(const glm::vec2& _origin, const glm::vec2& _destination) {
     // enable the layout for the line vertices
     s_layout->enable(*s_shader, 0, &verts);
 
-    glDrawArrays(GL_LINES, 0, 2);
+    GL_CHECK(glDrawArrays(GL_LINES, 0, 2));
     popState();
 
 }
@@ -91,7 +91,7 @@ void drawPoly(const glm::vec2* _polygon, size_t _n) {
     // enable the layout for the _polygon vertices
     s_layout->enable(*s_shader, 0, (void*)_polygon);
 
-    glDrawArrays(GL_LINE_LOOP, 0, _n);
+    GL_CHECK(glDrawArrays(GL_LINE_LOOP, 0, _n));
     popState();
 }
 

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -39,10 +39,10 @@ namespace RenderState {
         return GL_TEXTURE0 + _unit;
     }
 
-    void bindVertexBuffer(GLuint _id) { glBindBuffer(GL_ARRAY_BUFFER, _id); }
-    void bindIndexBuffer(GLuint _id) { glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _id); }
-    void activeTextureUnit(GLuint _unit) { glActiveTexture(getTextureUnit(_unit)); }
-    void bindTexture(GLenum _target, GLuint _textureId) { glBindTexture(_target, _textureId); }
+    void bindVertexBuffer(GLuint _id) { GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, _id)); }
+    void bindIndexBuffer(GLuint _id) { GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _id)); }
+    void activeTextureUnit(GLuint _unit) { GL_CHECK(glActiveTexture(getTextureUnit(_unit))); }
+    void bindTexture(GLenum _target, GLuint _textureId) { GL_CHECK(glBindTexture(_target, _textureId)); }
 
     void configure() {
         s_textureUnit = -1;
@@ -57,10 +57,10 @@ namespace RenderState {
         depthTest.init(GL_TRUE);
         depthWrite.init(GL_TRUE);
 
-        glDisable(GL_STENCIL_TEST);
-        glDepthFunc(GL_LESS);
-        glClearDepthf(1.0);
-        glDepthRangef(0.0, 1.0);
+        GL_CHECK(glDisable(GL_STENCIL_TEST));
+        GL_CHECK(glDepthFunc(GL_LESS));
+        GL_CHECK(glClearDepthf(1.0));
+        GL_CHECK(glDepthRangef(0.0, 1.0));
 
         static size_t max = std::numeric_limits<size_t>::max();
 

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gl.h"
+#include "gl/error.h"
 
 #include <tuple>
 #include <limits>
@@ -56,9 +57,9 @@ namespace RenderState {
         using Type = GLboolean;
         inline static void set(const Type& _type) {
             if (_type) {
-                glEnable(N);
+                GL_CHECK(glEnable(N));
             } else {
-                glDisable(N);
+                GL_CHECK(glDisable(N));
             }
         }
     };
@@ -98,7 +99,7 @@ namespace RenderState {
 
         template<int ...S>
         inline void call(seq<S...>) {
-            fn(std::get<S>(params) ...);
+            GL_CHECK(fn(std::get<S>(params) ...));
         }
     };
 

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -93,7 +93,7 @@ GLint ShaderProgram::getUniformLocation(const UniformLocation& _uniform) {
     }
 
     _uniform.generation = m_generation;
-    _uniform.location = glGetUniformLocation(0, _uniform.name.c_str());
+    _uniform.location = glGetUniformLocation(m_glProgram, _uniform.name.c_str());
     GL_CHECK();
 
     return _uniform.location;

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -79,7 +79,7 @@ GLint ShaderProgram::getAttribLocation(const std::string& _attribName) {
     if (location == -2) {
         // Get the actual location from OpenGL
         location = glGetAttribLocation(m_glProgram, _attribName.c_str());
-        GL_CHECK(void(0));
+        GL_CHECK();
     }
 
     return location;
@@ -93,8 +93,8 @@ GLint ShaderProgram::getUniformLocation(const UniformLocation& _uniform) {
     }
 
     _uniform.generation = m_generation;
-    _uniform.location = glGetUniformLocation(m_glProgram, _uniform.name.c_str());
-    GL_CHECK(void(0));
+    _uniform.location = glGetUniformLocation(0, _uniform.name.c_str());
+    GL_CHECK();
 
     return _uniform.location;
 }
@@ -176,7 +176,7 @@ bool ShaderProgram::build() {
 GLuint ShaderProgram::makeLinkedShaderProgram(GLint _fragShader, GLint _vertShader) {
 
     GLuint program = glCreateProgram();
-    GL_CHECK(void(0));
+    GL_CHECK();
 
     GL_CHECK(glAttachShader(program, _fragShader));
     GL_CHECK(glAttachShader(program, _vertShader));
@@ -206,7 +206,7 @@ GLuint ShaderProgram::makeLinkedShaderProgram(GLint _fragShader, GLint _vertShad
 GLuint ShaderProgram::makeCompiledShader(const std::string& _src, GLenum _type) {
 
     GLuint shader = glCreateShader(_type);
-    GL_CHECK(void(0));
+    GL_CHECK();
 
     const GLchar* source = (const GLchar*) _src.c_str();
     GL_CHECK(glShaderSource(shader, 1, &source, NULL));

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -116,7 +116,7 @@ Texture& Texture::operator=(Texture&& _other) {
 
 Texture::~Texture() {
     if (m_glHandle) {
-        Tangram::runOnMainLoop([id = m_glHandle](){ glDeleteTextures(1, &id); });
+        Tangram::runOnMainLoop([id = m_glHandle]() { GL_CHECK(glDeleteTextures(1, &id)); });
 
         // if the texture is bound, and deleted, the binding defaults to 0
         // according to the OpenGL spec, in this case we need to force the
@@ -206,15 +206,15 @@ void Texture::bind(GLuint _unit) {
 }
 
 void Texture::generate(GLuint _textureUnit) {
-    glGenTextures(1, &m_glHandle);
+   GL_CHECK(glGenTextures(1, &m_glHandle));
 
     bind(_textureUnit);
 
-    glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, m_options.filtering.min);
-    glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, m_options.filtering.mag);
+    GL_CHECK(glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, m_options.filtering.min));
+    GL_CHECK(glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, m_options.filtering.mag));
 
-    glTexParameteri(m_target, GL_TEXTURE_WRAP_S, m_options.wrapping.wraps);
-    glTexParameteri(m_target, GL_TEXTURE_WRAP_T, m_options.wrapping.wrapt);
+    GL_CHECK(glTexParameteri(m_target, GL_TEXTURE_WRAP_S, m_options.wrapping.wraps));
+    GL_CHECK(glTexParameteri(m_target, GL_TEXTURE_WRAP_T, m_options.wrapping.wrapt));
 
     m_generation = RenderState::generation();
 }
@@ -278,13 +278,13 @@ void Texture::update(GLuint _textureUnit, const GLuint* data) {
             LOGW("The hardware maximum texture size is currently reached");
         }
 
-        glTexImage2D(m_target, 0, m_options.internalFormat,
+        GL_CHECK(glTexImage2D(m_target, 0, m_options.internalFormat,
                      m_width, m_height, 0, m_options.format,
-                     GL_UNSIGNED_BYTE, data);
+                     GL_UNSIGNED_BYTE, data));
 
         if (data && m_generateMipmaps) {
             // generate the mipmaps for this texture
-            glGenerateMipmap(m_target);
+            GL_CHECK(glGenerateMipmap(m_target));
         }
         m_shouldResize = false;
         m_dirtyRanges.clear();
@@ -295,9 +295,9 @@ void Texture::update(GLuint _textureUnit, const GLuint* data) {
 
     for (auto& range : m_dirtyRanges) {
         size_t offset =  (range.min * m_width) / divisor;
-        glTexSubImage2D(m_target, 0, 0, range.min, m_width, range.max - range.min,
+        GL_CHECK(glTexSubImage2D(m_target, 0, 0, range.min, m_width, range.max - range.min,
                         m_options.format, GL_UNSIGNED_BYTE,
-                        data + offset);
+                        data + offset));
     }
     m_dirtyRanges.clear();
 }

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -2,6 +2,7 @@
 
 #include "platform.h"
 #include "stb_image.h"
+#include "gl/error.h"
 
 #include <cstring> // for memcpy
 #include <cstdlib>
@@ -75,7 +76,7 @@ void TextureCube::update(GLuint _textureUnit) {
 
     for (int i = 0; i < 6; ++i) {
         Face& f = m_faces[i];
-        glTexImage2D(CubeMapFace[i], 0, m_options.internalFormat, m_width, m_height, 0, m_options.format, GL_UNSIGNED_BYTE, f.m_data.data());
+        GL_CHECK(glTexImage2D(CubeMapFace[i], 0, m_options.internalFormat, m_width, m_height, 0, m_options.format, GL_UNSIGNED_BYTE, f.m_data.data()));
     }
 }
 

--- a/core/src/gl/vao.cpp
+++ b/core/src/gl/vao.cpp
@@ -13,7 +13,7 @@ Vao::Vao() {
 
 Vao::~Vao() {
     if (m_glVAOs) {
-        glDeleteVertexArrays(m_glnVAOs, m_glVAOs);
+        GL_CHECK(glDeleteVertexArrays(m_glnVAOs, m_glVAOs));
         delete[] m_glVAOs;
     }
 }
@@ -24,7 +24,7 @@ void Vao::init(ShaderProgram& _program, const std::vector<std::pair<uint32_t, ui
     m_glnVAOs = _vertexOffsets.size();
     m_glVAOs = new GLuint[m_glnVAOs];
 
-    glGenVertexArrays(m_glnVAOs, m_glVAOs);
+    GL_CHECK(glGenVertexArrays(m_glnVAOs, m_glVAOs));
 
     fastmap<std::string, GLuint> locations;
 
@@ -38,7 +38,7 @@ void Vao::init(ShaderProgram& _program, const std::vector<std::pair<uint32_t, ui
     for (size_t i = 0; i < _vertexOffsets.size(); ++i) {
         auto vertexIndexOffset = _vertexOffsets[i];
         int nVerts = vertexIndexOffset.second;
-        glBindVertexArray(m_glVAOs[i]);
+        GL_CHECK(glBindVertexArray(m_glVAOs[i]));
 
         RenderState::vertexBuffer.init(_vertexBuffer, true);
 
@@ -56,12 +56,12 @@ void Vao::init(ShaderProgram& _program, const std::vector<std::pair<uint32_t, ui
 
 void Vao::bind(unsigned int _index) {
     if (_index < m_glnVAOs) {
-        glBindVertexArray(m_glVAOs[_index]);
+        GL_CHECK(glBindVertexArray(m_glVAOs[_index]));
     }
 }
 
 void Vao::unbind() {
-    glBindVertexArray(0);
+    GL_CHECK(glBindVertexArray(0));
 }
 
 }

--- a/core/src/gl/vertexLayout.cpp
+++ b/core/src/gl/vertexLayout.cpp
@@ -1,5 +1,6 @@
-#include "vertexLayout.h"
-#include "shaderProgram.h"
+#include "gl/vertexLayout.h"
+#include "gl/shaderProgram.h"
+#include "gl/error.h"
 #include "platform.h"
 
 namespace Tangram {
@@ -69,8 +70,8 @@ void VertexLayout::enable(const fastmap<std::string, GLuint>& _locations, size_t
 
         if (location != -1) {
             void* offset = ((unsigned char*) attrib.offset) + _byteOffset;
-            glEnableVertexAttribArray(location);
-            glVertexAttribPointer(location, attrib.size, attrib.type, attrib.normalized, m_stride, offset);
+            GL_CHECK(glEnableVertexAttribArray(location));
+            GL_CHECK(glVertexAttribPointer(location, attrib.size, attrib.type, attrib.normalized, m_stride, offset));
         }
     }
 
@@ -93,12 +94,12 @@ void VertexLayout::enable(ShaderProgram& _program, size_t _byteOffset, void* _pt
             auto& loc = s_enabledAttribs[location];
             // Track currently enabled attribs by the program to which they are bound
             if (loc != glProgram) {
-                glEnableVertexAttribArray(location);
+                GL_CHECK(glEnableVertexAttribArray(location));
                 loc = glProgram;
             }
 
             void* data = (unsigned char*)_ptr + attrib.offset + _byteOffset;
-            glVertexAttribPointer(location, attrib.size, attrib.type, attrib.normalized, m_stride, data);
+            GL_CHECK(glVertexAttribPointer(location, attrib.size, attrib.type, attrib.normalized, m_stride, data));
         }
     }
 
@@ -109,7 +110,7 @@ void VertexLayout::enable(ShaderProgram& _program, size_t _byteOffset, void* _pt
         GLuint& boundProgram = locationProgramPair.second;
 
         if (boundProgram != glProgram && boundProgram != 0) {
-            glDisableVertexAttribArray(location);
+            GL_CHECK(glDisableVertexAttribArray(location));
             boundProgram = 0;
         }
     }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -160,9 +160,6 @@ void resize(int _newWidth, int _newHeight) {
     }
 
     Primitives::setResolution(_newWidth, _newHeight);
-
-    while (Error::hadGlError("Tangram::resize()")) {}
-
 }
 
 bool update(float _dt) {
@@ -277,8 +274,6 @@ void render() {
     m_labels->drawDebug(*m_view);
 
     FrameInfo::draw(*m_view, *m_tileManager);
-
-    while (Error::hadGlError("Tangram::render()")) {}
 }
 
 void setPositionNow(double _lon, double _lat) {
@@ -550,8 +545,6 @@ void setupGL() {
     Hardware::loadCapabilities();
 
     Hardware::printAvailableExtensions();
-
-    while (Error::hadGlError("Tangram::setupGL()")) {}
 }
 
 void runOnMainLoop(std::function<void()> _task) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -248,7 +248,7 @@ void render() {
     RenderState::depthWrite(GL_TRUE);
     auto& color = m_scene->background();
     RenderState::clearColor(color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 
     for (const auto& style : m_scene->styles()) {
         style->onBeginFrame();


### PR DESCRIPTION
When a gl error happens we have no information on the line related to an error, we just know that an error happened during the last frame without any information on the related GL call that has produced this error. This PR adds a macro to check for GL errors after gl function calls when `TANGRAM_DEBUG` is defined. 

- Don't check for gl errors unless `TANGRAM_DEBUG` is defined
- Consistently give line number / file / gl function call that relates to a gl error