### PR TITLE
Delete local refs to 'jstring's in JNI functions

### DIFF
--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -137,8 +137,9 @@ std::string systemFontFallbackPath(int _importance, int _weightHint) {
     JniThreadBinding jniEnv(jvm);
 
     jstring returnStr = (jstring) jniEnv->CallObjectMethod(tangramInstance, getFontFallbackFilePath, _importance, _weightHint);
-
-    return stringFromJString(jniEnv, returnStr);
+    std::string path = stringFromJString(jniEnv, returnStr);
+    jniEnv->DeleteLocalRef(returnStr);
+    return path;
 }
 
 std::string systemFontPath(const std::string& _family, const std::string& _weight, const std::string& _style) {
@@ -149,8 +150,10 @@ std::string systemFontPath(const std::string& _family, const std::string& _weigh
 
     jstring jkey = jniEnv->NewStringUTF(key.c_str());
     jstring returnStr = (jstring) jniEnv->CallObjectMethod(tangramInstance, getFontFilePath, jkey);
-
-    return stringFromJString(jniEnv, returnStr);
+    std::string path = stringFromJString(jniEnv, returnStr);
+    jniEnv->DeleteLocalRef(jkey);
+    jniEnv->DeleteLocalRef(returnStr);
+    return path;
 }
 
 void setContinuousRendering(bool _isContinuous) {


### PR DESCRIPTION
This fixes the JNI local reference table overflow described in https://github.com/mapzen/android/issues/110

There may be other places in our JNI code that temporarily leak local references, but these seem to be the only problematic cases.