### PR TITLE
fix: use the actual size of shader data, data is not null-terminated

### DIFF
--- a/core/src/gl/primitives.cpp
+++ b/core/src/gl/primitives.cpp
@@ -29,10 +29,8 @@ void init() {
     if (!s_initialized) {
         s_shader = std::unique_ptr<ShaderProgram>(new ShaderProgram());
 
-        std::string vert(reinterpret_cast<const char*>(debugPrimitive_vs_data));
-        std::string frag(reinterpret_cast<const char*>(debugPrimitive_fs_data));
-
-        s_shader->setSourceStrings(frag, vert);
+        s_shader->setSourceStrings(SHADER_SOURCE(debugPrimitive_fs),
+                                   SHADER_SOURCE(debugPrimitive_vs));
 
         s_layout = std::unique_ptr<VertexLayout>(new VertexLayout({
             {"a_position", 2, GL_FLOAT, false, 0},

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -106,6 +106,18 @@ public:
 
     void setDescription(std::string _description) { m_description = _description; }
 
+    static std::string shaderSourceBlock(const unsigned char* data, size_t size) {
+    std::string block;
+    if (data[size - 1] == '\n') {
+        block.append(reinterpret_cast<const char*>(data), size);
+    } else {
+        block.reserve(size + 2);
+        block.append(reinterpret_cast<const char*>(data), size);
+        block += '\n';
+    }
+    return block;
+}
+
 private:
 
     struct ShaderLocation {
@@ -162,5 +174,7 @@ private:
     std::string applySourceBlocks(const std::string& source, bool fragShader);
 
 };
+
+#define SHADER_SOURCE(NAME) ShaderProgram::shaderSourceBlock(NAME ## _data, NAME ## _size)
 
 }

--- a/core/src/scene/ambientLight.cpp
+++ b/core/src/scene/ambientLight.cpp
@@ -1,13 +1,12 @@
 #include "ambientLight.h"
 
-#include "glm/gtx/string_cast.hpp"
-#include "platform.h"
-
+#include "gl/shaderProgram.h"
 #include "shaders/ambientLight_glsl.h"
+
+#include "glm/gtx/string_cast.hpp"
 
 namespace Tangram {
 
-std::string AmbientLight::s_classBlock;
 std::string AmbientLight::s_typeName = "AmbientLight";
 
 AmbientLight::AmbientLight(const std::string& _name, bool _dynamic) :
@@ -32,10 +31,7 @@ void AmbientLight::setupProgram(const View& _view, LightUniforms& _uniforms) {
 }
 
 std::string AmbientLight::getClassBlock() {
-    if (s_classBlock.empty()) {
-        s_classBlock = std::string(reinterpret_cast<const char*>(ambientLight_glsl_data)) + "\n";
-    }
-    return s_classBlock;
+    return SHADER_SOURCE(ambientLight_glsl);
 }
 
 std::string AmbientLight::getInstanceDefinesBlock() {

--- a/core/src/scene/ambientLight.h
+++ b/core/src/scene/ambientLight.h
@@ -22,8 +22,6 @@ protected:
     virtual std::string getInstanceAssignBlock() override;
     virtual const std::string& getTypeName() override;
 
-    static std::string s_classBlock;
-
 private:
 
     static std::string s_typeName;

--- a/core/src/scene/directionalLight.cpp
+++ b/core/src/scene/directionalLight.cpp
@@ -8,7 +8,6 @@
 
 namespace Tangram {
 
-std::string DirectionalLight::s_classBlock;
 std::string DirectionalLight::s_typeName = "DirectionalLight";
 
 DirectionalLight::DirectionalLight(const std::string& _name, bool _dynamic) :
@@ -46,10 +45,7 @@ void DirectionalLight::setupProgram(const View& _view, LightUniforms& _uniforms)
 }
 
 std::string DirectionalLight::getClassBlock() {
-    if (s_classBlock.empty()) {
-        s_classBlock = std::string(reinterpret_cast<const char*>(directionalLight_glsl_data)) + "\n";
-    }
-    return s_classBlock;
+    return SHADER_SOURCE(directionalLight_glsl);
 }
 
 std::string DirectionalLight::getInstanceDefinesBlock() {

--- a/core/src/scene/directionalLight.h
+++ b/core/src/scene/directionalLight.h
@@ -37,8 +37,6 @@ protected:
     virtual std::string getInstanceAssignBlock() override;
     virtual const std::string& getTypeName() override;
 
-    static std::string s_classBlock;
-
     glm::vec3 m_direction;
 
 private:

--- a/core/src/scene/light.cpp
+++ b/core/src/scene/light.cpp
@@ -10,8 +10,6 @@
 
 namespace Tangram {
 
-std::string Light::s_mainLightingBlock;
-
 Light::Light(const std::string& _name, bool _dynamic):
     m_name(_name),
     m_ambient(0.0f),
@@ -81,10 +79,7 @@ void Light::assembleLights(std::map<std::string, std::vector<std::string>>& _sou
     }
 
     // After lights definitions are all added, add the main lighting functions
-    if (s_mainLightingBlock.empty()) {
-        s_mainLightingBlock = std::string(reinterpret_cast<const char*>(lights_glsl_data));
-    }
-    std::string lightingBlock = s_mainLightingBlock;
+    std::string lightingBlock = SHADER_SOURCE(lights_glsl);
 
     // The main lighting functions each contain a tag where all light instances should be computed;
     // Insert all of our "lights_to_compute" at this tag

--- a/core/src/scene/light.h
+++ b/core/src/scene/light.h
@@ -144,10 +144,6 @@ protected:
 
     bool m_dynamic;
 
-private:
-
-    static std::string s_mainLightingBlock;
-
 };
 
 }

--- a/core/src/scene/pointLight.cpp
+++ b/core/src/scene/pointLight.cpp
@@ -9,7 +9,6 @@
 
 namespace Tangram {
 
-std::string PointLight::s_classBlock;
 std::string PointLight::s_typeName = "PointLight";
 
 PointLight::PointLight(const std::string& _name, bool _dynamic) :
@@ -99,10 +98,7 @@ void PointLight::setupProgram(const View& _view, LightUniforms& _uniforms) {
 }
 
 std::string PointLight::getClassBlock() {
-    if (s_classBlock.empty()) {
-        s_classBlock = std::string(reinterpret_cast<const char*>(pointLight_glsl_data)) + "\n";
-    }
-    return s_classBlock;
+    return SHADER_SOURCE(pointLight_glsl);
 }
 
 std::string PointLight::getInstanceDefinesBlock() {

--- a/core/src/scene/pointLight.h
+++ b/core/src/scene/pointLight.h
@@ -49,8 +49,6 @@ protected:
     virtual std::string getInstanceAssignBlock() override;
     virtual const std::string& getTypeName() override;
 
-    static std::string s_classBlock;
-
     UnitVec<glm::vec3> m_position;
 
     float m_attenuation;

--- a/core/src/scene/skybox.cpp
+++ b/core/src/scene/skybox.cpp
@@ -14,11 +14,9 @@ Skybox::Skybox(std::string _file) : m_file(_file) {}
 
 void Skybox::init() {
 
-    std::string fragShaderSrcStr(reinterpret_cast<const char*>(cubemap_vs_data));
-    std::string vertShaderSrcStr(reinterpret_cast<const char*>(cubemap_fs_data));
-
     m_shader = std::make_unique<ShaderProgram>();
-    m_shader->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+    m_shader->setSourceStrings(SHADER_SOURCE(cubemap_fs),
+                               SHADER_SOURCE(cubemap_vs));
 
     m_texture = std::unique_ptr<Texture>(new TextureCube(m_file));
     auto layout = std::shared_ptr<VertexLayout>(new VertexLayout({

--- a/core/src/scene/spotLight.cpp
+++ b/core/src/scene/spotLight.cpp
@@ -9,7 +9,6 @@
 
 namespace Tangram {
 
-std::string SpotLight::s_classBlock;
 std::string SpotLight::s_typeName = "SpotLight";
 
 SpotLight::SpotLight(const std::string& _name, bool _dynamic) :
@@ -60,10 +59,7 @@ void SpotLight::setupProgram(const View& _view, LightUniforms& _uniforms ) {
 }
 
 std::string SpotLight::getClassBlock() {
-    if (s_classBlock.empty()) {
-        s_classBlock = std::string(reinterpret_cast<const char*>(spotLight_glsl_data)) + "\n";
-    }
-    return s_classBlock;
+    return SHADER_SOURCE(spotLight_glsl);
 }
 
 std::string SpotLight::getInstanceAssignBlock() {

--- a/core/src/scene/spotLight.h
+++ b/core/src/scene/spotLight.h
@@ -42,8 +42,6 @@ protected:
     virtual std::string getInstanceAssignBlock() override;
     virtual const std::string& getTypeName() override;
 
-    static std::string s_classBlock;
-
     glm::vec3 m_direction;
 
     float m_spotExponent;

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -38,10 +38,8 @@ void DebugStyle::constructVertexLayout() {
 
 void DebugStyle::constructShaderProgram() {
 
-    std::string vertShaderSrcStr(reinterpret_cast<const char*>(debug_vs_data));
-    std::string fragShaderSrcStr(reinterpret_cast<const char*>(debug_fs_data));
-
-    m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+    m_shaderProgram->setSourceStrings(SHADER_SOURCE(debug_fs),
+                                      SHADER_SOURCE(debug_vs));
 
 }
 

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -149,7 +149,7 @@ std::string Material::getDefinesBlock(){
 }
 
 std::string Material::getClassBlock() {
-    return std::string(reinterpret_cast<const char*>(material_glsl_data)) + "\n";
+    return SHADER_SOURCE(material_glsl);
 }
 
 std::unique_ptr<MaterialUniforms> Material::injectOnProgram(ShaderProgram& _shader ) {

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -39,10 +39,8 @@ void PointStyle::constructVertexLayout() {
 
 void PointStyle::constructShaderProgram() {
 
-    std::string fragShaderSrcStr(reinterpret_cast<const char*>(point_fs_data));
-    std::string vertShaderSrcStr(reinterpret_cast<const char*>(point_vs_data));
-
-    m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+    m_shaderProgram->setSourceStrings(SHADER_SOURCE(point_fs),
+                                      SHADER_SOURCE(point_vs));
 
     std::string defines;
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -71,10 +71,8 @@ void PolygonStyle::constructVertexLayout() {
 
 void PolygonStyle::constructShaderProgram() {
 
-    std::string vertShaderSrcStr(reinterpret_cast<const char*>(polygon_vs_data));
-    std::string fragShaderSrcStr(reinterpret_cast<const char*>(polygon_fs_data));
-
-    m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+    m_shaderProgram->setSourceStrings(SHADER_SOURCE(polygon_fs),
+                                      SHADER_SOURCE(polygon_vs));
 
     if (m_texCoordsGeneration) {
         m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_USE_TEX_COORDS\n");

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -81,10 +81,8 @@ void PolylineStyle::constructVertexLayout() {
 
 void PolylineStyle::constructShaderProgram() {
 
-    std::string vertShaderSrcStr(reinterpret_cast<const char*>(polyline_vs_data));
-    std::string fragShaderSrcStr(reinterpret_cast<const char*>(polyline_fs_data));
-
-    m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+    m_shaderProgram->setSourceStrings(SHADER_SOURCE(polyline_fs),
+                                      SHADER_SOURCE(polyline_vs));
 
     if (m_texCoordsGeneration) {
         m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_USE_TEX_COORDS\n");

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -164,9 +164,7 @@ void Style::setupRasters(const std::vector<std::shared_ptr<DataSource>>& _dataSo
             + std::to_string(numRasterSource) + "\n", false);
     m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_MODEL_POSITION_BASE_ZOOM_VARYING\n", false);
 
-    std::string rasterBlock(reinterpret_cast<const char*>(rasters_glsl_data));
-
-    m_shaderProgram->addSourceBlock("raster", rasterBlock);
+    m_shaderProgram->addSourceBlock("raster", SHADER_SOURCE(rasters_glsl));
 }
 
 void Style::onBeginDrawFrame(const View& _view, Scene& _scene) {

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -35,12 +35,14 @@ void TextStyle::constructVertexLayout() {
 }
 
 void TextStyle::constructShaderProgram() {
-    auto shaderFragData = m_sdf ? sdf_fs_data : text_fs_data;
 
-    std::string vertShaderSrcStr(reinterpret_cast<const char*>(point_vs_data));
-    std::string fragShaderSrcStr(reinterpret_cast<const char*>(shaderFragData));
-
-    m_shaderProgram->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+    if (m_sdf) {
+        m_shaderProgram->setSourceStrings(SHADER_SOURCE(sdf_fs),
+                                          SHADER_SOURCE(point_vs));
+    } else {
+        m_shaderProgram->setSourceStrings(SHADER_SOURCE(text_fs),
+                                          SHADER_SOURCE(point_vs));
+    }
 
     std::string defines = "#define TANGRAM_TEXT\n";
 


### PR DESCRIPTION
- fixes out of bounds reads of embedded shader data
- use SHADER_SOURCE macro for safe use of 'data' with respective 'size'