### PR TITLE
Make version name and version code available from BuildConfig

### DIFF
--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -25,6 +25,7 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 23
+    versionName VERSION_NAME
   }
 
   sourceSets.main {

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -11,6 +11,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 group = GROUP
 version = VERSION_NAME
 
+apply from: 'versioning.gradle'
+
 android {
   compileSdkVersion 23
 
@@ -25,6 +27,7 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 23
+    versionCode buildVersionCode()
     versionName VERSION_NAME
   }
 

--- a/android/tangram/versioning.gradle
+++ b/android/tangram/versioning.gradle
@@ -1,0 +1,36 @@
+ext {
+  /**
+   * Builds an Android version code from the version of the project.
+   * This is designed to handle the -SNAPSHOT and -RC format.
+   *
+   * I.e. during development the version ends with -SNAPSHOT. As the code stabilizes and release nears
+   * one or many Release Candidates are tagged. These all end with "-RC1", "-RC2" etc.
+   * And the final release is without any suffix.
+   *
+   * http://www.jayway.com/2015/03/11/automatic-versioncode-generation-in-android-gradle/
+   */
+  buildVersionCode = {
+    //The rules is as follows:
+    //-SNAPSHOT counts as 0
+    //-RC* counts as the RC number, i.e. 1 to 98
+    //final release counts as 99.
+    //Thus you can only have 98 Release Candidates, which ought to be enough for everyone
+
+    def candidate = "99"
+    def (major, minor, patch) = VERSION_NAME.toLowerCase().replaceAll('-', '').tokenize('.')
+    if (patch.endsWith("snapshot")) {
+      candidate = "0"
+      patch = patch.replaceAll("[^0-9]","")
+    } else {
+      def rc
+      (patch, rc) = patch.tokenize("rc")
+      if (rc) {
+        candidate = rc
+      }
+    }
+
+    (major, minor, patch, candidate) = [major, minor, patch, candidate].collect{it.toInteger()}
+
+    (major * 1000000) + (minor * 10000) + (patch * 100) + candidate;
+  }
+}


### PR DESCRIPTION
The Gradle plugin generates a class called BuildConfig at compile time, we can use it to access values determined at build time like the version name and version code:

```java
// Print the version of tangram in use.
Log.d(com.mapzen.tangram.BuildConfig.VERSION_NAME);
```

The version name is probably more useful than the version code, but version code seems to be used sometimes as well, so I [stole the script used in Eraser Map](https://github.com/mapzen/eraser-map/blob/master/versioning.gradle) to generate version codes automatically :)

Closes #795 