### PR TITLE
Re-add direct setter and getter for camera type

### DIFF
--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -95,6 +95,14 @@ extern "C" {
         Tangram::setPixelScale(scale);
     }
 
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetCameraType(JNIEnv* jniEnv, jobject obj, jint type) {
+        Tangram::setCameraType(type);
+    }
+
+    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeGetCameraType(JNIEnv* jniEnv, jobject obj) {
+        return Tangram::getCameraType();
+    }
+
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleTapGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
         Tangram::handleTapGesture(posX, posY);
     }

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -37,6 +37,15 @@ public class MapController implements Renderer {
         SINE,
     }
 
+    /**
+     * Options for changing the appearance of 3D geometry
+     */
+    public enum CameraType {
+        PERSPECTIVE,
+        ISOMETRIC,
+        FLAT,
+    }
+
     protected static EaseType DEFAULT_EASE_TYPE = EaseType.CUBIC;
 
     /**
@@ -350,6 +359,22 @@ public class MapController implements Renderer {
     }
 
     /**
+     * Set the camera type for the map view
+     * @param type A {@code CameraType}
+     */
+    public void setCameraType(CameraType type) {
+        nativeSetCameraType(type.ordinal());
+    }
+
+    /**
+     * Get the camera type currently in use for the map view
+     * @return A {@code CameraType}
+     */
+    public CameraType getCameraType() {
+        return CameraType.values()[nativeGetCameraType()];
+    }
+
+    /**
      * Find the geographic coordinates corresponding to the given position on screen
      * @param screenX Pixels from the left edge of the screen
      * @param screenY Pixels from the top edge of the screen
@@ -636,6 +661,8 @@ public class MapController implements Renderer {
     private synchronized native float nativeGetTilt();
     private synchronized native void nativeScreenToWorldCoordinates(double[] screenCoords);
     private synchronized native void nativeSetPixelScale(float scale);
+    private synchronized native void nativeSetCameraType(int type);
+    private synchronized native int nativeGetCameraType();
     private synchronized native void nativeHandleTapGesture(float posX, float posY);
     private synchronized native void nativeHandleDoubleTapGesture(float posX, float posY);
     private synchronized native void nativeHandlePanGesture(float startX, float startY, float endX, float endY);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -423,6 +423,19 @@ void setPixelScale(float _pixelsPerPoint) {
     }
 }
 
+void setCameraType(int _type) {
+
+    m_view->setCameraType(static_cast<CameraType>(_type));
+    requestRender();
+
+}
+
+int getCameraType() {
+
+    return static_cast<int>(m_view->cameraType());
+
+}
+
 void addDataSource(std::shared_ptr<DataSource> _source) {
     if (!m_tileManager) { return; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -91,6 +91,12 @@ void screenToWorldCoordinates(double& _x, double& _y);
 // Set the ratio of hardware pixels to logical pixels (defaults to 1.0)
 void setPixelScale(float _pixelsPerPoint);
 
+// Set the camera type (0 = perspective, 1 = isometric, 2 = flat)
+void setCameraType(int _type);
+
+// Get the camera type (0 = perspective, 1 = isometric, 2 = flat)
+int getCameraType();
+
 // Add a data source for adding drawable map data, which will be styled
 // according to the scene file using the provided data source name;
 void addDataSource(std::shared_ptr<DataSource> _source);

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -59,9 +59,11 @@ void View::setPixelScale(float _pixelsPerPoint) {
 }
 
 void View::setCameraType(CameraType _type) {
+
     m_type = _type;
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
+
 }
 
 void View::setSize(int _width, int _height) {


### PR DESCRIPTION
We had this feature before, and removed it in favor of using a "scene update" to change the camera type. While technically sufficient and correct, the "scene update" approach is much more cumbersome than a direct setter! Of course we can't add direct setters for every part of the scene, but since we provide direct control over every other aspect of the view (zoom, position, tilt, etc.) it seems reasonable that the camera type should be just as easy to access and modify. 