### PR TITLE
Texture: fix destruction and uninitialized member access

### DIFF
--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -86,9 +86,6 @@ std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _r
 
     auto texture = std::make_shared<Texture>(udata, dataSize, m_texOptions, m_genMipmap, true);
 
-    if (!texture->hasValidData() && dataSize > 0) {
-        LOGE("Texture for data source %s has failed to decode", m_name.c_str());
-    }
     return texture;
 }
 

--- a/core/src/gl/mesh.cpp
+++ b/core/src/gl/mesh.cpp
@@ -37,17 +37,21 @@ MeshBase::~MeshBase() {
     // Deleting a index/array buffer being used ends up setting up the current vertex/index buffer to 0
     // after the driver finishes using it, force the render state to be 0 for vertex/index buffer
 
-    if (m_glVertexBuffer) {
-        if (RenderState::vertexBuffer.compare(m_glVertexBuffer)) {
-            RenderState::vertexBuffer.init(0, false);
+    if (RenderState::isValidGeneration(m_generation)) {
+        if (m_glVertexBuffer) {
+            if (RenderState::vertexBuffer.compare(m_glVertexBuffer)) {
+                RenderState::vertexBuffer.init(0, false);
+            }
+            GL_CHECK(glDeleteBuffers(1, &m_glVertexBuffer));
         }
-        GL_CHECK(glDeleteBuffers(1, &m_glVertexBuffer));
-    }
-    if (m_glIndexBuffer) {
-        if (RenderState::indexBuffer.compare(m_glIndexBuffer)) {
-            RenderState::indexBuffer.init(0, false);
+        if (m_glIndexBuffer) {
+            if (RenderState::indexBuffer.compare(m_glIndexBuffer)) {
+                RenderState::indexBuffer.init(0, false);
+            }
+            GL_CHECK(glDeleteBuffers(1, &m_glIndexBuffer));
         }
-        GL_CHECK(glDeleteBuffers(1, &m_glIndexBuffer));
+    } else {
+        if (m_vaos) { m_vaos->discard(); }
     }
 
     if (m_glVertexData) {

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -25,18 +25,19 @@ ShaderProgram::ShaderProgram() {
 
 ShaderProgram::~ShaderProgram() {
 
-    if (m_glProgram != 0) {
-        GL_CHECK(glDeleteProgram(m_glProgram));
-    }
+    if (RenderState::isValidGeneration(m_generation)) {
+        if (m_glProgram != 0) {
+            GL_CHECK(glDeleteProgram(m_glProgram));
+        }
 
-    if (m_glFragmentShader != 0) {
-        GL_CHECK(glDeleteShader(m_glFragmentShader));
-    }
+        if (m_glFragmentShader != 0) {
+            GL_CHECK(glDeleteShader(m_glFragmentShader));
+        }
 
-    if (m_glVertexShader != 0) {
-        GL_CHECK(glDeleteShader(m_glVertexShader));
+        if (m_glVertexShader != 0) {
+            GL_CHECK(glDeleteShader(m_glVertexShader));
+        }
     }
-
     // Deleting a shader program being used ends up setting up the current shader program to 0
     // after the driver finishes using it, force this setup by setting the current program
     if (RenderState::shaderProgram.compare(m_glProgram)) {

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -20,6 +20,7 @@ Texture::Texture(unsigned int _width, unsigned int _height, TextureOptions _opti
     m_shouldResize = false;
     m_target = GL_TEXTURE_2D;
     m_generation = -1;
+    m_validData = true;
 
     resize(_width, _height);
 }
@@ -83,18 +84,7 @@ void Texture::loadImageFromMemory(const unsigned char* blob, unsigned int size, 
 }
 
 Texture::Texture(Texture&& _other) {
-    m_glHandle = _other.m_glHandle;
-    _other.m_glHandle = 0;
-
-    m_options = _other.m_options;
-    m_data = std::move(_other.m_data);
-    m_dirtyRanges = std::move(_other.m_dirtyRanges);
-    m_shouldResize = _other.m_shouldResize;
-    m_width = _other.m_width;
-    m_height = _other.m_height;
-    m_target = _other.m_target;
-    m_generation = _other.m_generation;
-    m_generateMipmaps = _other.m_generateMipmaps;
+    *this = std::move(_other);
 }
 
 Texture& Texture::operator=(Texture&& _other) {
@@ -110,6 +100,7 @@ Texture& Texture::operator=(Texture&& _other) {
     m_target = _other.m_target;
     m_generation = _other.m_generation;
     m_generateMipmaps = _other.m_generateMipmaps;
+    m_validData = _other.m_validData;
 
     return *this;
 }

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -103,14 +103,18 @@ Texture& Texture::operator=(Texture&& _other) {
 
 Texture::~Texture() {
     if (m_glHandle) {
-        Tangram::runOnMainLoop([id = m_glHandle]() { GL_CHECK(glDeleteTextures(1, &id)); });
+        Tangram::runOnMainLoop([id = m_glHandle, t = m_target, g = m_generation]() {
+                if (RenderState::isValidGeneration(g)) {
+                    GL_CHECK(glDeleteTextures(1, &id));
 
-        // if the texture is bound, and deleted, the binding defaults to 0
-        // according to the OpenGL spec, in this case we need to force the
-        // currently bound texture to 0 in the render states
-        if (RenderState::texture.compare(m_target, m_glHandle)) {
-            RenderState::texture.init(m_target, 0, false);
-        }
+                    // if the texture is bound, and deleted, the binding defaults to 0
+                    // according to the OpenGL spec, in this case we need to force the
+                    // currently bound texture to 0 in the render states
+                    if (RenderState::texture.compare(t, id)) {
+                        RenderState::texture.init(t, 0, false);
+                    }
+                }
+        });
     }
 }
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -82,16 +82,13 @@ public:
     /* Checks whether the texture has valid data and has been successfully uploaded to GPU */
     bool isValid() const;
 
-    /* Checks whether the texture has a valid data to upload to GPU */
-    bool hasValidData() const;
-
     typedef std::pair<GLuint, GLuint> TextureSlot;
 
     static void invalidateAllTextures();
 
     static bool isRepeatWrapping(TextureWrapping _wrapping);
 
-    void loadImageFromMemory(const unsigned char* blob, unsigned int size, bool flipOnLoad);
+    bool loadImageFromMemory(const unsigned char* blob, unsigned int size, bool flipOnLoad);
 
 protected:
 
@@ -122,7 +119,6 @@ private:
     size_t bytesPerPixel();
 
     bool m_generateMipmaps;
-    bool m_validData;
 };
 
 }

--- a/core/src/gl/vao.cpp
+++ b/core/src/gl/vao.cpp
@@ -64,5 +64,10 @@ void Vao::unbind() {
     GL_CHECK(glBindVertexArray(0));
 }
 
+void Vao::discard() {
+    delete[] m_glVAOs;
+    m_glVAOs = nullptr;
+}
+
 }
 

--- a/core/src/gl/vao.h
+++ b/core/src/gl/vao.h
@@ -20,6 +20,7 @@ public:
 
     void bind(unsigned int _index);
     void unbind();
+    void discard();
 
 private:
     GLuint* m_glVAOs;


### PR DESCRIPTION
if m_validData was accidental 0 font atlas were constantly re-uploaded