### PR TITLE
fix stand-alone raster-source

### DIFF
--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -59,7 +59,7 @@ public:
                m_urlTemplate == _other.m_urlTemplate;
     }
 
-    virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask = 0);
+    virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask = -1);
 
     /* @_cacheSize: Set size of in-memory cache for tile data in bytes.
      * This cache holds unprocessed tile data for fast recreation of recently used tiles.

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -12,7 +12,7 @@ namespace Tangram {
 
 class RasterTileTask : public DownloadTileTask {
 public:
-    RasterTileTask(TileID& _tileId, std::shared_ptr<DataSource> _source, bool _subTask)
+    RasterTileTask(TileID& _tileId, std::shared_ptr<DataSource> _source, int _subTask)
         : DownloadTileTask(_tileId, _source, _subTask) {}
 
     std::shared_ptr<Texture> m_texture;

--- a/core/src/tile/tileTask.h
+++ b/core/src/tile/tileTask.h
@@ -21,7 +21,7 @@ class TileTask {
 
 public:
 
-    TileTask(TileID& _tileId, std::shared_ptr<DataSource> _source, int _subTask = -1);
+    TileTask(TileID& _tileId, std::shared_ptr<DataSource> _source, int _subTask);
 
     // No copies
     TileTask(const TileTask& _other) = delete;
@@ -92,7 +92,7 @@ protected:
 
 class DownloadTileTask : public TileTask {
 public:
-    DownloadTileTask(TileID& _tileId, std::shared_ptr<DataSource> _source, bool _subTask)
+    DownloadTileTask(TileID& _tileId, std::shared_ptr<DataSource> _source, int _subTask)
         : TileTask(_tileId, _source, _subTask) {}
 
     virtual bool hasData() const override {


### PR DESCRIPTION
fix: int to bool casting, crash since task was considered as subtask