### PR TITLE
More consistent interface for converting between screen and geographic coordinates

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -1,6 +1,7 @@
 package com.mapzen.tangram.android;
 
 import android.app.Activity;
+import android.graphics.PointF;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Window;
@@ -125,7 +126,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
     @Override
     public boolean onSingleTapConfirmed(float x, float y) {
-        LngLat tappedPoint = map.coordinatesAtScreenPosition(x, y);
+        LngLat tappedPoint = map.screenPositionToLngLat(new PointF(x, y));
 
         if (lastTappedPoint != null) {
             Map<String, String> props = new HashMap<>();
@@ -154,7 +155,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     @Override
     public boolean onDoubleTap(float x, float y) {
         map.setZoomEased(map.getZoom() + 1.f, 500);
-        LngLat tapped = map.coordinatesAtScreenPosition(x, y);
+        LngLat tapped = map.screenPositionToLngLat(new PointF(x, y));
         LngLat current = map.getPosition();
         LngLat next = new LngLat(
                 .5 * (tapped.longitude + current.longitude),

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -56,17 +56,16 @@ extern "C" {
         return Tangram::getTilt();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeScreenToWorldCoordinates(JNIEnv* jniEnv, jobject obj, jdoubleArray screenPos) {
-        jdouble* arr = jniEnv->GetDoubleArrayElements(screenPos, NULL);
-        Tangram::screenToWorldCoordinates(arr[0], arr[1]);
-        jniEnv->ReleaseDoubleArrayElements(screenPos, arr, 0);
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeScreenPositionToLngLat(JNIEnv* jniEnv, jobject obj, jdoubleArray coordinates) {
+        jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
+        Tangram::screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
+        jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeLongitudeLatitudeToScreenPosition(JNIEnv* jniEnv, jobject obj, jdouble lon, jdouble lat, jfloatArray screenPosition) {
-        jfloat* arr = jniEnv->GetFloatArrayElements(screenPosition, NULL);
-        bool offViewport = Tangram::lonLatToScreenPosition(lon, lat, arr[0], arr[1]);
-        jniEnv->ReleaseFloatArrayElements(screenPosition, arr, 0);
-        return offViewport;
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeLngLatToScreenPosition(JNIEnv* jniEnv, jobject obj, jdoubleArray coordinates) {
+        jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
+        Tangram::lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
+        jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager, jstring stylePath) {

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -56,16 +56,18 @@ extern "C" {
         return Tangram::getTilt();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeScreenPositionToLngLat(JNIEnv* jniEnv, jobject obj, jdoubleArray coordinates) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeScreenPositionToLngLat(JNIEnv* jniEnv, jobject obj, jdoubleArray coordinates) {
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
-        Tangram::screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
+        bool ret = Tangram::screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
         jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
+        return ret;
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeLngLatToScreenPosition(JNIEnv* jniEnv, jobject obj, jdoubleArray coordinates) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeLngLatToScreenPosition(JNIEnv* jniEnv, jobject obj, jdoubleArray coordinates) {
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
-        Tangram::lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
+        bool ret = Tangram::lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
         jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
+        return ret;
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager, jstring stylePath) {

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -2,6 +2,7 @@ package com.mapzen.tangram;
 
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
+import android.graphics.PointF;
 import android.opengl.GLES20;
 import android.opengl.GLSurfaceView;
 import android.opengl.GLSurfaceView.Renderer;
@@ -377,25 +378,25 @@ public class MapController implements Renderer {
 
     /**
      * Find the geographic coordinates corresponding to the given position on screen
-     * @param screenX Pixels from the left edge of the screen
-     * @param screenY Pixels from the top edge of the screen
+     * @param screenPosition Position in pixels from the top-left corner of the map area
      * @return LngLat corresponding to the given point
      */
-    public LngLat coordinatesAtScreenPosition(double screenX, double screenY) {
-        double[] tmp = { screenX, screenY };
-        nativeScreenToWorldCoordinates(tmp);
+    public LngLat screenPositionToLngLat(PointF screenPosition) {
+        double[] tmp = { screenPosition.x, screenPosition.y };
+        nativeScreenPositionToLngLat(tmp);
         return new LngLat(tmp[0], tmp[1]);
     }
 
     /**
-     * Converts the geographic coordinates to a 2D screen position (in a top-left 2D screen axis,
-     * y-coordinate pointing down)
-     * @param position The geographic coordinate to be converted
-     * @param screenPosition The converted 2D position on the screen
-     * @return True if the geographic coordinates are not visible from the current camera orientation
+     * Find the position on screen corresponding to the given geographic coordinates
+     * @param lngLat Geographic coordinates
+     * @return Position in pixels from the top-left corner of the map area (the point
+     * may not lie within the viewable screen area)
      */
-    public boolean longitudeLatitudeToScreenPosition(LngLat position, float[] screenPosition) {
-        return nativeLongitudeLatitudeToScreenPosition(position.longitude, position.latitude, screenPosition);
+    public PointF lngLatToScreenPosition(LngLat lngLat) {
+        double[] tmp = { lngLat.longitude, lngLat.latitude };
+        nativeLngLatToScreenPosition(tmp);
+        return new PointF((float)tmp[0], (float)tmp[1]);
     }
 
     /**
@@ -671,7 +672,6 @@ public class MapController implements Renderer {
     private synchronized native void nativeSetPosition(double lon, double lat);
     private synchronized native void nativeSetPositionEased(double lon, double lat, float seconds, int ease);
     private synchronized native void nativeGetPosition(double[] lonLatOut);
-    private synchronized native boolean nativeLongitudeLatitudeToScreenPosition(double lon, double lat, float[] screenCoords);
     private synchronized native void nativeSetZoom(float zoom);
     private synchronized native void nativeSetZoomEased(float zoom, float seconds, int ease);
     private synchronized native float nativeGetZoom();
@@ -681,7 +681,8 @@ public class MapController implements Renderer {
     private synchronized native void nativeSetTilt(float radians);
     private synchronized native void nativeSetTiltEased(float radians, float seconds, int ease);
     private synchronized native float nativeGetTilt();
-    private synchronized native void nativeScreenToWorldCoordinates(double[] screenCoords);
+    private synchronized native void nativeScreenPositionToLngLat(double[] coordinates);
+    private synchronized native void nativeLngLatToScreenPosition(double[] coordinates);
     private synchronized native void nativeSetPixelScale(float scale);
     private synchronized native void nativeSetCameraType(int type);
     private synchronized native int nativeGetCameraType();

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -379,12 +379,15 @@ public class MapController implements Renderer {
     /**
      * Find the geographic coordinates corresponding to the given position on screen
      * @param screenPosition Position in pixels from the top-left corner of the map area
-     * @return LngLat corresponding to the given point
+     * @return LngLat corresponding to the given point, or null if the screen position
+     * does not intersect a geographic location (this can happen at high tilt angles).
      */
     public LngLat screenPositionToLngLat(PointF screenPosition) {
         double[] tmp = { screenPosition.x, screenPosition.y };
-        nativeScreenPositionToLngLat(tmp);
-        return new LngLat(tmp[0], tmp[1]);
+        if (nativeScreenPositionToLngLat(tmp)) {
+            return new LngLat(tmp[0], tmp[1]);
+        }
+        return null;
     }
 
     /**
@@ -681,8 +684,8 @@ public class MapController implements Renderer {
     private synchronized native void nativeSetTilt(float radians);
     private synchronized native void nativeSetTiltEased(float radians, float seconds, int ease);
     private synchronized native float nativeGetTilt();
-    private synchronized native void nativeScreenPositionToLngLat(double[] coordinates);
-    private synchronized native void nativeLngLatToScreenPosition(double[] coordinates);
+    private synchronized native boolean nativeScreenPositionToLngLat(double[] coordinates);
+    private synchronized native boolean nativeLngLatToScreenPosition(double[] coordinates);
     private synchronized native void nativeSetPixelScale(float scale);
     private synchronized native void nativeSetCameraType(int type);
     private synchronized native int nativeGetCameraType();

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -514,25 +514,25 @@ float getTilt() {
 
 }
 
-void screenToWorldCoordinates(double& _x, double& _y) {
+void screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat) {
 
     m_view->screenToGroundPlane(_x, _y);
     glm::dvec2 meters(_x + m_view->getPosition().x, _y + m_view->getPosition().y);
-    glm::dvec2 lonLat = m_view->getMapProjection().MetersToLonLat(meters);
-    _x = lonLat.x;
-    _y = lonLat.y;
+    glm::dvec2 lngLat = m_view->getMapProjection().MetersToLonLat(meters);
+    *_lng = lngLat.x;
+    *_lat = lngLat.y;
 
 }
 
-bool lonLatToScreenPosition(double _lon, double _lat, float& _x, float& _y) {
+bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y) {
     bool clipped = false;
 
-    glm::vec2 screenCoords = m_view->lonLatToScreenPosition(_lon, _lat, clipped);
+    glm::vec2 screenCoords = m_view->lonLatToScreenPosition(_lng, _lat, clipped);
 
-    _x = screenCoords.x;
-    _y = screenCoords.y;
+    *_x = screenCoords.x;
+    *_y = screenCoords.y;
 
-    bool withinViewport = _x >= 0.f && _x <= m_view->getWidth() && _y >= 0.f && _y <= m_view->getHeight();
+    bool withinViewport = *_x >= 0. && *_x <= m_view->getWidth() && *_y >= 0. && *_y <= m_view->getHeight();
 
     return clipped || !withinViewport;
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -514,14 +514,15 @@ float getTilt() {
 
 }
 
-void screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat) {
+bool screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat) {
 
-    m_view->screenToGroundPlane(_x, _y);
+    double intersection = m_view->screenToGroundPlane(_x, _y);
     glm::dvec2 meters(_x + m_view->getPosition().x, _y + m_view->getPosition().y);
     glm::dvec2 lngLat = m_view->getMapProjection().MetersToLonLat(meters);
     *_lng = lngLat.x;
     *_lat = lngLat.y;
 
+    return (intersection >= 0);
 }
 
 bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -534,7 +534,7 @@ bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y) {
 
     bool withinViewport = *_x >= 0. && *_x <= m_view->getWidth() && *_y >= 0. && *_y <= m_view->getHeight();
 
-    return clipped || !withinViewport;
+    return !clipped && withinViewport;
 }
 
 void setPixelScale(float _pixelsPerPoint) {

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -92,7 +92,7 @@ void screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat);
 
 // Given longitude and latitude coordinates, set the output coordinates to the
 // corresponding point in screen space (x right, y down); returns true if the
-// point is not visible on the screen
+// point is visible on the screen, otherwise returns false
 bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y);
 
 // Set the ratio of hardware pixels to logical pixels (defaults to 1.0)

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -86,14 +86,14 @@ void setTilt(float _radians, float _duration, EaseType _e = EaseType::quint);
 // Get the tilt angle of the view in radians; 0 corresponds to straight down
 float getTilt();
 
-// Transform coordinates in screen space (x right, y down) into their longitude
-// and latitude in the map view
-void screenToWorldCoordinates(double& _x, double& _y);
+// Given coordinates in screen space (x right, y down), set the output longitude
+// and latitude to the geographic location corresponding to that point
+void screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat);
 
-// Get the 2D screen position (top-left screen axis, y pointing down
-// from a longitude and latitude
-// Returns true if the (lat,lon) is not visible (out of the screen)
-bool lonLatToScreenPosition(double _lon, double _lat, float& _x, float& y);
+// Given longitude and latitude coordinates, set the output coordinates to the
+// corresponding point in screen space (x right, y down); returns true if the
+// point is not visible on the screen
+bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y);
 
 // Set the ratio of hardware pixels to logical pixels (defaults to 1.0)
 void setPixelScale(float _pixelsPerPoint);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -86,13 +86,14 @@ void setTilt(float _radians, float _duration, EaseType _e = EaseType::quint);
 // Get the tilt angle of the view in radians; 0 corresponds to straight down
 float getTilt();
 
-// Given coordinates in screen space (x right, y down), set the output longitude
-// and latitude to the geographic location corresponding to that point
-void screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat);
+// Given coordinates in screen space (x right, y down), set the output longitude and
+// latitude to the geographic location corresponding to that point; returns false if
+// no geographic position corresponds to the screen location, otherwise returns true
+bool screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat);
 
 // Given longitude and latitude coordinates, set the output coordinates to the
-// corresponding point in screen space (x right, y down); returns true if the
-// point is visible on the screen, otherwise returns false
+// corresponding point in screen space (x right, y down); returns false if the
+// point is not visible on the screen, otherwise returns true
 bool lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y);
 
 // Set the ratio of hardware pixels to logical pixels (defaults to 1.0)

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -78,8 +78,8 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
 
     if ((time - last_time_released) < double_tap_time) {
 
-        LngLat p { x, y };
-        Tangram::screenToWorldCoordinates(p.longitude, p.latitude);
+        LngLat p;
+        Tangram::screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
         Tangram::setPosition(p.longitude, p.latitude, 1.f);
 
         logMsg("pick feature\n");
@@ -94,8 +94,8 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
             }
         }
     } else if ((time - last_time_pressed) < single_tap_time) {
-        LngLat p1 {x, y};
-        Tangram::screenToWorldCoordinates(p1.longitude, p1.latitude);
+        LngLat p1;
+        Tangram::screenPositionToLngLat(x, y, &p1.longitude, &p1.latitude);
 
         if (!(last_point == LngLat{0, 0})) {
             LngLat p2 = last_point;

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -76,8 +76,8 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
 
     if ((time - last_time_released) < double_tap_time) {
         // Double tap recognized
-        LngLat p { x, y };
-        Tangram::screenToWorldCoordinates(p.longitude, p.latitude);
+        LngLat p;
+        Tangram::screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
         Tangram::setPosition(p.longitude, p.latitude, 1.f);
 
         logMsg("pick feature\n");
@@ -93,8 +93,8 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
         }
     } else if ((time - last_time_pressed) < single_tap_time) {
         // Single tap recognized
-        LngLat p1 {x, y};
-        Tangram::screenToWorldCoordinates(p1.longitude, p1.latitude);
+        LngLat p1;
+        Tangram::screenPositionToLngLat(x, y, &p1.longitude, &p1.latitude);
 
         if (!(last_point == LngLat{0, 0})) {
             LngLat p2 = last_point;


### PR DESCRIPTION
1. Uses consistent types and naming for the relevant function calls. It should be obvious that these functions are the inverse of one another. 

2. `lngLatToScreenPosition` returns `true` if the point _is_ visible (the opposite of the old behavior). This is a more subjective point but to me it seems much more intuitive to associate a "positive" result with something being visible, e.g. the following use case seems reasonable:
  ```c++
  if (lngLatToScreenPosition(lng, lat, &x, &y)) {
    // draw a marker on screen at (x, y)
  }
  ```
3. `screenPositionToLngLat` returns `true` if the screen position corresponds to a geographic location (i.e. if the ray cast has a positive intersection). This is meaningful information for tilted views.