### PR TITLE
Fix bad reference on scene when fetching textures asynchronously

### DIFF
--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -48,7 +48,7 @@ struct TestContext {
             LOGE("Parsing scene config '%s'", e.what());
             return;
         }
-        SceneLoader::applyConfig(sceneNode, *scene);
+        SceneLoader::applyConfig(sceneNode, scene);
 
         styleContext.initFunctions(*scene);
         styleContext.setKeywordZoom(0);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -42,33 +42,33 @@ struct SceneLoader {
 
     static bool loadScene(std::shared_ptr<Scene> _scene);
     static bool loadConfig(const std::string& _sceneString, Node& _root);
-    static bool applyConfig(Node& config, Scene& scene);
+    static bool applyConfig(Node& config, const std::shared_ptr<Scene>& scene);
     static void applyUpdates(Node& root, const std::vector<SceneUpdate>& updates);
-    static void applyGlobalProperties(Node& node, Scene& scene);
+    static void applyGlobalProperties(Node& node, const std::shared_ptr<Scene>& scene);
 
     /*** all public for testing ***/
 
-    static void loadBackground(Node background, Scene& scene);
-    static void loadSource(const std::string& name, const Node& source, const Node& sources, Scene& scene);
+    static void loadBackground(Node background, const std::shared_ptr<Scene>& scene);
+    static void loadSource(const std::string& name, const Node& source, const Node& sources, const std::shared_ptr<Scene>& scene);
     static void loadSourceRasters(std::shared_ptr<DataSource>& source, Node rasterNode, const Node& sources,
-                                  Scene& scene);
-    static void loadTexture(const std::pair<Node, Node>& texture, Scene& scene);
-    static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
-    static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
-    static void loadCameras(Node cameras, Scene& scene);
-    static void loadCamera(const Node& camera, Scene& scene);
-    static void loadStyleProps(Style& style, Node styleNode, Scene& scene);
-    static void loadMaterial(Node matNode, Material& material, Scene& scene, Style& style);
-    static void loadShaderConfig(Node shaders, Style& style, Scene& scene);
-    static SceneLayer loadSublayer(Node layer, const std::string& name, Scene& scene);
+                                  const std::shared_ptr<Scene>& scene);
+    static void loadTexture(const std::pair<Node, Node>& texture, const std::shared_ptr<Scene>& scene);
+    static void loadLayer(const std::pair<Node, Node>& layer, const std::shared_ptr<Scene>& scene);
+    static void loadLight(const std::pair<Node, Node>& light, const std::shared_ptr<Scene>& scene);
+    static void loadCameras(Node cameras, const std::shared_ptr<Scene>& scene);
+    static void loadCamera(const Node& camera, const std::shared_ptr<Scene>& scene);
+    static void loadStyleProps(Style& style, Node styleNode, const std::shared_ptr<Scene>& scene);
+    static void loadMaterial(Node matNode, Material& material, const std::shared_ptr<Scene>& scene, Style& style);
+    static void loadShaderConfig(Node shaders, Style& style, const std::shared_ptr<Scene>& scene);
+    static SceneLayer loadSublayer(Node layer, const std::string& name, const std::shared_ptr<Scene>& scene);
     static Filter generateFilter(Node filter, Scene& scene);
     static Filter generateAnyFilter(Node filter, Scene& scene);
     static Filter generateNoneFilter(Node filter, Scene& scene);
     static Filter generatePredicate(Node filter, std::string _key);
     /* loads a texture with default texture properties */
-    static bool loadTexture(const std::string& url, Scene& scene);
+    static bool loadTexture(const std::string& url, const std::shared_ptr<Scene>& scene);
     static std::shared_ptr<Texture> fetchTexture(const std::string& name, const std::string& url,
-            const TextureOptions& options, bool generateMipmaps, Scene& scene);
+            const TextureOptions& options, bool generateMipmaps, const std::shared_ptr<Scene>& scene);
     static bool extractTexFiltering(Node& filtering, TextureFiltering& filter);
 
     /*
@@ -77,20 +77,20 @@ struct SceneLoader {
      * fetched sprite atlas.
      */
     static void updateSpriteNodes(const std::string& texName,
-            std::shared_ptr<Texture>& texture, Scene& scene);
+            std::shared_ptr<Texture>& texture, const std::shared_ptr<Scene>& scene);
 
-    static MaterialTexture loadMaterialTexture(Node matCompNode, Scene& scene, Style& style);
+    static MaterialTexture loadMaterialTexture(Node matCompNode, const std::shared_ptr<Scene>& scene, Style& style);
 
-    static void parseStyleParams(Node params, Scene& scene, const std::string& propPrefix,
+    static void parseStyleParams(Node params, const std::shared_ptr<Scene>& scene, const std::string& propPrefix,
                                  std::vector<StyleParam>& out);
-    static void parseTransition(Node params, Scene& scene, std::vector<StyleParam>& out);
+    static void parseTransition(Node params, const std::shared_ptr<Scene>& scene, std::vector<StyleParam>& out);
 
-    static bool parseStyleUniforms(const Node& value, Scene* scene, StyleUniform& styleUniform);
+    static bool parseStyleUniforms(const Node& value, const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
 
-    static void parseGlobals(const Node& node, Scene& scene, const std::string& key="");
+    static void parseGlobals(const Node& node, const std::shared_ptr<Scene>& scene, const std::string& key="");
     static void parseLightPosition(Node position, PointLight& light);
 
-    static bool loadStyle(const std::string& styleName, Node config, Scene& scene);
+    static bool loadStyle(const std::string& styleName, Node config, const std::shared_ptr<Scene>& scene);
 
     static std::mutex m_textureMutex;
     SceneLoader() = delete;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -219,7 +219,7 @@ void Map::applySceneUpdates() {
 
             SceneLoader::applyUpdates(scene->config(), updates);
 
-            bool ok = SceneLoader::applyConfig(scene->config(), *scene);
+            bool ok = SceneLoader::applyConfig(scene->config(), scene);
 
             mainThreadJobQueue.add([scene, ok, this]() {
                     if (scene == m_nextScene) {

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -260,7 +260,7 @@ TEST_CASE( "Test evalFilter - Init filter function from yaml", "[Duktape][evalFi
 }
 
 TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][evalStyle]") {
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
     YAML::Node n0 = YAML::Load(R"(
             draw:
                 color: function() { return '#ffff00ff'; }
@@ -272,14 +272,14 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
 
     SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
 
-    REQUIRE(scene.functions().size() == 3);
+    REQUIRE(scene->functions().size() == 3);
 
     // for (auto& str : scene.functions()) {
     //     logMsg("F: '%s'\n", str.c_str());
     // }
 
     StyleContext ctx;
-    ctx.initFunctions(scene);
+    ctx.initFunctions(*scene);
 
     for (auto& style : styles) {
         //logMsg("S: %d - '%s' %d\n", style.key, style.toString().c_str(), style.function);
@@ -308,7 +308,7 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
 }
 
 TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
     YAML::Node n0 = YAML::Load(R"(
             global:
                 width: 2
@@ -331,11 +331,11 @@ TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
 
     SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
 
-    REQUIRE(scene.functions().size() == 4);
+    REQUIRE(scene->functions().size() == 4);
 
     StyleContext ctx;
-    ctx.initFunctions(scene);
-    ctx.setSceneGlobals(scene.globals());
+    ctx.initFunctions(*scene);
+    ctx.setSceneGlobals(scene->globals());
 
     for (auto& style : styles) {
         if (style.key == StyleParamKey::color) {

--- a/tests/unit/sceneLoaderTests.cpp
+++ b/tests/unit/sceneLoaderTests.cpp
@@ -16,17 +16,17 @@ using YAML::Node;
 
 TEST_CASE("Style with the same name as a built-in style are ignored") {
 
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
     SceneLoader::loadStyle("polygons", Node(), scene);
-    REQUIRE(scene.styles().size() == 0);
+    REQUIRE(scene->styles().size() == 0);
 
 }
 
 TEST_CASE("Correctly instantiate a style from a YAML configuration") {
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
 
-    scene.styles().emplace_back(new PolygonStyle("polygons"));
-    scene.styles().emplace_back(new PolylineStyle("lines"));
+    scene->styles().emplace_back(new PolygonStyle("polygons"));
+    scene->styles().emplace_back(new PolylineStyle("lines"));
 
     YAML::Node node = YAML::Load(R"END(
         animated: true
@@ -40,7 +40,7 @@ TEST_CASE("Correctly instantiate a style from a YAML configuration") {
 
     SceneLoader::loadStyle("roads", node, scene);
 
-    auto& styles = scene.styles();
+    auto& styles = scene->styles();
 
     REQUIRE(styles.size() == 3);
     REQUIRE(styles[0]->getName() == "polygons");

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -14,7 +14,7 @@ using namespace Tangram;
 using YAML::Node;
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[StyleUniforms][core][yaml]") {
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
 
     Node node = YAML::Load(R"END(
         u_float: 0.5
@@ -22,14 +22,14 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_float"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_float"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<float>());
     REQUIRE(uniformValues.value.get<float>() == 0.5);
     REQUIRE(uniformValues.type == "float");
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "[StyleUniforms][core][yaml]") {
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
 
     Node node = YAML::Load(R"END(
         u_true: true
@@ -38,19 +38,19 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_true"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_true"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 1);
     REQUIRE(uniformValues.type == "bool");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_false"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_false"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 0);
     REQUIRE(uniformValues.type == "bool");
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform value", "[StyleUniforms][core][yaml]") {
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
 
     Node node = YAML::Load(R"END(
         u_vec2: [0.1, 0.2]
@@ -61,20 +61,20 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec2"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec2"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec2>());
     REQUIRE(uniformValues.value.get<glm::vec2>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec2>().y == 0.2f);
     REQUIRE(uniformValues.type == "vec2");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec3"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec3"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec3>());
     REQUIRE(uniformValues.value.get<glm::vec3>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec3>().y == 0.2f);
     REQUIRE(uniformValues.value.get<glm::vec3>().z == 0.3f);
     REQUIRE(uniformValues.type == "vec3");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec4"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec4"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec4>());
     REQUIRE(uniformValues.value.get<glm::vec4>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec4>().y == 0.2f);
@@ -82,7 +82,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
     REQUIRE(uniformValues.value.get<glm::vec4>().w == 0.4f);
     REQUIRE(uniformValues.type == "vec4");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_array"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_array"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<UniformArray1f>());
     REQUIRE(uniformValues.value.get<UniformArray1f>()[0] == 0.1f);
     REQUIRE(uniformValues.value.get<UniformArray1f>()[1] == 0.2f);
@@ -92,7 +92,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", "[StyleUniforms][core][yaml]") {
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
 
     Node node = YAML::Load(R"END(
         u_tex : img/cross.png
@@ -101,12 +101,12 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<std::string>());
     REQUIRE(uniformValues.value.get<std::string>() == "img/cross.png");
     REQUIRE(uniformValues.type == "sampler2D");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex2"], &scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex2"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<UniformTextureArray>());
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names.size() == 3);
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names[0] == "img/cross.png");
@@ -115,7 +115,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
 }
 
 TEST_CASE( "Style Uniforms Parsing failure Tests: textures uniform value", "[StyleUniforms][core][yaml]") {
-    Scene scene;
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
 
     Node node = YAML::Load(R"END(
         u_tex : not_a_texture
@@ -126,9 +126,9 @@ TEST_CASE( "Style Uniforms Parsing failure Tests: textures uniform value", "[Sty
 
     StyleUniform uniformValues;
 
-    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex"], &scene, uniformValues));
-    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex2"], &scene, uniformValues));
-    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float0"], &scene, uniformValues));
-    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float1"], &scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex"], scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_tex2"], scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float0"], scene, uniformValues));
+    REQUIRE(!SceneLoader::parseStyleUniforms(node["u_uniform_float1"], scene, uniformValues));
 }
 


### PR DESCRIPTION
Should fix #829 . 

For safer use in async tasks, use a shared_ptr to the scene (retained in the lambda functions to fetch textures). What happens is that the reference to the scene used at the beginning of the [scene loader pipeline](https://github.com/tangrams/tangram-es/blob/master/core/src/scene/sceneLoader.cpp#L61) would become inconsistent in the lambda functions and could potentially result in bad access, since it's copying the address of the reference [here](https://github.com/tangrams/tangram-es/blob/master/core/src/scene/sceneLoader.cpp#L541).