### PR TITLE
Compare new and old scene paths on initialization

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -22,14 +22,14 @@ namespace Tangram {
 
 static std::atomic<int32_t> s_serial;
 
-Scene::Scene() : id(s_serial++) {
+Scene::Scene(const std::string& _path) : id(s_serial++), m_path(_path) {
     m_view = std::make_shared<View>();
     // For now we only have one projection..
     // TODO how to share projection with view?
     m_mapProjection.reset(new MercatorProjection());
 }
 
-Scene::Scene(const Scene& _other) : Scene() {
+Scene::Scene(const Scene& _other) : Scene(_other.path()) {
     m_config = _other.m_config;
     m_updates = _other.m_updates;
     m_clientDataSources = _other.m_clientDataSources;

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -40,7 +40,7 @@ public:
         yes, no, none
     };
 
-    Scene();
+    Scene(const std::string& _path = "");
     Scene(const Scene& _other);
     ~Scene();
 
@@ -58,6 +58,7 @@ public:
     auto& fontContext() { return m_fontContext; }
     auto& globals() { return m_globals; }
 
+    const auto& path() const { return m_path; }
     const auto& config() const { return m_config; }
     const auto& dataSources() const { return m_dataSources; };
     const auto& layers() const { return m_layers; };
@@ -97,6 +98,9 @@ public:
     std::shared_ptr<DataSource> getDataSource(const std::string& name);
 
 private:
+
+    // The file path from which this scene was loaded
+    std::string m_path;
 
     // The root node of the YAML scene configuration
     YAML::Node m_config;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -60,8 +60,8 @@ static std::bitset<8> g_flags = 0;
 
 void initialize(const char* _scenePath) {
 
-    if (m_tileManager) {
-        LOG("Notice: Already initialized");
+    if (m_scene && m_scene->path() == _scenePath) {
+        LOGD("Specified scene is already initalized.");
         return;
     }
 
@@ -71,7 +71,7 @@ void initialize(const char* _scenePath) {
     m_view = std::make_shared<View>();
 
     // Create a scene object
-    m_scene = std::make_shared<Scene>();
+    m_scene = std::make_shared<Scene>(_scenePath);
 
     // Input handler
     m_inputHandler = std::make_unique<InputHandler>(m_view);


### PR DESCRIPTION
Previously, if `Tangram::initialize` or `MapView$getMapAsync` were called repeatedly with different scene file paths, the new scene would not be loaded. This change compares the new and old scene file paths in `Tangram::initialize` and loads the new scene if the paths differ. 

Resolves https://github.com/tangrams/tangram-es/issues/729