### PR TITLE
Add checks to HTTP status codes for NSURLSession requests

### DIFF
--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -144,6 +144,8 @@ bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
 
         int statusCode = [httpResponse statusCode];
 
+        std::vector<char> rawDataVec;
+
         if (error != nil) {
 
             LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
@@ -154,11 +156,11 @@ bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
                 statusCode,
                 [[NSHTTPURLResponse localizedStringForStatusCode: statusCode] UTF8String],
                 [response.URL.absoluteString UTF8String]);
+            _callback(std::move(rawDataVec));
 
         } else {
 
             int dataLength = [data length];
-            std::vector<char> rawDataVec;
             rawDataVec.resize(dataLength);
             memcpy(rawDataVec.data(), (char *)[data bytes], dataLength);
             _callback(std::move(rawDataVec));

--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -140,17 +140,28 @@ bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
 
     void (^handler)(NSData*, NSURLResponse*, NSError*) = ^void (NSData* data, NSURLResponse* response, NSError* error) {
 
-        if(error == nil) {
+        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+
+        int statusCode = [httpResponse statusCode];
+
+        if (error != nil) {
+
+            LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
+
+        } else if (statusCode < 200 || statusCode >= 300) {
+
+            LOGE("Unsuccessful status code %d: \"%s\" from: %s",
+                statusCode,
+                [[NSHTTPURLResponse localizedStringForStatusCode: statusCode] UTF8String],
+                [response.URL.absoluteString UTF8String]);
+
+        } else {
 
             int dataLength = [data length];
             std::vector<char> rawDataVec;
             rawDataVec.resize(dataLength);
             memcpy(rawDataVec.data(), (char *)[data bytes], dataLength);
             _callback(std::move(rawDataVec));
-
-        } else {
-
-            logMsg("ERROR: response \"%s\" with error \"%s\".\n", response, std::string([error.localizedDescription UTF8String]).c_str());
 
         }
 

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -151,17 +151,28 @@ bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
             }
         }
 
-        if(error == nil) {
+        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+
+        int statusCode = [httpResponse statusCode];
+
+        if (error != nil) {
+
+            LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
+
+        } else if (statusCode < 200 || statusCode >= 300) {
+
+            LOGE("Unsuccessful status code %d: \"%s\" from: %s",
+                statusCode,
+                [[NSHTTPURLResponse localizedStringForStatusCode: statusCode] UTF8String],
+                [response.URL.absoluteString UTF8String]);
+
+        } else {
 
             int dataLength = [data length];
             std::vector<char> rawDataVec;
             rawDataVec.resize(dataLength);
             memcpy(rawDataVec.data(), (char *)[data bytes], dataLength);
             _callback(std::move(rawDataVec));
-
-        } else {
-
-            LOGE("Response \"%s\" with error \"%s\".", response, std::string([error.localizedDescription UTF8String]).c_str());
 
         }
 

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -155,6 +155,8 @@ bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
 
         int statusCode = [httpResponse statusCode];
 
+        std::vector<char> rawDataVec;
+
         if (error != nil) {
 
             LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
@@ -165,11 +167,11 @@ bool startUrlRequest(const std::string& _url, UrlCallback _callback) {
                 statusCode,
                 [[NSHTTPURLResponse localizedStringForStatusCode: statusCode] UTF8String],
                 [response.URL.absoluteString UTF8String]);
+            _callback(std::move(rawDataVec));
 
         } else {
 
             int dataLength = [data length];
-            std::vector<char> rawDataVec;
             rawDataVec.resize(dataLength);
             memcpy(rawDataVec.data(), (char *)[data bytes], dataLength);
             _callback(std::move(rawDataVec));


### PR DESCRIPTION
Status codes [200, 300) are accepted and their body data are used.

Resolves https://github.com/tangrams/tangram-es/issues/409.