### PR TITLE
Set client data sources to always be geometry-generating sources

### DIFF
--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -31,6 +31,7 @@ Point transformPoint(geojsonvt::TilePoint pt) {
 ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom)
     : DataSource(_name, _url, _maxZoom) {
 
+    m_generateGeometry = true;
     if (!_url.empty()) {
         // Load from file
         const auto& string = stringFromFile(_url.c_str(), PathType::resource);


### PR DESCRIPTION
Fixes an issue where client data sources were incorrectly removed when the scene is updated or reloaded.