### PR TITLE
Invalidate frame render state

### DIFF
--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -232,8 +232,8 @@ extern "C" {
         Tangram::setDebugFlag(static_cast<Tangram::DebugFlags>(flag), on);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeInvalidateGLStates(JNIEnv* jniEnv, jobject obj, jboolean invalidate) {
-        Tangram::invalidateGLStates(invalidate);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeUseCachedGlState(JNIEnv* jniEnv, jobject obj, jboolean use) {
+        Tangram::useCachedGlState(use);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeQueueSceneUpdate(JNIEnv* jnienv, jobject obj, jstring path, jstring value) {

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -232,6 +232,10 @@ extern "C" {
         Tangram::setDebugFlag(static_cast<Tangram::DebugFlags>(flag), on);
     }
 
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeInvalidateGLStates(JNIEnv* jniEnv, jobject obj, jboolean invalidate) {
+        Tangram::invalidateGLStates(invalidate);
+    }
+
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeQueueSceneUpdate(JNIEnv* jnienv, jobject obj, jstring path, jstring value) {
         const char* cPath = jnienv->GetStringUTFChars(path, NULL);
         const char* cValue = jnienv->GetStringUTFChars(value, NULL);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -636,13 +636,12 @@ public class MapController implements Renderer {
     }
 
     /**
-     * Whether to invalidate Open GL render state cachin between two frames.
-     * Usually Tangram would cache render state to reduce rendundant Open GL state changes.
-     * By default, invalidation is on. If you are concerned about efficiency and assume that
-     * your application doesn't modify the GL context, you can safely set invalidation to false.
+     * Set whether the OpenGL state will be cached between subsequent frames. This improves
+     * rendering efficiency, but can cause errors if your application code makes OpenGL calls.
+     * @param use Whether to use a cached OpenGL state; false by default
      */
-    public void invalidateGLStates(boolean invalidate) {
-        nativeInvalidateGLStates(invalidate);
+    public void useCachedGlState(boolean use) {
+        nativeUseCachedGlState(use);
     }
 
     // Native methods
@@ -684,7 +683,7 @@ public class MapController implements Renderer {
     private synchronized native void nativeQueueSceneUpdate(String componentPath, String value);
     private synchronized native void nativeApplySceneUpdates();
     private synchronized native void nativePickFeature(float posX, float posY, FeaturePickListener listener);
-    private synchronized native void nativeInvalidateGLStates(boolean invalidate);
+    private synchronized native void nativeUseCachedGlState(boolean use);
 
     private native void nativeOnUrlSuccess(byte[] rawDataBytes, long callbackPtr);
     private native void nativeOnUrlFailure(long callbackPtr);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -635,6 +635,16 @@ public class MapController implements Renderer {
         nativeApplySceneUpdates();
     }
 
+    /**
+     * Whether to invalidate Open GL render state cachin between two frames.
+     * Usually Tangram would cache render state to reduce rendundant Open GL state changes.
+     * By default, invalidation is on. If you are concerned about efficiency and assume that
+     * your application doesn't modify the GL context, you can safely set invalidation to false.
+     */
+    public void invalidateGLStates(boolean invalidate) {
+        nativeInvalidateGLStates(invalidate);
+    }
+
     // Native methods
     // ==============
 
@@ -674,6 +684,7 @@ public class MapController implements Renderer {
     private synchronized native void nativeQueueSceneUpdate(String componentPath, String value);
     private synchronized native void nativeApplySceneUpdates();
     private synchronized native void nativePickFeature(float posX, float posY, FeaturePickListener listener);
+    private synchronized native void nativeInvalidateGLStates(boolean invalidate);
 
     private native void nativeOnUrlSuccess(byte[] rawDataBytes, long callbackPtr);
     private native void nativeOnUrlFailure(long callbackPtr);

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -59,9 +59,8 @@ namespace RenderState {
         GL_CHECK(glBindTexture(_target, _textureId));
     }
 
-    void configure() {
+    void invalidate() {
         s_textureUnit = -1;
-        s_validGeneration++;
         VertexLayout::clearCache();
 
         blending.init(GL_FALSE);
@@ -85,6 +84,10 @@ namespace RenderState {
         texture.init(GL_TEXTURE_2D, max, false);
         texture.init(GL_TEXTURE_CUBE_MAP, max, false);
         textureUnit.init(max, false);
+    }
+
+    void increaseGeneration() {
+        s_validGeneration++;
     }
 
     bool isValidGeneration(int _generation) {

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -11,7 +11,8 @@ namespace Tangram {
 namespace RenderState {
 
     /* Configure the render states */
-    void configure();
+    void increaseGeneration();
+    void invalidate();
     /* Get the texture slot from a texture unit from 0 to TANGRAM_MAX_TEXTURE_UNIT-1 */
     GLuint getTextureUnit(GLuint _unit);
     /* Bind a vertex buffer */

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -55,7 +55,7 @@ void clearEase(EaseField _f) {
 
 static float g_time = 0.0;
 static std::bitset<8> g_flags = 0;
-static bool g_invalidateGLStates = true;
+static bool g_cacheGlState = false;
 
 
 void initialize(const char* _scenePath) {
@@ -244,7 +244,7 @@ void render() {
     FrameInfo::beginFrame();
 
     // Invalidate render states for new frame
-    if (g_invalidateGLStates) {
+    if (!g_cacheGlState) {
         RenderState::invalidate();
     }
 
@@ -541,8 +541,8 @@ const std::vector<TouchItem>& pickFeaturesAt(float _x, float _y) {
                                         _x, _y);
 }
 
-void invalidateGLStates(bool _invalidate) {
-    g_invalidateGLStates = _invalidate;
+void useCachedGlState(bool _useCache) {
+    g_cacheGlState = _useCache;
 }
 
 void setupGL() {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -3,7 +3,6 @@
 #include "platform.h"
 #include "scene/scene.h"
 #include "scene/sceneLoader.h"
-#include "scene/skybox.h"
 #include "style/material.h"
 #include "style/style.h"
 #include "labels/labels.h"
@@ -41,7 +40,6 @@ std::unique_ptr<TileManager> m_tileManager;
 std::shared_ptr<Scene> m_scene;
 std::shared_ptr<View> m_view;
 std::unique_ptr<Labels> m_labels;
-std::unique_ptr<Skybox> m_skybox;
 std::unique_ptr<InputHandler> m_inputHandler;
 
 std::array<Ease, 4> m_eases;
@@ -57,6 +55,7 @@ void clearEase(EaseField _f) {
 
 static float g_time = 0.0;
 static std::bitset<8> g_flags = 0;
+static bool g_invalidateGLStates = true;
 
 
 void initialize(const char* _scenePath) {
@@ -242,8 +241,12 @@ bool update(float _dt) {
 }
 
 void render() {
-
     FrameInfo::beginFrame();
+
+    // Invalidate render states for new frame
+    if (g_invalidateGLStates) {
+        RenderState::invalidate();
+    }
 
     // Set up openGL for new frame
     RenderState::depthWrite(GL_TRUE);
@@ -538,6 +541,10 @@ const std::vector<TouchItem>& pickFeaturesAt(float _x, float _y) {
                                         _x, _y);
 }
 
+void invalidateGLStates(bool _invalidate) {
+    g_invalidateGLStates = _invalidate;
+}
+
 void setupGL() {
 
     LOG("setup GL");
@@ -549,7 +556,8 @@ void setupGL() {
     // Reconfigure the render states. Increases context 'generation'.
     // The OpenGL context has been destroyed since the last time resources were
     // created, so we invalidate all data that depends on OpenGL object handles.
-    RenderState::configure();
+    RenderState::invalidate();
+    RenderState::increaseGeneration();
 
     // Set default primitive render color
     Primitives::setColor(0xffffff);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -129,6 +129,9 @@ void handleRotateGesture(float _posX, float _posY, float _rotation);
 // Respond to a two-finger shove with the given distance in screen coordinates
 void handleShoveGesture(float _distance);
 
+// Whether to cache gl render states
+void invalidateGLStates(bool _invalidate);
+
 enum DebugFlags {
     freeze_tiles = 0,   // While on, the set of tiles currently being drawn will not update to match the view
     proxy_colors,       // Applies a color change to every other zoom level of tiles to visualize proxy tile behavior

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -129,8 +129,9 @@ void handleRotateGesture(float _posX, float _posY, float _rotation);
 // Respond to a two-finger shove with the given distance in screen coordinates
 void handleShoveGesture(float _distance);
 
-// Whether to cache gl render states
-void invalidateGLStates(bool _invalidate);
+// Set whether the OpenGL state will be cached between subsequent frames; this improves rendering
+// efficiency, but can cause errors if your application code makes OpenGL calls (false by default)
+void useCachedGlState(bool _use);
 
 enum DebugFlags {
     freeze_tiles = 0,   // While on, the set of tiles currently being drawn will not update to match the view


### PR DESCRIPTION
Add an API call to be able to invalidate render state on a frame basis. By default invalidation is on. If that proves to be an inefficient default, we can change it to false (as discussed with @blair1618 and @tallytalwar) 

A quick stress test shows render state changes can have a big impact: 

**render state on**
<img width="1552" alt="screen shot 2016-06-10 at 11 44 48 am" src="https://cloud.githubusercontent.com/assets/7061573/15979402/cc548afc-2f31-11e6-8364-faa4f600e14d.png">
**render state off**
<img width="1552" alt="screen shot 2016-06-10 at 11 44 17 am" src="https://cloud.githubusercontent.com/assets/7061573/15979409/d0c9dc9a-2f31-11e6-924a-f78e595e2239.png">

Even if this invalidation would involve small redundant call between frames, we should test this carefully on device.

