### PR TITLE
Add a check in CMake to inform a user that submodules are missing

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -33,6 +33,11 @@ file(GLOB_RECURSE FOUND_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}/*.h")
 set(INCLUDE_DIRS "")
 list(APPEND INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}")
 
+check_submodule(${INCLUDE_DIR}/earcut.hpp)
+check_submodule(${INCLUDE_DIR}/glm)
+check_submodule(${INCLUDE_DIR}/isect2d)
+check_submodule(${INCLUDE_DIR}/variant)
+
 set(CORE_INCLUDE_DIRS ${INCLUDE_DIRS} CACHE INTERNAL "core include directories" FORCE)
 list(APPEND INCLUDE_DIRS ${INCLUDE_DIR})
 list(APPEND INCLUDE_DIRS ${INCLUDE_DIR}/mapbox)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -22,11 +22,13 @@ endif()
 ##############
 set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "Enable testing and parse tools")
 set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "Enable contrib stuff in library")
-add_subdirectory("yaml-cpp")
+check_submodule(${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp)
 
 
 ## css-color-parser-cpp ##
 ##########################
+check_submodule(${CMAKE_CURRENT_SOURCE_DIR}/css-color-parser-cpp)
 add_library(css-color-parser-cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/css-color-parser-cpp/csscolorparser.cpp)
 
@@ -37,6 +39,7 @@ target_include_directories(css-color-parser-cpp
 
 ## geojsonvt ##
 ###############
+check_submodule(${CMAKE_CURRENT_SOURCE_DIR}/geojson-vt-cpp)
 file(GLOB_RECURSE GEOJSON_VT_CPP_SOURCES "geojson-vt-cpp/src/*.cpp")
 add_library(geojson-vt-cpp ${GEOJSON_VT_CPP_SOURCES})
 target_include_directories(geojson-vt-cpp
@@ -59,6 +62,7 @@ target_compile_options(geojson-vt-cpp
 
 ## duktape ##
 #############
+check_submodule(${CMAKE_CURRENT_SOURCE_DIR}/duktape)
 add_library(duktape
   ${CMAKE_CURRENT_SOURCE_DIR}/duktape/duktape.c)
 
@@ -94,6 +98,7 @@ if(PLATFORM_LINUX OR PLATFORM_OSX)
   set(GLFW_BUILD_DOCS OFF CACHE BOOL "Build the GLFW documentation")
   set(GLFW_INSTALL OFF CACHE BOOL "Generate installation target")
 
+  check_submodule(${CMAKE_CURRENT_SOURCE_DIR}/glfw)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/glfw)
 
   target_include_directories(glfw
@@ -123,6 +128,7 @@ if((BENCHMARK OR USE_EXTERNAL_LIBS) AND (PLATFORM_LINUX OR PLATFORM_OSX))
   set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
   set(BENCHMARK_ENABLE_LTO OFF CACHE BOOL "")
 
+  check_submodule(${CMAKE_CURRENT_SOURCE_DIR}/benchmark)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/benchmark)
   target_compile_options(benchmark
     PRIVATE
@@ -139,4 +145,5 @@ endif()
 #set(GLM_ROOT ${PROJECT_SOURCE_DIR}/core/include/glm)
 set(GLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/core/include/glm)
 
+check_submodule(${CMAKE_CURRENT_SOURCE_DIR}/alfons)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/alfons)

--- a/toolchains/utils.cmake
+++ b/toolchains/utils.cmake
@@ -112,3 +112,13 @@ macro(add_resources TARGET RESOURCE_DIR)
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${RESOURCE_DIR} ${CMAKE_BINARY_DIR}/bin)
 
 endmacro(add_resources)
+
+macro(check_submodule SUBMODULE_DIR)
+
+    file(GLOB CONTENTS ${SUBMODULE_DIR})
+    list(LENGTH CONTENTS N_FILES)
+    if(N_FILES EQUAL 0)
+        message(FATAL_ERROR "\nOops! '${SUBMODULE_DIR}' should contain a git submodule.\nDid you remember to initialize the git submodules? Try:\ngit submodule init --recursive\n")
+    endif()
+
+endmacro(check_submodule)


### PR DESCRIPTION
A very frequent problem encountered by new users is that they will clone the repository and try to build it, only to receive error messages that some directories don't contain a `CMakeLists.txt`. This just means that submodules haven't been initialized correctly. This change adds a macro to stop the build and print an informational message when it detects that a certain directory is empty or doesn't exist. This macro is applied for all submodule uses in the build process. 