### PR TITLE
Refactor C++ interface into Map class

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -35,8 +35,6 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     MapData markers;
     boolean showTileInfo = false;
 
-    final static String tileApiKey = "?api_key=vector-tiles-tyHL4AY";
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -97,20 +95,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     }
 
     HttpHandler getHttpHandler() {
-        HttpHandler handler = new HttpHandler() {
-            @Override
-            public boolean onRequest(String url, Callback cb) {
-                url += tileApiKey;
-                return super.onRequest(url, cb);
-            }
-
-            @Override
-            public void onCancel(String url) {
-                url += tileApiKey;
-                super.onCancel(url);
-            }
-        };
-
+        HttpHandler handler = new HttpHandler();
         File cacheDir = getExternalCacheDir();
         if (cacheDir != null && cacheDir.exists()) {
             handler.setCache(new File(cacheDir, "tile_cache"), 30 * 1024 * 1024);

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -6,138 +6,203 @@
 
 extern "C" {
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPosition(JNIEnv* jniEnv, jobject obj, jdouble lon, jdouble lat) {
-        Tangram::setPosition(lon, lat);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPosition(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdouble lon, jdouble lat) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setPosition(lon, lat);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPositionEased(JNIEnv* jniEnv, jobject obj, jdouble lon, jdouble lat, jfloat duration, jint ease) {
-        Tangram::setPosition(lon, lat, duration, static_cast<Tangram::EaseType>(ease));
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPositionEased(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdouble lon, jdouble lat, jfloat duration, jint ease) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setPositionEased(lon, lat, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeGetPosition(JNIEnv* jniEnv, jobject obj, jdoubleArray lonLat) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeGetPosition(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdoubleArray lonLat) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jdouble* arr = jniEnv->GetDoubleArrayElements(lonLat, NULL);
-        Tangram::getPosition(arr[0], arr[1]);
+        map->getPosition(arr[0], arr[1]);
         jniEnv->ReleaseDoubleArrayElements(lonLat, arr, 0);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetZoom(JNIEnv* jniEnv, jobject obj, jfloat zoom) {
-        Tangram::setZoom(zoom);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat zoom) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setZoom(zoom);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetZoomEased(JNIEnv* jniEnv, jobject obj, jfloat zoom, jfloat duration, jint ease) {
-        Tangram::setZoom(zoom, duration, static_cast<Tangram::EaseType>(ease));
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetZoomEased(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat zoom, jfloat duration, jint ease) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setZoomEased(zoom, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetZoom(JNIEnv* jniEnv, jobject obj) {
-        return Tangram::getZoom();
+    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        return map->getZoom();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetRotation(JNIEnv* jniEnv, jobject obj, jfloat radians) {
-        Tangram::setRotation(radians);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetRotation(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radians) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setRotation(radians);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetRotationEased(JNIEnv* jniEnv, jobject obj, jfloat radians, jfloat duration, jint ease) {
-        Tangram::setRotation(radians, duration, static_cast<Tangram::EaseType>(ease));
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetRotationEased(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radians, jfloat duration, jint ease) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setRotationEased(radians, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetRotation(JNIEnv* jniEnv, jobject obj) {
-        return Tangram::getRotation();
+    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetRotation(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        return map->getRotation();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetTilt(JNIEnv* jniEnv, jobject obj, jfloat radians) {
-        Tangram::setTilt(radians);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetTilt(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radians) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setTilt(radians);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetTiltEased(JNIEnv* jniEnv, jobject obj, jfloat radians, jfloat duration, jint ease) {
-        Tangram::setTilt(radians, duration, static_cast<Tangram::EaseType>(ease));
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetTiltEased(JNIEnv* jniEnv, jobject obj,  jlong mapPtr, jfloat radians, jfloat duration, jint ease) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setTiltEased(radians, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetTilt(JNIEnv* jniEnv, jobject obj) {
-        return Tangram::getTilt();
+    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetTilt(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        return map->getTilt();
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeScreenPositionToLngLat(JNIEnv* jniEnv, jobject obj, jdoubleArray coordinates) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeScreenPositionToLngLat(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdoubleArray coordinates) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
-        bool ret = Tangram::screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
+        bool ret = map->screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
         jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
         return ret;
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeLngLatToScreenPosition(JNIEnv* jniEnv, jobject obj, jdoubleArray coordinates) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeLngLatToScreenPosition(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdoubleArray coordinates) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
-        bool ret = Tangram::lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
+        bool ret = map->lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
         jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
         return ret;
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager, jstring stylePath) {
+    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager, jstring stylePath) {
         setupJniEnv(jniEnv, tangramInstance, assetManager);
         const char* cStylePath = jniEnv->GetStringUTFChars(stylePath, NULL);
-        Tangram::initialize(cStylePath);
+        auto map = new Tangram::Map(cStylePath);
         jniEnv->ReleaseStringUTFChars(stylePath, cStylePath);
+        return reinterpret_cast<jlong>(map);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jstring path) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeDispose(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        delete map;
+    }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         const char* cPath = jniEnv->GetStringUTFChars(path, NULL);
-        Tangram::loadScene(cPath);
+        map->loadScene(cPath);
         jniEnv->ReleaseStringUTFChars(path, cPath);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeResize(JNIEnv* jniEnv, jobject obj, jint width, jint height) {
-        Tangram::resize(width, height);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeResize(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint width, jint height) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->resize(width, height);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeUpdate(JNIEnv* jniEnv, jobject obj, jfloat dt) {
-        return Tangram::update(dt);
+    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeUpdate(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat dt) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        return map->update(dt);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeRender(JNIEnv* jniEnv, jobject obj) {
-        Tangram::render();
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeRender(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->render();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetupGL(JNIEnv* jniEnv, jobject obj) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetupGL(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         bindJniEnvToThread(jniEnv);
-        Tangram::setupGL();
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setupGL();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPixelScale(JNIEnv* jniEnv, jobject obj, jfloat scale) {
-        Tangram::setPixelScale(scale);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPixelScale(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat scale) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setPixelScale(scale);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetCameraType(JNIEnv* jniEnv, jobject obj, jint type) {
-        Tangram::setCameraType(type);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetCameraType(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint type) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setCameraType(type);
     }
 
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeGetCameraType(JNIEnv* jniEnv, jobject obj) {
-        return Tangram::getCameraType();
+    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeGetCameraType(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        return map->getCameraType();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleTapGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
-        Tangram::handleTapGesture(posX, posY);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleTapGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->handleTapGesture(posX, posY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleDoubleTapGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY) {
-        Tangram::handleDoubleTapGesture(posX, posY);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleDoubleTapGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->handleDoubleTapGesture(posX, posY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandlePanGesture(JNIEnv* jniEnv, jobject obj, jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
-        Tangram::handlePanGesture(startX, startY, endX, endY);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandlePanGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->handlePanGesture(startX, startY, endX, endY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleFlingGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat velocityX, jfloat velocityY) {
-        Tangram::handleFlingGesture(posX, posY, velocityX, velocityY);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleFlingGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jfloat velocityX, jfloat velocityY) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->handleFlingGesture(posX, posY, velocityX, velocityY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandlePinchGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat scale, jfloat velocity) {
-        Tangram::handlePinchGesture(posX, posY, scale, velocity);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandlePinchGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jfloat scale, jfloat velocity) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->handlePinchGesture(posX, posY, scale, velocity);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleRotateGesture(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jfloat rotation) {
-        Tangram::handleRotateGesture(posX, posY, rotation);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleRotateGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jfloat rotation) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->handleRotateGesture(posX, posY, rotation);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleShoveGesture(JNIEnv* jniEnv, jobject obj, jfloat distance) {
-        Tangram::handleShoveGesture(distance);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleShoveGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat distance) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->handleShoveGesture(distance);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeOnUrlSuccess(JNIEnv* jniEnv, jobject obj, jbyteArray fetchedBytes, jlong callbackPtr) {
@@ -148,37 +213,46 @@ extern "C" {
         onUrlFailure(jniEnv, callbackPtr);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickFeature(JNIEnv* jniEnv, jobject obj, jfloat posX, jfloat posY, jobject listener) {
-        auto& items = Tangram::pickFeaturesAt(posX, posY);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickFeature(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jobject listener) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto& items = map->pickFeaturesAt(posX, posY);
         if (!items.empty()) {
             featurePickCallback(jniEnv, listener, items);
         }
     }
 
-    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeAddDataSource(JNIEnv* jniEnv, jobject obj, jstring name) {
-        auto source_name = stringFromJString(jniEnv, name);
-        auto source = std::shared_ptr<Tangram::DataSource>(new Tangram::ClientGeoJsonSource(source_name, ""));
-        Tangram::addDataSource(source);
+    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeAddDataSource(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring name) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto sourceName = stringFromJString(jniEnv, name);
+        auto source = std::shared_ptr<Tangram::DataSource>(new Tangram::ClientGeoJsonSource(sourceName, ""));
+        map->addDataSource(source);
         return reinterpret_cast<jlong>(source.get());
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeRemoveDataSource(JNIEnv* jniEnv, jobject obj, jlong pointer) {
-        assert(pointer > 0);
-        auto source_ptr = reinterpret_cast<Tangram::DataSource*>(pointer);
-        Tangram::removeDataSource(*source_ptr);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeRemoveDataSource(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        assert(sourcePtr > 0);
+        auto source = reinterpret_cast<Tangram::DataSource*>(sourcePtr);
+        map->removeDataSource(*source);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeClearDataSource(JNIEnv* jniEnv, jobject obj, jlong pointer) {
-        assert(pointer > 0);
-        auto source_ptr = reinterpret_cast<Tangram::DataSource*>(pointer);
-        Tangram::clearDataSource(*source_ptr, true, true);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeClearDataSource(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        assert(sourcePtr > 0);
+        auto source = reinterpret_cast<Tangram::DataSource*>(sourcePtr);
+        map->clearDataSource(*source, true, true);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddFeature(JNIEnv* jniEnv, jobject obj, jlong pointer,
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddFeature(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr,
         jdoubleArray jcoordinates, jintArray jrings, jobjectArray jproperties) {
 
-        assert(pointer > 0);
-        auto source_ptr = reinterpret_cast<Tangram::ClientGeoJsonSource*>(pointer);
+        assert(mapPtr > 0);
+        assert(sourcePtr > 0);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
 
         size_t n_points = jniEnv->GetArrayLength(jcoordinates) / 2;
         size_t n_rings = (jrings == NULL) ? 0 : jniEnv->GetArrayLength(jrings);
@@ -211,7 +285,7 @@ extern "C" {
                 }
                 polygon.push_back(std::move(ring));
             }
-            source_ptr->addPoly(properties, polygon);
+            source->addPoly(properties, polygon);
             jniEnv->ReleaseIntArrayElements(jrings, rings, JNI_ABORT);
         } else if (n_points > 1) {
             // If no rings defined but multiple points, this is a polyline feature.
@@ -219,49 +293,58 @@ extern "C" {
             for (size_t i = 0; i < n_points; ++i) {
                 polyline.push_back({coordinates[2 * i], coordinates[2 * i + 1]});
             }
-            source_ptr->addLine(properties, polyline);
+            source->addLine(properties, polyline);
         } else {
             // This is a point feature.
             auto point = Tangram::LngLat(coordinates[0], coordinates[1]);
-            source_ptr->addPoint(properties, point);
+            source->addPoint(properties, point);
         }
 
         jniEnv->ReleaseDoubleArrayElements(jcoordinates, coordinates, JNI_ABORT);
 
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddGeoJson(JNIEnv* jniEnv, jobject obj, jlong pointer, jstring geojson) {
-        assert(pointer > 0);
-        auto source_ptr = reinterpret_cast<Tangram::ClientGeoJsonSource*>(pointer);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddGeoJson(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr, jstring geojson) {
+        assert(mapPtr > 0);
+        assert(sourcePtr > 0);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
         auto data = stringFromJString(jniEnv, geojson);
-        source_ptr->addData(data);
+        source->addData(data);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetDebugFlag(JNIEnv* jniEnv, jobject obj, jint flag, jboolean on) {
         Tangram::setDebugFlag(static_cast<Tangram::DebugFlags>(flag), on);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeUseCachedGlState(JNIEnv* jniEnv, jobject obj, jboolean use) {
-        Tangram::useCachedGlState(use);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeUseCachedGlState(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jboolean use) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->useCachedGlState(use);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeCaptureSnapshot(JNIEnv* jniEnv, jobject obj, jintArray buffer) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeCaptureSnapshot(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jintArray buffer) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jint* ptr = jniEnv->GetIntArrayElements(buffer, NULL);
         unsigned int* data = reinterpret_cast<unsigned int*>(ptr);
-        Tangram::captureSnapshot(data);
+        map->captureSnapshot(data);
         jniEnv->ReleaseIntArrayElements(buffer, ptr, JNI_ABORT);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeQueueSceneUpdate(JNIEnv* jnienv, jobject obj, jstring path, jstring value) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeQueueSceneUpdate(JNIEnv* jnienv, jobject obj, jlong mapPtr, jstring path, jstring value) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         const char* cPath = jnienv->GetStringUTFChars(path, NULL);
         const char* cValue = jnienv->GetStringUTFChars(value, NULL);
-        Tangram::queueSceneUpdate(cPath, cValue);
+        map->queueSceneUpdate(cPath, cValue);
         jnienv->ReleaseStringUTFChars(path, cPath);
         jnienv->ReleaseStringUTFChars(value, cValue);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeApplySceneUpdates(JNIEnv* jnienv, jobject obj) {
-        Tangram::applySceneUpdates();
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeApplySceneUpdates(JNIEnv* jnienv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->applySceneUpdates();
     }
 
 }

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -98,11 +98,9 @@ extern "C" {
         return ret;
     }
 
-    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager, jstring stylePath) {
+    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager) {
         setupJniEnv(jniEnv, tangramInstance, assetManager);
-        const char* cStylePath = jniEnv->GetStringUTFChars(stylePath, NULL);
-        auto map = new Tangram::Map(cStylePath);
-        jniEnv->ReleaseStringUTFChars(stylePath, cStylePath);
+        auto map = new Tangram::Map();
         return reinterpret_cast<jlong>(map);
     }
 

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -59,7 +59,6 @@ PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT = 0;
 PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
 PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOESEXT = 0;
 
-
 void bindJniEnvToThread(JNIEnv* jniEnv) {
     jniEnv->GetJavaVM(&jvm);
     jniRenderThreadEnv = jniEnv;

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -755,10 +755,7 @@ public class MapController implements Renderer {
     private ViewCompleteListener viewCompleteListener;
     private FrameCaptureCallback frameCaptureCallback;
     private boolean frameCaptureAwaitCompleteView;
-
-    // A static map of client data sources added dynamically. This map has static storage duration
-    // because it should mimic the lifetime of native objects whose lifetime is the entire program.
-    private static Map<String, MapData> clientDataSources = new HashMap<>();
+    private Map<String, MapData> clientDataSources = new HashMap<>();
 
     // GLSurfaceView.Renderer methods
     // ==============================

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -112,7 +112,7 @@ public class MapController implements Renderer {
         int b[] = new int[w * h];
         int bt[] = new int[w * h];
 
-        nativeCaptureSnapshot(b);
+        nativeCaptureSnapshot(mapPointer, b);
 
         for (int i = 0; i < h; i++) {
             for (int j = 0; j < w; j++) {
@@ -179,7 +179,12 @@ public class MapController implements Renderer {
         // Parse font file desription
         fontFileParser.parse();
 
-        nativeInit(this, assetManager, scenePath);
+        mapPointer = nativeInit(this, assetManager, scenePath);
+    }
+
+    void dispose() {
+        nativeDispose(mapPointer);
+        mapPointer = 0;
     }
 
     static MapController getInstance(GLSurfaceView view, String sceneFilePath) {
@@ -192,7 +197,7 @@ public class MapController implements Renderer {
      */
     public void loadSceneFile(String path) {
         scenePath = path;
-        nativeLoadScene(path);
+        nativeLoadScene(mapPointer, path);
         requestRender();
     }
 
@@ -210,7 +215,7 @@ public class MapController implements Renderer {
      * @param position LngLat of the position to set
      */
     public void setPosition(LngLat position) {
-        nativeSetPosition(position.longitude, position.latitude);
+        nativeSetPosition(mapPointer, position.longitude, position.latitude);
     }
 
     /**
@@ -230,7 +235,7 @@ public class MapController implements Renderer {
      */
     public void setPositionEased(LngLat position, int duration, EaseType ease) {
         float seconds = duration / 1000.f;
-        nativeSetPositionEased(position.longitude, position.latitude, seconds, ease.ordinal());
+        nativeSetPositionEased(mapPointer, position.longitude, position.latitude, seconds, ease.ordinal());
     }
 
     /**
@@ -248,7 +253,7 @@ public class MapController implements Renderer {
      */
     public LngLat getPosition(LngLat out) {
         double[] tmp = { 0, 0 };
-        nativeGetPosition(tmp);
+        nativeGetPosition(mapPointer, tmp);
         return out.set(tmp[0], tmp[1]);
     }
 
@@ -257,7 +262,7 @@ public class MapController implements Renderer {
      * @param zoom Zoom level; lower values show more area
      */
     public void setZoom(float zoom) {
-        nativeSetZoom(zoom);
+        nativeSetZoom(mapPointer, zoom);
     }
 
     /**
@@ -277,7 +282,7 @@ public class MapController implements Renderer {
      */
     public void setZoomEased(float zoom, int duration, EaseType ease) {
         float seconds = duration / 1000.f;
-        nativeSetZoomEased(zoom, seconds, ease.ordinal());
+        nativeSetZoomEased(mapPointer, zoom, seconds, ease.ordinal());
     }
 
     /**
@@ -285,7 +290,7 @@ public class MapController implements Renderer {
      * @return Zoom level; lower values show more area
      */
     public float getZoom() {
-        return nativeGetZoom();
+        return nativeGetZoom(mapPointer);
     }
 
     /**
@@ -293,7 +298,7 @@ public class MapController implements Renderer {
      * @param rotation Counter-clockwise rotation in radians; 0 corresponds to North pointing up
      */
     public void setRotation(float rotation) {
-        nativeSetRotation(rotation);
+        nativeSetRotation(mapPointer, rotation);
     }
 
     /**
@@ -313,7 +318,7 @@ public class MapController implements Renderer {
      */
     public void setRotationEased(float rotation, int duration, EaseType ease) {
         float seconds = duration / 1000.f;
-        nativeSetRotationEased(rotation, seconds, ease.ordinal());
+        nativeSetRotationEased(mapPointer, rotation, seconds, ease.ordinal());
     }
 
     /**
@@ -321,7 +326,7 @@ public class MapController implements Renderer {
      * @return Counter-clockwise rotation in radians; 0 corresponds to North pointing up
      */
     public float getRotation() {
-        return nativeGetRotation();
+        return nativeGetRotation(mapPointer);
     }
 
     /**
@@ -329,7 +334,7 @@ public class MapController implements Renderer {
      * @param tilt Tilt angle in radians; 0 corresponds to straight down
      */
     public void setTilt(float tilt) {
-        nativeSetTilt(tilt);
+        nativeSetTilt(mapPointer, tilt);
     }
 
     /**
@@ -349,7 +354,7 @@ public class MapController implements Renderer {
      */
     public void setTiltEased(float tilt, int duration, EaseType ease) {
         float seconds = duration / 1000.f;
-        nativeSetTiltEased(tilt, seconds, ease.ordinal());
+        nativeSetTiltEased(mapPointer, tilt, seconds, ease.ordinal());
     }
 
     /**
@@ -357,7 +362,7 @@ public class MapController implements Renderer {
      * @return Tilt angle in radians; 0 corresponds to straight down
      */
     public float getTilt() {
-        return nativeGetTilt();
+        return nativeGetTilt(mapPointer);
     }
 
     /**
@@ -365,7 +370,7 @@ public class MapController implements Renderer {
      * @param type A {@code CameraType}
      */
     public void setCameraType(CameraType type) {
-        nativeSetCameraType(type.ordinal());
+        nativeSetCameraType(mapPointer, type.ordinal());
     }
 
     /**
@@ -373,7 +378,7 @@ public class MapController implements Renderer {
      * @return A {@code CameraType}
      */
     public CameraType getCameraType() {
-        return CameraType.values()[nativeGetCameraType()];
+        return CameraType.values()[nativeGetCameraType(mapPointer)];
     }
 
     /**
@@ -384,7 +389,7 @@ public class MapController implements Renderer {
      */
     public LngLat screenPositionToLngLat(PointF screenPosition) {
         double[] tmp = { screenPosition.x, screenPosition.y };
-        if (nativeScreenPositionToLngLat(tmp)) {
+        if (nativeScreenPositionToLngLat(mapPointer, tmp)) {
             return new LngLat(tmp[0], tmp[1]);
         }
         return null;
@@ -398,7 +403,7 @@ public class MapController implements Renderer {
      */
     public PointF lngLatToScreenPosition(LngLat lngLat) {
         double[] tmp = { lngLat.longitude, lngLat.latitude };
-        nativeLngLatToScreenPosition(tmp);
+        nativeLngLatToScreenPosition(mapPointer, tmp);
         return new PointF((float)tmp[0], (float)tmp[1]);
     }
 
@@ -415,7 +420,7 @@ public class MapController implements Renderer {
         if (mapData != null) {
             return mapData;
         }
-        long pointer = nativeAddDataSource(name);
+        long pointer = nativeAddDataSource(mapPointer, name);
         if (pointer <= 0) {
             throw new RuntimeException("Unable to create new data source");
         }
@@ -430,7 +435,7 @@ public class MapController implements Renderer {
      */
     void removeDataLayer(MapData mapData) {
         clientDataSources.remove(mapData.name);
-        nativeRemoveDataSource(mapData.pointer);
+        nativeRemoveDataSource(mapPointer, mapData.pointer);
     }
 
     /**
@@ -508,7 +513,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onPan(float startX, float startY, float endX, float endY) {
                 if (responder == null || !responder.onPan(startX, startY, endX, endY)) {
-                    nativeHandlePanGesture(startX, startY, endX, endY);
+                    nativeHandlePanGesture(mapPointer, startX, startY, endX, endY);
                 }
                 return true;
             }
@@ -516,7 +521,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onFling(float posX, float posY, float velocityX, float velocityY) {
                 if (responder == null || !responder.onFling(posX, posY, velocityX, velocityY)) {
-                    nativeHandleFlingGesture(posX, posY, velocityX, velocityY);
+                    nativeHandleFlingGesture(mapPointer, posX, posY, velocityX, velocityY);
                 }
                 return true;
             }
@@ -532,7 +537,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onRotate(float x, float y, float rotation) {
                 if (responder == null || !responder.onRotate(x, y, rotation)) {
-                    nativeHandleRotateGesture(x, y, rotation);
+                    nativeHandleRotateGesture(mapPointer, x, y, rotation);
                 }
                 return true;
             }
@@ -548,7 +553,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onScale(float x, float y, float scale, float velocity) {
                 if (responder == null || !responder.onScale(x, y, scale, velocity)) {
-                    nativeHandlePinchGesture(x, y, scale, velocity);
+                    nativeHandlePinchGesture(mapPointer, x, y, scale, velocity);
                 }
                 return true;
             }
@@ -564,7 +569,7 @@ public class MapController implements Renderer {
             @Override
             public boolean onShove(float distance) {
                 if (responder == null || !responder.onShove(distance)) {
-                    nativeHandleShoveGesture(distance);
+                    nativeHandleShoveGesture(mapPointer, distance);
                 }
                 return true;
             }
@@ -607,7 +612,7 @@ public class MapController implements Renderer {
      */
     public void pickFeature(float posX, float posY) {
         if (featurePickListener != null) {
-            nativePickFeature(posX, posY, featurePickListener);
+            nativePickFeature(mapPointer, posX, posY, featurePickListener);
         }
     }
 
@@ -640,14 +645,14 @@ public class MapController implements Renderer {
      * @param value A YAML valid string (example "{ property: true }" or "true")
      */
     public void queueSceneUpdate(String componentPath, String value) {
-        nativeQueueSceneUpdate(componentPath, value);
+        nativeQueueSceneUpdate(mapPointer, componentPath, value);
     }
 
     /**
      * Apply updates queued by queueSceneUpdate; this empties the current queue of updates
      */
     public void applySceneUpdates() {
-        nativeApplySceneUpdates();
+        nativeApplySceneUpdates(mapPointer);
     }
 
     /**
@@ -656,7 +661,27 @@ public class MapController implements Renderer {
      * @param use Whether to use a cached OpenGL state; false by default
      */
     public void useCachedGlState(boolean use) {
-        nativeUseCachedGlState(use);
+        nativeUseCachedGlState(mapPointer, use);
+    }
+
+
+    // Package private methods
+    // =======================
+
+    void removeDataSource(long sourcePtr) {
+        nativeRemoveDataSource(mapPointer, sourcePtr);
+    }
+
+    void clearDataSource(long sourcePtr) {
+        nativeClearDataSource(mapPointer, sourcePtr);
+    }
+
+    void addFeature(long sourcePtr, double[] coordinates, int[] rings, String[] properties) {
+        nativeAddFeature(mapPointer, sourcePtr, coordinates, rings, properties);
+    }
+
+    void addGeoJson(long sourcePtr, String geoJson) {
+        nativeAddGeoJson(mapPointer, sourcePtr, geoJson);
     }
 
     // Native methods
@@ -666,50 +691,51 @@ public class MapController implements Renderer {
         System.loadLibrary("tangram");
     }
 
-    private synchronized native void nativeInit(MapController instance, AssetManager assetManager, String stylePath);
-    private synchronized native void nativeLoadScene(String path);
-    private synchronized native void nativeSetupGL();
-    private synchronized native void nativeResize(int width, int height);
-    private synchronized native boolean nativeUpdate(float dt);
-    private synchronized native void nativeRender();
-    private synchronized native void nativeSetPosition(double lon, double lat);
-    private synchronized native void nativeSetPositionEased(double lon, double lat, float seconds, int ease);
-    private synchronized native void nativeGetPosition(double[] lonLatOut);
-    private synchronized native void nativeSetZoom(float zoom);
-    private synchronized native void nativeSetZoomEased(float zoom, float seconds, int ease);
-    private synchronized native float nativeGetZoom();
-    private synchronized native void nativeSetRotation(float radians);
-    private synchronized native void nativeSetRotationEased(float radians, float seconds, int ease);
-    private synchronized native float nativeGetRotation();
-    private synchronized native void nativeSetTilt(float radians);
-    private synchronized native void nativeSetTiltEased(float radians, float seconds, int ease);
-    private synchronized native float nativeGetTilt();
-    private synchronized native boolean nativeScreenPositionToLngLat(double[] coordinates);
-    private synchronized native boolean nativeLngLatToScreenPosition(double[] coordinates);
-    private synchronized native void nativeSetPixelScale(float scale);
-    private synchronized native void nativeSetCameraType(int type);
-    private synchronized native int nativeGetCameraType();
-    private synchronized native void nativeHandleTapGesture(float posX, float posY);
-    private synchronized native void nativeHandleDoubleTapGesture(float posX, float posY);
-    private synchronized native void nativeHandlePanGesture(float startX, float startY, float endX, float endY);
-    private synchronized native void nativeHandleFlingGesture(float posX, float posY, float velocityX, float velocityY);
-    private synchronized native void nativeHandlePinchGesture(float posX, float posY, float scale, float velocity);
-    private synchronized native void nativeHandleRotateGesture(float posX, float posY, float rotation);
-    private synchronized native void nativeHandleShoveGesture(float distance);
-    private synchronized native void nativeQueueSceneUpdate(String componentPath, String value);
-    private synchronized native void nativeApplySceneUpdates();
-    private synchronized native void nativePickFeature(float posX, float posY, FeaturePickListener listener);
-    private synchronized native void nativeUseCachedGlState(boolean use);
-    private synchronized native void nativeCaptureSnapshot(int[] buffer);
+    private synchronized native long nativeInit(MapController instance, AssetManager assetManager, String stylePath);
+    private synchronized native long nativeDispose(long mapPtr);
+    private synchronized native void nativeLoadScene(long mapPtr, String path);
+    private synchronized native void nativeSetupGL(long mapPtr);
+    private synchronized native void nativeResize(long mapPtr, int width, int height);
+    private synchronized native boolean nativeUpdate(long mapPtr, float dt);
+    private synchronized native void nativeRender(long mapPtr);
+    private synchronized native void nativeSetPosition(long mapPtr, double lon, double lat);
+    private synchronized native void nativeSetPositionEased(long mapPtr, double lon, double lat, float seconds, int ease);
+    private synchronized native void nativeGetPosition(long mapPtr, double[] lonLatOut);
+    private synchronized native void nativeSetZoom(long mapPtr, float zoom);
+    private synchronized native void nativeSetZoomEased(long mapPtr, float zoom, float seconds, int ease);
+    private synchronized native float nativeGetZoom(long mapPtr);
+    private synchronized native void nativeSetRotation(long mapPtr, float radians);
+    private synchronized native void nativeSetRotationEased(long mapPtr, float radians, float seconds, int ease);
+    private synchronized native float nativeGetRotation(long mapPtr);
+    private synchronized native void nativeSetTilt(long mapPtr, float radians);
+    private synchronized native void nativeSetTiltEased(long mapPtr, float radians, float seconds, int ease);
+    private synchronized native float nativeGetTilt(long mapPtr);
+    private synchronized native boolean nativeScreenPositionToLngLat(long mapPtr, double[] coordinates);
+    private synchronized native boolean nativeLngLatToScreenPosition(long mapPtr, double[] coordinates);
+    private synchronized native void nativeSetPixelScale(long mapPtr, float scale);
+    private synchronized native void nativeSetCameraType(long mapPtr, int type);
+    private synchronized native int nativeGetCameraType(long mapPtr);
+    private synchronized native void nativeHandleTapGesture(long mapPtr, float posX, float posY);
+    private synchronized native void nativeHandleDoubleTapGesture(long mapPtr, float posX, float posY);
+    private synchronized native void nativeHandlePanGesture(long mapPtr, float startX, float startY, float endX, float endY);
+    private synchronized native void nativeHandleFlingGesture(long mapPtr, float posX, float posY, float velocityX, float velocityY);
+    private synchronized native void nativeHandlePinchGesture(long mapPtr, float posX, float posY, float scale, float velocity);
+    private synchronized native void nativeHandleRotateGesture(long mapPtr, float posX, float posY, float rotation);
+    private synchronized native void nativeHandleShoveGesture(long mapPtr, float distance);
+    private synchronized native void nativeQueueSceneUpdate(long mapPtr, String componentPath, String value);
+    private synchronized native void nativeApplySceneUpdates(long mapPtr);
+    private synchronized native void nativePickFeature(long mapPtr, float posX, float posY, FeaturePickListener listener);
+    private synchronized native void nativeUseCachedGlState(long mapPtr, boolean use);
+    private synchronized native void nativeCaptureSnapshot(long mapPtr, int[] buffer);
 
     private native void nativeOnUrlSuccess(byte[] rawDataBytes, long callbackPtr);
     private native void nativeOnUrlFailure(long callbackPtr);
 
-    synchronized native long nativeAddDataSource(String name);
-    synchronized native void nativeRemoveDataSource(long pointer);
-    synchronized native void nativeClearDataSource(long pointer);
-    synchronized native void nativeAddFeature(long pointer, double[] coordinates, int[] rings, String[] properties);
-    synchronized native void nativeAddGeoJson(long pointer, String geojson);
+    synchronized native long nativeAddDataSource(long mapPtr, String name);
+    synchronized native void nativeRemoveDataSource(long mapPtr, long sourcePtr);
+    synchronized native void nativeClearDataSource(long mapPtr, long sourcePtr);
+    synchronized native void nativeAddFeature(long mapPtr, long sourcePtr, double[] coordinates, int[] rings, String[] properties);
+    synchronized native void nativeAddGeoJson(long mapPtr, long sourcePtr, String geoJson);
 
     native void nativeSetDebugFlag(int flag, boolean on);
 
@@ -717,6 +743,7 @@ public class MapController implements Renderer {
     // ===============
 
     private String scenePath;
+    private long mapPointer;
     private long time = System.nanoTime();
     private GLSurfaceView mapView;
     private AssetManager assetManager;
@@ -742,8 +769,8 @@ public class MapController implements Renderer {
         float delta = (newTime - time) / 1000000000.0f;
         time = newTime;
 
-        boolean viewComplete = nativeUpdate(delta);
-        nativeRender();
+        boolean viewComplete = nativeUpdate(mapPointer, delta);
+        nativeRender(mapPointer);
 
         if (viewComplete && viewCompleteListener != null) {
             viewCompleteListener.onViewComplete();
@@ -758,13 +785,13 @@ public class MapController implements Renderer {
 
     @Override
     public void onSurfaceChanged(GL10 gl, int width, int height) {
-        nativeSetPixelScale(displayMetrics.density);
-        nativeResize(width, height);
+        nativeSetPixelScale(mapPointer, displayMetrics.density);
+        nativeResize(mapPointer, width, height);
     }
 
     @Override
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
-        nativeSetupGL();
+        nativeSetupGL(mapPointer);
     }
 
     // Networking methods

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -692,7 +692,7 @@ public class MapController implements Renderer {
     }
 
     private synchronized native long nativeInit(MapController instance, AssetManager assetManager, String stylePath);
-    private synchronized native long nativeDispose(long mapPtr);
+    private synchronized native void nativeDispose(long mapPtr);
     private synchronized native void nativeLoadScene(long mapPtr, String path);
     private synchronized native void nativeSetupGL(long mapPtr);
     private synchronized native void nativeResize(long mapPtr, int width, int height);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -134,11 +134,8 @@ public class MapController implements Renderer {
      * It also provides the Context in which the map will function; the asset
      * bundle for this activity must contain all the local files that the map
      * will need.
-     * @param sceneFilePath Location of the YAML scene file within the assets directory
      */
-    protected MapController(GLSurfaceView view, String sceneFilePath) {
-
-        scenePath = sceneFilePath;
+    protected MapController(GLSurfaceView view) {
 
         // Set up MapView
         mapView = view;
@@ -179,7 +176,7 @@ public class MapController implements Renderer {
         // Parse font file desription
         fontFileParser.parse();
 
-        mapPointer = nativeInit(this, assetManager, scenePath);
+        mapPointer = nativeInit(this, assetManager);
     }
 
     void dispose() {
@@ -194,8 +191,8 @@ public class MapController implements Renderer {
         });
     }
 
-    static MapController getInstance(GLSurfaceView view, String sceneFilePath) {
-        return new MapController(view, sceneFilePath);
+    static MapController getInstance(GLSurfaceView view) {
+        return new MapController(view);
     }
 
     /**
@@ -698,7 +695,7 @@ public class MapController implements Renderer {
         System.loadLibrary("tangram");
     }
 
-    private synchronized native long nativeInit(MapController instance, AssetManager assetManager, String stylePath);
+    private synchronized native long nativeInit(MapController instance, AssetManager assetManager);
     private synchronized native void nativeDispose(long mapPtr);
     private synchronized native void nativeLoadScene(long mapPtr, String path);
     private synchronized native void nativeSetupGL(long mapPtr);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -822,7 +822,6 @@ public class MapController implements Renderer {
             @Override
             public void onFailure(Request request, IOException e) {
                 nativeOnUrlFailure(callbackPtr);
-                //e.printStackTrace();
             }
 
             @Override

--- a/android/tangram/src/com/mapzen/tangram/MapData.java
+++ b/android/tangram/src/com/mapzen/tangram/MapData.java
@@ -34,7 +34,7 @@ public class MapData {
      * @param geometry The feature to add
      */
     protected void addFeature(Geometry geometry) {
-        map.nativeAddFeature(pointer,
+        map.addFeature(pointer,
                 geometry.getCoordinateArray(),
                 geometry.getRingArray(),
                 geometry.getPropertyArray());
@@ -102,7 +102,7 @@ public class MapData {
      * @return This object, for chaining.
      */
     public MapData addGeoJson(String data) {
-        map.nativeAddGeoJson(pointer, data);
+        map.addGeoJson(pointer, data);
         return this;
     }
 
@@ -111,7 +111,7 @@ public class MapData {
      * @return This object, for chaining.
      */
     public MapData clear() {
-        map.nativeClearDataSource(pointer);
+        map.clearDataSource(pointer);
         return this;
     }
 

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -14,6 +14,7 @@ import android.widget.FrameLayout;
 public class MapView extends FrameLayout {
 
     protected GLSurfaceView glSurfaceView;
+    protected MapController mapController;
     protected AsyncTask<Void, Void, Boolean> getMapTask;
 
     public MapView(Context context) {
@@ -60,7 +61,11 @@ public class MapView extends FrameLayout {
             getMapTask.cancel(true);
         }
 
-        final MapController mapController = getMapInstance(sceneFilePath);
+        if (mapController != null) {
+            mapController.dispose();
+        }
+
+        mapController = getMapInstance(sceneFilePath);
 
         getMapTask = new AsyncTask<Void, Void, Boolean>() {
 

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -55,8 +55,6 @@ public class MapView extends FrameLayout {
     public void getMapAsync(@NonNull final OnMapReadyCallback callback,
                             @NonNull final String sceneFilePath) {
 
-        final Context context = getContext();
-
         disposeMap();
 
         mapController = getMapInstance(sceneFilePath);

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -57,13 +57,7 @@ public class MapView extends FrameLayout {
 
         final Context context = getContext();
 
-        if (getMapTask != null) {
-            getMapTask.cancel(true);
-        }
-
-        if (mapController != null) {
-            mapController.dispose();
-        }
+        disposeMap();
 
         mapController = getMapInstance(sceneFilePath);
 
@@ -100,6 +94,20 @@ public class MapView extends FrameLayout {
 
     }
 
+    protected void disposeMap() {
+
+        if (getMapTask != null) {
+            getMapTask.cancel(true);
+        }
+        getMapTask = null;
+
+        if (mapController != null) {
+            mapController.dispose();
+        }
+        mapController = null;
+
+    }
+
     /**
      * You must call this method from the parent Activity/Fragment's corresponding method.
      */
@@ -126,9 +134,7 @@ public class MapView extends FrameLayout {
      */
     public void onDestroy() {
 
-        if (getMapTask != null) {
-            getMapTask.cancel(true);
-        }
+        disposeMap();
 
     }
 

--- a/android/tangram/src/com/mapzen/tangram/MapView.java
+++ b/android/tangram/src/com/mapzen/tangram/MapView.java
@@ -57,7 +57,7 @@ public class MapView extends FrameLayout {
 
         disposeTask();
 
-        final MapController mapInstance = getMapInstance(sceneFilePath);
+        final MapController mapInstance = getMapInstance();
 
         getMapTask = new AsyncTask<Void, Void, Boolean>() {
 
@@ -86,8 +86,8 @@ public class MapView extends FrameLayout {
 
     }
 
-    protected MapController getMapInstance(String sceneFilePath) {
-        return MapController.getInstance(glSurfaceView, sceneFilePath);
+    protected MapController getMapInstance() {
+        return MapController.getInstance(glSurfaceView);
     }
 
     protected void configureGLSurfaceView() {

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -46,9 +46,9 @@ ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::st
             startUrlRequest(_url,
                     [&, this](std::vector<char>&& rawData) {
                         addData(std::string(rawData.begin(), rawData.end()));
-                        // delete all no-data tiles for this datasource and redo
-                        clearDataSource(*this, false, true);
+                        m_hasPendingData = false;
                     });
+            m_hasPendingData = true;
         } else {
             // Load from file
             const auto& string = stringFromFile(_url.c_str());
@@ -74,6 +74,10 @@ void ClientGeoJsonSource::addData(const std::string& _data) {
 }
 
 bool ClientGeoJsonSource::loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb) {
+
+    if (m_hasPendingData) {
+        return false;
+    }
 
     _cb.func(std::move(_task));
 

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -46,6 +46,7 @@ protected:
     std::unique_ptr<GeoJSONVT> m_store;
     mutable std::mutex m_mutexStore;
     std::vector<mapbox::util::geojsonvt::ProjectedFeature> m_features;
+    bool m_hasPendingData = false;
 
 };
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gl.h"
+#include "util/jobQueue.h"
 
 #include <vector>
 #include <memory>
@@ -113,6 +114,8 @@ protected:
 private:
 
     size_t bytesPerPixel();
+
+    JobQueue m_mainThreadJobQueue;
 
     bool m_generateMipmaps;
 };

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -33,10 +33,6 @@ struct Stops;
 
 class Scene {
 public:
-    struct Update {
-        std::string keys;
-        std::string value;
-    };
 
     struct Camera {
         CameraType type;

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -88,6 +88,9 @@ public:
     const Style* findStyle(const std::string& _name) const;
     const Light* findLight(const std::string& _name) const;
 
+    void updateTime(float _dt) { m_time += _dt; }
+    float time() const { return m_time; }
+
     int addIdForName(const std::string& _name);
     int getIdForName(const std::string& _name) const;
 
@@ -144,6 +147,8 @@ private:
     animate m_animated = none;
 
     float m_pixelScale = 1.0f;
+
+    float m_time = 0.0;
 };
 
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -74,7 +74,7 @@ bool SceneLoader::loadConfig(const std::string& _sceneString, Node& root) {
     return true;
 }
 
-void SceneLoader::applyUpdates(Node& root, const std::vector<Scene::Update>& updates) {
+void SceneLoader::applyUpdates(Node& root, const std::vector<SceneUpdate>& updates) {
 
     for (const auto& update : updates) {
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -2,6 +2,7 @@
 
 #include "gl/uniform.h"
 #include "scene/scene.h"
+#include "tangram.h"
 #include <string>
 #include <vector>
 #include <memory>
@@ -42,7 +43,7 @@ struct SceneLoader {
     static bool loadScene(std::shared_ptr<Scene> _scene);
     static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, Scene& scene);
-    static void applyUpdates(Node& root, const std::vector<Scene::Update>& updates);
+    static void applyUpdates(Node& root, const std::vector<SceneUpdate>& updates);
     static void applyGlobalProperties(Node& node, Scene& scene);
 
     /*** all public for testing ***/

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -179,7 +179,7 @@ void Style::onBeginDrawFrame(const View& _view, Scene& _scene) {
     RenderState::resetTextureUnit();
 
     // Set time uniforms style's shader programs
-    m_shaderProgram->setUniformf(m_uTime, Tangram::frameTime());
+    m_shaderProgram->setUniformf(m_uTime, _scene.time());
 
     m_shaderProgram->setUniformf(m_uDevicePixelRatio, m_pixelScale);
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -83,7 +83,16 @@ Map::Map(const char* _scenePath) {
 }
 
 Map::~Map() {
-
+    // Explicitly destroy all member objects so that we have a chance
+    // to run any resulting jobs sent to the JobQueue.
+    m_asyncWorker.reset();
+    m_inputHandler.reset();
+    m_labels.reset();
+    m_view.reset();
+    m_nextScene.reset();
+    m_tileManager.reset();
+    m_tileWorker.reset();
+    JobQueue::runJobsForCurrentThread();
 }
 
 void Map::setScene(std::shared_ptr<Scene>& _scene) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -44,16 +44,7 @@ void Map::clearEase(EaseField _f) {
 
 static std::bitset<8> g_flags = 0;
 
-Map::Map(const char* _scenePath) {
-
-    // For some unknown reasons, android fails to render the map, if same scene is reloaded, without resetting any of
-    // the other Tangram global resources, which is what this method does.
-    // As a work-around, re-initialization of an already loaded scene is done along with resetting all the Tangram
-    // global resources.
-    // NOTE: This will be refactored completely with Multiple Tangram Instances work being done in parallel.
-    if (m_scene && m_scene->path() == _scenePath) {
-        LOGD("Specified scene is already initalized.");
-    }
+Map::Map() {
 
     LOG("initialize");
 
@@ -61,7 +52,7 @@ Map::Map(const char* _scenePath) {
     m_view = std::make_shared<View>();
 
     // Create a scene object
-    m_scene = std::make_shared<Scene>(_scenePath);
+    m_scene = std::make_shared<Scene>();
 
     // Input handler
     m_inputHandler = std::make_unique<InputHandler>(m_view);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -41,7 +41,6 @@ void Map::clearEase(EaseField _f) {
     m_eases[static_cast<size_t>(_f)] = none;
 }
 
-static float g_time = 0.0;
 static std::bitset<8> g_flags = 0;
 std::mutex g_tasksMutex;
 std::queue<std::function<void()>> g_tasks;
@@ -249,7 +248,7 @@ bool Map::update(float _dt) {
 
     FrameInfo::beginUpdate();
 
-    g_time += _dt;
+    m_scene->updateTime(_dt);
 
     bool viewComplete = true;
 
@@ -673,11 +672,6 @@ void runOnMainLoop(std::function<void()> _task) {
 
 void runAsyncTask(std::function<void()> _task) {
     m_asyncWorker.enqueue(std::move(_task));
-}
-
-float frameTime() {
-    // FIXME: g_time should be a member of each Map instance
-    return g_time;
 }
 
 void setDebugFlag(DebugFlags _flag, bool _on) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -24,50 +24,31 @@
 #include "util/ease.h"
 #include "debug/textDisplay.h"
 #include "debug/frameInfo.h"
-#include <memory>
-#include <array>
+
 #include <cmath>
 #include <bitset>
-#include <mutex>
-#include <queue>
-#include <thread>
 
 namespace Tangram {
 
 const static size_t MAX_WORKERS = 2;
 
-std::mutex m_tilesMutex;
-std::mutex m_tasksMutex;
-std::mutex m_sceneMutex;
-std::queue<std::function<void()>> m_tasks;
-std::unique_ptr<TileWorker> m_tileWorker;
-std::unique_ptr<TileManager> m_tileManager;
-std::shared_ptr<Scene> m_scene;
-std::shared_ptr<View> m_view;
-std::unique_ptr<Labels> m_labels;
-std::unique_ptr<InputHandler> m_inputHandler;
-
-std::shared_ptr<Scene> m_nextScene;
-std::vector<Scene::Update> m_sceneUpdates;
-
-std::array<Ease, 4> m_eases;
-enum class EaseField { position, zoom, rotation, tilt };
-void setEase(EaseField _f, Ease _e) {
+void Map::setEase(EaseField _f, Ease _e) {
     m_eases[static_cast<size_t>(_f)] = _e;
     requestRender();
 }
-void clearEase(EaseField _f) {
+void Map::clearEase(EaseField _f) {
     static Ease none = {};
     m_eases[static_cast<size_t>(_f)] = none;
 }
 
 static float g_time = 0.0;
 static std::bitset<8> g_flags = 0;
-static bool g_cacheGlState = false;
+std::mutex g_tasksMutex;
+std::queue<std::function<void()>> g_tasks;
 
 AsyncWorker m_asyncWorker;
 
-void initialize(const char* _scenePath) {
+Map::Map(const char* _scenePath) {
 
     // For some unknown reasons, android fails to render the map, if same scene is reloaded, without resetting any of
     // the other Tangram global resources, which is what this method does.
@@ -102,7 +83,11 @@ void initialize(const char* _scenePath) {
 
 }
 
-void setScene(std::shared_ptr<Scene>& _scene) {
+Map::~Map() {
+
+}
+
+void Map::setScene(std::shared_ptr<Scene>& _scene) {
     {
         std::lock_guard<std::mutex> lock(m_sceneMutex);
         m_scene = _scene;
@@ -155,7 +140,7 @@ void setScene(std::shared_ptr<Scene>& _scene) {
     }
 }
 
-void loadScene(const char* _scenePath, bool _useScenePosition) {
+void Map::loadScene(const char* _scenePath, bool _useScenePosition) {
     LOG("Loading scene file: %s", _scenePath);
 
     // Copy old scene
@@ -167,7 +152,7 @@ void loadScene(const char* _scenePath, bool _useScenePosition) {
     }
 }
 
-void loadSceneAsync(const char* _scenePath, bool _useScenePosition, MapReady _platformCallback) {
+void Map::loadSceneAsync(const char* _scenePath, bool _useScenePosition, MapReady _platformCallback) {
     LOG("Loading scene file (async): %s", _scenePath);
 
     {
@@ -177,11 +162,11 @@ void loadSceneAsync(const char* _scenePath, bool _useScenePosition, MapReady _pl
         m_nextScene->useScenePosition = _useScenePosition;
     }
 
-    Tangram::runAsyncTask([scene = m_nextScene, _platformCallback](){
+    Tangram::runAsyncTask([scene = m_nextScene, _platformCallback, this](){
 
             bool ok = SceneLoader::loadScene(scene);
 
-            Tangram::runOnMainLoop([scene, ok, _platformCallback]() {
+            Tangram::runOnMainLoop([scene, ok, _platformCallback, this]() {
                     {
                         std::lock_guard<std::mutex> lock(m_sceneMutex);
                         if (scene == m_nextScene) {
@@ -191,20 +176,20 @@ void loadSceneAsync(const char* _scenePath, bool _useScenePosition, MapReady _pl
 
                     if (ok) {
                         auto s = scene;
-                        Tangram::setScene(s);
-                        Tangram::applySceneUpdates();
+                        setScene(s);
+                        applySceneUpdates();
                         if (_platformCallback) { _platformCallback(); }
                     }
                 });
         });
 }
 
-void queueSceneUpdate(const char* _path, const char* _value) {
+void Map::queueSceneUpdate(const char* _path, const char* _value) {
     std::lock_guard<std::mutex> lock(m_sceneMutex);
     m_sceneUpdates.push_back({_path, _value});
 }
 
-void applySceneUpdates() {
+void Map::applySceneUpdates() {
 
     LOG("Applying %d scene updates", m_sceneUpdates.size());
 
@@ -213,7 +198,7 @@ void applySceneUpdates() {
         return;
     }
 
-    std::vector<Scene::Update> updates;
+    std::vector<SceneUpdate> updates;
     {
         std::lock_guard<std::mutex> lock(m_sceneMutex);
         if (m_sceneUpdates.empty()) { return; }
@@ -225,13 +210,13 @@ void applySceneUpdates() {
         m_sceneUpdates.clear();
     }
 
-    Tangram::runAsyncTask([scene = m_nextScene, updates = std::move(updates)](){
+    Tangram::runAsyncTask([scene = m_nextScene, updates = std::move(updates), this](){
 
             SceneLoader::applyUpdates(scene->config(), updates);
 
             bool ok = SceneLoader::applyConfig(scene->config(), *scene);
 
-            Tangram::runOnMainLoop([scene, ok]() {
+            Tangram::runOnMainLoop([scene, ok, this]() {
                     if (scene == m_nextScene) {
                         std::lock_guard<std::mutex> lock(m_sceneMutex);
                         m_nextScene.reset();
@@ -239,14 +224,14 @@ void applySceneUpdates() {
 
                     if (ok) {
                         auto s = scene;
-                        Tangram::setScene(s);
-                        Tangram::applySceneUpdates();
+                        setScene(s);
+                        applySceneUpdates();
                     }
                 });
         });
 }
 
-void resize(int _newWidth, int _newHeight) {
+void Map::resize(int _newWidth, int _newHeight) {
 
     LOGS("resize: %d x %d", _newWidth, _newHeight);
     LOG("resize: %d x %d", _newWidth, _newHeight);
@@ -260,7 +245,7 @@ void resize(int _newWidth, int _newHeight) {
     Primitives::setResolution(_newWidth, _newHeight);
 }
 
-bool update(float _dt) {
+bool Map::update(float _dt) {
 
     FrameInfo::beginUpdate();
 
@@ -277,15 +262,15 @@ bool update(float _dt) {
 
     size_t nTasks = 0;
     {
-        std::lock_guard<std::mutex> lock(m_tasksMutex);
-        nTasks = m_tasks.size();
+        std::lock_guard<std::mutex> lock(g_tasksMutex);
+        nTasks = g_tasks.size();
     }
     while (nTasks-- > 0) {
         std::function<void()> task;
         {
-            std::lock_guard<std::mutex> lock(m_tasksMutex);
-            task = m_tasks.front();
-            m_tasks.pop();
+            std::lock_guard<std::mutex> lock(g_tasksMutex);
+            task = g_tasks.front();
+            g_tasks.pop();
         }
         task();
     }
@@ -343,11 +328,12 @@ bool update(float _dt) {
     return viewComplete;
 }
 
-void render() {
+void Map::render() {
+
     FrameInfo::beginFrame();
 
     // Invalidate render states for new frame
-    if (!g_cacheGlState) {
+    if (!m_cacheGlState) {
         RenderState::invalidate();
     }
 
@@ -383,23 +369,23 @@ void render() {
     FrameInfo::draw(*m_view, *m_tileManager);
 }
 
-int getViewportHeight() {
+int Map::getViewportHeight() {
     return m_view->getHeight();
 }
 
-int getViewportWidth() {
+int Map::getViewportWidth() {
     return m_view->getWidth();
 }
 
-float getPixelScale() {
+float Map::getPixelScale() {
     return m_view->pixelScale();
 }
 
-void captureSnapshot(unsigned int* _data) {
+void Map::captureSnapshot(unsigned int* _data) {
     GL_CHECK(glReadPixels(0, 0, m_view->getWidth(), m_view->getHeight(), GL_RGBA, GL_UNSIGNED_BYTE, (GLvoid*)_data));
 }
 
-void setPositionNow(double _lon, double _lat) {
+void Map::setPositionNow(double _lon, double _lat) {
 
     glm::dvec2 meters = m_view->getMapProjection().LonLatToMeters({ _lon, _lat});
     m_view->setPosition(meters.x, meters.y);
@@ -408,14 +394,14 @@ void setPositionNow(double _lon, double _lat) {
 
 }
 
-void setPosition(double _lon, double _lat) {
+void Map::setPosition(double _lon, double _lat) {
 
     setPositionNow(_lon, _lat);
     clearEase(EaseField::position);
 
 }
 
-void setPosition(double _lon, double _lat, float _duration, EaseType _e) {
+void Map::setPositionEased(double _lon, double _lat, float _duration, EaseType _e) {
 
     double lon_start, lat_start;
     getPosition(lon_start, lat_start);
@@ -424,7 +410,7 @@ void setPosition(double _lon, double _lat, float _duration, EaseType _e) {
 
 }
 
-void getPosition(double& _lon, double& _lat) {
+void Map::getPosition(double& _lon, double& _lat) {
 
     glm::dvec2 meters(m_view->getPosition().x, m_view->getPosition().y);
     glm::dvec2 degrees = m_view->getMapProjection().MetersToLonLat(meters);
@@ -433,7 +419,7 @@ void getPosition(double& _lon, double& _lat) {
 
 }
 
-void setZoomNow(float _z) {
+void Map::setZoomNow(float _z) {
 
     m_view->setZoom(_z);
     m_inputHandler->cancelFling();
@@ -441,14 +427,14 @@ void setZoomNow(float _z) {
 
 }
 
-void setZoom(float _z) {
+void Map::setZoom(float _z) {
 
     setZoomNow(_z);
     clearEase(EaseField::zoom);
 
 }
 
-void setZoom(float _z, float _duration, EaseType _e) {
+void Map::setZoomEased(float _z, float _duration, EaseType _e) {
 
     float z_start = getZoom();
     auto cb = [=](float t) { setZoomNow(ease(z_start, _z, t, _e)); };
@@ -456,27 +442,27 @@ void setZoom(float _z, float _duration, EaseType _e) {
 
 }
 
-float getZoom() {
+float Map::getZoom() {
 
     return m_view->getZoom();
 
 }
 
-void setRotationNow(float _radians) {
+void Map::setRotationNow(float _radians) {
 
     m_view->setRoll(_radians);
     requestRender();
 
 }
 
-void setRotation(float _radians) {
+void Map::setRotation(float _radians) {
 
     setRotationNow(_radians);
     clearEase(EaseField::rotation);
 
 }
 
-void setRotation(float _radians, float _duration, EaseType _e) {
+void Map::setRotationEased(float _radians, float _duration, EaseType _e) {
 
     float radians_start = getRotation();
 
@@ -490,28 +476,28 @@ void setRotation(float _radians, float _duration, EaseType _e) {
 
 }
 
-float getRotation() {
+float Map::getRotation() {
 
     return m_view->getRoll();
 
 }
 
 
-void setTiltNow(float _radians) {
+void Map::setTiltNow(float _radians) {
 
     m_view->setPitch(_radians);
     requestRender();
 
 }
 
-void setTilt(float _radians) {
+void Map::setTilt(float _radians) {
 
     setTiltNow(_radians);
     clearEase(EaseField::tilt);
 
 }
 
-void setTilt(float _radians, float _duration, EaseType _e) {
+void Map::setTiltEased(float _radians, float _duration, EaseType _e) {
 
     float tilt_start = getTilt();
     auto cb = [=](float t) { setTiltNow(ease(tilt_start, _radians, t, _e)); };
@@ -519,13 +505,13 @@ void setTilt(float _radians, float _duration, EaseType _e) {
 
 }
 
-float getTilt() {
+float Map::getTilt() {
 
     return m_view->getPitch();
 
 }
 
-bool screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat) {
+bool Map::screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat) {
 
     double intersection = m_view->screenToGroundPlane(_x, _y);
     glm::dvec2 meters(_x + m_view->getPosition().x, _y + m_view->getPosition().y);
@@ -536,7 +522,7 @@ bool screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat) {
     return (intersection >= 0);
 }
 
-bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y) {
+bool Map::lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y) {
     bool clipped = false;
 
     glm::vec2 screenCoords = m_view->lonLatToScreenPosition(_lng, _lat, clipped);
@@ -549,7 +535,7 @@ bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y) {
     return !clipped && withinViewport;
 }
 
-void setPixelScale(float _pixelsPerPoint) {
+void Map::setPixelScale(float _pixelsPerPoint) {
 
     if (m_view) {
         m_view->setPixelScale(_pixelsPerPoint);
@@ -564,32 +550,32 @@ void setPixelScale(float _pixelsPerPoint) {
     }
 }
 
-void setCameraType(int _type) {
+void Map::setCameraType(int _type) {
 
     m_view->setCameraType(static_cast<CameraType>(_type));
     requestRender();
 
 }
 
-int getCameraType() {
+int Map::getCameraType() {
 
     return static_cast<int>(m_view->cameraType());
 
 }
 
-void addDataSource(std::shared_ptr<DataSource> _source) {
+void Map::addDataSource(std::shared_ptr<DataSource> _source) {
     if (!m_tileManager) { return; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);
     m_tileManager->addClientDataSource(_source);
 }
 
-bool removeDataSource(DataSource& source) {
+bool Map::removeDataSource(DataSource& source) {
     if (!m_tileManager) { return false; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);
     return m_tileManager->removeClientDataSource(source);
 }
 
-void clearDataSource(DataSource& _source, bool _data, bool _tiles) {
+void Map::clearDataSource(DataSource& _source, bool _data, bool _tiles) {
     if (!m_tileManager) { return; }
     std::lock_guard<std::mutex> lock(m_tilesMutex);
 
@@ -599,52 +585,105 @@ void clearDataSource(DataSource& _source, bool _data, bool _tiles) {
     requestRender();
 }
 
-void handleTapGesture(float _posX, float _posY) {
+void Map::handleTapGesture(float _posX, float _posY) {
 
     m_inputHandler->handleTapGesture(_posX, _posY);
 
 }
 
-void handleDoubleTapGesture(float _posX, float _posY) {
+void Map::handleDoubleTapGesture(float _posX, float _posY) {
 
     m_inputHandler->handleDoubleTapGesture(_posX, _posY);
 
 }
 
-void handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
+void Map::handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
 
     m_inputHandler->handlePanGesture(_startX, _startY, _endX, _endY);
 
 }
 
-void handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY) {
+void Map::handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY) {
 
     m_inputHandler->handleFlingGesture(_posX, _posY, _velocityX, _velocityY);
 
 }
 
-void handlePinchGesture(float _posX, float _posY, float _scale, float _velocity) {
+void Map::handlePinchGesture(float _posX, float _posY, float _scale, float _velocity) {
 
     m_inputHandler->handlePinchGesture(_posX, _posY, _scale, _velocity);
 
 }
 
-void handleRotateGesture(float _posX, float _posY, float _radians) {
+void Map::handleRotateGesture(float _posX, float _posY, float _radians) {
 
     m_inputHandler->handleRotateGesture(_posX, _posY, _radians);
 
 }
 
-void handleShoveGesture(float _distance) {
+void Map::handleShoveGesture(float _distance) {
 
     m_inputHandler->handleShoveGesture(_distance);
 
 }
 
+void Map::setupGL() {
+
+    LOG("setup GL");
+
+    if (m_tileManager) {
+        m_tileManager->clearTileSets();
+    }
+
+    // Reconfigure the render states. Increases context 'generation'.
+    // The OpenGL context has been destroyed since the last time resources were
+    // created, so we invalidate all data that depends on OpenGL object handles.
+    RenderState::increaseGeneration();
+    RenderState::invalidate();
+
+    // Set default primitive render color
+    Primitives::setColor(0xffffff);
+
+    // Load GL extensions and capabilities
+    Hardware::loadExtensions();
+    Hardware::loadCapabilities();
+
+    Hardware::printAvailableExtensions();
+}
+
+void Map::useCachedGlState(bool _useCache) {
+    m_cacheGlState = _useCache;
+}
+
+const std::vector<TouchItem>& Map::pickFeaturesAt(float _x, float _y) {
+    return m_labels->getFeaturesAtPoint(*m_view, 0, m_scene->styles(),
+                                        m_tileManager->getVisibleTiles(),
+                                        _x, _y);
+}
+
+void runOnMainLoop(std::function<void()> _task) {
+    std::lock_guard<std::mutex> lock(g_tasksMutex);
+    g_tasks.emplace(std::move(_task));
+    // FIXME: The collection of tasks should be a mapping from thread IDs to lists of tasks;
+    // Any resources that need to be disposed on a GL thread can store the ID of the thread
+    // that they are created on, then pass that ID into this function when they are
+    // disposed; this ensures that multiple tangram instances on multiple threads can all
+    // safely dispose their GL resources on the same thread that created them.
+}
+
+void runAsyncTask(std::function<void()> _task) {
+    m_asyncWorker.enqueue(std::move(_task));
+}
+
+float frameTime() {
+    // FIXME: g_time should be a member of each Map instance
+    return g_time;
+}
+
 void setDebugFlag(DebugFlags _flag, bool _on) {
 
     g_flags.set(_flag, _on);
-    m_view->setZoom(m_view->getZoom()); // Force the view to refresh
+    // m_view->setZoom(m_view->getZoom()); // Force the view to refresh
 
 }
 
@@ -657,67 +696,17 @@ bool getDebugFlag(DebugFlags _flag) {
 void toggleDebugFlag(DebugFlags _flag) {
 
     g_flags.flip(_flag);
-    m_view->setZoom(m_view->getZoom()); // Force the view to refresh
+    // m_view->setZoom(m_view->getZoom()); // Force the view to refresh
 
     // Rebuild tiles for debug modes that needs it
-    if (_flag == DebugFlags::proxy_colors
-     || _flag == DebugFlags::tile_bounds
-     || _flag == DebugFlags::all_labels
-     || _flag == DebugFlags::tile_infos) {
-        if (m_tileManager) {
-            std::lock_guard<std::mutex> lock(m_tilesMutex);
-            m_tileManager->clearTileSets();
-        }
-    }
-}
-
-const std::vector<TouchItem>& pickFeaturesAt(float _x, float _y) {
-    return m_labels->getFeaturesAtPoint(*m_view, 0, m_scene->styles(),
-                                        m_tileManager->getVisibleTiles(),
-                                        _x, _y);
-}
-
-void useCachedGlState(bool _useCache) {
-    g_cacheGlState = _useCache;
-}
-
-void setupGL() {
-
-    LOG("setup GL");
-
-    if (m_tileManager) {
-        m_tileManager->clearTileSets();
-    }
-
-    // Reconfigure the render states. Increases context 'generation'.
-    // The OpenGL context has been destroyed since the last time resources were
-    // created, so we invalidate all data that depends on OpenGL object handles.
-    RenderState::invalidate();
-    RenderState::increaseGeneration();
-
-    // Set default primitive render color
-    Primitives::setColor(0xffffff);
-
-    // Load GL extensions and capabilities
-    Hardware::loadExtensions();
-    Hardware::loadCapabilities();
-
-    Hardware::printAvailableExtensions();
-}
-
-void runOnMainLoop(std::function<void()> _task) {
-    std::lock_guard<std::mutex> lock(m_tasksMutex);
-    m_tasks.emplace(std::move(_task));
-
-    requestRender();
-}
-
-void runAsyncTask(std::function<void()> _task) {
-    m_asyncWorker.enqueue(std::move(_task));
-}
-
-float frameTime() {
-    return g_time;
+    // if (_flag == DebugFlags::proxy_colors
+    //  || _flag == DebugFlags::tile_bounds
+    //  || _flag == DebugFlags::tile_infos) {
+    //     if (m_tileManager) {
+    //         std::lock_guard<std::mutex> lock(m_tilesMutex);
+    //         m_tileManager->clearTileSets();
+    //     }
+    // }
 }
 
 }

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -35,14 +35,13 @@ class Map {
 
 public:
 
-    // Create resources and initialize the map view using the scene file at the
-    // given resource path
-    Map(const char* _scenePath);
-
+    // Create an empty map object. To display a map, call either loadScene() or loadSceneAsync().
+    Map();
     ~Map();
 
     // Load the scene at the given absolute file path asynchronously
     void loadSceneAsync(const char* _scenePath, bool _useScenePosition = false, std::function<void(void)> _platformCallback = {});
+
     // Load the scene at the given absolute file path synchronously
     void loadScene(const char* _scenePath, bool _useScenePosition = false);
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -11,6 +11,7 @@
 
 namespace Tangram {
 
+class AsyncWorker;
 class DataSource;
 class InputHandler;
 class Labels;
@@ -179,6 +180,9 @@ public:
 
     const std::vector<TouchItem>& pickFeaturesAt(float _x, float _y);
 
+    // Run this task asynchronously to Tangram's main update loop.
+    void runAsyncTask(std::function<void()> _task);
+
 private:
 
     enum class EaseField { position, zoom, rotation, tilt };
@@ -200,14 +204,12 @@ private:
     std::shared_ptr<View> m_view;
     std::unique_ptr<Labels> m_labels;
     std::unique_ptr<InputHandler> m_inputHandler;
+    std::unique_ptr<AsyncWorker> m_asyncWorker;
     std::vector<SceneUpdate> m_sceneUpdates;
     std::array<Ease, 4> m_eases;
     bool m_cacheGlState;
 
 };
-
-// Run this task asynchronously to Tangram's main update loop.
-void runAsyncTask(std::function<void()> _task);
 
 enum DebugFlags {
     freeze_tiles = 0,   // While on, the set of tiles currently being drawn will not update to match the view

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -206,8 +206,6 @@ private:
 
 };
 
-void runOnMainLoop(std::function<void()> _task);
-
 // Run this task asynchronously to Tangram's main update loop.
 void runAsyncTask(std::function<void()> _task);
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -211,8 +211,6 @@ void runOnMainLoop(std::function<void()> _task);
 // Run this task asynchronously to Tangram's main update loop.
 void runAsyncTask(std::function<void()> _task);
 
-float frameTime();
-
 enum DebugFlags {
     freeze_tiles = 0,   // While on, the set of tiles currently being drawn will not update to match the view
     proxy_colors,       // Applies a color change to every other zoom level of tiles to visualize proxy tile behavior

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -2,144 +2,216 @@
 
 #include "data/properties.h"
 #include "util/ease.h"
+#include <array>
 #include <memory>
-#include <vector>
+#include <mutex>
+#include <queue>
 #include <string>
-
-/* Tangram API
- *
- * Primary interface for controlling and managing the lifecycle of a Tangram
- * map surface
- */
+#include <vector>
 
 namespace Tangram {
 
 class DataSource;
+class InputHandler;
+class Labels;
+class Scene;
+class TileManager;
+class TileWorker;
+class View;
 
-// Create resources and initialize the map view using the scene file at the
-// given resource path
-void initialize(const char* _scenePath);
+struct TouchItem {
+    std::shared_ptr<Properties> properties;
+    float position[2];
+    float distance;
+};
 
-// Load the scene at the given absolute file path asynchronously
-void loadSceneAsync(const char* _scenePath, bool _useScenePosition = false, std::function<void(void)> _platformCallback = {});
-// Load the scene at the given absolute file path synchronously
-void loadScene(const char* _scenePath, bool _useScenePosition = false);
+struct SceneUpdate {
+    std::string keys;
+    std::string value;
+};
 
-// Request an update to the scene configuration; the path is a series of yaml keys
-// separated by a '.' and the value is a string of yaml to replace the current value
-// at the given path in the scene
-void queueSceneUpdate(const char* _path, const char* _value);
+class Map {
 
-// Apply all previously requested scene updates
-void applySceneUpdates();
+public:
 
-// Initialize graphics resources; OpenGL context must be created prior to calling this
-void setupGL();
+    // Create resources and initialize the map view using the scene file at the
+    // given resource path
+    Map(const char* _scenePath);
 
-// Resize the map view to a new width and height (in pixels)
-void resize(int _newWidth, int _newHeight);
+    ~Map();
 
-// Update the map state with the time interval since the last update, returns
-// true when the current view is completely loaded (all tiles are available and
-// no animation in progress)
-bool update(float _dt);
+    // Load the scene at the given absolute file path asynchronously
+    void loadSceneAsync(const char* _scenePath, bool _useScenePosition = false, std::function<void(void)> _platformCallback = {});
+    // Load the scene at the given absolute file path synchronously
+    void loadScene(const char* _scenePath, bool _useScenePosition = false);
 
-// Render a new frame of the map view (if needed)
-void render();
+    // Request an update to the scene configuration; the path is a series of yaml keys
+    // separated by a '.' and the value is a string of yaml to replace the current value
+    // at the given path in the scene
+    void queueSceneUpdate(const char* _path, const char* _value);
 
-// Set the position of the map view in degrees longitude and latitude; if duration
-// (in seconds) is provided, position eases to the set value over the duration;
-// calling either version of the setter overrides all previous calls
-void setPosition(double _lon, double _lat);
-void setPosition(double _lon, double _lat, float _duration, EaseType _e = EaseType::quint);
+    // Apply all previously requested scene updates
+    void applySceneUpdates();
 
-// Set the values of the arguments to the position of the map view in degrees
-// longitude and latitude
-void getPosition(double& _lon, double& _lat);
+    // Initialize graphics resources; OpenGL context must be created prior to calling this
+    void setupGL();
 
-// Set the fractional zoom level of the view; if duration (in seconds) is provided,
-// zoom eases to the set value over the duration; calling either version of the setter
-// overrides all previous calls
-void setZoom(float _z);
-void setZoom(float _z, float _duration, EaseType _e = EaseType::quint);
+    // Resize the map view to a new width and height (in pixels)
+    void resize(int _newWidth, int _newHeight);
 
-// Get the fractional zoom level of the view
-float getZoom();
+    // Update the map state with the time interval since the last update, returns
+    // true when the current view is completely loaded (all tiles are available and
+    // no animation in progress)
+    bool update(float _dt);
 
-// Set the counter-clockwise rotation of the view in radians; 0 corresponds to
-// North pointing up; if duration (in seconds) is provided, rotation eases to the
-// the set value over the duration; calling either version of the setter overrides
-// all previous calls
-void setRotation(float _radians);
-void setRotation(float _radians, float _duration, EaseType _e = EaseType::quint);
+    // Render a new frame of the map view (if needed)
+    void render();
 
-// Get the counter-clockwise rotation of the view in radians; 0 corresponds to
-// North pointing up
-float getRotation();
+    // Gets the viewport height in physical pixels (framebuffer size)
+    int getViewportHeight();
 
-// Set the tilt angle of the view in radians; 0 corresponds to straight down;
-// if duration (in seconds) is provided, tilt eases to the set value over the
-// duration; calling either version of the setter overrides all previous calls
-void setTilt(float _radians);
-void setTilt(float _radians, float _duration, EaseType _e = EaseType::quint);
+    // Gets the viewport width in physical pixels (framebuffer size)
+    int getViewportWidth();
 
-// Get the tilt angle of the view in radians; 0 corresponds to straight down
-float getTilt();
+    // Set the ratio of hardware pixels to logical pixels (defaults to 1.0)
+    void setPixelScale(float _pixelsPerPoint);
 
-// Given coordinates in screen space (x right, y down), set the output longitude and
-// latitude to the geographic location corresponding to that point; returns false if
-// no geographic position corresponds to the screen location, otherwise returns true
-bool screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat);
+    // Gets the pixel scale
+    float getPixelScale();
 
-// Given longitude and latitude coordinates, set the output coordinates to the
-// corresponding point in screen space (x right, y down); returns false if the
-// point is not visible on the screen, otherwise returns true
-bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y);
+    // Capture a snapshot of the current frame and store it in the allocated _data
+    // _data is expected to be of size getViewportHeight() * getViewportWidth()
+    // Pixel data is stored starting from the lower left corner of the viewport
+    // Each pixel(x, y) would be located at _data[y * getViewportWidth() + x]
+    // Each unsigned int corresponds to an RGBA pixel value
+    void captureSnapshot(unsigned int* _data);
 
-// Set the ratio of hardware pixels to logical pixels (defaults to 1.0)
-void setPixelScale(float _pixelsPerPoint);
+    // Set the position of the map view in degrees longitude and latitude; if duration
+    // (in seconds) is provided, position eases to the set value over the duration;
+    // calling either version of the setter overrides all previous calls
+    void setPosition(double _lon, double _lat);
+    void setPositionEased(double _lon, double _lat, float _duration, EaseType _e = EaseType::quint);
 
-// Set the camera type (0 = perspective, 1 = isometric, 2 = flat)
-void setCameraType(int _type);
+    // Set the values of the arguments to the position of the map view in degrees
+    // longitude and latitude
+    void getPosition(double& _lon, double& _lat);
 
-// Get the camera type (0 = perspective, 1 = isometric, 2 = flat)
-int getCameraType();
+    // Set the fractional zoom level of the view; if duration (in seconds) is provided,
+    // zoom eases to the set value over the duration; calling either version of the setter
+    // overrides all previous calls
+    void setZoom(float _z);
+    void setZoomEased(float _z, float _duration, EaseType _e = EaseType::quint);
 
-// Add a data source for adding drawable map data, which will be styled
-// according to the scene file using the provided data source name;
-void addDataSource(std::shared_ptr<DataSource> _source);
+    // Get the fractional zoom level of the view
+    float getZoom();
 
-// Remove a data source from the map; returns true if the source was found
-// and removed, otherwise returns false.
-bool removeDataSource(DataSource& _source);
+    // Set the counter-clockwise rotation of the view in radians; 0 corresponds to
+    // North pointing up; if duration (in seconds) is provided, rotation eases to the
+    // the set value over the duration; calling either version of the setter overrides
+    // all previous calls
+    void setRotation(float _radians);
+    void setRotationEased(float _radians, float _duration, EaseType _e = EaseType::quint);
 
-void clearDataSource(DataSource& _source, bool _data, bool _tiles);
+    // Get the counter-clockwise rotation of the view in radians; 0 corresponds to
+    // North pointing up
+    float getRotation();
 
-// Respond to a tap at the given screen coordinates (x right, y down)
-void handleTapGesture(float _posX, float _posY);
+    // Set the tilt angle of the view in radians; 0 corresponds to straight down;
+    // if duration (in seconds) is provided, tilt eases to the set value over the
+    // duration; calling either version of the setter overrides all previous calls
+    void setTilt(float _radians);
+    void setTiltEased(float _radians, float _duration, EaseType _e = EaseType::quint);
 
-// Respond to a double tap at the given screen coordinates (x right, y down)
-void handleDoubleTapGesture(float _posX, float _posY);
+    // Get the tilt angle of the view in radians; 0 corresponds to straight down
+    float getTilt();
 
-// Respond to a drag with the given displacement in screen coordinates (x right, y down)
-void handlePanGesture(float _startX, float _startY, float _endX, float _endY);
+    // Set the camera type (0 = perspective, 1 = isometric, 2 = flat)
+    void setCameraType(int _type);
 
-// Respond to a fling from the given position with the given velocity in screen coordinates
-void handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY);
+    // Get the camera type (0 = perspective, 1 = isometric, 2 = flat)
+    int getCameraType();
 
-// Respond to a pinch at the given position in screen coordinates with the given
-// incremental scale
-void handlePinchGesture(float _posX, float _posY, float _scale, float _velocity);
+    // Given coordinates in screen space (x right, y down), set the output longitude and
+    // latitude to the geographic location corresponding to that point; returns false if
+    // no geographic position corresponds to the screen location, otherwise returns true
+    bool screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat);
 
-// Respond to a rotation gesture with the given incremental rotation in radians
-void handleRotateGesture(float _posX, float _posY, float _rotation);
+    // Given longitude and latitude coordinates, set the output coordinates to the
+    // corresponding point in screen space (x right, y down); returns false if the
+    // point is not visible on the screen, otherwise returns true
+    bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y);
 
-// Respond to a two-finger shove with the given distance in screen coordinates
-void handleShoveGesture(float _distance);
+    // Add a data source for adding drawable map data, which will be styled
+    // according to the scene file using the provided data source name;
+    void addDataSource(std::shared_ptr<DataSource> _source);
 
-// Set whether the OpenGL state will be cached between subsequent frames; this improves rendering
-// efficiency, but can cause errors if your application code makes OpenGL calls (false by default)
-void useCachedGlState(bool _use);
+    // Remove a data source from the map; returns true if the source was found
+    // and removed, otherwise returns false.
+    bool removeDataSource(DataSource& _source);
+
+    void clearDataSource(DataSource& _source, bool _data, bool _tiles);
+
+    // Respond to a tap at the given screen coordinates (x right, y down)
+    void handleTapGesture(float _posX, float _posY);
+
+    // Respond to a double tap at the given screen coordinates (x right, y down)
+    void handleDoubleTapGesture(float _posX, float _posY);
+
+    // Respond to a drag with the given displacement in screen coordinates (x right, y down)
+    void handlePanGesture(float _startX, float _startY, float _endX, float _endY);
+
+    // Respond to a fling from the given position with the given velocity in screen coordinates
+    void handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY);
+
+    // Respond to a pinch at the given position in screen coordinates with the given
+    // incremental scale
+    void handlePinchGesture(float _posX, float _posY, float _scale, float _velocity);
+
+    // Respond to a rotation gesture with the given incremental rotation in radians
+    void handleRotateGesture(float _posX, float _posY, float _rotation);
+
+    // Respond to a two-finger shove with the given distance in screen coordinates
+    void handleShoveGesture(float _distance);
+
+    // Set whether the OpenGL state will be cached between subsequent frames; this improves rendering
+    // efficiency, but can cause errors if your application code makes OpenGL calls (false by default)
+    void useCachedGlState(bool _use);
+
+    const std::vector<TouchItem>& pickFeaturesAt(float _x, float _y);
+
+private:
+
+    enum class EaseField { position, zoom, rotation, tilt };
+
+    void setEase(EaseField _f, Ease _e);
+    void clearEase(EaseField _f);
+    void setScene(std::shared_ptr<Scene>& _scene);
+    void setPositionNow(double _lon, double _lat);
+    void setZoomNow(float _z);
+    void setRotationNow(float _radians);
+    void setTiltNow(float _radians);
+
+    std::mutex m_tilesMutex;
+    std::mutex m_sceneMutex;
+    std::unique_ptr<TileWorker> m_tileWorker;
+    std::unique_ptr<TileManager> m_tileManager;
+    std::shared_ptr<Scene> m_scene;
+    std::shared_ptr<Scene> m_nextScene;
+    std::shared_ptr<View> m_view;
+    std::unique_ptr<Labels> m_labels;
+    std::unique_ptr<InputHandler> m_inputHandler;
+    std::vector<SceneUpdate> m_sceneUpdates;
+    std::array<Ease, 4> m_eases;
+    bool m_cacheGlState;
+
+};
+
+void runOnMainLoop(std::function<void()> _task);
+
+// Run this task asynchronously to Tangram's main update loop.
+void runAsyncTask(std::function<void()> _task);
+
+float frameTime();
 
 enum DebugFlags {
     freeze_tiles = 0,   // While on, the set of tiles currently being drawn will not update to match the view
@@ -160,38 +232,6 @@ bool getDebugFlag(DebugFlags _flag);
 
 // Toggle the boolean state of a debug feature (see debug.h)
 void toggleDebugFlag(DebugFlags _flag);
-
-// Run this task on Tangram's main update loop.
-void runOnMainLoop(std::function<void()> _task);
-
-// Run this task asynchronously to Tangram's main update loop.
-void runAsyncTask(std::function<void()> _task);
-
-// Gets the viewport height in physical pixels (framebuffer size)
-int getViewportHeight();
-
-// Gets the viewport width in physical pixels (framebuffer size)
-int getViewportWidth();
-
-// Gets the pixel scale
-float getPixelScale();
-
-// Capture a snapshot of the current frame and store it in the allocated _data
-// _data is expected to be of size getViewportHeight() * getViewportWidth()
-// Pixel data is stored starting from the lower left corner of the viewport
-// Each pixel(x, y) would be located at _data[y * getViewportWidth() + x]
-// Each unsigned int corresponds to an RGBA pixel value
-void captureSnapshot(unsigned int* _data);
-
-struct TouchItem {
-    std::shared_ptr<Properties> properties;
-    float position[2];
-    float distance;
-};
-
-const std::vector<TouchItem>& pickFeaturesAt(float _x, float _y);
-
-float frameTime();
 
 }
 

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "tile/tileTask.h"
+#include "util/jobQueue.h"
 
 #include <memory>
 #include <vector>
@@ -39,6 +40,8 @@ private:
 
     void run(Worker* instance);
 
+    void disposeBuilder(std::unique_ptr<TileBuilder> _builder);
+
     bool m_running;
 
     std::vector<std::unique_ptr<Worker>> m_workers;
@@ -47,6 +50,8 @@ private:
 
     std::mutex m_mutex;
     std::vector<std::shared_ptr<TileTask>> m_queue;
+
+    JobQueue m_mainThreadJobQueue;
 
 };
 

--- a/core/src/util/jobQueue.cpp
+++ b/core/src/util/jobQueue.cpp
@@ -1,0 +1,41 @@
+#include "jobQueue.h"
+#include <mutex>
+#include <unordered_map>
+
+namespace Tangram {
+
+std::unordered_map<JobQueue::ThreadId, std::vector<JobQueue::Job>> jobsForThreads;
+std::mutex jobMutex;
+
+void JobQueue::makeCurrentThreadTarget() {
+    m_threadId = std::this_thread::get_id();
+}
+
+void JobQueue::add(Job job) {
+    std::lock_guard<std::mutex> lock(jobMutex);
+    jobsForThreads[m_threadId].push_back(job);
+}
+
+void JobQueue::runJobsForCurrentThread() {
+    auto currentThreadId = std::this_thread::get_id();
+
+    const auto& entry = jobsForThreads.find(currentThreadId);
+    if (entry == jobsForThreads.end()) {
+        // Nothing to do here.
+        return;
+    }
+
+    auto& jobs = entry->second;
+    while (!jobs.empty()) {
+        Job job;
+        {
+            std::lock_guard<std::mutex> lock(jobMutex);
+            job.swap(jobs.back());
+            jobs.pop_back();
+        }
+        job();
+    }
+
+}
+
+} //namespace Tangram

--- a/core/src/util/jobQueue.cpp
+++ b/core/src/util/jobQueue.cpp
@@ -11,7 +11,7 @@ void JobQueue::makeCurrentThreadTarget() {
     m_threadId = std::this_thread::get_id();
 }
 
-void JobQueue::add(Job job) {
+void JobQueue::add(Job job) const {
     std::lock_guard<std::mutex> lock(jobMutex);
     jobsForThreads[m_threadId].push_back(job);
 }

--- a/core/src/util/jobQueue.h
+++ b/core/src/util/jobQueue.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <functional>
+#include <thread>
+#include <vector>
+
+namespace Tangram {
+
+// JobQueue allows you to send runnable jobs to a target thread:
+//   1. Set the target thread for the JobQueue by calling makeCurrentThreadTarget() once on the target thread.
+//   2. From any thread, call add() with the job you want to run on the target thread.
+//   3. Call JobQueue::runJobsForCurrentThread() on the target thread.
+// This is useful for OpenGL resources that must be created and destroyed on the GL thread.
+
+class JobQueue {
+
+public:
+    using Job = std::function<void()>;
+    using ThreadId = std::thread::id;
+
+    JobQueue() = default;
+    ~JobQueue() = default;
+
+    void makeCurrentThreadTarget();
+    void add(Job job);
+
+    static void runJobsForCurrentThread();
+
+private:
+    ThreadId m_threadId;
+
+};
+
+}

--- a/core/src/util/jobQueue.h
+++ b/core/src/util/jobQueue.h
@@ -22,7 +22,7 @@ public:
     ~JobQueue() = default;
 
     void makeCurrentThreadTarget();
-    void add(Job job);
+    void add(Job job) const;
 
     static void runJobsForCurrentThread();
 

--- a/ios/src/ViewController.h
+++ b/ios/src/ViewController.h
@@ -6,13 +6,14 @@
 //  Copyright (c) 2014 Mapzen. All rights reserved.
 //
 
+#include "tangram.h"
+
 #import <UIKit/UIKit.h>
 #import <GLKit/GLKit.h>
 
-struct TileID;
-
 @interface ViewController : GLKViewController <UIGestureRecognizerDelegate>
 
+@property (nonatomic) Tangram::Map* map;
 @property (nonatomic) bool continuous;
 - (void)renderOnce;
 

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -216,6 +216,10 @@
 
 - (void)tearDownGL
 {
+    if (self.map) {
+        delete self.map;
+        self.map = nullptr;
+    }
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/ios/src/ViewController.mm
+++ b/ios/src/ViewController.mm
@@ -201,7 +201,7 @@
     [EAGLContext setCurrentContext:self.context];
 
     if (!self.map) {
-        self.map = new Tangram::Map("scene.yaml");
+        self.map = new Tangram::Map();
         self.map->loadSceneAsync("scene.yaml");
     }
     self.map->setupGL();

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -393,6 +393,11 @@ int main(int argc, char* argv[]) {
 
     finishUrlRequests();
 
+    if (map) {
+        delete map;
+        map = nullptr;
+    }
+
     curl_global_cleanup();
     glfwTerminate();
     return 0;

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -262,7 +262,7 @@ void init_main_window(bool recreate) {
 
     // Setup tangram
     if (!map) {
-        map = new Tangram::Map(sceneFile.c_str());
+        map = new Tangram::Map();
         map->loadSceneAsync(sceneFile.c_str());
     }
 

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -258,11 +258,6 @@ void window_size_callback(GLFWwindow* window, int width, int height) {
 
 }
 
-void updatePostInit() {
-    //stamford, ct location
-    Tangram::setPosition(-73.5387, 41.0534, 1.0);
-}
-
 void init_main_window(bool recreate) {
 
     // Setup tangram

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -390,6 +390,11 @@ int main(int argc, char* argv[]) {
 
     finishUrlRequests();
 
+    if (map) {
+        delete map;
+        map = nullptr;
+    }
+
     glfwTerminate();
     return 0;
 }

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -279,7 +279,7 @@ void init_main_window(bool recreate) {
 
     // Setup tangram
     if (!map) {
-        map = new Tangram::Map(sceneFile.c_str());
+        map = new Tangram::Map();
         map->loadSceneAsync(sceneFile.c_str());
     }
 

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -13,6 +13,7 @@ void init_main_window(bool recreate);
 std::string sceneFile = "scene.yaml";
 
 GLFWwindow* main_window = nullptr;
+Tangram::Map* map = nullptr;
 int width = 800;
 int height = 600;
 float density = 1.0;
@@ -60,14 +61,14 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
 
     if (was_panning && action == GLFW_RELEASE) {
         was_panning = false;
-        Tangram::handleFlingGesture(x, y,
-                                    clamp(last_x_velocity, -2000.0, 2000.0),
-                                    clamp(last_y_velocity, -2000.0, 2000.0));
+        auto vx = clamp(last_x_velocity, -2000.0, 2000.0);
+        auto vy = clamp(last_y_velocity, -2000.0, 2000.0);
+        map->handleFlingGesture(x, y, vx, vy);
         return; // Clicks with movement don't count as taps, so stop here
     }
 
     if (action == GLFW_PRESS) {
-        Tangram::handlePanGesture(0.0f, 0.0f, 0.0f, 0.0f);
+        map->handlePanGesture(0.0f, 0.0f, 0.0f, 0.0f);
         last_x_down = x;
         last_y_down = y;
         last_time_pressed = time;
@@ -77,13 +78,13 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
     if ((time - last_time_released) < double_tap_time) {
         // Double tap recognized
         LngLat p;
-        Tangram::screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
-        Tangram::setPosition(p.longitude, p.latitude, 1.f);
+        map->screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
+        map->setPositionEased(p.longitude, p.latitude, 1.f);
 
         logMsg("pick feature\n");
-        Tangram::clearDataSource(*data_source, true, true);
+        map->clearDataSource(*data_source, true, true);
 
-        auto picks = Tangram::pickFeaturesAt(x, y);
+        auto picks = map->pickFeaturesAt(x, y);
         std::string name;
         logMsg("picked %d features\n", picks.size());
         for (const auto& it : picks) {
@@ -94,7 +95,7 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
     } else if ((time - last_time_pressed) < single_tap_time) {
         // Single tap recognized
         LngLat p1;
-        Tangram::screenPositionToLngLat(x, y, &p1.longitude, &p1.latitude);
+        map->screenPositionToLngLat(x, y, &p1.longitude, &p1.latitude);
 
         if (!(last_point == LngLat{0, 0})) {
             LngLat p2 = last_point;
@@ -133,7 +134,7 @@ void cursor_pos_callback(GLFWwindow* window, double x, double y) {
     if (action == GLFW_PRESS) {
 
         if (was_panning) {
-            Tangram::handlePanGesture(last_x_down, last_y_down, x, y);
+            map->handlePanGesture(last_x_down, last_y_down, x, y);
         }
 
         was_panning = true;
@@ -159,11 +160,11 @@ void scroll_callback(GLFWwindow* window, double scrollx, double scrolly) {
     bool shoving = glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS || glfwGetKey(window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS;
 
     if (shoving) {
-        Tangram::handleShoveGesture(scroll_distance_multiplier * scrolly);
+        map->handleShoveGesture(scroll_distance_multiplier * scrolly);
     } else if (rotating) {
-        Tangram::handleRotateGesture(x, y, scroll_span_multiplier * scrolly);
+        map->handleRotateGesture(x, y, scroll_span_multiplier * scrolly);
     } else {
-        Tangram::handlePinchGesture(x, y, 1.0 + scroll_span_multiplier * scrolly, 0.f);
+        map->handlePinchGesture(x, y, 1.0 + scroll_span_multiplier * scrolly, 0.f);
     }
 
 }
@@ -200,13 +201,13 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 recreate_context = true;
                 break;
             case GLFW_KEY_R:
-                Tangram::loadSceneAsync(sceneFile.c_str());
+                map->loadSceneAsync(sceneFile.c_str());
                 break;
             case GLFW_KEY_Z:
-                Tangram::setZoom(Tangram::getZoom() + 1.f, 1.5f);
+                map->setZoomEased(map->getZoom() + 1.f, 1.5f);
                 break;
             case GLFW_KEY_N:
-                Tangram::setRotation(0.f, 1.f);
+                map->setRotationEased(0.f, 1.f);
                 break;
             case GLFW_KEY_S:
                 if (pixel_scale == 1.0) {
@@ -216,30 +217,30 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 } else {
                     pixel_scale = 1.0;
                 }
-                Tangram::loadSceneAsync(sceneFile.c_str());
-                Tangram::setPixelScale(pixel_scale);
+                map->loadSceneAsync(sceneFile.c_str());
+                map->setPixelScale(pixel_scale);
                 break;
             case GLFW_KEY_P:
-                Tangram::queueSceneUpdate("cameras", "{ main_camera: { type: perspective } }");
-                Tangram::applySceneUpdates();
+                map->queueSceneUpdate("cameras", "{ main_camera: { type: perspective } }");
+                map->applySceneUpdates();
                 break;
             case GLFW_KEY_I:
-                Tangram::queueSceneUpdate("cameras", "{ main_camera: { type: isometric } }");
-                Tangram::applySceneUpdates();
+                map->queueSceneUpdate("cameras", "{ main_camera: { type: isometric } }");
+                map->applySceneUpdates();
                 break;
             case GLFW_KEY_G:
                 static bool geoJSON = false;
                 if (!geoJSON) {
                     LOGS("Switching to GeoJSON data source");
-                    Tangram::queueSceneUpdate("sources.osm.type", "GeoJSON");
-                    Tangram::queueSceneUpdate("sources.osm.url", "https://vector.mapzen.com/osm/all/{z}/{x}/{y}.json");
+                    map->queueSceneUpdate("sources.osm.type", "GeoJSON");
+                    map->queueSceneUpdate("sources.osm.url", "https://vector.mapzen.com/osm/all/{z}/{x}/{y}.json");
                 } else {
                     LOGS("Switching to MVT data source");
-                    Tangram::queueSceneUpdate("sources.osm.type", "MVT");
-                    Tangram::queueSceneUpdate("sources.osm.url", "https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt");
+                    map->queueSceneUpdate("sources.osm.type", "MVT");
+                    map->queueSceneUpdate("sources.osm.url", "https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt");
                 }
                 geoJSON = !geoJSON;
-                Tangram::applySceneUpdates();
+                map->applySceneUpdates();
                 break;
             case GLFW_KEY_ESCAPE:
                 glfwSetWindowShouldClose(main_window, true);
@@ -253,7 +254,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void drop_callback(GLFWwindow* window, int count, const char** paths) {
 
     sceneFile = std::string(paths[0]);
-    Tangram::loadSceneAsync(sceneFile.c_str());
+    map->loadSceneAsync(sceneFile.c_str());
 
 }
 
@@ -269,16 +270,18 @@ void framebuffer_size_callback(GLFWwindow* window, int fWidth, int fHeight) {
         recreate_context = true;
         density = new_density;
     }
-    Tangram::setPixelScale(density);
-    Tangram::resize(fWidth, fHeight);
+    map->setPixelScale(density);
+    map->resize(fWidth, fHeight);
 
 }
 
 void init_main_window(bool recreate) {
 
     // Setup tangram
-    Tangram::initialize(sceneFile.c_str());
-    Tangram::loadSceneAsync(sceneFile.c_str());
+    if (!map) {
+        map = new Tangram::Map(sceneFile.c_str());
+        map->loadSceneAsync(sceneFile.c_str());
+    }
 
     if (!recreate) {
         // Destroy old window
@@ -306,13 +309,13 @@ void init_main_window(bool recreate) {
     }
 
     // Setup graphics
-    Tangram::setupGL();
+    map->setupGL();
     int fWidth = 0, fHeight = 0;
     glfwGetFramebufferSize(main_window, &fWidth, &fHeight);
     framebuffer_size_callback(main_window, fWidth, fHeight);
 
     data_source = std::make_shared<ClientGeoJsonSource>("touch", "");
-    Tangram::addDataSource(data_source);
+    map->addDataSource(data_source);
 
 }
 
@@ -363,8 +366,8 @@ int main(int argc, char* argv[]) {
         lastTime = currentTime;
 
         // Render
-        Tangram::update(delta);
-        Tangram::render();
+        map->update(delta);
+        map->render();
 
         // Swap front and back buffers
         glfwSwapBuffers(main_window);

--- a/rpi/src/main.cpp
+++ b/rpi/src/main.cpp
@@ -64,6 +64,11 @@ int main(int argc, char **argv){
         }
     }
 
+    if (map) {
+        delete map;
+        map = nullptr;
+    }
+
     curl_global_cleanup();
     closeGL();
     return 0;

--- a/rpi/src/main.cpp
+++ b/rpi/src/main.cpp
@@ -30,6 +30,8 @@
 struct timeval tv;
 unsigned long long timePrev, timeStart;
 
+Tangram::Map* map = nullptr;
+
 static bool bUpdate = true;
 
 //==============================================================================
@@ -98,21 +100,21 @@ void setup(int argc, char **argv) {
         }
     }
 
-    Tangram::initialize(scene.c_str());
-    Tangram::loadSceneAsync(scene.c_str());
-    Tangram::setupGL();
-    Tangram::resize(width, height);
+    map = new Tangram::Map();
+    map->loadSceneAsync(scene.c_str());
+    map->setupGL();
+    map->resize(width, height);
     if (lon != 0.0f && lat != 0.0f) {
-        Tangram::setPosition(lon,lat);
+        map->setPosition(lon,lat);
     }
     if (zoom != 0.0f) {
-        Tangram::setZoom(zoom);
+        map->setZoom(zoom);
     }
     if (tilt != 0.0f) {
-        Tangram::setTilt(glm::radians(tilt));
+        map->setTilt(glm::radians(tilt));
     }
     if (rot != 0.0f) {
-        Tangram::setRotation(glm::radians(rot));
+        map->setRotation(glm::radians(rot));
     }
 }
 
@@ -125,11 +127,11 @@ void newFrame() {
 
     //logMsg("New frame (delta %d msec)\n",delta);
 
-    Tangram::update(delta);
+    map->update(delta);
     timePrev = timeNow;
 
     // Render
-    Tangram::render();
+    map->render();
 
     renderGL();
 }
@@ -139,22 +141,22 @@ void newFrame() {
 void onKeyPress(int _key) {
     switch (_key) {
         case KEY_ZOOM_IN:
-            Tangram::handlePinchGesture(0.0,0.0,0.5,0.0);
+            map->handlePinchGesture(0.0,0.0,0.5,0.0);
             break;
         case KEY_ZOOM_OUT:
-            Tangram::handlePinchGesture(0.0,0.0,2.0,0.0);
+            map->handlePinchGesture(0.0,0.0,2.0,0.0);
             break;
         case KEY_UP:
-            Tangram::handlePanGesture(0.0,0.0,0.0,100.0);
+            map->handlePanGesture(0.0,0.0,0.0,100.0);
             break;
         case KEY_DOWN:
-            Tangram::handlePanGesture(0.0,0.0,0.0,-100.0);
+            map->handlePanGesture(0.0,0.0,0.0,-100.0);
             break;
         case KEY_LEFT:
-            Tangram::handlePanGesture(0.0,0.0,100.0,0.0);
+            map->handlePanGesture(0.0,0.0,100.0,0.0);
             break;
         case KEY_RIGHT:
-            Tangram::handlePanGesture(0.0,0.0,-100.0,0.0);
+            map->handlePanGesture(0.0,0.0,-100.0,0.0);
             break;
         case KEY_ESC:
             bUpdate = false;
@@ -176,10 +178,7 @@ void onMouseClick(float _x, float _y, int _button) {
 void onMouseDrag(float _x, float _y, int _button) {
     if( _button == 1 ){
 
-        Tangram::handlePanGesture(  _x-getMouseVelX()*1.0,
-                                    _y+getMouseVelY()*1.0,
-                                    _x,
-                                    _y);
+        map->handlePanGesture(_x - getMouseVelX(), _y + getMouseVelY(), _x, _y);
 
     } else if( _button == 2 ){
         if ( getKeyPressed() == 'r') {
@@ -188,11 +187,11 @@ void onMouseDrag(float _x, float _y, int _button) {
             if( _x < getWindowWidth()/2.0 ) {
                 scale *= -1.0;
             }
-            Tangram::handleRotateGesture(getWindowWidth()/2.0, getWindowHeight()/2.0, rot*scale);
+            map->handleRotateGesture(getWindowWidth()/2.0, getWindowHeight()/2.0, rot*scale);
         } else if ( getKeyPressed() == 't') {
-            Tangram::handleShoveGesture(getMouseVelY()*0.005);
+            map->handleShoveGesture(getMouseVelY()*0.005);
         } else {
-            Tangram::handlePinchGesture(getWindowWidth()/2.0, getWindowHeight()/2.0, 1.0 + getMouseVelY()*0.001, 0.f);
+            map->handlePinchGesture(getWindowWidth()/2.0, getWindowHeight()/2.0, 1.0 + getMouseVelY()*0.001, 0.f);
         }
 
     }

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Scene update tests") {
 
     REQUIRE(SceneLoader::loadConfig(sceneString, scene.config()));
 
-    std::vector<Scene::Update> updates;
+    std::vector<SceneUpdate> updates;
     // Update
     updates.push_back({"lights.light1.ambient", "0.9"});
     updates.push_back({"lights.light1.type", "spotlight"});
@@ -86,7 +86,7 @@ TEST_CASE("Scene update tests") {
 
 TEST_CASE("Scene update tests, ensure update ordering is preserved") {
     Scene scene;
-    std::vector<Scene::Update> updates;
+    std::vector<SceneUpdate> updates;
 
     REQUIRE(!sceneString.empty());
 


### PR DESCRIPTION
A few things remain to finish this implementation:
- ~~Make async task dispatch safe for multiple instances~~
- Make debug flags trigger tile rebuilding when necessary (not strictly necessary?)
- ~~Create and access a `RenderState` instance for each GL thread~~ (separate PR)

Items to consider:

1. There are other possible approaches to managing multiple Tangram instances. An alternative would be to require an object handle as an argument to all of the main interface functions, e.g.

  ```
  auto mapHandle = Tangram::init();
  Tangram::loadSceneAsync(mapHandle, sceneFilePath);
  ```

  where `mapHandle` is an integer or a void pointer. I spent a little time trying this and it seems very possible, but often more verbose. The advantages of this would be that the internal operation of Tangram could be totally hidden from the calling context and it would then be much easier to write a pure C interface to the library. 

2. This current implementation has the drawback of exposing the types and declarations for all the members in `Tangram::Map` to the calling application. This could be addressed by wrapping the actual map data structure in another class such that the outer class only needs to hold an opaque pointer to the implementation class. 

3. The main interface in this implementation is now the `Tangram::Map` class, but it resides in files called "tangram.h" and "tangram.cpp". For consistency with the rest of our source files, we may want to rename these to "map.h" and "map.cpp". 