### PR TITLE
Add interface to offset the map position within the viewport

### DIFF
--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -161,6 +161,20 @@ extern "C" {
         return map->getCameraType();
     }
 
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetViewOffset(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint xPixels, jint yPixels) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setViewOffset(xPixels, yPixels);
+    }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeGetViewOffset(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jintArray offset) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        jint* arr = jniEnv->GetIntArrayElements(offset, NULL);
+        map->getViewOffset(&arr[0], &arr[1]);
+        jniEnv->ReleaseIntArrayElements(offset, arr, JNI_ABORT);
+    }
+
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleTapGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -2,6 +2,7 @@ package com.mapzen.tangram;
 
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
+import android.graphics.Point;
 import android.graphics.PointF;
 import android.opengl.GLES20;
 import android.opengl.GLSurfaceView;
@@ -412,6 +413,25 @@ public class MapController implements Renderer {
     }
 
     /**
+     * Set the displacement of the map's position from the center of the view.
+     * @param xPixels displacement right from the view center
+     * @param yPixels displacement down from the view center
+     */
+    public void setViewOffset(int xPixels, int yPixels) {
+        nativeSetViewOffset(mapPointer, xPixels, yPixels);
+    }
+
+    /**
+     * Get the displacement of the map's position from the center of the view.
+     * @return Point containing the x (right) and y (down) displacement of the center.
+     */
+    public Point getViewOffset() {
+        int[] tmp = { 0, 0 };
+        nativeGetViewOffset(mapPointer, tmp);
+        return new Point(tmp[0], tmp[1]);
+    }
+
+    /**
      * Find the geographic coordinates corresponding to the given position on screen
      * @param screenPosition Position in pixels from the top-left corner of the map area
      * @return LngLat corresponding to the given point, or null if the screen position
@@ -768,6 +788,8 @@ public class MapController implements Renderer {
     private synchronized native void nativeSetPixelScale(long mapPtr, float scale);
     private synchronized native void nativeSetCameraType(long mapPtr, int type);
     private synchronized native int nativeGetCameraType(long mapPtr);
+    private synchronized native void nativeSetViewOffset(long mapPtr, int xPixels, int yPixels);
+    private synchronized native void nativeGetViewOffset(long mapPtr, int[] offset);
     private synchronized native void nativeHandleTapGesture(long mapPtr, float posX, float posY);
     private synchronized native void nativeHandleDoubleTapGesture(long mapPtr, float posX, float posY);
     private synchronized native void nativeHandlePanGesture(long mapPtr, float startX, float startY, float endX, float endY);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -593,6 +593,20 @@ int Map::getCameraType() {
 
 }
 
+void Map::setViewOffset(int xPixels, int yPixels) {
+
+    impl->view.setOffset(xPixels, yPixels);
+
+}
+
+void Map::getViewOffset(int *xPixels, int *yPixels) {
+
+    auto offset = impl->view.offset();
+    *xPixels = offset.x;
+    *yPixels = offset.y;
+
+}
+
 void Map::addDataSource(std::shared_ptr<DataSource> _source) {
     std::lock_guard<std::mutex> lock(impl->tilesMutex);
     impl->tileManager.addClientDataSource(_source);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -130,6 +130,14 @@ public:
     // Get the camera type (0 = perspective, 1 = isometric, 2 = flat)
     int getCameraType();
 
+    // Set the displacement of the map's position from the center of the display.
+    // The location set as the map position will appear at the screen position
+    // (w/2 + xPixels, h/2 + yPixels) where 'w' and 'h' are the viewport width and height.
+    void setViewOffset(int xPixels, int yPixels);
+
+    // Get the displacement of the map's position from the center of the display.
+    void getViewOffset(int* xPixels, int* yPixels);
+
     // Given coordinates in screen space (x right, y down), set the output longitude and
     // latitude to the geographic location corresponding to that point; returns false if
     // no geographic position corresponds to the screen location, otherwise returns true

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -128,6 +128,13 @@ float View::getFocalLength() const {
 
 }
 
+void View::setOffset(int xPixels, int yPixels) {
+
+    m_offset.x = xPixels;
+    m_offset.y = yPixels;
+
+}
+
 
 void View::setMaxPitch(float degrees) {
 
@@ -388,6 +395,12 @@ void View::updateMatrices() {
 
         // Inject the shear in the projection matrix
         m_proj *= shear;
+    }
+
+    // Add the view offset (some call this the "principle point offset")
+    {
+        m_proj[2][0] = (-2.f * m_offset.x) / m_vpWidth; // (right + left) / (right - left);
+        m_proj[2][1] = (-2.f * m_offset.y) / m_vpHeight; // (top + bottom) / (top - bottom);
     }
 
     m_viewProj = m_proj * m_view;

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -377,8 +377,8 @@ void View::updateMatrices() {
             far = std::min(far, maxTileDistance);
             m_proj = glm::perspective(fovy, m_aspect, near, far);
             // Adjust for vanishing point.
-            m_proj[2][0] -= m_vanishingPoint.x / getWidth();
-            m_proj[2][1] -= m_vanishingPoint.y / getHeight();
+            m_proj[2][0] -= 2.f * m_vanishingPoint.x / getWidth();
+            m_proj[2][1] -= 2.f * m_vanishingPoint.y / getHeight();
             break;
         case CameraType::isometric:
         case CameraType::flat:
@@ -405,8 +405,8 @@ void View::updateMatrices() {
 
     // Add the view offset (some call this the "principle point offset")
     if (m_type == CameraType::perspective) {
-        m_proj[2][0] = (-2.f * m_offset.x) / m_vpWidth; // (right + left) / (right - left);
-        m_proj[2][1] = (-2.f * m_offset.y) / m_vpHeight; // (top + bottom) / (top - bottom);
+        m_proj[2][0] -= (2.f * m_offset.x) / m_vpWidth; // (right + left) / (right - left);
+        m_proj[2][1] -= (2.f * m_offset.y) / m_vpHeight; // (top + bottom) / (top - bottom);
     }
 
     m_viewProj = m_proj * m_view;

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -132,6 +132,7 @@ void View::setOffset(int xPixels, int yPixels) {
 
     m_offset.x = xPixels;
     m_offset.y = yPixels;
+    m_dirtyMatrices = true;
 
 }
 

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -50,6 +50,9 @@ public:
     void setVanishingPoint(float x, float y) { m_vanishingPoint = { x, y }; }
     auto vanishingPoint() const { return m_vanishingPoint; }
 
+    void setOffset(int xPixels, int yPixels);
+    auto offset() const { return m_offset; }
+
     // Set the vertical field-of-view angle, in radians.
     void setFieldOfView(float radians);
 
@@ -200,6 +203,7 @@ protected:
     glm::vec3 m_eye;
     glm::vec2 m_obliqueAxis;
     glm::vec2 m_vanishingPoint;
+    glm::ivec2 m_offset;
 
     glm::mat4 m_view;
     glm::mat4 m_orthoViewport;


### PR DESCRIPTION
This adds a parameters to the projection matrix that effectively shift the viewport by a given offset in screen space. This works great for vertical offsets, but feels a little weird for horizontal offsets since the camera perspective is no longer centered on the middle of the screen.

Resolves #841 
