### PR TITLE
[rfc] simplify resources root handling

### DIFF
--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -229,10 +229,10 @@ unsigned char* bytesFromFileSystem(const char* _path, size_t& _size) {
 
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length, _type);
+    unsigned char* bytes = bytesFromFile(_path, length);
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
 
@@ -240,7 +240,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
 
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
     size_t len = strlen(_path);
 

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -252,7 +252,7 @@ unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
         } else {
             // For unclear reasons, the AAssetManager will fail to open a file at
             // path "filepath" if the path is instead given as "./filepath"
-            if (len >= 2 && _path[0] == '.' && _path[1] = '/') { _path += 2; }
+            if (len >= 2 && (_path[0] == '.') && (_path[1] == '/')) { _path += 2; }
 
             return bytesFromAssetManager(_path, _size);
         }

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -39,8 +39,7 @@ struct TestContext {
 
     void loadScene(const char* sceneFile) {
         scene = std::make_shared<Scene>(sceneFile);
-        auto sceneRelPath = setResourceRoot(sceneFile, scene->resourceRoot());
-        auto sceneString = stringFromFile(sceneRelPath.c_str(), PathType::resource, "");
+        auto sceneString = stringFromFile(sceneFile);
 
         YAML::Node sceneNode;
 

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -32,13 +32,13 @@ Point transformPoint(geojsonvt::TilePoint pt) {
 }
 
 // TODO: pass scene's resourcePath to constructor to be used with `stringFromFile`
-ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url,
-        const std::string& _resourceRoot, int32_t _maxZoom)
+ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom)
     : DataSource(_name, _url, _maxZoom) {
 
     // TODO: handle network url for client datasource data
     // TODO: generic uri handling
     m_generateGeometry = true;
+
     if (!_url.empty()) {
         std::regex r("^(http|https):/");
         std::smatch match;
@@ -51,7 +51,7 @@ ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::st
                     });
         } else {
             // Load from file
-            const auto& string = stringFromFile(_url.c_str(), PathType::resource, _resourceRoot.c_str());
+            const auto& string = stringFromFile(_url.c_str());
             addData(string);
         }
     }

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -23,8 +23,7 @@ class ClientGeoJsonSource : public DataSource {
 
 public:
 
-    ClientGeoJsonSource(const std::string& _name, const std::string& _url, const std::string& _resourceRoot = "",
-            int32_t _maxZoom = 18);
+    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -58,8 +58,6 @@ bool Texture::loadImageFromMemory(const unsigned char* blob, unsigned int size, 
 
     setData(&blackPixel, 1);
 
-    LOGE("Decoding image from memory failed");
-
     return false;
 }
 

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -9,16 +9,16 @@
 
 namespace Tangram {
 
-TextureCube::TextureCube(std::string _file, const std::string& _resourcePath,
-        TextureOptions _options) : Texture(0u, 0u, _options) {
+TextureCube::TextureCube(std::string _file, TextureOptions _options)
+    : Texture(0u, 0u, _options) {
 
     m_target = GL_TEXTURE_CUBE_MAP;
-    load(_file, _resourcePath);
+    load(_file);
 }
 
-void TextureCube::load(const std::string& _file, const std::string& _resourcePath) {
-    unsigned int size;
-    unsigned char* data = bytesFromFile(_file.c_str(), PathType::resource, &size, _resourcePath.c_str());
+void TextureCube::load(const std::string& _file) {
+    size_t size;
+    unsigned char* data = bytesFromFile(_file.c_str(), size);
     unsigned char* pixels;
     int width, height, comp;
 

--- a/core/src/gl/textureCube.h
+++ b/core/src/gl/textureCube.h
@@ -11,7 +11,7 @@ namespace Tangram {
 class TextureCube : public Texture {
 
 public:
-    TextureCube(std::string _file, const std::string& _resourceName = "",
+    TextureCube(std::string _file,
             TextureOptions _options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}});
 
     void update(GLuint _textureUnit) override;
@@ -39,7 +39,7 @@ private:
 
     std::vector<Face> m_faces;
 
-    void load(const std::string& _file, const std::string& _resourcePath);
+    void load(const std::string& _filePath);
 
 };
 

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -30,26 +30,20 @@ bool isContinuousRendering();
 /* get system path of a font file */
 std::string systemFontPath(const std::string& _name, const std::string& _weight, const std::string& _face);
 
-enum class PathType : char {
-    absolute, // resolved relative to the filesystem root
-    internal, // resolved relative to the application storage directory
-    resource, // resolved relative to the resource root
-};
-
 /* Read a file as a string
  *
- * Opens the file at the _path, resolved with _type, and returns a string with its contents.
+ * Opens the file at the _path and returns a string with its contents.
  * If the file cannot be found or read, the returned string is empty.
  */
-std::string stringFromFile(const char* _path, PathType _type = PathType::absolute);
+std::string stringFromFile(const char* _path);
 
 /* Read a file into memory
  *
- * Opens the file at _path, resolved with _type, then allocates and returns a pointer to memory
+ * Opens the file at _path then allocates and returns a pointer to memory
  * containing the contents of the file. The size of the memory in bytes is written to _size.
  * If the file cannot be read, nothing is allocated and nullptr is returned.
  */
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type = PathType::absolute);
+unsigned char* bytesFromFile(const char* _path, size_t& _size);
 
 /* Function type for receiving data from a successful network request */
 using UrlCallback = std::function<void(std::vector<char>&&)>;

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -36,16 +36,12 @@ enum class PathType : char {
     resource, // resolved relative to the resource root
 };
 
-/* Set a path to act as the resource root. All other resource paths will be resolved relative to this root.
- * The string returned is the path to the given file relative to the new root resource directory. */
-std::string setResourceRoot(const char* _path, std::string& resourceRoot);
-
 /* Read a file as a string
  *
  * Opens the file at the _path, resolved with _type, and returns a string with its contents.
  * If the file cannot be found or read, the returned string is empty.
  */
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot = nullptr);
+std::string stringFromFile(const char* _path, PathType _type = PathType::absolute);
 
 /* Read a file into memory
  *
@@ -53,7 +49,7 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
  * containing the contents of the file. The size of the memory in bytes is written to _size.
  * If the file cannot be read, nothing is allocated and nullptr is returned.
  */
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot = nullptr);
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type = PathType::absolute);
 
 /* Function type for receiving data from a successful network request */
 using UrlCallback = std::function<void(std::vector<char>&&)>;

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -75,7 +75,7 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
             });
         } else {
             std::unique_lock<std::mutex> lock(sceneMutex);
-            processScene(path, getSceneString(path, ""));
+            processScene(path, getSceneString(path));
         }
     }
 
@@ -241,7 +241,7 @@ void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath)
     }
 }
 
-std::string Importer::getSceneString(const std::string &scenePath, const std::string& resourceRoot) {
+std::string Importer::getSceneString(const std::string &scenePath) {
     return stringFromFile(scenePath.c_str());
 }
 

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -86,7 +86,7 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
 
 void Importer::processScene(const std::string &scenePath, const std::string &sceneString) {
 
-    LOG("Process: '%s'", scenePath.c_str());
+    LOGD("Process: '%s'", scenePath.c_str());
 
     try {
         auto sceneNode = YAML::Load(sceneString);
@@ -120,7 +120,7 @@ std::string Importer::normalizePath(const std::string &_path,
         path = std::regex_replace(_parentPath, r, _path);
     }
 
-    LOG("Normalize '%s', '%s' => '%s'", _parentPath.c_str(), _path.c_str(), path.c_str());
+    LOGD("Normalize '%s', '%s' => '%s'", _parentPath.c_str(), _path.c_str(), path.c_str());
 
     return path;
 }

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -22,8 +22,9 @@ bool isUrl(const std::string &path) {
 Node Importer::applySceneImports(const std::string& scenePath, const std::string& resourceRoot) {
 
     std::string path;
+    std::string fullPath = resourceRoot + scenePath;
 
-    m_sceneQueue.push_back(resourceRoot + scenePath);
+    m_sceneQueue.push_back(fullPath);
 
     while (true) {
         {
@@ -70,13 +71,11 @@ Node Importer::applySceneImports(const std::string& scenePath, const std::string
             });
         } else {
             std::unique_lock<std::mutex> lock(sceneMutex);
-            auto sceneString = stringFromFile(path.c_str());
-
-            processScene(path, sceneString);
+            processScene(path, getSceneString(path, ""));
         }
     }
 
-    auto root = importScenes(scenePath);
+    auto root = importScenes(fullPath);
 
     return root;
 }
@@ -232,12 +231,7 @@ void Importer::normalizeSceneTextures(Node& root, const std::string& parentPath)
 }
 
 std::string Importer::getSceneString(const std::string &scenePath, const std::string& resourceRoot) {
-
-    if (scenePath[0] == '/') {
-        return stringFromFile(scenePath.c_str());
-    }
-
-    return stringFromFile((resourceRoot + scenePath).c_str());
+    return stringFromFile(scenePath.c_str());
 }
 
 std::vector<std::string> Importer::getScenesToImport(const Node& scene) {
@@ -284,9 +278,7 @@ Node Importer::importScenes(const std::string& scenePath) {
     auto importScenesSorted = getImportOrder(scenePath);
 
     if (importScenesSorted.size() == 1) {
-        auto import = importScenesSorted[0];
-
-        return m_scenes[import];
+        return m_scenes[importScenesSorted[0]];
     }
 
     Node root = Node();

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -29,7 +29,7 @@ public:
 
 // protected for testing purposes, else could be private
 protected:
-    virtual std::string getSceneString(const std::string& scenePath, const std::string& resourceRoot);
+    virtual std::string getSceneString(const std::string& scenePath);
     void processScene(const std::string& scenePath, const std::string& sceneString);
 
     // Get the sequence of scene names that are designated to be imported into the

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -47,7 +47,6 @@ protected:
     //void mergeMapFieldsTaskingLast(const std::string& key, Node target, const std::vector<Node>& imports);
     void mergeMapFields(Node& target, const Node& import);
 
-    std::string getFilename(const std::string& scenePath);
     void normalizeSceneTextures(Node& root, const std::string& parentPath);
     void setNormalizedTexture(Node& texture, const std::vector<std::string>& names,
             const std::string& parentPath);

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -45,7 +45,7 @@ Scene::Scene(const std::string& _path)
         }
     }
 
-    LOG("Scene '%s' => '%s' : '%s'", _path.c_str(), m_resourceRoot.c_str(), m_path.c_str());
+    LOGD("Scene '%s' => '%s' : '%s'", _path.c_str(), m_resourceRoot.c_str(), m_path.c_str());
 
     m_fontContext->setSceneResourceRoot(m_resourceRoot);
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -39,7 +39,7 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static bool loadScene(const std::string& _scenePath, std::shared_ptr<Scene> _scene);
+    static bool loadScene(std::shared_ptr<Scene> _scene);
     static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, Scene& scene);
     static void applyUpdates(Node& root, const std::vector<Scene::Update>& updates);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -158,12 +158,9 @@ void loadScene(const char* _scenePath, bool _useScenePosition) {
 
     // Copy old scene
     auto scene = std::make_shared<Scene>(_scenePath);
-
-    auto scenePath = setResourceRoot(_scenePath, scene->resourceRoot());
     scene->useScenePosition = _useScenePosition;
-    scene->fontContext()->setSceneResourceRoot(scene->resourceRoot());
 
-    if (SceneLoader::loadScene(scenePath, scene)) {
+    if (SceneLoader::loadScene(scene)) {
         setScene(scene);
     }
 }
@@ -180,10 +177,7 @@ void loadSceneAsync(const char* _scenePath, bool _useScenePosition, MapReady _pl
 
     Tangram::runAsyncTask([scene = m_nextScene, _platformCallback](){
 
-            auto scenePath = setResourceRoot(scene->path().c_str(), scene->resourceRoot());
-            scene->fontContext()->setSceneResourceRoot(scene->resourceRoot());
-
-            bool ok = SceneLoader::loadScene(scenePath, scene);
+            bool ok = SceneLoader::loadScene(scene);
 
             Tangram::runOnMainLoop([scene, ok, _platformCallback]() {
                     {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -64,9 +64,8 @@ FontContext::FontContext() :
 
     int size = BASE_SIZE;
     auto loadFonts = [&](const char* path) {
-        unsigned int dataSize;
-        char* data = reinterpret_cast<char*>(bytesFromFile(path, PathType::resource, &dataSize,
-                    m_sceneResourceRoot.c_str()));
+        size_t dataSize;
+        char* data = reinterpret_cast<char*>(bytesFromFile(path, dataSize));
         if (data) {
             for (int i = 0; i < 3; i++, size += STEP_SIZE) {
                 m_font[i] = m_alfons.addFont("default", alfons::InputSource(data, dataSize), size);
@@ -75,9 +74,8 @@ FontContext::FontContext() :
         }
     };
     auto addFaces = [&](const char* path) {
-        unsigned int dataSize;
-        char* data = reinterpret_cast<char*>(bytesFromFile(path, PathType::resource, &dataSize,
-                    m_sceneResourceRoot.c_str()));
+        size_t dataSize;
+        char* data = reinterpret_cast<char*>(bytesFromFile(path, dataSize));
         if (data) {
             for (int i = 0; i < 3; i++, size += STEP_SIZE) {
                     m_font[i]->addFace(m_alfons.addFontFace(alfons::InputSource(data, dataSize), size));
@@ -285,21 +283,32 @@ auto FontContext::getFont(const std::string& _family, const std::string& _style,
     auto font = m_alfons.getFont(fontName, fontSize);
     if (font->hasFaces()) { return font; }
 
-    unsigned int dataSize = 0;
+    size_t dataSize = 0;
     unsigned char* data = nullptr;
 
     // Assuming bundled ttf file follows this convention
     auto bundledFontPath = "fonts/" + _family + "-" + _weight + _style + ".ttf";
-    if (!(data = bytesFromFile(bundledFontPath.c_str(), PathType::resource, &dataSize, m_sceneResourceRoot.c_str())) &&
-        !(data = bytesFromFile(bundledFontPath.c_str(), PathType::internal, &dataSize, m_sceneResourceRoot.c_str()))) {
-        const std::string sysFontPath = systemFontPath(_family, _weight, _style);
-        if (!(data = bytesFromFile(sysFontPath.c_str(), PathType::absolute, &dataSize, m_sceneResourceRoot.c_str())) ) {
 
-            LOGE("Could not load font file %s", fontName.c_str());
-            // add fallbacks from default font
-            font->addFaces(*m_font[sizeIndex]);
-            return font;
+    do {
+        if (!m_sceneResourceRoot.empty()) {
+            auto resourceFontPath = m_sceneResourceRoot + bundledFontPath;
+            data = bytesFromFile(resourceFontPath.c_str(), dataSize);
+            if (data) { break; }
         }
+
+        data = bytesFromFile(bundledFontPath.c_str(), dataSize);
+        if (data) { break; }
+
+        auto sysFontPath = systemFontPath(_family, _weight, _style);
+        data = bytesFromFile(sysFontPath.c_str(), dataSize);
+
+    } while(0);
+
+    if (!data) {
+        LOGE("Could not load font file %s", fontName.c_str());
+        // add fallbacks from default font
+        font->addFaces(*m_font[sizeIndex]);
+        return font;
     }
 
     font->addFace(m_alfons.addFontFace(alfons::InputSource(reinterpret_cast<char*>(data), dataSize), fontSize));

--- a/core/src/util/base64.h
+++ b/core/src/util/base64.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// public domain from https://en.wikibooks.org/wiki/Algorithm_Implementation
+
+#include <string>
+#include <vector>
+
+struct Base64 {
+
+static bool checkPrefix(const std::string &path) {
+    return path.substr(0, 22) == "data:image/png;base64,";
+}
+
+static void stripPrefix(std::string &data) {
+    data.erase(0, 22);
+}
+
+const static char padCharacter = ('=');
+
+static std::vector<unsigned char> decode(const std::string& input) {
+    if (input.length() % 4) // Sanity check
+        throw std::runtime_error("Non-Valid base64!");
+    size_t padding = 0;
+    if (input.length()) {
+        if (input[input.length() - 1] == padCharacter) padding++;
+        if (input[input.length() - 2] == padCharacter) padding++;
+    }
+    // Setup a vector to hold the result
+    std::vector<unsigned char> decodedBytes;
+    decodedBytes.reserve(((input.length() / 4) * 3) - padding);
+    uint32_t temp = 0; // Holds decoded quanta
+    std::string::const_iterator cursor = input.begin();
+    while (cursor < input.end()) {
+        for (size_t quantumPosition = 0; quantumPosition < 4; quantumPosition++) {
+            temp <<= 6;
+            if (*cursor >= 0x41 && *cursor <= 0x5A) // This area will need tweaking if
+                temp |= *cursor - 0x41;             // you are using an alternate alphabet
+            else if (*cursor >= 0x61 && *cursor <= 0x7A)
+                temp |= *cursor - 0x47;
+            else if (*cursor >= 0x30 && *cursor <= 0x39)
+                temp |= *cursor + 0x04;
+            else if (*cursor == 0x2B)
+                temp |= 0x3E; // change to 0x2D for URL alphabet
+            else if (*cursor == 0x2F)
+                temp |= 0x3F;                 // change to 0x5F for URL alphabet
+            else if (*cursor == padCharacter) // pad
+            {
+                switch (input.end() - cursor) {
+                case 1: // One pad character
+                    decodedBytes.push_back((temp >> 16) & 0x000000FF);
+                    decodedBytes.push_back((temp >> 8) & 0x000000FF);
+                    return decodedBytes;
+                case 2: // Two pad characters
+                    decodedBytes.push_back((temp >> 10) & 0x000000FF);
+                    return decodedBytes;
+                default: throw std::runtime_error("Invalid Padding in Base 64!");
+                }
+            } else
+                throw std::runtime_error("Non-Valid Character in Base 64!");
+            cursor++;
+        }
+        decodedBytes.push_back((temp >> 16) & 0x000000FF);
+        decodedBytes.push_back((temp >> 8) & 0x000000FF);
+        decodedBytes.push_back((temp)&0x000000FF);
+    }
+    return decodedBytes;
+}
+};

--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -58,7 +58,7 @@ bool isContinuousRendering() {
 
 }
 
-NSString* resolvePath(const char* _path, PathType _type) {
+NSString* resolvePath(const char* _path) {
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
@@ -68,9 +68,9 @@ NSString* resolvePath(const char* _path, PathType _type) {
     return [resources stringByAppendingPathComponent:path];
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path);
     NSString* str = [NSString stringWithContentsOfFile:path
                                           usedEncoding:NULL
                                                  error:NULL];
@@ -83,9 +83,9 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return std::string([str UTF8String]);
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path);
     NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
     if (data == nil) {

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -335,10 +335,10 @@ int main(int argc, char* argv[]) {
     }
 
     struct stat sb;
-    if (stat(sceneFile.c_str(), &sb) == -1) {
-        logMsg("scene file not found!");
-        exit(EXIT_FAILURE);
-    }
+    //if (stat(sceneFile.c_str(), &sb) == -1) {
+        //logMsg("scene file not found!");
+        //exit(EXIT_FAILURE);
+    //}
     auto last_mod = sb.st_mtime;
 
     init_main_window(false);
@@ -384,12 +384,12 @@ int main(int argc, char* argv[]) {
         }
 
         if (scene_editing_mode) {
-            if (stat(sceneFile.c_str(), &sb) == 0) {
+            //if (stat(sceneFile.c_str(), &sb) == 0) {
                 if (last_mod != sb.st_mtime) {
                     Tangram::loadSceneAsync(sceneFile.c_str());
                     last_mod = sb.st_mtime;
                 }
-            }
+            //}
         }
     }
 

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -66,10 +66,10 @@ bool isContinuousRendering() {
 
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
     size_t length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length, _type);
+    unsigned char* bytes = bytesFromFile(_path, length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -77,7 +77,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -66,46 +66,10 @@ bool isContinuousRendering() {
 
 }
 
-std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
-    std::regex r("^(http|https):/");
-    std::smatch match;
-    std::string path(_path);
-
-    if (std::regex_search(path, match, r)) {
-        _sceneResourceRoot = "";
-        return path;
-    }
-
-    std::string dir(_path);
-
-    _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
-
-    std::string base(_path);
-
-    return std::string(basename(&base[0]));
-
-}
-
-std::string resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    switch (_type) {
-    case PathType::absolute:
-    case PathType::internal:
-        return std::string(_path);
-    case PathType::resource:
-        if (_resourceRoot) {
-            return std::string(_resourceRoot) + _path;
-        }
-        return _path;
-    }
-    return "";
-}
-
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length, _resourceRoot);
+    size_t length = 0;
+    unsigned char* bytes = bytesFromFile(_path, length, _type);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -113,25 +77,23 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
 
-    std::string path = resolvePath(_path, _type, _resourceRoot);
-
-    std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", path.c_str());
-        *_size = 0;
+        logMsg("Failed to read file at path: %s\n", _path);
+        _size = 0;
         return nullptr;
     }
 
-    *_size = resource.tellg();
+    _size = resource.tellg();
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * (*_size));
+    char* cdata = (char*) malloc(sizeof(char) * (_size));
 
-    resource.read(cdata, *_size);
+    resource.read(cdata, _size);
     resource.close();
 
     return reinterpret_cast<unsigned char *>(cdata);

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -47,54 +47,19 @@ bool isContinuousRendering() {
 
 }
 
-std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
-
-    std::regex r("^(http|https):/");
-    std::smatch match;
-    std::string p(_path);
-
-    if (std::regex_search(p, match, r)) {
-        _sceneResourceRoot = "";
-        return p;
-    }
+NSString* resolvePath(const char* _path, PathType _type) {
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
-    if (*_path != '/') {
-        NSString* resources = [[NSBundle mainBundle] resourcePath];
-        path = [resources stringByAppendingPathComponent:path];
-    }
+    if (*_path == '/') { return path; }
 
-    _sceneResourceRoot = std::string([ [path stringByDeletingLastPathComponent] UTF8String]);
-
-    return std::string([[path lastPathComponent] UTF8String]);
-
+    NSString* resources = [[NSBundle mainBundle] resourcePath];
+    return [resources stringByAppendingPathComponent:path];
 }
 
-NSString* resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
-    NSString* resourceRoot = NULL;
-    if (_resourceRoot == NULL) {
-        resourceRoot = @".";
-    } else {
-        resourceRoot = [NSString stringWithUTF8String:(_resourceRoot)];
-    }
-
-    NSString* path = [NSString stringWithUTF8String:_path];
-
-    switch (_type) {
-    case PathType::internal:
-        return [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:path];
-    case PathType::resource:
-        return [resourceRoot stringByAppendingPathComponent:path];
-    case PathType::absolute:
-        return path;
-    }
-}
-
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    NSString* path = resolvePath(_path, _type, _resourceRoot);
+    NSString* path = resolvePath(_path, _type);
     NSString* str = [NSString stringWithContentsOfFile:path
                                           usedEncoding:NULL
                                                  error:NULL];
@@ -107,21 +72,20 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
     return std::string([str UTF8String]);
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size,
-                                const char* _resourceRoot) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
 
-    NSString* path = resolvePath(_path, _type, _resourceRoot);
+    NSString* path = resolvePath(_path, _type);
     NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
     if (data == nil) {
         LOGW("Failed to read file at path: %s", [path UTF8String]);
-        *_size = 0;
+        _size = 0;
         return nullptr;
     }
 
-    *_size = data.length;
-    unsigned char* ptr = (unsigned char*)malloc(*_size);
-    [data getBytes:ptr length:*_size];
+    _size = data.length;
+    unsigned char* ptr = (unsigned char*)malloc(_size);
+    [data getBytes:ptr length:_size];
 
     return ptr;
 }

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -47,7 +47,7 @@ bool isContinuousRendering() {
 
 }
 
-NSString* resolvePath(const char* _path, PathType _type) {
+NSString* resolvePath(const char* _path) {
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
@@ -57,9 +57,9 @@ NSString* resolvePath(const char* _path, PathType _type) {
     return [resources stringByAppendingPathComponent:path];
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path);
     NSString* str = [NSString stringWithContentsOfFile:path
                                           usedEncoding:NULL
                                                  error:NULL];
@@ -72,9 +72,9 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return std::string([str UTF8String]);
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
-    NSString* path = resolvePath(_path, _type);
+    NSString* path = resolvePath(_path);
     NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
     if (data == nil) {

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -53,10 +53,10 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length);
+    unsigned char* bytes = bytesFromFile(_path, &length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -64,7 +64,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -53,46 +53,10 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
-
-    std::regex r("^(http|https):/");
-    std::smatch match;
-    std::string path(_path);
-
-    if (std::regex_search(path, match, r)) {
-        _sceneResourceRoot = "";
-        return path;
-    }
-
-    std::string dir(_path);
-
-    _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
-
-    std::string base(_path);
-
-    return std::string(basename(&base[0]));
-
-}
-
-std::string resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    switch (_type) {
-    case PathType::absolute:
-    case PathType::internal:
-        return std::string(_path);
-    case PathType::resource:
-        if (_resourceRoot) {
-            return std::string(_resourceRoot) + _path;
-        }
-        return _path;
-    }
-    return "";
-}
-
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
     unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length, _resourceRoot);
+    unsigned char* bytes = bytesFromFile(_path, _type, &length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -100,25 +64,23 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
 
-    std::string path = resolvePath(_path, _type, _resourceRoot);
-
-    std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", path.c_str());
+        logMsg("Failed to read file at path: %s\n", _path);
         *_size = 0;
         return nullptr;
     }
 
-    *_size = resource.tellg();
+    _size = resource.tellg();
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * (*_size));
+    char* cdata = (char*) malloc(sizeof(char) * _size);
 
-    resource.read(cdata, *_size);
+    resource.read(cdata, _size);
     resource.close();
 
     return reinterpret_cast<unsigned char *>(cdata);

--- a/scenes/import.yaml
+++ b/scenes/import.yaml
@@ -1,0 +1,2 @@
+import:
+    - import/test.yaml

--- a/scenes/import/test.yaml
+++ b/scenes/import/test.yaml
@@ -1,0 +1,2 @@
+import:
+    - ../scene.yaml

--- a/tests/src/platform_mock.cpp
+++ b/tests/src/platform_mock.cpp
@@ -29,10 +29,10 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string stringFromFile(const char* _path, PathType _type) {
+std::string stringFromFile(const char* _path) {
 
     size_t length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length, _type);
+    unsigned char* bytes = bytesFromFile(_path, length);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -40,7 +40,7 @@ std::string stringFromFile(const char* _path, PathType _type) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size) {
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 

--- a/tests/src/platform_mock.cpp
+++ b/tests/src/platform_mock.cpp
@@ -29,37 +29,10 @@ bool isContinuousRendering() {
     return s_isContinuousRendering;
 }
 
-std::string setResourceRoot(const char* _path, std::string& _sceneResourceRoot) {
+std::string stringFromFile(const char* _path, PathType _type) {
 
-    std::string dir(_path);
-
-    _sceneResourceRoot = std::string(dirname(&dir[0])) + '/';
-
-    std::string base(_path);
-
-    return std::string(basename(&base[0]));
-
-}
-
-std::string resolvePath(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    switch (_type) {
-    case PathType::absolute:
-    case PathType::internal:
-        return std::string(_path);
-    case PathType::resource:
-        if (_resourceRoot) {
-            return std::string(_resourceRoot) + _path;
-        }
-        return _path;
-    }
-    return "";
-}
-
-std::string stringFromFile(const char* _path, PathType _type, const char* _resourceRoot) {
-
-    unsigned int length = 0;
-    unsigned char* bytes = bytesFromFile(_path, _type, &length);
+    size_t length = 0;
+    unsigned char* bytes = bytesFromFile(_path, length, _type);
 
     std::string out(reinterpret_cast<char*>(bytes), length);
     free(bytes);
@@ -67,25 +40,23 @@ std::string stringFromFile(const char* _path, PathType _type, const char* _resou
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, PathType _type, unsigned int* _size, const char* _resourceRoot) {
+unsigned char* bytesFromFile(const char* _path, size_t& _size, PathType _type) {
 
-    std::string path = resolvePath(_path, _type, _resourceRoot);
-
-    std::ifstream resource(path.c_str(), std::ifstream::ate | std::ifstream::binary);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", path.c_str());
-        *_size = 0;
+        logMsg("Failed to read file at path: %s\n", _path);
+        _size = 0;
         return nullptr;
     }
 
-    *_size = resource.tellg();
+    _size = resource.tellg();
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * (*_size));
+    char* cdata = (char*) malloc(sizeof(char) * _size);
 
-    resource.read(cdata, *_size);
+    resource.read(cdata, _size);
     resource.close();
 
     return reinterpret_cast<unsigned char *>(cdata);

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -35,8 +35,8 @@ std::shared_ptr<alfons::Font> font;
 void initFont(std::string _font = TEST_FONT) {
     font = fontManager.addFont("default", alfons::InputSource(_font), TEST_FONT_SIZE);
 
-    unsigned int dataSize = 0;
-    unsigned char* data = bytesFromFile(_font.c_str(), PathType::internal, &dataSize);
+    size_t dataSize = 0;
+    unsigned char* data = bytesFromFile(_font.c_str(), dataSize, PathType::internal);
 
     auto face = fontManager.addFontFace(alfons::InputSource(reinterpret_cast<char*>(data), dataSize), TEST_FONT_SIZE);
 

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -36,7 +36,7 @@ void initFont(std::string _font = TEST_FONT) {
     font = fontManager.addFont("default", alfons::InputSource(_font), TEST_FONT_SIZE);
 
     size_t dataSize = 0;
-    unsigned char* data = bytesFromFile(_font.c_str(), dataSize, PathType::internal);
+    unsigned char* data = bytesFromFile(_font.c_str(), dataSize);
 
     auto face = fontManager.addFontFace(alfons::InputSource(reinterpret_cast<char*>(data), dataSize), TEST_FONT_SIZE);
 

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -15,7 +15,7 @@ public:
     TestImporter();
 
 protected:
-    virtual std::string getSceneString(const std::string& scenePath, const std::string& resourceRoot) override {
+    virtual std::string getSceneString(const std::string& scenePath) override {
         return m_testScenes[scenePath];
     }
 

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -39,6 +39,17 @@ TestImporter::TestImporter() {
                                     name: thisCar
                                     )END");
 
+    m_testScenes["/absolutePath/car.yaml"] = std::string(R"END(
+                                import: import/car.yaml
+                                type: car
+                                )END");
+
+    m_testScenes["/absolutePath/import/car.yaml"] = std::string(R"END(
+                                name: vehicle
+                                type: vehicle
+                                category: vehicle
+                                )END");
+
     m_testScenes["/absolutePath/thisCar.yaml"] = std::string(R"END(
                                     import: [import/car.yaml, car.yaml]
                                     name: thisCar


### PR DESCRIPTION
- either a path is relative, then bytesFromFile uses bundled resource path
- or a path is absolute then bytesFromFile just loads that file
- relative path replacements are all done in Scene Importer.

no more headaches, hopefully :)


PathType could also be removed, unless I'm missing something 