### PR TITLE
Url scene import

### DIFF
--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -88,6 +88,7 @@ extern "C" {
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetupGL(JNIEnv* jniEnv, jobject obj) {
+        bindJniEnvToThread(jniEnv);
         Tangram::setupGL();
     }
 

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -26,6 +26,8 @@
 #include <fstream>
 #include <algorithm>
 
+#include <regex>
+
 /* Followed the following document for JavaVM tips when used with native threads
  * http://android.wooyd.org/JNIExample/#NWD1sCYeT-I
  * http://developer.android.com/training/articles/perf-jni.html and
@@ -176,10 +178,19 @@ bool isContinuousRendering() {
 
 std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
 
-    _sceneResourceRoot = std::string(dirname(_path));
+    std::regex r("^(http|https):/");
+    std::smatch match;
+    std::string path(_path);
+
+    if (std::regex_search(path, match, r)) {
+        _sceneResourceRoot = "";
+        return path;
+    }
+
+    _sceneResourceRoot = std::string(dirname(path));
 
     // TODO: InternalResource boolean should also be on Scene instead of being static
-    s_useInternalResources = (*_path != '/');
+    s_useInternalResources = (*path != '/');
 
     // For unclear reasons, the AAssetManager will fail to open a file at
     // path "filepath" if the path is instead given as "./filepath", so in
@@ -191,7 +202,7 @@ std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) 
         _sceneResourceRoot += '/';
     }
 
-    return std::string(basename(_path));
+    return std::string(basename(path));
 
 }
 

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -187,10 +187,10 @@ std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) 
         return path;
     }
 
-    _sceneResourceRoot = std::string(dirname(path));
+    _sceneResourceRoot = std::string(dirname(_path));
 
     // TODO: InternalResource boolean should also be on Scene instead of being static
-    s_useInternalResources = (*path != '/');
+    s_useInternalResources = (*_path != '/');
 
     // For unclear reasons, the AAssetManager will fail to open a file at
     // path "filepath" if the path is instead given as "./filepath", so in
@@ -202,7 +202,7 @@ std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) 
         _sceneResourceRoot += '/';
     }
 
-    return std::string(basename(path));
+    return std::string(basename(_path));
 
 }
 

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -229,10 +229,10 @@ unsigned char* bytesFromFileSystem(const char* _path, size_t& _size) {
 
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length, _type);
+    unsigned char* bytes = bytesFromFile(_path, length);
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
 
@@ -240,7 +240,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
 
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
     size_t len = strlen(_path);
 

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -60,10 +60,14 @@ PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT = 0;
 PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
 PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOESEXT = 0;
 
-void setupJniEnv(JNIEnv* jniEnv, jobject _tangramInstance, jobject _assetManager) {
+
+void bindJniEnvToThread(JNIEnv* jniEnv) {
     jniEnv->GetJavaVM(&jvm);
     jniRenderThreadEnv = jniEnv;
+}
 
+void setupJniEnv(JNIEnv* jniEnv, jobject _tangramInstance, jobject _assetManager) {
+    bindJniEnvToThread(jniEnv);
     if (tangramInstance) {
         jniEnv->DeleteGlobalRef(tangramInstance);
     }

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -252,7 +252,7 @@ unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
         } else {
             // For unclear reasons, the AAssetManager will fail to open a file at
             // path "filepath" if the path is instead given as "./filepath"
-            if (len >= 2 && _path[0] == '.' && _path[1] = '/') { _path += 2; }
+            if (len >= 2 && (_path[0] == '.') && (_path[1] == '/')) { _path += 2; }
 
             return bytesFromAssetManager(_path, _size);
         }

--- a/android/tangram/jni/platform_android.h
+++ b/android/tangram/jni/platform_android.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <jni.h>
 
+void bindJniEnvToThread(JNIEnv* jniEnv);
 void setupJniEnv(JNIEnv* _jniEnv, jobject _tangramInstance, jobject _assetManager);
 void onUrlSuccess(JNIEnv* jniEnv, jbyteArray jFetchedBytes, jlong jCallbackPtr);
 void onUrlFailure(JNIEnv* jniEnv, jlong jCallbackPtr);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -747,9 +747,6 @@ public class MapController implements Renderer {
 
     @Override
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
-        nativeInit(this, assetManager, scenePath);
-        // nativeInit() is safe to call twice, this invocation ensures that the jni
-        // environment is attached to the rendering thread
         nativeSetupGL();
     }
 

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -68,6 +68,7 @@ public class MapView extends FrameLayout {
             @SuppressWarnings("WrongThread")
             protected Boolean doInBackground(Void... params) {
                 mapController.init();
+                mapController.loadSceneFile(sceneFilePath);
                 return true;
             }
 

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -38,10 +38,9 @@ struct TestContext {
     std::unique_ptr<TileBuilder> tileBuilder;
 
     void loadScene(const char* sceneFile) {
+        scene = std::make_shared<Scene>(sceneFile);
         auto sceneRelPath = setResourceRoot(sceneFile, scene->resourceRoot());
-        scene->fontContext()->setSceneResourceRoot(scene->resourceRoot());
-
-        auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource, scene->resourceRoot().c_str());
+        auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource, "");
 
         YAML::Node sceneNode;
 
@@ -50,12 +49,12 @@ struct TestContext {
             LOGE("Parsing scene config '%s'", e.what());
             return;
         }
-        scene = std::make_shared<Scene>();
         SceneLoader::applyConfig(sceneNode, *scene);
 
         styleContext.initFunctions(*scene);
         styleContext.setKeywordZoom(0);
 
+        LOG("Here");
         source = *scene->dataSources().begin();
         tileBuilder = std::make_unique<TileBuilder>(scene);
     }

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -38,8 +38,10 @@ struct TestContext {
     std::unique_ptr<TileBuilder> tileBuilder;
 
     void loadScene(const char* sceneFile) {
-        auto sceneRelPath = setResourceRoot(sceneFile);
-        auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource);
+        auto sceneRelPath = setResourceRoot(sceneFile, scene->resourceRoot());
+        scene->fontContext()->setSceneResourceRoot(scene->resourceRoot());
+
+        auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource, scene->resourceRoot().c_str());
 
         YAML::Node sceneNode;
 

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -39,8 +39,7 @@ struct TestContext {
 
     void loadScene(const char* sceneFile) {
         scene = std::make_shared<Scene>(sceneFile);
-        auto sceneRelPath = setResourceRoot(sceneFile, scene->resourceRoot());
-        auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource, "");
+        auto sceneString = stringFromFile(sceneFile);
 
         YAML::Node sceneNode;
 

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -54,7 +54,6 @@ struct TestContext {
         styleContext.initFunctions(*scene);
         styleContext.setKeywordZoom(0);
 
-        LOG("Here");
         source = *scene->dataSources().begin();
         tileBuilder = std::make_unique<TileBuilder>(scene);
     }

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -28,13 +28,17 @@ Point transformPoint(geojsonvt::TilePoint pt) {
     return { pt.x / extent, 1. - pt.y / extent, 0 };
 }
 
-ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom)
+// TODO: pass scene's resourcePath to constructor to be used with `stringFromFile`
+ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url,
+        const std::string& _resourceRoot, int32_t _maxZoom)
     : DataSource(_name, _url, _maxZoom) {
 
+    // TODO: handle network url for client datasource data
+    // TODO: generic uri handling
     m_generateGeometry = true;
     if (!_url.empty()) {
         // Load from file
-        const auto& string = stringFromFile(_url.c_str(), PathType::resource);
+        const auto& string = stringFromFile(_url.c_str(), PathType::resource, _resourceRoot.c_str());
         addData(string);
     }
 }

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -32,13 +32,13 @@ Point transformPoint(geojsonvt::TilePoint pt) {
 }
 
 // TODO: pass scene's resourcePath to constructor to be used with `stringFromFile`
-ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url,
-        const std::string& _resourceRoot, int32_t _maxZoom)
+ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom)
     : DataSource(_name, _url, _maxZoom) {
 
     // TODO: handle network url for client datasource data
     // TODO: generic uri handling
     m_generateGeometry = true;
+
     if (!_url.empty()) {
         std::regex r("^(http|https):/");
         std::smatch match;
@@ -51,7 +51,7 @@ ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::st
                     });
         } else {
             // Load from file
-            const auto& string = stringFromFile(_url.c_str(), PathType::resource, _resourceRoot.c_str());
+            const auto& string = stringFromFile(_url.c_str());
             addData(string);
         }
     }

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -23,7 +23,8 @@ class ClientGeoJsonSource : public DataSource {
 
 public:
 
-    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom = 18);
+    ClientGeoJsonSource(const std::string& _name, const std::string& _url, const std::string& _resourceRoot = "",
+            int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -23,8 +23,7 @@ class ClientGeoJsonSource : public DataSource {
 
 public:
 
-    ClientGeoJsonSource(const std::string& _name, const std::string& _url, const std::string& _resourceRoot = "",
-            int32_t _maxZoom = 18);
+    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -58,8 +58,6 @@ bool Texture::loadImageFromMemory(const unsigned char* blob, unsigned int size, 
 
     setData(&blackPixel, 1);
 
-    LOGE("Decoding image from memory failed");
-
     return false;
 }
 

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -23,24 +23,6 @@ Texture::Texture(unsigned int _width, unsigned int _height, TextureOptions _opti
     resize(_width, _height);
 }
 
-Texture::Texture(const std::string& _file, const std::string& _resourcePath, TextureOptions _options,
-        bool _generateMipmaps, bool _flipOnLoad)
-    : Texture(0u, 0u, _options, _generateMipmaps) {
-
-    unsigned int size;
-    unsigned char* data;
-
-    data = bytesFromFile(_file.c_str(), PathType::resource, &size, _resourcePath.c_str());
-
-    if (data) {
-        loadImageFromMemory(data, size, _flipOnLoad);
-    } else {
-        LOGE("Failed to read Texture file: %s", _file.c_str());
-    }
-
-    free(data);
-}
-
 Texture::Texture(const unsigned char* data, size_t dataSize, TextureOptions options, bool generateMipmaps, bool _flipOnLoad)
     : Texture(0u, 0u, options, generateMipmaps) {
 

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -23,13 +23,14 @@ Texture::Texture(unsigned int _width, unsigned int _height, TextureOptions _opti
     resize(_width, _height);
 }
 
-Texture::Texture(const std::string& _file, TextureOptions _options, bool _generateMipmaps, bool _flipOnLoad)
+Texture::Texture(const std::string& _file, const std::string& _resourcePath, TextureOptions _options,
+        bool _generateMipmaps, bool _flipOnLoad)
     : Texture(0u, 0u, _options, _generateMipmaps) {
 
     unsigned int size;
     unsigned char* data;
 
-    data = bytesFromFile(_file.c_str(), PathType::resource, &size);
+    data = bytesFromFile(_file.c_str(), PathType::resource, &size, _resourcePath.c_str());
 
     if (data) {
         loadImageFromMemory(data, size, _flipOnLoad);

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -42,10 +42,6 @@ public:
             TextureOptions _options = DEFAULT_TEXTURE_OPTION},
             bool _generateMipmaps = false, bool _flipOnLoad = false);
 
-    Texture(const std::string& _file, const std::string& _resourcePath = "",
-            TextureOptions _options = DEFAULT_TEXTURE_OPTION},
-            bool _generateMipmaps = false, bool _flipOnLoad = false);
-
     Texture(Texture&& _other);
     Texture& operator=(Texture&& _other);
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -42,7 +42,7 @@ public:
             TextureOptions _options = DEFAULT_TEXTURE_OPTION},
             bool _generateMipmaps = false, bool _flipOnLoad = false);
 
-    Texture(const std::string& _file,
+    Texture(const std::string& _file, const std::string& _resourcePath = "",
             TextureOptions _options = DEFAULT_TEXTURE_OPTION},
             bool _generateMipmaps = false, bool _flipOnLoad = false);
 

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -9,15 +9,16 @@
 
 namespace Tangram {
 
-TextureCube::TextureCube(std::string _file, TextureOptions _options) : Texture(0u, 0u, _options) {
+TextureCube::TextureCube(std::string _file, const std::string& _resourcePath,
+        TextureOptions _options) : Texture(0u, 0u, _options) {
 
     m_target = GL_TEXTURE_CUBE_MAP;
-    load(_file);
+    load(_file, _resourcePath);
 }
 
-void TextureCube::load(const std::string& _file) {
+void TextureCube::load(const std::string& _file, const std::string& _resourcePath) {
     unsigned int size;
-    unsigned char* data = bytesFromFile(_file.c_str(), PathType::resource, &size);
+    unsigned char* data = bytesFromFile(_file.c_str(), PathType::resource, &size, _resourcePath.c_str());
     unsigned char* pixels;
     int width, height, comp;
 

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -9,16 +9,16 @@
 
 namespace Tangram {
 
-TextureCube::TextureCube(std::string _file, const std::string& _resourcePath,
-        TextureOptions _options) : Texture(0u, 0u, _options) {
+TextureCube::TextureCube(std::string _file, TextureOptions _options)
+    : Texture(0u, 0u, _options) {
 
     m_target = GL_TEXTURE_CUBE_MAP;
-    load(_file, _resourcePath);
+    load(_file);
 }
 
-void TextureCube::load(const std::string& _file, const std::string& _resourcePath) {
-    unsigned int size;
-    unsigned char* data = bytesFromFile(_file.c_str(), PathType::resource, &size, _resourcePath.c_str());
+void TextureCube::load(const std::string& _file) {
+    size_t size;
+    unsigned char* data = bytesFromFile(_file.c_str(), size);
     unsigned char* pixels;
     int width, height, comp;
 

--- a/core/src/gl/textureCube.h
+++ b/core/src/gl/textureCube.h
@@ -9,25 +9,25 @@
 namespace Tangram {
 
 class TextureCube : public Texture {
-    
+
 public:
-    TextureCube(std::string _file, TextureOptions _options =
-                {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}});
-    
+    TextureCube(std::string _file, const std::string& _resourceName = "",
+            TextureOptions _options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}});
+
     void update(GLuint _textureUnit) override;
-    
+
     void resize(const unsigned int _width, const unsigned int _height) = delete;
     void setData(const GLuint* _data, unsigned int _dataSize) = delete;
     void setSubData(const GLuint* _subData, unsigned int _xoff, unsigned int _yoff, unsigned int _width, unsigned int _height) = delete;
-    
+
 private:
-    
+
     struct Face {
         GLenum m_face;
         std::vector<unsigned int> m_data;
         int m_offset;
     };
-    
+
     const GLenum CubeMapFace[6] {
         GL_TEXTURE_CUBE_MAP_POSITIVE_X,
         GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
@@ -36,10 +36,10 @@ private:
         GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
         GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
     };
-    
+
     std::vector<Face> m_faces;
-    
-    void load(const std::string& _file);
+
+    void load(const std::string& _file, const std::string& _resourcePath);
 
 };
 

--- a/core/src/gl/textureCube.h
+++ b/core/src/gl/textureCube.h
@@ -11,7 +11,7 @@ namespace Tangram {
 class TextureCube : public Texture {
 
 public:
-    TextureCube(std::string _file, const std::string& _resourceName = "",
+    TextureCube(std::string _file,
             TextureOptions _options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}});
 
     void update(GLuint _textureUnit) override;
@@ -39,7 +39,7 @@ private:
 
     std::vector<Face> m_faces;
 
-    void load(const std::string& _file, const std::string& _resourcePath);
+    void load(const std::string& _filePath);
 
 };
 

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -13,6 +13,9 @@
  */
 void logMsg(const char* fmt, ...);
 
+/* Function type for a mapReady callback*/
+using MapReady = std::function<void(void)>;
+
 /* Request that a new frame be rendered by the windowing system
  */
 void requestRender();

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -35,14 +35,14 @@ enum class PathType : char {
 
 /* Set a path to act as the resource root. All other resource paths will be resolved relative to this root.
  * The string returned is the path to the given file relative to the new root resource directory. */
-std::string setResourceRoot(const char* _path);
+std::string setResourceRoot(const char* _path, std::string& resourceRoot);
 
 /* Read a file as a string
  *
  * Opens the file at the _path, resolved with _type, and returns a string with its contents.
  * If the file cannot be found or read, the returned string is empty.
  */
-std::string stringFromFile(const char* _path, PathType _type);
+std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot = nullptr);
 
 /* Read a file into memory
  *
@@ -50,7 +50,7 @@ std::string stringFromFile(const char* _path, PathType _type);
  * containing the contents of the file. The size of the memory in bytes is written to _size.
  * If the file cannot be read, nothing is allocated and nullptr is returned.
  */
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size);
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot = nullptr);
 
 /* Function type for receiving data from a successful network request */
 using UrlCallback = std::function<void(std::vector<char>&&)>;
@@ -79,7 +79,7 @@ std::string systemFontFallbackPath(int _importance, int _weightHint);
 
 void initGLExtensions();
 
-/* 
+/*
  * Log utilities:
  * LOGD: Debug log, LOG_LEVEL >= 3
  * LOGW: Warning log, LOG_LEVEL >= 2

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -30,26 +30,20 @@ bool isContinuousRendering();
 /* get system path of a font file */
 std::string systemFontPath(const std::string& _name, const std::string& _weight, const std::string& _face);
 
-enum class PathType : char {
-    absolute, // resolved relative to the filesystem root
-    internal, // resolved relative to the application storage directory
-    resource, // resolved relative to the resource root
-};
-
 /* Read a file as a string
  *
- * Opens the file at the _path, resolved with _type, and returns a string with its contents.
+ * Opens the file at the _path and returns a string with its contents.
  * If the file cannot be found or read, the returned string is empty.
  */
-std::string stringFromFile(const char* _path, PathType _type = PathType::absolute);
+std::string stringFromFile(const char* _path);
 
 /* Read a file into memory
  *
- * Opens the file at _path, resolved with _type, then allocates and returns a pointer to memory
+ * Opens the file at _path then allocates and returns a pointer to memory
  * containing the contents of the file. The size of the memory in bytes is written to _size.
  * If the file cannot be read, nothing is allocated and nullptr is returned.
  */
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type = PathType::absolute);
+unsigned char* bytesFromFile(const char* _path, size_t& _size);
 
 /* Function type for receiving data from a successful network request */
 using UrlCallback = std::function<void(std::vector<char>&&)>;

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -36,16 +36,12 @@ enum class PathType : char {
     resource, // resolved relative to the resource root
 };
 
-/* Set a path to act as the resource root. All other resource paths will be resolved relative to this root.
- * The string returned is the path to the given file relative to the new root resource directory. */
-std::string setResourceRoot(const char* _path, std::string& resourceRoot);
-
 /* Read a file as a string
  *
  * Opens the file at the _path, resolved with _type, and returns a string with its contents.
  * If the file cannot be found or read, the returned string is empty.
  */
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot = nullptr);
+std::string stringFromFile(const char* _path, PathType _type = PathType::absolute);
 
 /* Read a file into memory
  *
@@ -53,7 +49,7 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
  * containing the contents of the file. The size of the memory in bytes is written to _size.
  * If the file cannot be read, nothing is allocated and nullptr is returned.
  */
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot = nullptr);
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type = PathType::absolute);
 
 /* Function type for receiving data from a successful network request */
 using UrlCallback = std::function<void(std::vector<char>&&)>;

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -57,11 +57,12 @@ void Importer::normalizeSceneImports(Node& root, const std::string& parentPath) 
 void Importer::setNormalizedTexture(Node& texture, const std::vector<std::string>& names,
         const std::string& parentPath) {
 
-    for (auto& name : names) {
+    for (size_t index = 0; index < names.size(); index++) {
+        auto& name = names[index];
         if (m_textureNames.find(name) == m_textureNames.end()) {
             m_textureNames.insert(name);
             if (names.size() > 1) {
-                texture.push_back(normalizePath(name, parentPath));
+                texture[index] = normalizePath(name, parentPath);
             } else {
                 texture = normalizePath(name, parentPath);
             }
@@ -131,7 +132,7 @@ void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath)
 bool Importer::loadScene(const std::string& path) {
 
     auto scenePath = path;
-    auto sceneString = stringFromFile(setResourceRoot(scenePath.c_str()).c_str(), PathType::resource);
+    auto sceneString = stringFromFile(scenePath.c_str(), PathType::resource);
     auto sceneName = getFilename(scenePath);
 
     if (m_scenes.find(sceneName) != m_scenes.end()) { return true; }

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -34,6 +34,7 @@ Node Importer::applySceneImports(const std::string& scenePath) {
             if (m_scenes.find(path) != m_scenes.end()) { continue; }
         }
 
+        // TODO: generic handling of uri
         std::regex r("^(http|https):/");
         std::smatch match;
         if (std::regex_search(path, match, r)) {

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -1,0 +1,124 @@
+#include "importer.h"
+#include "platform.h"
+#include "util/topologicalSort.h"
+#include "yaml-cpp/yaml.h"
+
+#include <regex>
+
+using YAML::Node;
+using YAML::NodeType;
+
+namespace Tangram {
+
+Node Importer::applySceneImports(const std::string& scenePath) {
+
+    if (loadScene(scenePath)) {
+        return importScenes(scenePath);
+    }
+
+    return Node();
+}
+
+bool Importer::loadScene(const std::string& scenePath) {
+
+    auto sceneString = stringFromFile(setResourceRoot(scenePath.c_str()).c_str(), PathType::resource);
+    auto sceneName = scenePath;
+
+    try {
+        auto root = YAML::Load(sceneString);
+        auto imports = getScenesToImport(root);
+        std::regex r("[^//]+$");
+        std::smatch match;
+        if (std::regex_search(sceneName, match, r)) { sceneName = match[0]; }
+        for (const auto& import : imports) {
+            // TODO: What happens when parsing fails for an import
+            // Relative path of imports with respect to the original
+            auto importPath = std::regex_replace(scenePath, r, import);
+            loadScene(importPath);
+        }
+        m_scenes[sceneName] = root;
+    }
+    catch (YAML::ParserException e) {
+        LOGE("Parsing scene config '%s'", e.what());
+        return false;
+    }
+    return true;
+}
+
+std::vector<std::string> Importer::getScenesToImport(const Node& scene) {
+
+    std::vector<std::string> sceneNames;
+
+    if (const Node& import = scene["import"]) {
+        if (import.IsScalar()) {
+            sceneNames.push_back(import.Scalar());
+        }
+        else if (import.IsSequence()) {
+            for (const auto& imp : import) {
+                if (imp.IsScalar()) { sceneNames.push_back(imp.Scalar()); }
+            }
+        }
+    }
+
+    return sceneNames;
+}
+
+std::vector<std::string> Importer::getImportOrder() {
+
+    std::vector<std::pair<std::string, std::string>> dependencies;
+
+    for (const auto& scene : m_scenes) {
+        const auto& name = scene.first.k;
+        const auto& sceneRoot = scene.second;
+        for (const auto& import : getScenesToImport(sceneRoot)) {
+            dependencies.push_back( {import, name} );
+        }
+    }
+
+    return topologicalSort(dependencies);
+}
+
+Node Importer::importScenes(const std::string& sceneName) {
+
+    auto importScenesSorted = getImportOrder();
+
+    Node root = Node();
+
+    for (const auto& import : importScenesSorted) {
+        const auto& importRoot = m_scenes[import];
+        if (!importRoot.IsMap()) { continue; }
+        mergeMapFields(root, importRoot);
+    }
+
+    return root;
+
+}
+
+void Importer::mergeMapFields(Node& target, const Node& import) {
+
+    for (const auto& entry : import) {
+
+        const auto &key = entry.first.Scalar();
+
+        if (!target[key]) {
+            target[key] = entry.second;
+            continue;
+        }
+
+        switch(entry.second.Type()) {
+            case NodeType::Scalar:
+            case NodeType::Sequence:
+                target[key] = entry.second;
+                break;
+            case NodeType::Map: {
+                Node newTarget = target[key];
+                mergeMapFields(newTarget, entry.second);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+}
+
+}

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -140,10 +140,11 @@ void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath)
 bool Importer::loadScene(const std::string& path) {
 
     auto scenePath = path;
-    auto sceneString = stringFromFile(scenePath.c_str(), PathType::resource);
     auto sceneName = getFilename(scenePath);
 
     if (m_scenes.find(sceneName) != m_scenes.end()) { return true; }
+
+    auto sceneString = stringFromFile(scenePath.c_str(), PathType::resource);
 
     // Make sure all references from uber scene file are relative to itself, instead of being
     // absolute paths (Example: when loading a file using command line args).
@@ -195,14 +196,14 @@ std::vector<std::string> Importer::getImportOrder() {
         const auto& sceneRoot = scene.second;
         for (const auto& import : getScenesToImport(sceneRoot)) {
             auto importName = getFilename(import);
-            // TODO: fixme do not allow cycles
             dependencies.push_back( {importName, name} );
         }
     }
 
-    if (dependencies.empty()) {
-        // only possible when only 1 scene to load with no imports
-        return {m_scenes.map[0].first.k};
+    auto sortedScenes = topologicalSort(dependencies);
+
+    if (sortedScenes.empty()) {
+        return { m_scenes.map[0].first.k };
     }
 
     return topologicalSort(dependencies);

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -59,13 +59,21 @@ void Importer::setNormalizedTexture(Node& texture, const std::vector<std::string
 
     for (size_t index = 0; index < names.size(); index++) {
         auto& name = names[index];
+        std::string normTexPath;
+
+        //get normalized texture path
         if (m_textureNames.find(name) == m_textureNames.end()) {
-            m_textureNames.insert(name);
-            if (names.size() > 1) {
-                texture[index] = normalizePath(name, parentPath);
-            } else {
-                texture = normalizePath(name, parentPath);
-            }
+            normTexPath = normalizePath(name, parentPath);
+            m_textureNames[name] = normTexPath;
+        } else {
+            normTexPath = m_textureNames.at(name);
+        }
+
+        //set yaml node with normalized texture path
+        if (names.size() > 1) {
+            texture[index] = normTexPath;
+        } else {
+            texture = normTexPath;
         }
     }
 }

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -1,5 +1,6 @@
 #include "importer.h"
 #include "platform.h"
+#include "scene/sceneLoader.h"
 #include "util/topologicalSort.h"
 #include "yaml-cpp/yaml.h"
 
@@ -19,24 +20,137 @@ Node Importer::applySceneImports(const std::string& scenePath) {
     return Node();
 }
 
-bool Importer::loadScene(const std::string& scenePath) {
+std::string Importer::getFilename(const std::string& filePath) {
+    std::string sceneName = filePath;
+    std::regex r("[^//]+$");
+    std::smatch match;
+    if (std::regex_search(sceneName, match, r)) { sceneName = match[0]; }
+    return sceneName;
+}
 
+std::string Importer::normalizePath(const std::string &path,
+                                         const std::string &parentPath) {
+
+    //TODO: Handle network urls
+
+    if (path[0] == '/') {
+        //absolute path, return as it is
+        return path;
+    }
+
+    std::regex r("[^//]+$");
+    return std::regex_replace(parentPath, r, path);
+}
+
+void Importer::normalizeSceneImports(Node& root, const std::string& parentPath) {
+    if (Node import = root["import"]) {
+        if (import.IsScalar()) {
+            import = normalizePath(import.Scalar(), parentPath);
+        } else if (import.IsSequence()) {
+            for (Node imp : import) {
+                if (imp.IsScalar()) { imp = normalizePath(imp.Scalar(), parentPath); }
+            }
+        }
+    }
+}
+
+void Importer::setNormalizedTexture(Node& texture, const std::vector<std::string>& names,
+        const std::string& parentPath) {
+
+    for (auto& name : names) {
+        if (m_textureNames.find(name) == m_textureNames.end()) {
+            m_textureNames.insert(name);
+            if (names.size() > 1) {
+                texture.push_back(normalizePath(name, parentPath));
+            } else {
+                texture = normalizePath(name, parentPath);
+            }
+        }
+    }
+}
+
+void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath) {
+
+    if (Node textures = root["textures"]) {
+        for (auto texture : textures) {
+            if (Node textureUrl = texture.second["url"]) {
+                setNormalizedTexture(textureUrl, {textureUrl.Scalar()}, parentPath);
+            }
+        }
+    }
+
+    if (Node styles = root["styles"]) {
+
+        for (auto styleNode : styles) {
+
+            auto style = styleNode.second;
+            //style->texture
+            if (Node texture = style["texture"]) {
+                if (texture.IsScalar()) {
+                    setNormalizedTexture(texture, {texture.Scalar()}, parentPath);
+                }
+            }
+
+            //style->material->texture
+            if (Node material = style["material"]) {
+                for (auto& prop : {"emission", "ambient", "diffuse", "specular", "normal"}) {
+                    if (auto propNode = material[prop]) {
+                        if (auto matTexture = material[propNode]["texture"]) {
+                            if (matTexture.IsScalar()) {
+                                setNormalizedTexture(matTexture, {matTexture.Scalar()}, parentPath);
+                            }
+                        }
+                    }
+                }
+            }
+
+            //style->shader->uniforms->texture
+            if (Node shaders = style["shaders"]) {
+                if (Node uniforms = shaders["uniforms"]) {
+                    for (auto uniformNode : uniforms) {
+                        StyleUniform styleUniform;
+                        auto uniformValue = uniformNode.second;
+                        if (SceneLoader::parseStyleUniforms(uniformValue, nullptr, styleUniform) &&
+                                styleUniform.type == "sampler2D") {
+                            if (styleUniform.value.is<UniformTextureArray>()) {
+                                setNormalizedTexture(uniformValue,
+                                             styleUniform.value.get<UniformTextureArray>().names,
+                                             parentPath);
+                            } else {
+                                auto name = styleUniform.value.get<std::string>();
+                                setNormalizedTexture(uniformValue, {name}, parentPath);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+bool Importer::loadScene(const std::string& path) {
+
+    auto scenePath = path;
     auto sceneString = stringFromFile(setResourceRoot(scenePath.c_str()).c_str(), PathType::resource);
-    auto sceneName = scenePath;
+    auto sceneName = getFilename(scenePath);
+
+    if (m_scenes.find(sceneName) != m_scenes.end()) { return true; }
+
+    // Make sure all references from uber scene file are relative to itself, instead of being
+    // absolute paths (Example: when loading a file using command line args).
+    // TODO: Could be made better later.
+    if (m_scenes.size() == 0 && scenePath[0] == '/') { scenePath = getFilename(scenePath); }
 
     try {
         auto root = YAML::Load(sceneString);
+        normalizeSceneImports(root, scenePath);
+        normalizeSceneTextures(root, scenePath);
         auto imports = getScenesToImport(root);
-        std::regex r("[^//]+$");
-        std::smatch match;
-        if (std::regex_search(sceneName, match, r)) { sceneName = match[0]; }
+        m_scenes[sceneName] = root;
         for (const auto& import : imports) {
             // TODO: What happens when parsing fails for an import
-            // Relative path of imports with respect to the original
-            auto importPath = std::regex_replace(scenePath, r, import);
-            loadScene(importPath);
+            loadScene(import);
         }
-        m_scenes[sceneName] = root;
     }
     catch (YAML::ParserException e) {
         LOGE("Parsing scene config '%s'", e.what());
@@ -71,8 +185,15 @@ std::vector<std::string> Importer::getImportOrder() {
         const auto& name = scene.first.k;
         const auto& sceneRoot = scene.second;
         for (const auto& import : getScenesToImport(sceneRoot)) {
-            dependencies.push_back( {import, name} );
+            auto importName = getFilename(import);
+            // TODO: fixme do not allow cycles
+            dependencies.push_back( {importName, name} );
         }
+    }
+
+    if (dependencies.empty()) {
+        // only possible when only 1 scene to load with no imports
+        return {m_scenes.map[0].first.k};
     }
 
     return topologicalSort(dependencies);
@@ -99,6 +220,9 @@ void Importer::mergeMapFields(Node& target, const Node& import) {
     for (const auto& entry : import) {
 
         const auto &key = entry.first.Scalar();
+
+        // do not merge ignore property
+        if (key == "import") { continue; }
 
         if (!target[key]) {
             target[key] = entry.second;

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -61,6 +61,9 @@ void Importer::setNormalizedTexture(Node& texture, const std::vector<std::string
         auto& name = names[index];
         std::string normTexPath;
 
+        // if texture url is a named texture then move on (this has been already resolved
+        if (m_globalTextures.find(name) != m_globalTextures.end()) { continue; }
+
         //get normalized texture path
         if (m_textureNames.find(name) == m_textureNames.end()) {
             normTexPath = normalizePath(name, parentPath);
@@ -84,6 +87,7 @@ void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath)
         for (auto texture : textures) {
             if (Node textureUrl = texture.second["url"]) {
                 setNormalizedTexture(textureUrl, {textureUrl.Scalar()}, parentPath);
+                m_globalTextures.insert(texture.first.Scalar());
             }
         }
     }

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -36,8 +36,6 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
                 });
 
 
-            if (progressCounter == MAX_SCENE_DOWNLOAD) { continue; }
-
             if (m_sceneQueue.empty()) {
                 if (progressCounter == 0) {
                     break;
@@ -58,11 +56,11 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
         if (std::regex_search(path, match, r)) {
             progressCounter++;
             startUrlRequest(path,
-                    [&](std::vector<char>&& rawData) {
+                    [&, p = path](std::vector<char>&& rawData) {
 
                     if (!rawData.empty()) {
                         std::unique_lock<std::mutex> lock(sceneMutex);
-                        processScene(path, std::string(rawData.data(), rawData.size()));
+                        processScene(p, std::string(rawData.data(), rawData.size()));
                     }
                     progressCounter--;
                     m_condition.notify_all();

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -74,6 +74,7 @@ void Importer::processScene(const std::string &scenePath, const std::string &sce
     try {
         auto root = YAML::Load(sceneString);
         normalizeSceneImports(root, path);
+        normalizeSceneDataSources(root, scenePath);
         normalizeSceneTextures(root, path);
         auto imports = getScenesToImport(root);
         m_scenes[path] = root;
@@ -116,6 +117,16 @@ void Importer::normalizeSceneImports(Node& root, const std::string& parentPath) 
         } else if (import.IsSequence()) {
             for (Node imp : import) {
                 if (imp.IsScalar()) { imp = normalizePath(imp.Scalar(), parentPath); }
+            }
+        }
+    }
+}
+
+void Importer::normalizeSceneDataSources(Node &root, const std::string &parentPath) {
+    if (Node sources = root["sources"]) {
+        for (auto source : sources) {
+            if (Node sourceUrl = source.second["url"]) {
+                sourceUrl = normalizePath(sourceUrl.Scalar(), parentPath);
             }
         }
     }

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -99,14 +99,14 @@ std::string Importer::getFilename(const std::string& filePath) {
 std::string Importer::normalizePath(const std::string &path,
                                          const std::string &parentPath) {
 
-    //TODO: Handle network urls
-
-    if (path[0] == '/') {
-        //absolute path, return as it is
+    std::regex r("^(http|https):/");
+    std::smatch match;
+    if (path[0] == '/' || std::regex_search(path, match, r)) {
+        //absolute path or network url , return as it is
         return path;
     }
 
-    std::regex r("[^//]+$");
+    r = std::regex("[^//]+$");
     return std::regex_replace(parentPath, r, path);
 }
 

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -13,7 +13,7 @@ namespace Tangram {
 
 std::atomic_uint Importer::progressCounter(0);
 
-Node Importer::applySceneImports(const std::string& scenePath) {
+Node Importer::applySceneImports(const std::string& scenePath, const std::string& resourceRoot) {
 
     std::string sceneString;
     std::string path;
@@ -54,7 +54,7 @@ Node Importer::applySceneImports(const std::string& scenePath) {
             }
         } else {
             std::unique_lock<std::mutex> lock(sceneMutex);
-            processScene(path, getSceneString(path));
+            processScene(path, getSceneString(path, resourceRoot));
         }
     }
 
@@ -219,8 +219,8 @@ void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath)
     }
 }
 
-std::string Importer::getSceneString(const std::string &scenePath) {
-    return stringFromFile(scenePath.c_str(), PathType::resource);
+std::string Importer::getSceneString(const std::string &scenePath, const std::string& resourceRoot) {
+    return stringFromFile(scenePath.c_str(), PathType::resource, resourceRoot.c_str());
 }
 
 std::vector<std::string> Importer::getScenesToImport(const Node& scene) {

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -60,7 +60,6 @@ Node Importer::applySceneImports(const std::string& scenePath) {
 
     auto root = importScenes(scenePath);
 
-    //TODO: clear importer data
     return root;
 }
 

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -246,7 +246,7 @@ std::vector<std::string> Importer::getImportOrder(const std::string& baseScene) 
     std::vector<std::pair<std::string, std::string>> dependencies;
 
     for (const auto& scene : m_scenes) {
-        const auto& name = scene.first.k;
+        const auto& name = scene.first;
         const auto& sceneRoot = scene.second;
         for (const auto& import : getScenesToImport(sceneRoot)) {
             dependencies.push_back( {import, name} );

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -259,7 +259,7 @@ std::vector<std::string> Importer::getImportOrder(const std::string& baseScene) 
         return { baseScene };
     }
 
-    return topologicalSort(dependencies);
+    return sortedScenes;
 }
 
 Node Importer::importScenes(const std::string& scenePath) {

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -44,7 +44,7 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
                         [&](std::vector<char>&& rawData) {
                         std::unique_lock<std::mutex> lock(sceneMutex);
                         progressCounter--;
-                        processScene(path, rawData.data());
+                        processScene(path, std::string(rawData.data(), rawData.size()));
                         m_condition.notify_all();
                     });
             } else {

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -58,7 +58,10 @@ Node Importer::applySceneImports(const std::string& scenePath) {
         }
     }
 
-    return importScenes(scenePath);
+    auto root = importScenes(scenePath);
+
+    //TODO: clear importer data
+    return root;
 }
 
 void Importer::processScene(const std::string &scenePath, const std::string &sceneString) {

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -75,7 +75,7 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
             });
         } else {
             std::unique_lock<std::mutex> lock(sceneMutex);
-            processScene(path, getSceneString(path, ""));
+            processScene(path, getSceneString(path));
         }
     }
 
@@ -241,7 +241,7 @@ void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath)
     }
 }
 
-std::string Importer::getSceneString(const std::string &scenePath, const std::string& resourceRoot) {
+std::string Importer::getSceneString(const std::string &scenePath) {
     return stringFromFile(scenePath.c_str());
 }
 

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -86,7 +86,7 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
 
 void Importer::processScene(const std::string &scenePath, const std::string &sceneString) {
 
-    LOG("Process: '%s'", scenePath.c_str());
+    LOGD("Process: '%s'", scenePath.c_str());
 
     try {
         auto sceneNode = YAML::Load(sceneString);
@@ -120,7 +120,7 @@ std::string Importer::normalizePath(const std::string &_path,
         path = std::regex_replace(_parentPath, r, _path);
     }
 
-    LOG("Normalize '%s', '%s' => '%s'", _parentPath.c_str(), _path.c_str(), path.c_str());
+    LOGD("Normalize '%s', '%s' => '%s'", _parentPath.c_str(), _path.c_str(), path.c_str());
 
     return path;
 }

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -279,10 +279,18 @@ Node Importer::importScenes(const std::string& scenePath) {
 
     auto importScenesSorted = getImportOrder(scenePath);
 
+    if (importScenesSorted.size() == 1) {
+        auto import = importScenesSorted[0];
+
+        if (import[0] == '/') { import = getFilename(import); }
+
+        return m_scenes[import];
+    }
+
     Node root = Node();
 
     for (auto& import : importScenesSorted) {
-        if (importScenesSorted.size() == 1 && import[0] == '/') { import = getFilename(import); }
+
         const auto& importRoot = m_scenes[import];
         if (!importRoot.IsMap()) { continue; }
         mergeMapFields(root, importRoot);

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -22,8 +22,9 @@ bool isUrl(const std::string &path) {
 Node Importer::applySceneImports(const std::string& scenePath, const std::string& resourceRoot) {
 
     std::string path;
+    std::string fullPath = resourceRoot + scenePath;
 
-    m_sceneQueue.push_back(resourceRoot + scenePath);
+    m_sceneQueue.push_back(fullPath);
 
     while (true) {
         {
@@ -70,13 +71,11 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
             });
         } else {
             std::unique_lock<std::mutex> lock(sceneMutex);
-            auto sceneString = stringFromFile(path.c_str());
-
-            processScene(path, sceneString);
+            processScene(path, getSceneString(path, ""));
         }
     }
 
-    auto root = importScenes(scenePath);
+    auto root = importScenes(fullPath);
 
     return root;
 }
@@ -232,12 +231,7 @@ void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath)
 }
 
 std::string Importer::getSceneString(const std::string &scenePath, const std::string& resourceRoot) {
-
-    if (scenePath[0] == '/') {
-        return stringFromFile(scenePath.c_str());
-    }
-
-    return stringFromFile((resourceRoot + scenePath).c_str());
+    return stringFromFile(scenePath.c_str());
 }
 
 std::vector<std::string> Importer::getScenesToImport(const Node& scene) {
@@ -284,9 +278,7 @@ Node Importer::importScenes(const std::string& scenePath) {
     auto importScenesSorted = getImportOrder(scenePath);
 
     if (importScenesSorted.size() == 1) {
-        auto import = importScenesSorted[0];
-
-        return m_scenes[import];
+        return m_scenes[importScenesSorted[0]];
     }
 
     Node root = Node();

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <unordered_set>
+#include <unordered_map>
 
 #include "util/fastmap.h"
 
@@ -43,7 +43,7 @@ private:
 
     // import scene to respective root nodes
     fastmap<std::string, Node> m_scenes;
-    std::unordered_set<std::string> m_textureNames;
+    std::unordered_map<std::string, std::string> m_textureNames;
 
     std::string getFilename(const std::string& scenePath);
     void normalizeSceneTextures(Node& root, const std::string& parentPath);

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "util/fastmap.h"
 
@@ -42,6 +43,14 @@ private:
 
     // import scene to respective root nodes
     fastmap<std::string, Node> m_scenes;
+    std::unordered_set<std::string> m_textureNames;
+
+    std::string getFilename(const std::string& scenePath);
+    void normalizeSceneTextures(Node& root, const std::string& parentPath);
+    void setNormalizedTexture(Node& texture, const std::vector<std::string>& names,
+            const std::string& parentPath);
+    void normalizeSceneImports(Node& root, const std::string& parentPath);
+    std::string normalizePath(const std::string& path, const std::string& parentPath);
 
 };
 

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -24,7 +24,8 @@ public:
 
 // protected for testing purposes, else could be private
 protected:
-    virtual bool loadScene(const std::string& scenePath);
+    virtual std::string getSceneString(const std::string& scenePath);
+    bool loadScene(const std::string& scenePath);
 
     // Get the sequence of scene names that are designated to be imported into the
     // input scene node by its 'import' fields.
@@ -32,7 +33,7 @@ protected:
 
     // Get a sequence of scene names ordered such that if scene 'a' imports scene
     // 'b', 'b' will always precede 'a' in the sequence.
-    std::vector<std::string> getImportOrder();
+    std::vector<std::string> getImportOrder(const std::string& baseScene);
 
 
     // loads all the imported scenes and the master scene and returns a unified YAML root node.

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "util/fastmap.h"
+
+namespace YAML {
+    class Node;
+}
+
+namespace Tangram {
+
+class Importer {
+
+public:
+
+    using Node = YAML::Node;
+
+    // Loads the main scene with deep merging dependentent imported scenes.
+    Node applySceneImports(const std::string& scenePath);
+
+private:
+
+    // Get the sequence of scene names that are designated to be imported into the
+    // input scene node by its 'import' fields.
+    std::vector<std::string> getScenesToImport(const Node& scene);
+
+    // Get a sequence of scene names ordered such that if scene 'a' imports scene
+    // 'b', 'b' will always precede 'a' in the sequence.
+    std::vector<std::string> getImportOrder();
+
+    // loads import scenes recursively and saves in m_scenes
+    bool loadScene(const std::string& scenePath);
+
+    // loads all the imported scenes and the master scene and returns a unified YAML root node.
+    Node importScenes(const std::string& sceneName);
+
+    //void mergeMapFieldsTaskingLast(const std::string& key, Node target, const std::vector<Node>& imports);
+    void mergeMapFields(Node& target, const Node& import);
+
+    // import scene to respective root nodes
+    fastmap<std::string, Node> m_scenes;
+
+};
+
+}

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "util/fastmap.h"
 
@@ -42,16 +43,18 @@ protected:
     //void mergeMapFieldsTaskingLast(const std::string& key, Node target, const std::vector<Node>& imports);
     void mergeMapFields(Node& target, const Node& import);
 
-    // import scene to respective root nodes
-    fastmap<std::string, Node> m_scenes;
-    std::unordered_map<std::string, std::string> m_textureNames;
-
     std::string getFilename(const std::string& scenePath);
     void normalizeSceneTextures(Node& root, const std::string& parentPath);
     void setNormalizedTexture(Node& texture, const std::vector<std::string>& names,
             const std::string& parentPath);
     void normalizeSceneImports(Node& root, const std::string& parentPath);
     std::string normalizePath(const std::string& path, const std::string& parentPath);
+
+private:
+    // import scene to respective root nodes
+    fastmap<std::string, Node> m_scenes;
+    std::unordered_set<std::string> m_globalTextures;
+    std::unordered_map<std::string, std::string> m_textureNames;
 
 };
 

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
+#include <mutex>
+#include <atomic>
 
 #include "util/fastmap.h"
 
@@ -26,7 +28,7 @@ public:
 // protected for testing purposes, else could be private
 protected:
     virtual std::string getSceneString(const std::string& scenePath);
-    bool loadScene(const std::string& scenePath);
+    void processScene(const std::string& scenePath, const std::string& sceneString);
 
     // Get the sequence of scene names that are designated to be imported into the
     // input scene node by its 'import' fields.
@@ -56,6 +58,12 @@ private:
     std::unordered_set<std::string> m_globalTextures;
     std::unordered_map<std::string, std::string> m_textureNames;
 
+    std::vector<std::string> m_sceneQueue;
+    static std::atomic_uint progressCounter;
+    std::mutex sceneMutex;
+    std::mutex queueMutex;
+
+    const unsigned int MAX_SCENE_DOWNLOAD = 8;
 };
 
 }

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -7,6 +7,7 @@
 #include <unordered_set>
 #include <mutex>
 #include <atomic>
+#include <condition_variable>
 
 #include "util/fastmap.h"
 
@@ -61,7 +62,7 @@ private:
     std::vector<std::string> m_sceneQueue;
     static std::atomic_uint progressCounter;
     std::mutex sceneMutex;
-    std::mutex queueMutex;
+    std::condition_variable m_condition;
 
     const unsigned int MAX_SCENE_DOWNLOAD = 8;
 };

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -22,7 +22,9 @@ public:
     // Loads the main scene with deep merging dependentent imported scenes.
     Node applySceneImports(const std::string& scenePath);
 
-private:
+// protected for testing purposes, else could be private
+protected:
+    virtual bool loadScene(const std::string& scenePath);
 
     // Get the sequence of scene names that are designated to be imported into the
     // input scene node by its 'import' fields.
@@ -32,8 +34,6 @@ private:
     // 'b', 'b' will always precede 'a' in the sequence.
     std::vector<std::string> getImportOrder();
 
-    // loads import scenes recursively and saves in m_scenes
-    bool loadScene(const std::string& scenePath);
 
     // loads all the imported scenes and the master scene and returns a unified YAML root node.
     Node importScenes(const std::string& sceneName);

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -64,7 +64,7 @@ private:
     std::mutex sceneMutex;
     std::condition_variable m_condition;
 
-    const unsigned int MAX_SCENE_DOWNLOAD = 8;
+    const unsigned int MAX_SCENE_DOWNLOAD = 4;
 };
 
 }

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -51,6 +51,7 @@ protected:
     void setNormalizedTexture(Node& texture, const std::vector<std::string>& names,
             const std::string& parentPath);
     void normalizeSceneImports(Node& root, const std::string& parentPath);
+    void normalizeSceneDataSources(Node& root, const std::string& parentPath);
     std::string normalizePath(const std::string& path, const std::string& parentPath);
 
 private:

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -56,7 +57,7 @@ protected:
 
 private:
     // import scene to respective root nodes
-    fastmap<std::string, Node> m_scenes;
+    std::map<std::string, Node> m_scenes;
     std::unordered_set<std::string> m_globalTextures;
     std::unordered_map<std::string, std::string> m_textureNames;
 

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -24,11 +24,11 @@ public:
     using Node = YAML::Node;
 
     // Loads the main scene with deep merging dependentent imported scenes.
-    Node applySceneImports(const std::string& scenePath);
+    Node applySceneImports(const std::string& scenePath, const std::string& resourceRoot);
 
 // protected for testing purposes, else could be private
 protected:
-    virtual std::string getSceneString(const std::string& scenePath);
+    virtual std::string getSceneString(const std::string& scenePath, const std::string& resourceRoot);
     void processScene(const std::string& scenePath, const std::string& sceneString);
 
     // Get the sequence of scene names that are designated to be imported into the

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -24,7 +24,7 @@ public:
     using Node = YAML::Node;
 
     // Loads the main scene with deep merging dependentent imported scenes.
-    Node applySceneImports(const std::string& scenePath, const std::string& resourceRoot);
+    Node applySceneImports(const std::string& scenePath, const std::string& resourceRoot = "");
 
 // protected for testing purposes, else could be private
 protected:

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -29,7 +29,7 @@ public:
 
 // protected for testing purposes, else could be private
 protected:
-    virtual std::string getSceneString(const std::string& scenePath, const std::string& resourceRoot);
+    virtual std::string getSceneString(const std::string& scenePath);
     void processScene(const std::string& scenePath, const std::string& sceneString);
 
     // Get the sequence of scene names that are designated to be imported into the

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -47,7 +47,6 @@ protected:
     //void mergeMapFieldsTaskingLast(const std::string& key, Node target, const std::vector<Node>& imports);
     void mergeMapFields(Node& target, const Node& import);
 
-    std::string getFilename(const std::string& scenePath);
     void normalizeSceneTextures(Node& root, const std::string& parentPath);
     void setNormalizedTexture(Node& texture, const std::vector<std::string>& names,
             const std::string& parentPath);

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -34,10 +34,11 @@ Scene::Scene(const std::string& _path)
     m_mapProjection.reset(new MercatorProjection());
 }
 
-Scene::Scene(const Scene& _other) : Scene(_other.path()) {
+Scene::Scene(const Scene& _other)
+    : Scene(_other.path()) {
+
     m_config = _other.m_config;
     m_updates = _other.m_updates;
-    m_clientDataSources = _other.m_clientDataSources;
     m_view = _other.m_view;
     m_fontContext = _other.m_fontContext;
 }
@@ -98,23 +99,6 @@ void Scene::queueUpdate(std::string path, std::string value) {
     auto keys = splitString(path, COMPONENT_PATH_DELIMITER);
     std::lock_guard<std::mutex> lock(m_updatesMutex);
     m_updates.push_back({ keys, value });
-}
-
-void Scene::addClientDataSource(std::shared_ptr<DataSource> _source) {
-    m_clientDataSources.push_back(_source);
-}
-
-void Scene::removeClientDataSource(DataSource& _source) {
-    auto it = std::remove_if(m_clientDataSources.begin(), m_clientDataSources.end(),
-        [&](auto& s) { return s.get() == &_source; });
-    m_clientDataSources.erase(it, m_clientDataSources.end());
-}
-
-const std::vector<std::shared_ptr<DataSource>> Scene::getAllDataSources() const {
-    auto sources = m_dataSources;
-
-    sources.insert(sources.end(), m_clientDataSources.begin(), m_clientDataSources.end());
-    return sources;
 }
 
 std::shared_ptr<DataSource> Scene::getDataSource(const std::string& name) {

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -25,8 +25,6 @@ Scene::Scene(const std::string& _path)
     : id(s_serial++),
       m_path(_path),
       m_fontContext(std::make_shared<FontContext>()) {
-
-    m_view = std::make_shared<View>();
     // For now we only have one projection..
     // TODO how to share projection with view?
     m_mapProjection.reset(new MercatorProjection());
@@ -35,7 +33,6 @@ Scene::Scene(const std::string& _path)
 Scene::Scene(const Scene& _other)
     : Scene(_other.path()) {
     m_config = _other.m_config;
-    m_view = _other.m_view;
     m_fontContext = _other.m_fontContext;
 }
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -96,6 +96,7 @@ std::shared_ptr<Texture> Scene::getTexture(const std::string& textureName) const
 
 void Scene::queueUpdate(std::string path, std::string value) {
     auto keys = splitString(path, COMPONENT_PATH_DELIMITER);
+    std::lock_guard<std::mutex> lock(m_updatesMutex);
     m_updates.push_back({ keys, value });
 }
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -53,6 +53,14 @@ const Style* Scene::findStyle(const std::string& _name) const {
 
 }
 
+Style* Scene::findStyle(const std::string& _name) {
+
+    for (auto& style : m_styles) {
+        if (style->getName() == _name) { return style.get(); }
+    }
+    return nullptr;
+}
+
 int Scene::addIdForName(const std::string& _name) {
     int id = getIdForName(_name);
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -17,8 +17,6 @@
 #include <atomic>
 #include <algorithm>
 
-#define COMPONENT_PATH_DELIMITER '.'
-
 namespace Tangram {
 
 static std::atomic<int32_t> s_serial;
@@ -36,9 +34,7 @@ Scene::Scene(const std::string& _path)
 
 Scene::Scene(const Scene& _other)
     : Scene(_other.path()) {
-
     m_config = _other.m_config;
-    m_updates = _other.m_updates;
     m_view = _other.m_view;
     m_fontContext = _other.m_fontContext;
 }
@@ -93,12 +89,6 @@ std::shared_ptr<Texture> Scene::getTexture(const std::string& textureName) const
         return nullptr;
     }
     return texIt->second;
-}
-
-void Scene::queueUpdate(std::string path, std::string value) {
-    auto keys = splitString(path, COMPONENT_PATH_DELIMITER);
-    std::lock_guard<std::mutex> lock(m_updatesMutex);
-    m_updates.push_back({ keys, value });
 }
 
 std::shared_ptr<DataSource> Scene::getDataSource(const std::string& name) {

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -24,6 +24,7 @@ static std::atomic<int32_t> s_serial;
 Scene::Scene(const std::string& _path)
     : id(s_serial++),
       m_path(_path),
+      m_resourceRoot(""),
       m_fontContext(std::make_shared<FontContext>()) {
     // For now we only have one projection..
     // TODO how to share projection with view?
@@ -34,6 +35,7 @@ Scene::Scene(const Scene& _other)
     : Scene(_other.path()) {
     m_config = _other.m_config;
     m_fontContext = _other.m_fontContext;
+    m_resourceRoot = _other.resourceRoot();
 }
 
 Scene::~Scene() {}

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -45,7 +45,7 @@ Scene::Scene(const std::string& _path)
         }
     }
 
-    LOG("Scene '%s' => '%s' : '%s'", _path.c_str(), m_resourceRoot.c_str(), m_path.c_str());
+    LOGD("Scene '%s' => '%s' : '%s'", _path.c_str(), m_resourceRoot.c_str(), m_path.c_str());
 
     m_fontContext->setSceneResourceRoot(m_resourceRoot);
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -33,7 +33,7 @@ struct Stops;
 class Scene {
 public:
     struct Update {
-        std::vector<std::string> keys;
+        std::string keys;
         std::string value;
     };
 
@@ -70,7 +70,6 @@ public:
     const auto& mapProjection() const { return m_mapProjection; };
     const auto& fontContext() const { return m_fontContext; }
     const auto& globals() const { return m_globals; }
-    const auto& updates() const { return m_updates; }
 
     const Style* findStyle(const std::string& _name) const;
     const Light* findLight(const std::string& _name) const;
@@ -85,10 +84,6 @@ public:
 
     void animated(bool animated) { m_animated = animated ? yes : no; }
     animate animated() const { return m_animated; }
-
-    void queueUpdate(std::string path, std::string value);
-
-    void clearUpdates() { m_updates.clear(); }
 
     std::shared_ptr<DataSource> getDataSource(const std::string& name);
 
@@ -113,8 +108,6 @@ private:
     std::unordered_map<std::string, std::shared_ptr<SpriteAtlas>> m_spriteAtlases;
     std::unordered_map<std::string, YAML::Node> m_globals;
 
-    std::vector<Update> m_updates;
-
     // Container of all strings used in styling rules; these need to be
     // copied and compared frequently when applying styling, so rules use
     // integer indices into this container to represent strings
@@ -128,7 +121,6 @@ private:
     std::shared_ptr<FontContext> m_fontContext;
 
     animate m_animated = none;
-    std::mutex m_updatesMutex;
 };
 
 }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -57,6 +57,7 @@ public:
     auto& background() { return m_background; }
     auto& fontContext() { return m_fontContext; }
     auto& globals() { return m_globals; }
+    Style* findStyle(const std::string& _name);
 
     const auto& path() const { return m_path; }
     const auto& config() const { return m_config; }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -90,11 +90,6 @@ public:
 
     void clearUpdates() { m_updates.clear(); }
 
-    void addClientDataSource(std::shared_ptr<DataSource> _source);
-    void removeClientDataSource(DataSource& _source);
-
-    const std::vector<std::shared_ptr<DataSource>> getAllDataSources() const;
-
     std::shared_ptr<DataSource> getDataSource(const std::string& name);
 
     std::shared_ptr<Texture> getTexture(const std::string& name) const;
@@ -112,7 +107,6 @@ private:
 
     std::vector<DataLayer> m_layers;
     std::vector<std::shared_ptr<DataSource>> m_dataSources;
-    std::vector<std::shared_ptr<DataSource>> m_clientDataSources;
     std::vector<std::unique_ptr<Style>> m_styles;
     std::vector<std::unique_ptr<Light>> m_lights;
     std::unordered_map<std::string, std::shared_ptr<Texture>> m_textures;

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -63,6 +63,7 @@ public:
 
     auto& camera() { return m_camera; }
 
+    auto& resourceRoot() { return m_resourceRoot; }
     auto& config() { return m_config; }
     auto& dataSources() { return m_dataSources; };
     auto& layers() { return m_layers; };
@@ -78,6 +79,7 @@ public:
     Style* findStyle(const std::string& _name);
 
     const auto& path() const { return m_path; }
+    const auto& resourceRoot() const { return m_resourceRoot; }
     const auto& config() const { return m_config; }
     const auto& dataSources() const { return m_dataSources; };
     const auto& layers() const { return m_layers; };
@@ -111,6 +113,8 @@ private:
 
     // The file path from which this scene was loaded
     std::string m_path;
+
+    std::string m_resourceRoot;
 
     // The root node of the YAML scene configuration
     YAML::Node m_config;

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -2,6 +2,8 @@
 
 #include "util/color.h"
 #include "util/fastmap.h"
+#include "view/view.h"
+
 #include <list>
 #include <memory>
 #include <mutex>
@@ -37,6 +39,20 @@ public:
         std::string value;
     };
 
+    struct Camera {
+        CameraType type;
+
+        // perspective
+        glm::vec2 vanishingPoint = {0, 0};
+        float fieldOfView = 0.25 * PI;
+        std::shared_ptr<Stops> fovStops;
+
+        // isometric
+        glm::vec2 obliqueAxis = {0, 1};
+    };
+
+    Camera m_camera;
+
     enum animate {
         yes, no, none
     };
@@ -45,8 +61,9 @@ public:
     Scene(const Scene& _other);
     ~Scene();
 
+    auto& camera() { return m_camera; }
+
     auto& config() { return m_config; }
-    auto& view() { return m_view; }
     auto& dataSources() { return m_dataSources; };
     auto& layers() { return m_layers; };
     auto& styles() { return m_styles; };
@@ -79,6 +96,7 @@ public:
 
     const int32_t id;
 
+    bool useScenePosition = true;
     glm::dvec2 startPosition = { 0, 0 };
     float startZoom = 0;
 
@@ -98,7 +116,6 @@ private:
     YAML::Node m_config;
 
     std::unique_ptr<MapProjection> m_mapProjection;
-    std::shared_ptr<View> m_view;
 
     std::vector<DataLayer> m_layers;
     std::vector<std::shared_ptr<DataSource>> m_dataSources;

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -4,6 +4,7 @@
 #include "util/fastmap.h"
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -133,6 +134,7 @@ private:
     std::shared_ptr<FontContext> m_fontContext;
 
     animate m_animated = none;
+    std::mutex m_updatesMutex;
 };
 
 }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -6,7 +6,6 @@
 
 #include <list>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 #include <unordered_map>

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -24,7 +24,6 @@ class FontContext;
 class Light;
 class MapProjection;
 class SpriteAtlas;
-class View;
 struct Stops;
 
 /* Singleton container of <Style> information

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -18,7 +18,6 @@
 #include "style/rasterStyle.h"
 #include "scene/dataLayer.h"
 #include "scene/filters.h"
-#include "scene/importer.h"
 #include "scene/sceneLayer.h"
 #include "scene/spriteAtlas.h"
 #include "scene/stops.h"
@@ -47,13 +46,14 @@ const std::string DELIMITER = ":";
 // TODO: make this configurable: 16MB default in-memory DataSource cache:
 constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
+const std::unique_ptr<Importer> SceneLoader::sceneImporter(new Importer());
+
 void SceneLoader::loadScene(const std::string& _scenePath, std::shared_ptr<Scene> _scene,
         const std::function<void(std::shared_ptr<Scene>&)>& _setScene) {
 
     std::async(std::launch::async,[&]() {
                 Node& root = _scene->config();
-                Importer sceneImporter;
-                if ( (root = sceneImporter.applySceneImports(_scenePath)) ) {
+                if ( (root = sceneImporter->applySceneImports(_scenePath)) ) {
                     applyConfig(root, *_scene);
                     _setScene(_scene);
                 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -525,6 +525,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
                 std::lock_guard<std::mutex> lock(m_textureMutex);
                 // TODO: replaced in scene textures but not in sprite texture!!!
                 scene.textures()[name] = texture;
+                scene.spriteAtlases()[name]->updateSpriteNodes(texture);
             });
         texture = std::make_shared<Texture>(nullptr, 0, options, generateMipmaps, true);
     } else {
@@ -580,8 +581,9 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
     auto texture = fetchTexture(name, file, options, generateMipmaps, scene);
     if (!texture) { return; }
 
+    std::lock_guard<std::mutex> lock(m_textureMutex);
     if (Node sprites = textureConfig["sprites"]) {
-        std::shared_ptr<SpriteAtlas> atlas(new SpriteAtlas(texture, file));
+        std::shared_ptr<SpriteAtlas> atlas(new SpriteAtlas(texture));
 
         for (auto it = sprites.begin(); it != sprites.end(); ++it) {
 
@@ -598,7 +600,6 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
         }
         scene.spriteAtlases()[name] = atlas;
     }
-    std::lock_guard<std::mutex> lock(m_textureMutex);
     scene.textures().emplace(name, texture);
 }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -19,6 +19,7 @@
 #include "style/rasterStyle.h"
 #include "scene/dataLayer.h"
 #include "scene/filters.h"
+#include "scene/importer.h"
 #include "scene/sceneLayer.h"
 #include "scene/spriteAtlas.h"
 #include "scene/stops.h"
@@ -45,11 +46,13 @@ const std::string DELIMITER = ":";
 // TODO: make this configurable: 16MB default in-memory DataSource cache:
 constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
-bool SceneLoader::loadScene(const std::string& _sceneString, Scene& _scene) {
+bool SceneLoader::loadScene(const std::string& _scenePath, Scene& _scene) {
 
     Node& root = _scene.config();
 
-    if (loadConfig(_sceneString, root)) {
+    Importer sceneImporter;
+
+    if ( (root = sceneImporter.applySceneImports(_scenePath)) ) {
         applyConfig(root, _scene);
         return true;
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1280,11 +1280,14 @@ bool SceneLoader::parseStyleUniforms(const Node& value, Scene* scene, StyleUnifo
         } else {
             const std::string& strVal = value.Scalar();
             styleUniform.type = "sampler2D";
-            std::shared_ptr<Texture> texture = scene->getTexture(strVal);
 
-            if (!texture && !loadTexture(strVal, *scene)) {
-                LOGW("Can't load texture with name %s", strVal.c_str());
-                return false;
+            if (scene) {
+                std::shared_ptr<Texture> texture = scene->getTexture(strVal);
+
+                if (!texture && !loadTexture(strVal, *scene)) {
+                    LOGW("Can't load texture with name %s", strVal.c_str());
+                    return false;
+                }
             }
 
             styleUniform.value = strVal;
@@ -1325,11 +1328,14 @@ bool SceneLoader::parseStyleUniforms(const Node& value, Scene* scene, StyleUnifo
             for (const auto& strVal : value) {
                 const std::string& textureName = strVal.Scalar();
                 textureArrayUniform.names.push_back(textureName);
-                std::shared_ptr<Texture> texture = scene->getTexture(textureName);
 
-                if (!texture && !loadTexture(textureName, *scene)) {
-                    LOGW("Can't load texture with name %s", textureName.c_str());
-                    return false;
+                if (scene) {
+                    std::shared_ptr<Texture> texture = scene->getTexture(textureName);
+
+                    if (!texture && !loadTexture(textureName, *scene)) {
+                        LOGW("Can't load texture with name %s", textureName.c_str());
+                        return false;
+                    }
                 }
             }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -39,6 +39,8 @@ using YAML::Node;
 using YAML::NodeType;
 using YAML::BadConversion;
 
+#define COMPONENT_PATH_DELIMITER '.'
+
 #define LOGNode(fmt, node, ...) LOGW(fmt ":\n'%s'\n", ## __VA_ARGS__, Dump(node).c_str())
 
 namespace Tangram {
@@ -76,11 +78,13 @@ void SceneLoader::applyUpdates(Node& root, const std::vector<Scene::Update>& upd
 
     for (const auto& update : updates) {
 
+        auto keys = splitString(update.keys, COMPONENT_PATH_DELIMITER);
+
         auto node = root;
         std::string key;
-        for (auto it = update.keys.begin(); it != update.keys.end(); ++it) {
+        for (auto it = keys.begin(); it != keys.end(); ++it) {
             key = *it;
-            if (it + 1 == update.keys.end()) { break; } // Stop before last key.
+            if (it + 1 == keys.end()) { break; } // Stop before last key.
             node.reset(node[key]); // Node safely becomes invalid is key is not present.
         }
 
@@ -92,7 +96,7 @@ void SceneLoader::applyUpdates(Node& root, const std::vector<Scene::Update>& upd
             }
         } else {
             std::string path;
-            for (const auto& k : update.keys) { path += "." + k; }
+            for (const auto& k : keys) { path += "." + k; }
             LOGW("Cannot update scene - key not found: %s", path.c_str());
         }
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -317,7 +317,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
             const std::string& name = uniform.first.Scalar();
             StyleUniform styleUniform;
 
-            if (parseStyleUniforms(uniform.second, scene, styleUniform)) {
+            if (parseStyleUniforms(uniform.second, &scene, styleUniform)) {
                 if (styleUniform.value.is<UniformArray1f>()) {
                     UniformArray1f& array = styleUniform.value.get<UniformArray1f>();
                     shader.addSourceBlock("uniforms", "uniform float " + name +
@@ -648,7 +648,6 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, Scene& scene) {
         else { LOGW("Unrecognized lighting type '%s'", lighting.c_str()); }
     }
 
-    // TODO: Handle inlined texture with URL
     if (Node textureNode = styleNode["texture"]) {
         if (auto pointStyle = dynamic_cast<PointStyle*>(&style)) {
             const std::string& textureName = textureNode.Scalar();
@@ -1267,7 +1266,7 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
     }
 }
 
-bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene, StyleUniform& styleUniform) {
+bool SceneLoader::parseStyleUniforms(const Node& value, Scene* scene, StyleUniform& styleUniform) {
     if (value.IsScalar()) { // float, bool or string (texture)
         double fValue;
         bool bValue;
@@ -1281,9 +1280,9 @@ bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene, StyleUnifo
         } else {
             const std::string& strVal = value.Scalar();
             styleUniform.type = "sampler2D";
-            std::shared_ptr<Texture> texture = scene.getTexture(strVal);
+            std::shared_ptr<Texture> texture = scene->getTexture(strVal);
 
-            if (!texture && !loadTexture(strVal, scene)) {
+            if (!texture && !loadTexture(strVal, *scene)) {
                 LOGW("Can't load texture with name %s", strVal.c_str());
                 return false;
             }
@@ -1326,9 +1325,9 @@ bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene, StyleUnifo
             for (const auto& strVal : value) {
                 const std::string& textureName = strVal.Scalar();
                 textureArrayUniform.names.push_back(textureName);
-                std::shared_ptr<Texture> texture = scene.getTexture(textureName);
+                std::shared_ptr<Texture> texture = scene->getTexture(textureName);
 
-                if (!texture && !loadTexture(textureName, scene)) {
+                if (!texture && !loadTexture(textureName, *scene)) {
                     LOGW("Can't load texture with name %s", textureName.c_str());
                     return false;
                 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -339,7 +339,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, Scene& scene) {
 
                 style.styleUniforms().emplace_back(name, styleUniform.value);
             } else {
-                LOGNode("Style uniform parsing failure '%s'", uniform.second);
+                LOGNode("Style uniform parsing failure", uniform.second);
             }
         }
     }
@@ -895,7 +895,7 @@ void SceneLoader::parseLightPosition(Node position, PointLight& light) {
         StyleParam::parseVec3(positionSequence, {Unit::meter, Unit::pixel}, lightPos);
         light.setPosition(lightPos);
     } else {
-        LOGNode("Wrong light position parameter %s", position);
+        LOGNode("Wrong light position parameter", position);
     }
 }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -57,7 +57,7 @@ bool SceneLoader::loadScene(const std::string& _scenePath, std::shared_ptr<Scene
 
     Importer sceneImporter;
 
-    if ( (root = sceneImporter.applySceneImports(_scenePath)) ) {
+    if ( (root = sceneImporter.applySceneImports(_scenePath, _scene->resourceRoot())) ) {
         applyConfig(root, *_scene);
         return true;
     }
@@ -552,9 +552,9 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
     } else {
         unsigned char* blob;
         if (url[0] == '/') {
-            blob = bytesFromFile(url.c_str(), PathType::absolute, &size);
+            blob = bytesFromFile(url.c_str(), PathType::absolute, &size, scene.resourceRoot().c_str());
         } else {
-            blob = bytesFromFile(url.c_str(), PathType::resource, &size);
+            blob = bytesFromFile(url.c_str(), PathType::resource, &size, scene.resourceRoot().c_str());
         }
 
         if (!blob) {
@@ -836,7 +836,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
         if (tiled) {
             sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url, maxZoom));
         } else {
-            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, maxZoom));
+            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, _scene.resourceRoot(), maxZoom));
         }
     } else if (type == "TopoJSON") {
         sourcePtr = std::shared_ptr<DataSource>(new TopoJsonSource(name, url, maxZoom));

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -32,7 +32,6 @@
 #include <vector>
 #include <algorithm>
 #include <iterator>
-#include <unordered_map>
 #include <regex>
 
 using YAML::Node;
@@ -450,7 +449,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, Scene& scene,
         if (!loadTexture(name, scene)) {
             LOGW("Not able to load material texture: %s", name.c_str());
             return MaterialTexture();
-        };
+        }
     }
 
     if (Node mappingNode = matCompNode["mapping"]) {

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -2,6 +2,7 @@
 
 #include "gl/uniform.h"
 #include "scene/scene.h"
+#include "scene/importer.h"
 
 #include <string>
 #include <vector>
@@ -82,6 +83,7 @@ struct SceneLoader {
 
     static bool loadStyle(const std::string& styleName, Node config, Scene& scene);
 
+    static const std::unique_ptr<Importer> sceneImporter;
 
     SceneLoader() = delete;
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -74,7 +74,7 @@ struct SceneLoader {
                                  std::vector<StyleParam>& out);
     static void parseTransition(Node params, Scene& scene, std::vector<StyleParam>& out);
 
-    static bool parseStyleUniforms(const Node& value, Scene& scene, StyleUniform& styleUniform);
+    static bool parseStyleUniforms(const Node& value, Scene* scene, StyleUniform& styleUniform);
 
     static void parseGlobals(const Node& node, Scene& scene, const std::string& key="");
     static void parseLightPosition(Node position, PointLight& light);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -39,7 +39,8 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static bool loadScene(const std::string& _scenePath, Scene& _scene);
+    static void loadScene(const std::string& _scenePath, std::shared_ptr<Scene> _scene,
+            const std::function<void(std::shared_ptr<Scene>&)>& _setScene);
     static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, Scene& scene);
     static void applyUpdates(Node& root, const std::vector<Scene::Update>& updates);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -39,7 +39,7 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static bool loadScene(const std::string& _sceneString, Scene& _scene);
+    static bool loadScene(const std::string& _scenePath, Scene& _scene);
     static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, Scene& scene);
     static void applyUpdates(Node& root, const std::vector<Scene::Update>& updates);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -10,6 +10,7 @@
 #include <tuple>
 #include <unordered_set>
 #include <sstream>
+#include <mutex>
 
 #include "yaml-cpp/yaml.h"
 #include "glm/vec2.hpp"
@@ -30,6 +31,7 @@ class PointLight;
 class DataSource;
 struct Filter;
 struct TextureFiltering;
+struct TextureOptions;
 
 // 0: type, 1: values
 struct StyleUniform {
@@ -68,6 +70,8 @@ struct SceneLoader {
     static Filter generatePredicate(Node filter, std::string _key);
     /* loads a texture with default texture properties */
     static bool loadTexture(const std::string& url, Scene& scene);
+    static std::shared_ptr<Texture> fetchTexture(const std::string& name, const std::string& url,
+            const TextureOptions& options, bool generateMipmaps, Scene& scene);
     static bool extractTexFiltering(Node& filtering, TextureFiltering& filter);
 
     static MaterialTexture loadMaterialTexture(Node matCompNode, Scene& scene, Style& style);
@@ -84,7 +88,7 @@ struct SceneLoader {
     static bool loadStyle(const std::string& styleName, Node config, Scene& scene);
 
     static const std::unique_ptr<Importer> sceneImporter;
-
+    static std::mutex m_textureMutex;
     SceneLoader() = delete;
 
 };

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <memory>
 #include <tuple>
+#include <unordered_map>
 #include <unordered_set>
 #include <sstream>
 #include <mutex>
@@ -73,6 +74,9 @@ struct SceneLoader {
     static std::shared_ptr<Texture> fetchTexture(const std::string& name, const std::string& url,
             const TextureOptions& options, bool generateMipmaps, Scene& scene);
     static bool extractTexFiltering(Node& filtering, TextureFiltering& filter);
+
+    static void updateSpriteNodes(const std::string& texName,
+            std::shared_ptr<Texture>& texture, Scene& scene);
 
     static MaterialTexture loadMaterialTexture(Node matCompNode, Scene& scene, Style& style);
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -2,8 +2,6 @@
 
 #include "gl/uniform.h"
 #include "scene/scene.h"
-#include "scene/importer.h"
-
 #include <string>
 #include <vector>
 #include <memory>
@@ -43,8 +41,7 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static void loadScene(const std::string& _scenePath, std::shared_ptr<Scene> _scene,
-            const std::function<void(std::shared_ptr<Scene>&)>& _setScene);
+    static bool loadScene(const std::string& _scenePath, std::shared_ptr<Scene> _scene);
     static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, Scene& scene);
     static void applyUpdates(Node& root, const std::vector<Scene::Update>& updates);
@@ -91,7 +88,6 @@ struct SceneLoader {
 
     static bool loadStyle(const std::string& styleName, Node config, Scene& scene);
 
-    static const std::unique_ptr<Importer> sceneImporter;
     static std::mutex m_textureMutex;
     SceneLoader() = delete;
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -39,7 +39,7 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static bool loadScene(const std::string& _scenePath, std::shared_ptr<Scene> _scene);
+    static bool loadScene(std::shared_ptr<Scene> _scene);
     static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, Scene& scene);
     static void applyUpdates(Node& root, const std::vector<Scene::Update>& updates);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -6,8 +6,6 @@
 #include <vector>
 #include <memory>
 #include <tuple>
-#include <unordered_map>
-#include <unordered_set>
 #include <sstream>
 #include <mutex>
 
@@ -72,6 +70,11 @@ struct SceneLoader {
             const TextureOptions& options, bool generateMipmaps, Scene& scene);
     static bool extractTexFiltering(Node& filtering, TextureFiltering& filter);
 
+    /*
+     * Sprite nodes are created using a default 1x1 black texture when sprite atlas is requested over the network.
+     * Once a sprite atlas has been fetched, sprite nodes need to be updated according to the width/height of the
+     * fetched sprite atlas.
+     */
     static void updateSpriteNodes(const std::string& texName,
             std::shared_ptr<Texture>& texture, Scene& scene);
 

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -3,7 +3,7 @@
 
 namespace Tangram {
 
-SpriteAtlas::SpriteAtlas(std::shared_ptr<Texture> _texture, const std::string& _file) : m_file(_file), m_texture(_texture) {}
+SpriteAtlas::SpriteAtlas(std::shared_ptr<Texture> _texture) : m_texture(_texture) {}
 
 void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size) {
 
@@ -11,7 +11,7 @@ void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm
     glm::vec2 uvBL = _origin / atlasSize;
     glm::vec2 uvTR = (_origin + _size) / atlasSize;
 
-    m_spritesNodes[_name] = SpriteNode { uvBL, uvTR, _size };
+    m_spritesNodes[_name] = SpriteNode { uvBL, uvTR, _size, _origin };
 }
 
 bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) const {
@@ -22,6 +22,13 @@ bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) con
 
     _node = it->second;
     return true;
+}
+
+void SpriteAtlas::updateSpriteNodes(std::shared_ptr<Texture> _texture) {
+    m_texture = _texture;
+    for (auto& spriteNode : m_spritesNodes) {
+        addSpriteNode(spriteNode.first.k, spriteNode.second.m_origin, spriteNode.second.m_size);
+    }
 }
 
 void SpriteAtlas::bind(GLuint _slot) {

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -27,6 +27,7 @@ bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) con
 void SpriteAtlas::updateSpriteNodes(std::shared_ptr<Texture> _texture) {
     m_texture = _texture;
     for (auto& spriteNode : m_spritesNodes) {
+        // Use the origin of the spriteNode set when the node was created
         addSpriteNode(spriteNode.first.k, spriteNode.second.m_origin, spriteNode.second.m_size);
     }
 }

--- a/core/src/scene/spriteAtlas.h
+++ b/core/src/scene/spriteAtlas.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include "gl/texture.h"
+#include "util/fastmap.h"
 #include "glm/glm.hpp"
 
 namespace Tangram {
@@ -11,23 +12,24 @@ struct SpriteNode {
     glm::vec2 m_uvBL;
     glm::vec2 m_uvTR;
     glm::vec2 m_size;
+    glm::vec2 m_origin;
 };
 
 class SpriteAtlas {
 
 public:
-    SpriteAtlas(std::shared_ptr<Texture> _texture, const std::string& _file);
+    SpriteAtlas(std::shared_ptr<Texture> _texture);
 
     /* Creates a sprite node in the atlas located at _origin in the texture by a size in pixels _size */
     void addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size);
     bool getSpriteNode(const std::string& _name, SpriteNode& _node) const;
+    void updateSpriteNodes(std::shared_ptr<Texture> _texture);
 
     /* Bind the atlas in the driver */
     void bind(GLuint _slot);
 
 private:
-    std::map<std::string, SpriteNode> m_spritesNodes;
-    std::string m_file;
+    fastmap<std::string, SpriteNode> m_spritesNodes;
     std::shared_ptr<Texture> m_texture;
 };
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -118,11 +118,12 @@ void setScene(std::shared_ptr<Scene>& _scene) {
 
 void loadScene(const char* _scenePath) {
     LOG("Loading scene file: %s", _scenePath);
-	
+
 	// Copy old scene
     auto scene = std::make_shared<Scene>(*m_scene);
 
-    if (SceneLoader::loadScene(_scenePath, *scene)) {
+    auto scenePath = setResourceRoot(_scenePath);
+    if (SceneLoader::loadScene(scenePath, *scene)) {
         setScene(scene);
     }
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -87,9 +87,10 @@ void initialize(const char* _scenePath) {
 
     loadScene(_scenePath);
 
-    glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
-    m_view->setPosition(projPos.x, projPos.y);
-    m_view->setZoom(m_scene->startZoom);
+    // TODO: Remove the following 3 lines, to be done by setScene
+    //glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
+    //m_view->setPosition(projPos.x, projPos.y);
+    //m_view->setZoom(m_scene->startZoom);
 
     LOG("finish initialize");
 
@@ -98,6 +99,11 @@ void initialize(const char* _scenePath) {
 void setScene(std::shared_ptr<Scene>& _scene) {
     m_scene = _scene;
     m_view = _scene->view();
+
+    glm::dvec2 projPos = m_view->getMapProjection().LonLatToMeters(m_scene->startPosition);
+    m_view->setPosition(projPos.x, projPos.y);
+    m_view->setZoom(m_scene->startZoom);
+
     m_inputHandler->setView(m_view);
     m_tileManager->setDataSources(_scene->getAllDataSources());
     m_tileWorker->setScene(_scene);
@@ -123,9 +129,8 @@ void loadScene(const char* _scenePath) {
     auto scene = std::make_shared<Scene>(*m_scene);
 
     auto scenePath = setResourceRoot(_scenePath);
-    if (SceneLoader::loadScene(scenePath, *scene)) {
-        setScene(scene);
-    }
+    //TODO: consequence of async scene loading on queueSceneUpdate
+    SceneLoader::loadScene(scenePath, scene, setScene);
 }
 
 void queueSceneUpdate(const char* _path, const char* _value) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -118,13 +118,11 @@ void setScene(std::shared_ptr<Scene>& _scene) {
 
 void loadScene(const char* _scenePath) {
     LOG("Loading scene file: %s", _scenePath);
-
-    auto sceneString = stringFromFile(setResourceRoot(_scenePath).c_str(), PathType::resource);
-
-    // Copy old scene
+	
+	// Copy old scene
     auto scene = std::make_shared<Scene>(*m_scene);
 
-    if (SceneLoader::loadScene(sceneString, *scene)) {
+    if (SceneLoader::loadScene(_scenePath, *scene)) {
         setScene(scene);
     }
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -6,6 +6,7 @@
 #include "style/material.h"
 #include "style/style.h"
 #include "labels/labels.h"
+#include "text/fontContext.h"
 #include "tile/tileManager.h"
 #include "tile/tile.h"
 #include "gl/error.h"
@@ -216,7 +217,8 @@ void loadScene(const char* _scenePath, bool _useScenePosition) {
 
     Tangram::runAsyncTask([scene = m_nextScene](){
 
-            auto scenePath = setResourceRoot(scene->path().c_str());
+            auto scenePath = setResourceRoot(scene->path().c_str(), scene->resourceRoot());
+            scene->fontContext()->setSceneResourceRoot(scene->resourceRoot());
 
             bool ok = SceneLoader::loadScene(scenePath, scene);
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -166,7 +166,7 @@ void setScene(std::shared_ptr<Scene>& _scene) {
     m_view->setZoom(m_scene->startZoom);
 
     m_inputHandler->setView(m_view);
-    m_tileManager->setDataSources(_scene->getAllDataSources());
+    m_tileManager->setDataSources(_scene->dataSources());
     m_tileWorker->setScene(_scene);
     setPixelScale(m_view->pixelScale());
 
@@ -553,15 +553,13 @@ int getCameraType() {
 void addDataSource(std::shared_ptr<DataSource> _source) {
     if (!m_tileManager) { return; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);
-    m_scene->addClientDataSource(_source);
-    m_tileManager->addDataSource(_source);
+    m_tileManager->addClientDataSource(_source);
 }
 
 bool removeDataSource(DataSource& source) {
     if (!m_tileManager) { return false; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);
-    m_scene->removeClientDataSource(source);
-    return m_tileManager->removeDataSource(source);
+    return m_tileManager->removeClientDataSource(source);
 }
 
 void clearDataSource(DataSource& _source, bool _data, bool _tiles) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -210,10 +210,9 @@ void loadScene(const char* _scenePath, bool _useScenePosition) {
     {
         std::lock_guard<std::mutex> lock(m_sceneMutex);
         m_sceneUpdates.clear();
+        m_nextScene = std::make_shared<Scene>(_scenePath);
+        m_nextScene->useScenePosition = _useScenePosition;
     }
-
-    m_nextScene = std::make_shared<Scene>(_scenePath);
-    m_nextScene->useScenePosition = _useScenePosition;
 
     Tangram::runAsyncTask([scene = m_nextScene](){
 
@@ -223,6 +222,7 @@ void loadScene(const char* _scenePath, bool _useScenePosition) {
 
             Tangram::runOnMainLoop([scene, ok]() {
                     if (scene == m_nextScene) {
+                        std::lock_guard<std::mutex> lock(m_sceneMutex);
                         m_nextScene.reset();
                     } else { return; }
 
@@ -269,6 +269,7 @@ void applySceneUpdates() {
 
             Tangram::runOnMainLoop([scene, ok]() {
                     if (scene == m_nextScene) {
+                        std::lock_guard<std::mutex> lock(m_sceneMutex);
                         m_nextScene.reset();
                     } else { return; }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -223,10 +223,12 @@ void loadScene(const char* _scenePath, bool _useScenePosition) {
             bool ok = SceneLoader::loadScene(scenePath, scene);
 
             Tangram::runOnMainLoop([scene, ok]() {
-                    if (scene == m_nextScene) {
+                    {
                         std::lock_guard<std::mutex> lock(m_sceneMutex);
-                        m_nextScene.reset();
-                    } else { return; }
+                        if (scene == m_nextScene) {
+                            m_nextScene.reset();
+                        } else { return; }
+                    }
 
                     if (ok) {
                         auto s = scene;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -24,7 +24,6 @@
 #include "util/ease.h"
 #include "debug/textDisplay.h"
 #include "debug/frameInfo.h"
-#include <atomic>
 #include <memory>
 #include <array>
 #include <cmath>
@@ -49,9 +48,6 @@ std::unique_ptr<Labels> m_labels;
 std::unique_ptr<InputHandler> m_inputHandler;
 
 std::shared_ptr<Scene> m_nextScene;
-std::atomic_bool m_sceneLoading(false);
-std::atomic_bool m_sceneUpdating(false);
-std::atomic_bool m_newSceneUpdates(false);
 std::vector<Scene::Update> m_sceneUpdates;
 
 std::array<Ease, 4> m_eases;
@@ -339,7 +335,7 @@ bool update(float _dt) {
     bool tilesLoading = m_tileManager->hasLoadingTiles();
     bool labelsNeedUpdate = m_labels->needUpdate();
 
-    if (viewChanged || tilesChanged || tilesLoading || labelsNeedUpdate) {
+    if (viewChanged || tilesChanged || tilesLoading || labelsNeedUpdate || !bool(m_nextScene)) {
         viewComplete = false;
     }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -13,6 +13,7 @@
 #include "gl/shaderProgram.h"
 #include "gl/renderState.h"
 #include "gl/primitives.h"
+#include "util/asyncWorker.h"
 #include "util/inputHandler.h"
 #include "tile/tileCache.h"
 #include "util/fastmap.h"
@@ -67,57 +68,6 @@ void clearEase(EaseField _f) {
 static float g_time = 0.0;
 static std::bitset<8> g_flags = 0;
 static bool g_cacheGlState = false;
-
-
-class AsyncWorker {
-public:
-
-    AsyncWorker() {
-        thread = std::thread(&AsyncWorker::run, this);
-    }
-
-    ~AsyncWorker() {
-        {
-            std::unique_lock<std::mutex> lock(m_mutex);
-            m_running = false;
-        }
-        m_condition.notify_all();
-        thread.join();
-    }
-
-    void enqueue(std::function<void()> _task) {
-        {
-            std::unique_lock<std::mutex> lock(m_mutex);
-            if (!m_running) { return; }
-
-            m_queue.push_back(std::move(_task));
-        }
-        m_condition.notify_one();
-    }
-
-private:
-
-    void run() {
-        while (true) {
-            std::function<void()> task;
-            {
-                std::unique_lock<std::mutex> lock(m_mutex);
-                m_condition.wait(lock, [&]{ return !m_running || !m_queue.empty(); });
-                if (!m_running) { break; }
-
-                task = std::move(m_queue.front());
-                m_queue.pop_front();
-            }
-            task();
-        }
-    }
-
-    std::thread thread;
-    bool m_running = true;
-    std::condition_variable m_condition;
-    std::mutex m_mutex;
-    std::deque<std::function<void()>> m_queue;
-};
 
 AsyncWorker m_asyncWorker;
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -123,9 +123,13 @@ AsyncWorker m_asyncWorker;
 
 void initialize(const char* _scenePath) {
 
+    // For some unknown reasons, android fails to render the map, if same scene is reloaded, without resetting any of
+    // the other Tangram global resources, which is what this method does.
+    // As a work-around, re-initialization of an already loaded scene is done along with resetting all the Tangram
+    // global resources.
+    // NOTE: This will be refactored completely with Multiple Tangram Instances work being done in parallel.
     if (m_scene && m_scene->path() == _scenePath) {
         LOGD("Specified scene is already initalized.");
-        return;
     }
 
     LOG("initialize");

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -158,12 +158,9 @@ void loadScene(const char* _scenePath, bool _useScenePosition) {
 
     // Copy old scene
     auto scene = std::make_shared<Scene>(_scenePath);
-
-    auto scenePath = setResourceRoot(_scenePath, scene->resourceRoot());
     scene->useScenePosition = _useScenePosition;
-    scene->fontContext()->setSceneResourceRoot(scene->resourceRoot());
 
-    if (SceneLoader::loadScene(scenePath, scene)) {
+    if (SceneLoader::loadScene(scene)) {
         setScene(scene);
     }
 }
@@ -180,10 +177,7 @@ void loadSceneAsync(const char* _scenePath, bool _useScenePosition, MapReady _pl
 
     Tangram::runAsyncTask([scene = m_nextScene, _platformCallback](){
 
-            auto scenePath = setResourceRoot(scene->path().c_str(), scene->resourceRoot());
-            scene->fontContext()->setSceneResourceRoot(scene->resourceRoot());
-
-            bool ok = SceneLoader::loadScene(scenePath, scene);
+            bool ok = SceneLoader::loadScene(scene);
 
             Tangram::runOnMainLoop([scene, ok, _platformCallback]() {
                     {

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -20,7 +20,9 @@ class DataSource;
 // given resource path
 void initialize(const char* _scenePath);
 
-// Load the scene at the given absolute file path
+// Load the scene at the given absolute file path asynchronously
+void loadSceneAsync(const char* _scenePath, bool _useScenePosition = false, std::function<void(void)> _platformCallback = {});
+// Load the scene at the given absolute file path synchronously
 void loadScene(const char* _scenePath, bool _useScenePosition = false);
 
 // Request an update to the scene configuration; the path is a series of yaml keys

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -21,7 +21,7 @@ class DataSource;
 void initialize(const char* _scenePath);
 
 // Load the scene at the given absolute file path
-void loadScene(const char* _scenePath);
+void loadScene(const char* _scenePath, bool _useScenePosition = false);
 
 // Request an update to the scene configuration; the path is a series of yaml keys
 // separated by a '.' and the value is a string of yaml to replace the current value

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -154,6 +154,7 @@ bool getDebugFlag(DebugFlags _flag);
 void toggleDebugFlag(DebugFlags _flag);
 
 void runOnMainLoop(std::function<void()> _task);
+void runAsyncTask(std::function<void()> _task);
 
 struct TouchItem {
     std::shared_ptr<Properties> properties;

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -155,7 +155,10 @@ bool getDebugFlag(DebugFlags _flag);
 // Toggle the boolean state of a debug feature (see debug.h)
 void toggleDebugFlag(DebugFlags _flag);
 
+// Run this task on Tangram's main update loop.
 void runOnMainLoop(std::function<void()> _task);
+
+// Run this task asynchronously to Tangram's main update loop.
 void runAsyncTask(std::function<void()> _task);
 
 struct TouchItem {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -28,7 +28,8 @@ namespace Tangram {
 FontContext::FontContext() :
     m_sdfRadius(SDF_WIDTH),
     m_atlas(*this, GlyphTexture::size, m_sdfRadius),
-    m_batch(m_atlas, m_scratch) {
+    m_batch(m_atlas, m_scratch),
+    m_sceneResourceRoot("") {
 
 // TODO: make this platform independent
 #if defined(PLATFORM_ANDROID)
@@ -64,7 +65,8 @@ FontContext::FontContext() :
     int size = BASE_SIZE;
     auto loadFonts = [&](const char* path) {
         unsigned int dataSize;
-        char* data = reinterpret_cast<char*>(bytesFromFile(path, PathType::resource, &dataSize));
+        char* data = reinterpret_cast<char*>(bytesFromFile(path, PathType::resource, &dataSize,
+                    m_sceneResourceRoot.c_str()));
         if (data) {
             for (int i = 0; i < 3; i++, size += STEP_SIZE) {
                 m_font[i] = m_alfons.addFont("default", alfons::InputSource(data, dataSize), size);
@@ -74,7 +76,8 @@ FontContext::FontContext() :
     };
     auto addFaces = [&](const char* path) {
         unsigned int dataSize;
-        char* data = reinterpret_cast<char*>(bytesFromFile(path, PathType::resource, &dataSize));
+        char* data = reinterpret_cast<char*>(bytesFromFile(path, PathType::resource, &dataSize,
+                    m_sceneResourceRoot.c_str()));
         if (data) {
             for (int i = 0; i < 3; i++, size += STEP_SIZE) {
                     m_font[i]->addFace(m_alfons.addFontFace(alfons::InputSource(data, dataSize), size));
@@ -287,10 +290,10 @@ auto FontContext::getFont(const std::string& _family, const std::string& _style,
 
     // Assuming bundled ttf file follows this convention
     auto bundledFontPath = "fonts/" + _family + "-" + _weight + _style + ".ttf";
-    if (!(data = bytesFromFile(bundledFontPath.c_str(), PathType::resource, &dataSize)) &&
-        !(data = bytesFromFile(bundledFontPath.c_str(), PathType::internal, &dataSize))) {
+    if (!(data = bytesFromFile(bundledFontPath.c_str(), PathType::resource, &dataSize, m_sceneResourceRoot.c_str())) &&
+        !(data = bytesFromFile(bundledFontPath.c_str(), PathType::internal, &dataSize, m_sceneResourceRoot.c_str()))) {
         const std::string sysFontPath = systemFontPath(_family, _weight, _style);
-        if (!(data = bytesFromFile(sysFontPath.c_str(), PathType::absolute, &dataSize)) ) {
+        if (!(data = bytesFromFile(sysFontPath.c_str(), PathType::absolute, &dataSize, m_sceneResourceRoot.c_str())) ) {
 
             LOGE("Could not load font file %s", fontName.c_str());
             // add fallbacks from default font

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -34,7 +34,7 @@ FontContext::FontContext() :
 // TODO: make this platform independent
 #if defined(PLATFORM_ANDROID)
     auto fontPath = systemFontPath("sans-serif", "400", "normal");
-    LOG("FONT %s", fontPath.c_str());
+    LOGD("FONT %s", fontPath.c_str());
 
     int size = BASE_SIZE;
     for (int i = 0; i < 3; i++, size += STEP_SIZE) {
@@ -53,7 +53,7 @@ FontContext::FontContext() :
         }
         fontPath = ANDROID_FONT_PATH;
         fontPath += fallback;
-        LOG("FALLBACK %s", fontPath.c_str());
+        LOGD("FALLBACK %s", fontPath.c_str());
 
         int size = BASE_SIZE;
         for (int i = 0; i < 3; i++, size += STEP_SIZE) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -64,9 +64,8 @@ FontContext::FontContext() :
 
     int size = BASE_SIZE;
     auto loadFonts = [&](const char* path) {
-        unsigned int dataSize;
-        char* data = reinterpret_cast<char*>(bytesFromFile(path, PathType::resource, &dataSize,
-                    m_sceneResourceRoot.c_str()));
+        size_t dataSize;
+        char* data = reinterpret_cast<char*>(bytesFromFile(path, dataSize));
         if (data) {
             for (int i = 0; i < 3; i++, size += STEP_SIZE) {
                 m_font[i] = m_alfons.addFont("default", alfons::InputSource(data, dataSize), size);
@@ -75,9 +74,8 @@ FontContext::FontContext() :
         }
     };
     auto addFaces = [&](const char* path) {
-        unsigned int dataSize;
-        char* data = reinterpret_cast<char*>(bytesFromFile(path, PathType::resource, &dataSize,
-                    m_sceneResourceRoot.c_str()));
+        size_t dataSize;
+        char* data = reinterpret_cast<char*>(bytesFromFile(path, dataSize));
         if (data) {
             for (int i = 0; i < 3; i++, size += STEP_SIZE) {
                     m_font[i]->addFace(m_alfons.addFontFace(alfons::InputSource(data, dataSize), size));
@@ -285,21 +283,32 @@ auto FontContext::getFont(const std::string& _family, const std::string& _style,
     auto font = m_alfons.getFont(fontName, fontSize);
     if (font->hasFaces()) { return font; }
 
-    unsigned int dataSize = 0;
+    size_t dataSize = 0;
     unsigned char* data = nullptr;
 
     // Assuming bundled ttf file follows this convention
     auto bundledFontPath = "fonts/" + _family + "-" + _weight + _style + ".ttf";
-    if (!(data = bytesFromFile(bundledFontPath.c_str(), PathType::resource, &dataSize, m_sceneResourceRoot.c_str())) &&
-        !(data = bytesFromFile(bundledFontPath.c_str(), PathType::internal, &dataSize, m_sceneResourceRoot.c_str()))) {
-        const std::string sysFontPath = systemFontPath(_family, _weight, _style);
-        if (!(data = bytesFromFile(sysFontPath.c_str(), PathType::absolute, &dataSize, m_sceneResourceRoot.c_str())) ) {
 
-            LOGE("Could not load font file %s", fontName.c_str());
-            // add fallbacks from default font
-            font->addFaces(*m_font[sizeIndex]);
-            return font;
+    do {
+        if (!m_sceneResourceRoot.empty()) {
+            auto resourceFontPath = m_sceneResourceRoot + bundledFontPath;
+            data = bytesFromFile(resourceFontPath.c_str(), dataSize);
+            if (data) { break; }
         }
+
+        data = bytesFromFile(bundledFontPath.c_str(), dataSize);
+        if (data) { break; }
+
+        auto sysFontPath = systemFontPath(_family, _weight, _style);
+        data = bytesFromFile(sysFontPath.c_str(), dataSize);
+
+    } while(0);
+
+    if (!data) {
+        LOGE("Could not load font file %s", fontName.c_str());
+        // add fallbacks from default font
+        font->addFaces(*m_font[sizeIndex]);
+        return font;
     }
 
     font->addFace(m_alfons.addFontFace(alfons::InputSource(reinterpret_cast<char*>(data), dataSize), fontSize));

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -90,6 +90,8 @@ public:
         std::vector<GlyphQuad>* quads;
     };
 
+    void setSceneResourceRoot(const std::string& sceneResourceRoot) { m_sceneResourceRoot = sceneResourceRoot; }
+
 private:
     float m_sdfRadius;
     ScratchBuffer m_scratch;
@@ -112,6 +114,7 @@ private:
     // textures and a MeshCallback implemented by TextStyleBuilder for adding glyph quads.
     alfons::TextBatch m_batch;
     TextWrapper m_textWrapper;
+    std::string m_sceneResourceRoot;
 };
 
 }

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -60,9 +60,9 @@ public:
 
     bool hasLoadingTiles() { return m_tilesInProgress > 0; }
 
-    void addDataSource(std::shared_ptr<DataSource> _dataSource);
+    void addClientDataSource(std::shared_ptr<DataSource> _dataSource);
 
-    bool removeDataSource(DataSource& dataSource);
+    bool removeClientDataSource(DataSource& dataSource);
 
     std::unique_ptr<TileCache>& getTileCache() { return m_tileCache; }
 
@@ -179,9 +179,13 @@ private:
     };
 
     struct TileSet {
+        TileSet(std::shared_ptr<DataSource> _source, bool _clientDataSource)
+            : source(_source), clientDataSource(_clientDataSource) {}
+
         std::shared_ptr<DataSource> source;
         std::map<TileID, TileEntry> tiles;
         int64_t sourceGeneration;
+        bool clientDataSource;
     };
 
     void updateTileSet(TileSet& tileSet, const ViewState& _view, const std::set<TileID>& _visibleTiles);

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -73,7 +73,7 @@ void TileWorker::run(Worker* instance) {
             }
 
             if (!builder) {
-                LOGE("Missing Scene/StyleContext in TileWorker!");
+                LOGD("Missing Scene/StyleContext in TileWorker");
                 continue;
             }
 

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -73,7 +73,6 @@ void TileWorker::run(Worker* instance) {
             }
 
             if (!builder) {
-                LOGD("Missing Scene/StyleContext in TileWorker");
                 continue;
             }
 

--- a/core/src/util/asyncWorker.h
+++ b/core/src/util/asyncWorker.h
@@ -1,0 +1,57 @@
+#include <thread>
+#include <mutex>
+#include <deque>
+
+namespace Tangram {
+
+class AsyncWorker {
+public:
+
+    AsyncWorker() {
+        thread = std::thread(&AsyncWorker::run, this);
+    }
+
+    ~AsyncWorker() {
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            m_running = false;
+        }
+        m_condition.notify_all();
+        thread.join();
+    }
+
+    void enqueue(std::function<void()> _task) {
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            if (!m_running) { return; }
+
+            m_queue.push_back(std::move(_task));
+        }
+        m_condition.notify_one();
+    }
+
+private:
+
+    void run() {
+        while (true) {
+            std::function<void()> task;
+            {
+                std::unique_lock<std::mutex> lock(m_mutex);
+                m_condition.wait(lock, [&]{ return !m_running || !m_queue.empty(); });
+                if (!m_running) { break; }
+
+                task = std::move(m_queue.front());
+                m_queue.pop_front();
+            }
+            task();
+        }
+    }
+
+    std::thread thread;
+    bool m_running = true;
+    std::condition_variable m_condition;
+    std::mutex m_mutex;
+    std::deque<std::function<void()>> m_queue;
+};
+
+}

--- a/core/src/util/base64.h
+++ b/core/src/util/base64.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// public domain from https://en.wikibooks.org/wiki/Algorithm_Implementation
+
+#include <string>
+#include <vector>
+
+struct Base64 {
+
+static bool checkPrefix(const std::string &path) {
+    return path.substr(0, 22) == "data:image/png;base64,";
+}
+
+static void stripPrefix(std::string &data) {
+    data.erase(0, 22);
+}
+
+const static char padCharacter = ('=');
+
+static std::vector<unsigned char> decode(const std::string& input) {
+    if (input.length() % 4) // Sanity check
+        throw std::runtime_error("Non-Valid base64!");
+    size_t padding = 0;
+    if (input.length()) {
+        if (input[input.length() - 1] == padCharacter) padding++;
+        if (input[input.length() - 2] == padCharacter) padding++;
+    }
+    // Setup a vector to hold the result
+    std::vector<unsigned char> decodedBytes;
+    decodedBytes.reserve(((input.length() / 4) * 3) - padding);
+    uint32_t temp = 0; // Holds decoded quanta
+    std::string::const_iterator cursor = input.begin();
+    while (cursor < input.end()) {
+        for (size_t quantumPosition = 0; quantumPosition < 4; quantumPosition++) {
+            temp <<= 6;
+            if (*cursor >= 0x41 && *cursor <= 0x5A) // This area will need tweaking if
+                temp |= *cursor - 0x41;             // you are using an alternate alphabet
+            else if (*cursor >= 0x61 && *cursor <= 0x7A)
+                temp |= *cursor - 0x47;
+            else if (*cursor >= 0x30 && *cursor <= 0x39)
+                temp |= *cursor + 0x04;
+            else if (*cursor == 0x2B)
+                temp |= 0x3E; // change to 0x2D for URL alphabet
+            else if (*cursor == 0x2F)
+                temp |= 0x3F;                 // change to 0x5F for URL alphabet
+            else if (*cursor == padCharacter) // pad
+            {
+                switch (input.end() - cursor) {
+                case 1: // One pad character
+                    decodedBytes.push_back((temp >> 16) & 0x000000FF);
+                    decodedBytes.push_back((temp >> 8) & 0x000000FF);
+                    return decodedBytes;
+                case 2: // Two pad characters
+                    decodedBytes.push_back((temp >> 10) & 0x000000FF);
+                    return decodedBytes;
+                default: throw std::runtime_error("Invalid Padding in Base 64!");
+                }
+            } else
+                throw std::runtime_error("Non-Valid Character in Base 64!");
+            cursor++;
+        }
+        decodedBytes.push_back((temp >> 16) & 0x000000FF);
+        decodedBytes.push_back((temp >> 8) & 0x000000FF);
+        decodedBytes.push_back((temp)&0x000000FF);
+    }
+    return decodedBytes;
+}
+};

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -202,6 +202,7 @@
     [EAGLContext setCurrentContext:self.context];
 
     Tangram::initialize("scene.yaml");
+    Tangram::loadSceneAsync("scene.yaml");
     Tangram::setupGL();
 
     int width = self.view.bounds.size.width;

--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -58,7 +58,7 @@ bool isContinuousRendering() {
 
 }
 
-NSString* resolvePath(const char* _path, PathType _type) {
+NSString* resolvePath(const char* _path) {
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
@@ -68,9 +68,9 @@ NSString* resolvePath(const char* _path, PathType _type) {
     return [resources stringByAppendingPathComponent:path];
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path);
     NSString* str = [NSString stringWithContentsOfFile:path
                                           usedEncoding:NULL
                                                  error:NULL];
@@ -83,9 +83,9 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return std::string([str UTF8String]);
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path);
     NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
     if (data == nil) {

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -192,7 +192,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 Tangram::toggleDebugFlag(Tangram::DebugFlags::tangram_stats);
                 break;
             case GLFW_KEY_R:
-                Tangram::loadScene(sceneFile.c_str());
+                Tangram::loadSceneAsync(sceneFile.c_str());
                 break;
             case GLFW_KEY_E:
                 if (scene_editing_mode) {
@@ -204,7 +204,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                     setContinuousRendering(true);
                     glfwSwapInterval(1);
                 }
-                Tangram::loadScene(sceneFile.c_str());
+                Tangram::loadSceneAsync(sceneFile.c_str());
                 break;
             case GLFW_KEY_BACKSPACE:
                 recreate_context = true;
@@ -220,7 +220,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 } else {
                     pixel_scale = 1.0;
                 }
-                Tangram::loadScene(sceneFile.c_str());
+                Tangram::loadSceneAsync(sceneFile.c_str());
                 Tangram::setPixelScale(pixel_scale);
 
                 break;
@@ -244,7 +244,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void drop_callback(GLFWwindow* window, int count, const char** paths) {
 
     sceneFile = std::string(paths[0]);
-    Tangram::loadScene(sceneFile.c_str());
+    Tangram::loadSceneAsync(sceneFile.c_str());
 
 }
 
@@ -257,10 +257,16 @@ void window_size_callback(GLFWwindow* window, int width, int height) {
 
 }
 
+void updatePostInit() {
+    //stamford, ct location
+    Tangram::setPosition(-73.5387, 41.0534, 1.0);
+}
+
 void init_main_window(bool recreate) {
 
     // Setup tangram
     Tangram::initialize(sceneFile.c_str());
+    Tangram::loadSceneAsync(sceneFile.c_str(), true, updatePostInit);
 
     if (!recreate) {
         // Destroy old window
@@ -380,7 +386,7 @@ int main(int argc, char* argv[]) {
         if (scene_editing_mode) {
             if (stat(sceneFile.c_str(), &sb) == 0) {
                 if (last_mod != sb.st_mtime) {
-                    Tangram::loadScene(sceneFile.c_str());
+                    Tangram::loadSceneAsync(sceneFile.c_str());
                     last_mod = sb.st_mtime;
                 }
             }

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -335,10 +335,10 @@ int main(int argc, char* argv[]) {
     }
 
     struct stat sb;
-    if (stat(sceneFile.c_str(), &sb) == -1) {
-        logMsg("scene file not found!");
-        exit(EXIT_FAILURE);
-    }
+    //if (stat(sceneFile.c_str(), &sb) == -1) {
+        //logMsg("scene file not found!");
+        //exit(EXIT_FAILURE);
+    //}
     auto last_mod = sb.st_mtime;
 
     init_main_window(false);
@@ -384,12 +384,12 @@ int main(int argc, char* argv[]) {
         }
 
         if (scene_editing_mode) {
-            if (stat(sceneFile.c_str(), &sb) == 0) {
+            //if (stat(sceneFile.c_str(), &sb) == 0) {
                 if (last_mod != sb.st_mtime) {
                     Tangram::loadSceneAsync(sceneFile.c_str());
                     last_mod = sb.st_mtime;
                 }
-            }
+            //}
         }
     }
 

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -76,11 +76,11 @@ std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) 
         return path;
     }
 
-    std::string dir(path);
+    std::string dir(_path);
 
     _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
 
-    std::string base(path);
+    std::string base(_path);
 
     return std::string(basename(&base[0]));
 

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -13,6 +13,8 @@
 #include <sys/resource.h>
 #include <sys/syscall.h>
 
+#include <regex>
+
 #define NUM_WORKERS 3
 
 PFNGLBINDVERTEXARRAYPROC glBindVertexArrayOESEXT = 0;
@@ -65,11 +67,20 @@ bool isContinuousRendering() {
 
 std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
 
-    std::string dir(_path);
+    std::regex r("^(http|https):/");
+    std::smatch match;
+    std::string path(_path);
+
+    if (std::regex_search(path, match, r)) {
+        _sceneResourceRoot = "";
+        return path;
+    }
+
+    std::string dir(path);
 
     _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
 
-    std::string base(_path);
+    std::string base(path);
 
     return std::string(basename(&base[0]));
 

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -2,6 +2,7 @@
 #include <stdarg.h>
 #include <iostream>
 #include <fstream>
+#include <functional>
 #include <string>
 #include <list>
 

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -66,10 +66,10 @@ bool isContinuousRendering() {
 
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
     size_t length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length, _type);
+    unsigned char* bytes = bytesFromFile(_path, length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -77,7 +77,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -66,46 +66,10 @@ bool isContinuousRendering() {
 
 }
 
-std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
-    std::regex r("^(http|https):/");
-    std::smatch match;
-    std::string path(_path);
-
-    if (std::regex_search(path, match, r)) {
-        _sceneResourceRoot = "";
-        return path;
-    }
-
-    std::string dir(_path);
-
-    _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
-
-    std::string base(_path);
-
-    return std::string(basename(&base[0]));
-
-}
-
-std::string resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    switch (_type) {
-    case PathType::absolute:
-    case PathType::internal:
-        return std::string(_path);
-    case PathType::resource:
-        if (_resourceRoot) {
-            return std::string(_resourceRoot) + _path;
-        }
-        return _path;
-    }
-    return "";
-}
-
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length, _resourceRoot);
+    size_t length = 0;
+    unsigned char* bytes = bytesFromFile(_path, length, _type);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -113,25 +77,23 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
 
-    std::string path = resolvePath(_path, _type, _resourceRoot);
-
-    std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", path.c_str());
-        *_size = 0;
+        logMsg("Failed to read file at path: %s\n", _path);
+        _size = 0;
         return nullptr;
     }
 
-    *_size = resource.tellg();
+    _size = resource.tellg();
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * (*_size));
+    char* cdata = (char*) malloc(sizeof(char) * (_size));
 
-    resource.read(cdata, *_size);
+    resource.read(cdata, _size);
     resource.close();
 
     return reinterpret_cast<unsigned char *>(cdata);

--- a/linux/src/urlWorker.cpp
+++ b/linux/src/urlWorker.cpp
@@ -63,6 +63,9 @@ void UrlWorker::perform(std::unique_ptr<UrlTask> _task) {
         m_task->callback(std::move(m_task->content));
         m_task.reset();
 
+        // Run processNetworkQueue() for pending tasks
+        requestRender();
+
         return true;
     });
 }

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -342,15 +342,15 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    // Initialize networking
+    NSurlInit();
+
     // Initialize the windowing library
     if (!glfwInit()) {
         return -1;
     }
 
     init_main_window(false);
-
-    // Initialize networking
-    NSurlInit();
 
     double lastTime = glfwGetTime();
 

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -200,7 +200,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 recreate_context = true;
                 break;
             case GLFW_KEY_R:
-                Tangram::loadScene(sceneFile.c_str());
+                Tangram::loadSceneAsync(sceneFile.c_str());
                 break;
             case GLFW_KEY_Z:
                 Tangram::setZoom(Tangram::getZoom() + 1.f, 1.5f);
@@ -216,7 +216,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 } else {
                     pixel_scale = 1.0;
                 }
-                Tangram::loadScene(sceneFile.c_str());
+                Tangram::loadSceneAsync(sceneFile.c_str());
                 Tangram::setPixelScale(pixel_scale);
                 break;
             case GLFW_KEY_P:
@@ -253,7 +253,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void drop_callback(GLFWwindow* window, int count, const char** paths) {
 
     sceneFile = std::string(paths[0]);
-    Tangram::loadScene(sceneFile.c_str());
+    Tangram::loadSceneAsync(sceneFile.c_str());
 
 }
 
@@ -278,6 +278,7 @@ void init_main_window(bool recreate) {
 
     // Setup tangram
     Tangram::initialize(sceneFile.c_str());
+    Tangram::loadSceneAsync(sceneFile.c_str());
 
     if (!recreate) {
         // Destroy old window

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -5,6 +5,7 @@
 #import <cstdio>
 #import <cstdarg>
 #import <fstream>
+#import <regex>
 
 #include <mutex>
 #include <sys/resource.h>
@@ -16,8 +17,6 @@ static bool s_isContinuousRendering = false;
 
 static bool s_stopUrlRequests = false;
 static std::mutex s_urlRequestsMutex;
-
-static NSMutableString* s_resourceRoot = NULL;
 
 NSURLSession* defaultSession;
 
@@ -48,7 +47,16 @@ bool isContinuousRendering() {
 
 }
 
-std::string setResourceRoot(const char* _path) {
+std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
+
+    std::regex r("^(http|https):/");
+    std::smatch match;
+    std::string p(_path);
+
+    if (std::regex_search(p, match, r)) {
+        _sceneResourceRoot = "";
+        return p;
+    }
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
@@ -57,16 +65,19 @@ std::string setResourceRoot(const char* _path) {
         path = [resources stringByAppendingPathComponent:path];
     }
 
-    s_resourceRoot = [ [path stringByDeletingLastPathComponent] mutableCopy];
+    _sceneResourceRoot = std::string([ [path stringByDeletingLastPathComponent] UTF8String]);
 
     return std::string([[path lastPathComponent] UTF8String]);
 
 }
 
-NSString* resolvePath(const char* _path, PathType _type) {
+NSString* resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
 
-    if (s_resourceRoot == NULL) {
-        setResourceRoot(".");
+    NSString* resourceRoot = NULL;
+    if (_resourceRoot == NULL) {
+        resourceRoot = @".";
+    } else {
+        resourceRoot = [NSString stringWithUTF8String:(_resourceRoot)];
     }
 
     NSString* path = [NSString stringWithUTF8String:_path];
@@ -75,15 +86,15 @@ NSString* resolvePath(const char* _path, PathType _type) {
     case PathType::internal:
         return [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:path];
     case PathType::resource:
-        return [s_resourceRoot stringByAppendingPathComponent:path];
+        return [resourceRoot stringByAppendingPathComponent:path];
     case PathType::absolute:
         return path;
     }
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path, _type, _resourceRoot);
     NSString* str = [NSString stringWithContentsOfFile:path
                                           usedEncoding:NULL
                                                  error:NULL];
@@ -96,9 +107,10 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return std::string([str UTF8String]);
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size,
+                                const char* _resourceRoot) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path, _type, _resourceRoot);
     NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
     if (data == nil) {

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -47,54 +47,19 @@ bool isContinuousRendering() {
 
 }
 
-std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
-
-    std::regex r("^(http|https):/");
-    std::smatch match;
-    std::string p(_path);
-
-    if (std::regex_search(p, match, r)) {
-        _sceneResourceRoot = "";
-        return p;
-    }
+NSString* resolvePath(const char* _path, PathType _type) {
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
-    if (*_path != '/') {
-        NSString* resources = [[NSBundle mainBundle] resourcePath];
-        path = [resources stringByAppendingPathComponent:path];
-    }
+    if (*_path == '/') { return path; }
 
-    _sceneResourceRoot = std::string([ [path stringByDeletingLastPathComponent] UTF8String]);
-
-    return std::string([[path lastPathComponent] UTF8String]);
-
+    NSString* resources = [[NSBundle mainBundle] resourcePath];
+    return [resources stringByAppendingPathComponent:path];
 }
 
-NSString* resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
-    NSString* resourceRoot = NULL;
-    if (_resourceRoot == NULL) {
-        resourceRoot = @".";
-    } else {
-        resourceRoot = [NSString stringWithUTF8String:(_resourceRoot)];
-    }
-
-    NSString* path = [NSString stringWithUTF8String:_path];
-
-    switch (_type) {
-    case PathType::internal:
-        return [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:path];
-    case PathType::resource:
-        return [resourceRoot stringByAppendingPathComponent:path];
-    case PathType::absolute:
-        return path;
-    }
-}
-
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    NSString* path = resolvePath(_path, _type, _resourceRoot);
+    NSString* path = resolvePath(_path, _type);
     NSString* str = [NSString stringWithContentsOfFile:path
                                           usedEncoding:NULL
                                                  error:NULL];
@@ -107,21 +72,20 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
     return std::string([str UTF8String]);
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size,
-                                const char* _resourceRoot) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
 
-    NSString* path = resolvePath(_path, _type, _resourceRoot);
+    NSString* path = resolvePath(_path, _type);
     NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
     if (data == nil) {
         LOGW("Failed to read file at path: %s", [path UTF8String]);
-        *_size = 0;
+        _size = 0;
         return nullptr;
     }
 
-    *_size = data.length;
-    unsigned char* ptr = (unsigned char*)malloc(*_size);
-    [data getBytes:ptr length:*_size];
+    _size = data.length;
+    unsigned char* ptr = (unsigned char*)malloc(_size);
+    [data getBytes:ptr length:_size];
 
     return ptr;
 }

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -47,7 +47,7 @@ bool isContinuousRendering() {
 
 }
 
-NSString* resolvePath(const char* _path, PathType _type) {
+NSString* resolvePath(const char* _path) {
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
@@ -57,9 +57,9 @@ NSString* resolvePath(const char* _path, PathType _type) {
     return [resources stringByAppendingPathComponent:path];
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path);
     NSString* str = [NSString stringWithContentsOfFile:path
                                           usedEncoding:NULL
                                                  error:NULL];
@@ -72,9 +72,9 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return std::string([str UTF8String]);
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path);
     NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
     if (data == nil) {

--- a/rpi/src/main.cpp
+++ b/rpi/src/main.cpp
@@ -45,6 +45,7 @@ int main(int argc, char **argv){
 
     // Set background color and clear buffers
     Tangram::initialize("scene.yaml");
+    Tangram::loadSceneAsync("scene.yaml");
     Tangram::setupGL();
     Tangram::resize(getWindowWidth(), getWindowHeight());
 

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -11,6 +11,8 @@
 #include <string>
 #include <list>
 
+#include <regex>
+
 #define NUM_WORKERS 3
 
 static bool s_isContinuousRendering = false;
@@ -53,11 +55,20 @@ bool isContinuousRendering() {
 
 std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
 
-    std::string dir(_path);
+    std::regex r("^(http|https):/");
+    std::smatch match;
+    std::string path(_path);
+
+    if (std::regex_search(path, match, r)) {
+        _sceneResourceRoot = "";
+        return path;
+    }
+
+    std::string dir(path);
 
     _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
 
-    std::string base(_path);
+    std::string base(path);
 
     return std::string(basename(&base[0]));
 

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -14,7 +14,6 @@
 #define NUM_WORKERS 3
 
 static bool s_isContinuousRendering = false;
-static std::string s_resourceRoot;
 
 static UrlWorker s_Workers[NUM_WORKERS];
 static std::list<std::unique_ptr<UrlTask>> s_urlTaskQueue;
@@ -52,11 +51,11 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string setResourceRoot(const char* _path) {
+std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
 
     std::string dir(_path);
 
-    s_resourceRoot = std::string(dirname(&dir[0])) + '/';
+    _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
 
     std::string base(_path);
 
@@ -64,21 +63,25 @@ std::string setResourceRoot(const char* _path) {
 
 }
 
-std::string resolvePath(const char* _path, PathType _type) {
+std::string resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
 
     switch (_type) {
     case PathType::absolute:
     case PathType::internal:
         return std::string(_path);
     case PathType::resource:
-        return s_resourceRoot + _path;
+        if (_resourceRoot) {
+            return std::string(_resourceRoot) + _path;
+        }
+        return _path;
     }
+    return "";
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length);
+    unsigned char* bytes = bytesFromFile(_path, _type, &length, _resourceRoot);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -86,9 +89,9 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot) {
 
-    std::string path = resolvePath(_path, _type);
+    std::string path = resolvePath(_path, _type, _resourceRoot);
 
     std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
 

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -64,11 +64,11 @@ std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) 
         return path;
     }
 
-    std::string dir(path);
+    std::string dir(_path);
 
     _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
 
-    std::string base(path);
+    std::string base(_path);
 
     return std::string(basename(&base[0]));
 

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -53,10 +53,10 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length);
+    unsigned char* bytes = bytesFromFile(_path, &length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -64,7 +64,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -53,46 +53,10 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
-
-    std::regex r("^(http|https):/");
-    std::smatch match;
-    std::string path(_path);
-
-    if (std::regex_search(path, match, r)) {
-        _sceneResourceRoot = "";
-        return path;
-    }
-
-    std::string dir(_path);
-
-    _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
-
-    std::string base(_path);
-
-    return std::string(basename(&base[0]));
-
-}
-
-std::string resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    switch (_type) {
-    case PathType::absolute:
-    case PathType::internal:
-        return std::string(_path);
-    case PathType::resource:
-        if (_resourceRoot) {
-            return std::string(_resourceRoot) + _path;
-        }
-        return _path;
-    }
-    return "";
-}
-
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length, _resourceRoot);
+    unsigned char* bytes = bytesFromFile(_path, _type, &length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -100,25 +64,23 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
 
-    std::string path = resolvePath(_path, _type, _resourceRoot);
-
-    std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", path.c_str());
+        logMsg("Failed to read file at path: %s\n", _path);
         *_size = 0;
         return nullptr;
     }
 
-    *_size = resource.tellg();
+    _size = resource.tellg();
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * (*_size));
+    char* cdata = (char*) malloc(sizeof(char) * _size);
 
-    resource.read(cdata, *_size);
+    resource.read(cdata, _size);
     resource.close();
 
     return reinterpret_cast<unsigned char *>(cdata);

--- a/scenes/import.yaml
+++ b/scenes/import.yaml
@@ -1,0 +1,2 @@
+import:
+    - import/test.yaml

--- a/scenes/import/test.yaml
+++ b/scenes/import/test.yaml
@@ -1,0 +1,2 @@
+import:
+    - ../scene.yaml

--- a/tests/src/platform_mock.cpp
+++ b/tests/src/platform_mock.cpp
@@ -10,7 +10,6 @@
 //#include <sys/resource.h>
 
 static bool s_isContinuousRendering = false;
-static std::string s_resourceRoot;
 
 void logMsg(const char* fmt, ...) {
     va_list args;
@@ -30,11 +29,11 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string setResourceRoot(const char* _path) {
+std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
 
     std::string dir(_path);
 
-    s_resourceRoot = std::string(dirname(&dir[0])) + '/';
+    _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
 
     std::string base(_path);
 
@@ -42,19 +41,22 @@ std::string setResourceRoot(const char* _path) {
 
 }
 
-std::string resolvePath(const char* _path, PathType _type) {
+std::string resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
 
     switch (_type) {
     case PathType::absolute:
     case PathType::internal:
         return std::string(_path);
     case PathType::resource:
-        return s_resourceRoot + _path;
+        if (_resourceRoot) {
+            return std::string(_resourceRoot) + _path;
+        }
+        return _path;
     }
     return "";
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
 
     unsigned int length = 0;
     unsigned char* bytes = bytesFromFile(_path, _type, &length);
@@ -65,9 +67,9 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size) {
+unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot) {
 
-    std::string path = resolvePath(_path, _type);
+    std::string path = resolvePath(_path, _type, _resourceRoot);
 
     std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
 

--- a/tests/src/platform_mock.cpp
+++ b/tests/src/platform_mock.cpp
@@ -29,10 +29,10 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
     size_t length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length, _type);
+    unsigned char* bytes = bytesFromFile(_path, length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -40,7 +40,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 

--- a/tests/src/platform_mock.cpp
+++ b/tests/src/platform_mock.cpp
@@ -29,37 +29,10 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
-    std::string dir(_path);
-
-    _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
-
-    std::string base(_path);
-
-    return std::string(basename(&base[0]));
-
-}
-
-std::string resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    switch (_type) {
-    case PathType::absolute:
-    case PathType::internal:
-        return std::string(_path);
-    case PathType::resource:
-        if (_resourceRoot) {
-            return std::string(_resourceRoot) + _path;
-        }
-        return _path;
-    }
-    return "";
-}
-
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length);
+    size_t length = 0;
+    unsigned char* bytes = bytesFromFile(_path, length, _type);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -67,25 +40,23 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
 
-    std::string path = resolvePath(_path, _type, _resourceRoot);
-
-    std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", path.c_str());
-        *_size = 0;
+        logMsg("Failed to read file at path: %s\n", _path);
+        _size = 0;
         return nullptr;
     }
 
-    *_size = resource.tellg();
+    _size = resource.tellg();
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * (*_size));
+    char* cdata = (char*) malloc(sizeof(char) * _size);
 
-    resource.read(cdata, *_size);
+    resource.read(cdata, _size);
     resource.close();
 
     return reinterpret_cast<unsigned char *>(cdata);

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -35,8 +35,8 @@ std::shared_ptr<alfons::Font> font;
 void initFont(std::string _font = TEST_FONT) {
     font = fontManager.addFont("default", alfons::InputSource(_font), TEST_FONT_SIZE);
 
-    unsigned int dataSize = 0;
-    unsigned char* data = bytesFromFile(_font.c_str(), PathType::internal, &dataSize);
+    size_t dataSize = 0;
+    unsigned char* data = bytesFromFile(_font.c_str(), dataSize, PathType::internal);
 
     auto face = fontManager.addFontFace(alfons::InputSource(reinterpret_cast<char*>(data), dataSize), TEST_FONT_SIZE);
 

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -36,7 +36,7 @@ void initFont(std::string _font = TEST_FONT) {
     font = fontManager.addFont("default", alfons::InputSource(_font), TEST_FONT_SIZE);
 
     size_t dataSize = 0;
-    unsigned char* data = bytesFromFile(_font.c_str(), dataSize, PathType::internal);
+    unsigned char* data = bytesFromFile(_font.c_str(), dataSize);
 
     auto face = fontManager.addFontFace(alfons::InputSource(reinterpret_cast<char*>(data), dataSize), TEST_FONT_SIZE);
 

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -70,6 +70,7 @@ TestImporter::TestImporter() {
                         shaders:
                             uniforms:
                                 u_tex3: "importResources/tex.png"
+                                u_tex4: tex1
             )END");
     m_testScenes["scene.yaml"] = std::string(
             R"END(
@@ -85,6 +86,8 @@ TestImporter::TestImporter() {
                             uniforms:
                                 u_tex1: "resources/tex/sameName.png"
                                 u_tex2: ["uTex1.png", "resources/uTex2.png"]
+                    styleB:
+                        texture: tex5
             )END");
 }
 
@@ -146,9 +149,13 @@ TEST_CASE( "Texture path tests after importing process", "[scene-import][core]")
 
     const auto& styleNode = root["styles"]["styleA"];
     const auto& uniformsNode = styleNode["shaders"]["uniforms"];
+
     REQUIRE(styleNode["texture"].Scalar() == "resources/tex/sameName.png");
+    REQUIRE(root["styles"]["styleB"]["texture"].Scalar() == "tex5");
+
     REQUIRE(uniformsNode["u_tex1"].Scalar() == "resources/tex/sameName.png");
     REQUIRE(uniformsNode["u_tex2"][0].Scalar() == "uTex1.png");
     REQUIRE(uniformsNode["u_tex2"][1].Scalar() == "resources/uTex2.png");
     REQUIRE(uniformsNode["u_tex3"].Scalar() == "import/importResources/tex.png");
+    REQUIRE(uniformsNode["u_tex4"].Scalar() == "tex1");
 }

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -1,0 +1,111 @@
+#include "catch.hpp"
+
+#include <iostream>
+#include <vector>
+
+#include "yaml-cpp/yaml.h"
+#include "scene/importer.h"
+
+using namespace Tangram;
+using namespace YAML;
+
+class TestImporter : public Importer {
+
+public:
+    TestImporter();
+
+protected:
+    // The only thing different here is the call to `getSceneString` instead of reading and
+    // loading a yaml file, which is in the parent importer class
+    virtual bool loadScene(const std::string& scenePath) override;
+
+private:
+    std::string getSceneString(const std::string& scenePath) {
+        return m_testScenes[scenePath];
+    }
+
+    std::unordered_map<std::string, std::string> m_testScenes;
+};
+
+TestImporter::TestImporter() {
+    // Set multiple scenes here, basically set m_testScenes
+
+    m_testScenes["import/vehicle.yaml"] = std::string(R"END(
+                                name: vehicle
+                                type: vehicle
+                                category: vehicle
+                                )END");
+
+    m_testScenes["car.yaml"] = std::string(R"END(
+                                import: import/vehicle.yaml
+                                type: car
+                                )END");
+
+    m_testScenes["thisCar.yaml"] = std::string(R"END(
+                                    import: [import/vehicle.yaml, car.yaml]
+                                    name: thisCar
+                                    )END");
+
+    m_testScenes["/absolutePath/thisCar.yaml"] = std::string(R"END(
+                                    import: [import/vehicle.yaml, car.yaml]
+                                    name: thisCar
+                                    )END");
+
+
+    // All about textures
+    // TODO: scenes to test texture importing
+}
+
+bool TestImporter::loadScene(const std::string& path) {
+    auto scenePath = path;
+    auto sceneString = getSceneString(scenePath); // Importer.cpp read the scene from the file
+    auto sceneName = getFilename(scenePath);
+
+    if (m_scenes.find(sceneName) != m_scenes.end()) { return true; }
+
+    // Make sure all references from uber scene file are relative to itself, instead of being
+    // absolute paths (Example: when loading a file using command line args).
+    // TODO: Could be made better later.
+    if (m_scenes.size() == 0 && scenePath[0] == '/') { scenePath = getFilename(scenePath); }
+
+    try {
+        auto root = YAML::Load(sceneString);
+        normalizeSceneImports(root, scenePath);
+        normalizeSceneTextures(root, scenePath);
+        auto imports = getScenesToImport(root);
+        m_scenes[sceneName] = root;
+        for (const auto& import : imports) {
+            // TODO: What happens when parsing fails for an import
+            loadScene(import);
+        }
+    }
+    catch (YAML::ParserException e) {
+        //LOGE("Parsing scene config '%s'", e.what());
+        return false;
+    }
+    return true;
+}
+
+TEST_CASE( "Basic importing - property overriding", "[scene-import][core]") {
+
+    TestImporter importer;
+    auto root = importer.applySceneImports("thisCar.yaml");
+
+    REQUIRE(root["name"].Scalar() == "thisCar");
+    REQUIRE(root["type"].Scalar() == "car");
+    REQUIRE(root["category"].Scalar() == "vehicle");
+
+    // see if imports worked ... order
+    // see if texture urls are good
+    // what happens to texture urls which are common between scenes
+    //  - common names
+    //  - common urls
+}
+
+TEST_CASE( "Basic importing with absolute path scene file - property overriding", "[scene-import][core]") {
+    TestImporter importer;
+    auto root = importer.applySceneImports("/absolutePath/thisCar.yaml");
+    REQUIRE(root["name"].Scalar() == "thisCar");
+    REQUIRE(root["type"].Scalar() == "car");
+    REQUIRE(root["category"].Scalar() == "vehicle");
+}

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -15,7 +15,7 @@ public:
     TestImporter();
 
 protected:
-    virtual std::string getSceneString(const std::string& scenePath) override {
+    virtual std::string getSceneString(const std::string& scenePath, const std::string& resourceRoot) override {
         return m_testScenes[scenePath];
     }
 

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -15,7 +15,7 @@ public:
     TestImporter();
 
 protected:
-    virtual std::string getSceneString(const std::string& scenePath, const std::string& resourceRoot) override {
+    virtual std::string getSceneString(const std::string& scenePath) override {
         return m_testScenes[scenePath];
     }
 

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -39,6 +39,17 @@ TestImporter::TestImporter() {
                                     name: thisCar
                                     )END");
 
+    m_testScenes["/absolutePath/car.yaml"] = std::string(R"END(
+                                import: import/car.yaml
+                                type: car
+                                )END");
+
+    m_testScenes["/absolutePath/import/car.yaml"] = std::string(R"END(
+                                name: vehicle
+                                type: vehicle
+                                category: vehicle
+                                )END");
+
     m_testScenes["/absolutePath/thisCar.yaml"] = std::string(R"END(
                                     import: [import/car.yaml, car.yaml]
                                     name: thisCar

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -54,21 +54,21 @@ TEST_CASE("Scene update tests") {
 
     REQUIRE(SceneLoader::loadConfig(sceneString, scene.config()));
 
+    std::vector<Scene::Update> updates;
     // Update
-    scene.queueUpdate("lights.light1.ambient", "0.9");
-    scene.queueUpdate("lights.light1.type", "spotlight");
-    scene.queueUpdate("lights.light1.origin", "ground");
-    scene.queueUpdate("layers.poi_icons.draw.icons.interactive", "false");
-    scene.queueUpdate("styles.heightglow.shaders.uniforms.u_time_expand", "5.0");
-    scene.queueUpdate("cameras.iso-camera.active", "true");
-    scene.queueUpdate("cameras.iso-camera.type", "perspective");
-    scene.queueUpdate("global.default_order", "function() { return 0.0; }");
-    scene.queueUpdate("global.non_existing_property0", "true");
-    scene.queueUpdate("global.non_existing_property1.non_existing_property_deep", "true");
+    updates.push_back({"lights.light1.ambient", "0.9"});
+    updates.push_back({"lights.light1.type", "spotlight"});
+    updates.push_back({"lights.light1.origin", "ground"});
+    updates.push_back({"layers.poi_icons.draw.icons.interactive", "false"});
+    updates.push_back({"styles.heightglow.shaders.uniforms.u_time_expand", "5.0"});
+    updates.push_back({"cameras.iso-camera.active", "true"});
+    updates.push_back({"cameras.iso-camera.type", "perspective"});
+    updates.push_back({"global.default_order", "function() { return 0.0; }"});
+    updates.push_back({"global.non_existing_property0", "true"});
+    updates.push_back({"global.non_existing_property1.non_existing_property_deep", "true"});
 
     // Tangram apply scene updates, reload the scene
-    SceneLoader::applyUpdates(scene.config(), scene.updates());
-    scene.clearUpdates();
+    SceneLoader::applyUpdates(scene.config(), updates);
 
     const Node& root = scene.config();
 
@@ -86,22 +86,22 @@ TEST_CASE("Scene update tests") {
 
 TEST_CASE("Scene update tests, ensure update ordering is preserved") {
     Scene scene;
+    std::vector<Scene::Update> updates;
 
     REQUIRE(!sceneString.empty());
 
     REQUIRE(SceneLoader::loadConfig(sceneString, scene.config()));
 
     // Update
-    scene.queueUpdate("lights.light1.ambient", "0.9");
-    scene.queueUpdate("lights.light2.ambient", "0.0");
+    updates.push_back({"lights.light1.ambient", "0.9"});
+    updates.push_back({"lights.light2.ambient", "0.0"});
 
     // Delete lights
-    scene.queueUpdate("lights", "null");
-    scene.queueUpdate("lights.light2.ambient", "0.0");
+    updates.push_back({"lights", "null"});
+    updates.push_back({"lights.light2.ambient", "0.0"});
 
     // Tangram apply scene updates, reload the scene
-    SceneLoader::applyUpdates(scene.config(), scene.updates());
-    scene.clearUpdates();
+    SceneLoader::applyUpdates(scene.config(), updates);
 
     const Node& root = scene.config();
 

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -22,7 +22,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_float"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_float"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<float>());
     REQUIRE(uniformValues.value.get<float>() == 0.5);
     REQUIRE(uniformValues.type == "float");
@@ -38,12 +38,12 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_true"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_true"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 1);
     REQUIRE(uniformValues.type == "bool");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_false"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_false"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 0);
     REQUIRE(uniformValues.type == "bool");
@@ -61,20 +61,20 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec2"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec2"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec2>());
     REQUIRE(uniformValues.value.get<glm::vec2>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec2>().y == 0.2f);
     REQUIRE(uniformValues.type == "vec2");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec3"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec3"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec3>());
     REQUIRE(uniformValues.value.get<glm::vec3>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec3>().y == 0.2f);
     REQUIRE(uniformValues.value.get<glm::vec3>().z == 0.3f);
     REQUIRE(uniformValues.type == "vec3");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec4"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec4"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec4>());
     REQUIRE(uniformValues.value.get<glm::vec4>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec4>().y == 0.2f);
@@ -82,7 +82,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
     REQUIRE(uniformValues.value.get<glm::vec4>().w == 0.4f);
     REQUIRE(uniformValues.type == "vec4");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_array"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_array"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<UniformArray1f>());
     REQUIRE(uniformValues.value.get<UniformArray1f>()[0] == 0.1f);
     REQUIRE(uniformValues.value.get<UniformArray1f>()[1] == 0.2f);
@@ -101,12 +101,12 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<std::string>());
     REQUIRE(uniformValues.value.get<std::string>() == "img/cross.png");
     REQUIRE(uniformValues.type == "sampler2D");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex2"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex2"], &scene, uniformValues));
     REQUIRE(uniformValues.value.is<UniformTextureArray>());
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names.size() == 3);
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names[0] == "img/cross.png");
@@ -126,9 +126,9 @@ TEST_CASE( "Style Uniforms Parsing failure Tests: textures uniform value", "[Sty
 
     StyleUniform uniformValues;
 
-    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex"], scene, uniformValues));
-    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex2"], scene, uniformValues));
-    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float0"], scene, uniformValues));
-    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float1"], scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex"], &scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex2"], &scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float0"], &scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float1"], &scene, uniformValues));
 }
 


### PR DESCRIPTION
Fixes #714 
Fixes #723 

Is everything async yet!
Task of making scene loading asynchronously, resulted in making a bunch of other things run asyncly.

Some tasks handles in this PR:
- Scene Imports (Refer [import](https://github.com/tangrams/tangram-docs/blob/c506f7c65e676844b5418e5404c8efe9cb65157d/pages/import.md) documentation.)
- Async scene loading
- Async scene updating
- Import/Load network resources (scene files, textures, non-tiled datasource)
- Removed static `s_resourceRoot` for each platform, its now a part of each Scene been loaded. This is also required for multiple Tangram instancing.
- retains previous synchronous `sceneLoad` functionality (specifically for android). To be used with android clients. Basically it gets tricky for android platform to pass callback from android through tangram pipeline, while making sure callback executed on the initial UI thread it originated from. Which is handled gracefully by the `AsyncTask` implementation. All other platforms can use `loadSceneAsync` functionality and can also pass in callback to perform tasks post loading of the scene/map.
  - NOTE: For android, we can still use `sceneLoadAsync` (and get rid of synchronous `sceneLoad` call all together), a `callback`, to be executed post scene loading could be posted back from JNI to be run on the UI thread using `runOnUiThread` functionality on android. This can take care of running `addView(glSurfaceView)` on the UI Thread. 

    This being said, it might require some complicated JNI handshakes, and could be done later as a separate PR.

TODO:
- [x] Tangram "View Complete" logic should take async scene loading/updating into account. Basically if any scene load/update is pending it should return `false`.

Note: 
- A subsequent PR can help reduce some code here by using a generic URI handler.
- A subsequent PR can handle remote loading of font files, which in itself could be a big task. Plus we currently do not have a use for the same. (cc. @hjanetzek) 