### PR TITLE
Fix over-zoomed line precision

### DIFF
--- a/core/resources/shaders/polyline.vs
+++ b/core/resources/shaders/polyline.vs
@@ -96,7 +96,8 @@ void main() {
         // Interpolate between zoom levels
         width += dwdz * clamp(dz, 0.0, 1.0);
         // Scale pixel dimensions to be consistent in screen space
-        width *= exp2(-dz);
+        // and adjust scale for overzooming.
+        width *= exp2(-dz + (u_tile_origin.w - u_tile_origin.z));
 
         // Modify line width in model space before extrusion
         #pragma tangram: width

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -106,7 +106,7 @@ public:
 
             void set(float _width, float _dWdZ, float _height, float _order) {
                 height = { glm::round(_height * position_scale), _order * order_scale};
-                width = glm::vec2{_width, _dWdZ} * extrusion_scale;
+                width = { glm::round(_width * extrusion_scale), glm::round(_dWdZ * extrusion_scale) };
             }
         } fill, stroke;
 

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -163,8 +163,8 @@ void PolylineStyleBuilder<V>::setup(const Tile& tile) {
 
     // When a tile is overzoomed, we are actually styling the area of its
     // 'source' tile, which will have a larger effective pixel size at the
-    // 'style' zoom level.
-    m_tileSizePixels *= std::exp2(id.s - id.z);
+    // 'style' zoom level. This scaling is performed in the vertex shader to
+    // prevent loss of precision for small dimensions in packed attributes.
 }
 
 template <class V>


### PR DESCRIPTION
See https://github.com/tangrams/tangram/issues/267 and https://github.com/tangrams/tangram/pull/310

When a tile is over-zoomed many times, the width attributes of lines (encoded as 16-bit integers) can become small enough, relative to their "source" tile, that they are rounded to zero. This causes lines to disappear on tiles that are sufficiently over-zoomed, particularly when the width is very small to begin with. 

This change moves a re-scaling operation from the polyline building process to the vertex shader, making width precision is undiminished with repeated over-zooming. 