### PR TITLE
Make Tangram::Map implementation private

### DIFF
--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -1,24 +1,14 @@
 #pragma once
 
 #include "data/properties.h"
-#include "util/ease.h"
-#include <array>
+#include <functional>
 #include <memory>
-#include <mutex>
-#include <queue>
 #include <string>
 #include <vector>
 
 namespace Tangram {
 
-class AsyncWorker;
 class DataSource;
-class InputHandler;
-class Labels;
-class Scene;
-class TileManager;
-class TileWorker;
-class View;
 
 struct TouchItem {
     std::shared_ptr<Properties> properties;
@@ -29,6 +19,13 @@ struct TouchItem {
 struct SceneUpdate {
     std::string keys;
     std::string value;
+};
+
+enum class EaseType : char {
+    linear = 0,
+    cubic,
+    quint,
+    sine,
 };
 
 class Map {
@@ -184,29 +181,8 @@ public:
 
 private:
 
-    enum class EaseField { position, zoom, rotation, tilt };
-
-    void setEase(EaseField _f, Ease _e);
-    void clearEase(EaseField _f);
-    void setScene(std::shared_ptr<Scene>& _scene);
-    void setPositionNow(double _lon, double _lat);
-    void setZoomNow(float _z);
-    void setRotationNow(float _radians);
-    void setTiltNow(float _radians);
-
-    std::mutex m_tilesMutex;
-    std::mutex m_sceneMutex;
-    std::unique_ptr<TileWorker> m_tileWorker;
-    std::unique_ptr<TileManager> m_tileManager;
-    std::shared_ptr<Scene> m_scene;
-    std::shared_ptr<Scene> m_nextScene;
-    std::shared_ptr<View> m_view;
-    std::unique_ptr<Labels> m_labels;
-    std::unique_ptr<InputHandler> m_inputHandler;
-    std::unique_ptr<AsyncWorker> m_asyncWorker;
-    std::vector<SceneUpdate> m_sceneUpdates;
-    std::array<Ease, 4> m_eases;
-    bool m_cacheGlState;
+    class Impl;
+    std::unique_ptr<Impl> impl;
 
 };
 

--- a/core/src/util/ease.h
+++ b/core/src/util/ease.h
@@ -1,18 +1,12 @@
 #pragma once
 
+#include "tangram.h"
 #include <cmath>
 #include <functional>
 
 namespace Tangram {
 
 using EaseCb = std::function<void (float)>;
-
-enum class EaseType : char {
-    linear = 0,
-    cubic,
-    quint,
-    sine,
-};
 
 template<typename T>
 T ease(T _start, T _end, float _t, EaseType _e) {

--- a/core/src/util/inputHandler.cpp
+++ b/core/src/util/inputHandler.cpp
@@ -25,11 +25,11 @@
 
 namespace Tangram {
 
-InputHandler::InputHandler(std::shared_ptr<View> _view) : m_view(_view) {}
+InputHandler::InputHandler(View& _view) : m_view(_view) {}
 
 void InputHandler::update(float _dt) {
 
-    auto velocityPanPixels = m_view->pixelsPerMeter() / m_view->pixelScale() * m_velocityPan;
+    auto velocityPanPixels = m_view.pixelsPerMeter() / m_view.pixelScale() * m_velocityPan;
 
     bool isFlinging = glm::length(velocityPanPixels) > THRESHOLD_STOP_PAN ||
                       std::abs(m_velocityZoom) > THRESHOLD_STOP_ZOOM;
@@ -37,10 +37,10 @@ void InputHandler::update(float _dt) {
     if (isFlinging) {
 
         m_velocityPan -= _dt * DAMPING_PAN * m_velocityPan;
-        m_view->translate(_dt * m_velocityPan.x, _dt * m_velocityPan.y);
+        m_view.translate(_dt * m_velocityPan.x, _dt * m_velocityPan.y);
 
         m_velocityZoom -= _dt * DAMPING_ZOOM * m_velocityZoom;
-        m_view->zoom(m_velocityZoom * _dt);
+        m_view.zoom(m_velocityZoom * _dt);
 
         requestRender();
     }
@@ -50,13 +50,13 @@ void InputHandler::handleTapGesture(float _posX, float _posY) {
 
     onGesture();
 
-    double viewCenterX = 0.5 * m_view->getWidth();
-    double viewCenterY = 0.5 * m_view->getHeight();
+    double viewCenterX = 0.5 * m_view.getWidth();
+    double viewCenterY = 0.5 * m_view.getHeight();
 
-    m_view->screenToGroundPlane(viewCenterX, viewCenterY);
-    m_view->screenToGroundPlane(_posX, _posY);
+    m_view.screenToGroundPlane(viewCenterX, viewCenterY);
+    m_view.screenToGroundPlane(_posX, _posY);
 
-    m_view->translate((_posX - viewCenterX), (_posY - viewCenterY));
+    m_view.translate((_posX - viewCenterX), (_posY - viewCenterY));
 
 }
 
@@ -70,19 +70,19 @@ void InputHandler::handlePanGesture(float _startX, float _startY, float _endX, f
 
     onGesture();
 
-    m_view->screenToGroundPlane(_startX, _startY);
-    m_view->screenToGroundPlane(_endX, _endY);
+    m_view.screenToGroundPlane(_startX, _startY);
+    m_view.screenToGroundPlane(_endX, _endY);
 
     float dx = _startX - _endX;
     float dy = _startY - _endY;
 
-    m_view->translate(dx, dy);
+    m_view.translate(dx, dy);
 
 }
 
 void InputHandler::handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY) {
 
-    if (glm::length(glm::vec2(_velocityX, _velocityY)) / m_view->pixelScale() <= THRESHOLD_START_PAN) {
+    if (glm::length(glm::vec2(_velocityX, _velocityY)) / m_view.pixelScale() <= THRESHOLD_START_PAN) {
         return;
     }
 
@@ -95,8 +95,8 @@ void InputHandler::handleFlingGesture(float _posX, float _posY, float _velocityX
     float endX = _posX + epsilon * _velocityX;
     float endY = _posY + epsilon * _velocityY;
 
-    m_view->screenToGroundPlane(startX, startY);
-    m_view->screenToGroundPlane(endX, endY);
+    m_view.screenToGroundPlane(startX, startY);
+    m_view.screenToGroundPlane(endX, endY);
 
     float dx = (startX - endX) / epsilon;
     float dy = (startY - endY) / epsilon;
@@ -109,13 +109,13 @@ void InputHandler::handlePinchGesture(float _posX, float _posY, float _scale, fl
 
     onGesture();
 
-    float z = m_view->getZoom();
+    float z = m_view.getZoom();
     static float invLog2 = 1 / log(2);
-    m_view->zoom(log(_scale) * invLog2);
+    m_view.zoom(log(_scale) * invLog2);
 
-    m_view->screenToGroundPlane(_posX, _posY);
-    float s = pow(2, m_view->getZoom() - z) - 1;
-    m_view->translate(s * _posX, s * _posY);
+    m_view.screenToGroundPlane(_posX, _posY);
+    float s = pow(2, m_view.getZoom() - z) - 1;
+    m_view.translate(s * _posX, s * _posY);
 
     // Take the derivative of zoom as a function of scale:
     // z(s) = log2(s) + C
@@ -132,14 +132,14 @@ void InputHandler::handleRotateGesture(float _posX, float _posY, float _radians)
     onGesture();
 
     // Get vector from center of rotation to view center
-    m_view->screenToGroundPlane(_posX, _posY);
+    m_view.screenToGroundPlane(_posX, _posY);
     glm::vec2 offset(_posX, _posY);
 
     // Rotate vector by gesture rotation and apply difference as translation
     glm::vec2 translation = offset - glm::rotate(offset, _radians);
-    m_view->translate(translation.x, translation.y);
+    m_view.translate(translation.x, translation.y);
 
-    m_view->roll(_radians);
+    m_view.roll(_radians);
 
 }
 
@@ -147,8 +147,8 @@ void InputHandler::handleShoveGesture(float _distance) {
 
     onGesture();
 
-    float angle = -M_PI * _distance / m_view->getHeight();
-    m_view->pitch(angle);
+    float angle = -M_PI * _distance / m_view.getHeight();
+    m_view.pitch(angle);
 
 }
 

--- a/core/src/util/inputHandler.h
+++ b/core/src/util/inputHandler.h
@@ -9,7 +9,7 @@ namespace Tangram {
 class InputHandler {
 
 public:
-    InputHandler(std::shared_ptr<View> _view);
+    InputHandler(View& _view);
 
     void handleTapGesture(float _posX, float _posY);
     void handleDoubleTapGesture(float _posX, float _posY);
@@ -23,7 +23,7 @@ public:
 
     void cancelFling();
 
-    void setView(std::shared_ptr<View> _view) { m_view = _view; }
+    void setView(View& _view) { m_view = _view; }
 
 private:
 
@@ -31,7 +31,7 @@ private:
 
     void onGesture();
 
-    std::shared_ptr<View> m_view;
+    View& m_view;
 
     // fling deltas on zoom and translation
     glm::vec2 m_velocityPan;


### PR DESCRIPTION
Instead of holding all of our subsystem objects directly in the `Map` class, `Map` now holds a `unique_ptr` to an object of the private class `Map::Impl` and all of the subsystem objects are members of `Map::Impl`.

This significantly reduces the declarations needed in `tangram.h` and in the future will allow us to change the implementation of `Map` without changing this header. 