### PR TITLE
added beginChangeBlock() and endChangeBlock() to MapData.

### DIFF
--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -241,8 +241,24 @@ extern "C" {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         assert(sourcePtr > 0);
-        auto source = reinterpret_cast<Tangram::DataSource*>(sourcePtr);
-        map->clearDataSource(*source, true, true);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
+        source->clearData();
+    }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeBeginChangeBlock(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        assert(sourcePtr > 0);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
+        source->beginChangeBlock();
+    }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeEndChangeBlock(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        assert(sourcePtr > 0);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
+        source->endChangeBlock();
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddFeature(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr,

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -688,6 +688,16 @@ public class MapController implements Renderer {
         nativeAddGeoJson(mapPointer, sourcePtr, geoJson);
     }
 
+    void beginChangeBlock(long sourcePtr)
+    {
+	nativeBeginChangeBlock(mapPointer, sourcePtr);
+    }
+
+    void endChangeBlock(long sourcePtr)
+    {
+	nativeEndChangeBlock(mapPointer, sourcePtr);
+    }
+
     // Native methods
     // ==============
 
@@ -740,6 +750,9 @@ public class MapController implements Renderer {
     synchronized native void nativeClearDataSource(long mapPtr, long sourcePtr);
     synchronized native void nativeAddFeature(long mapPtr, long sourcePtr, double[] coordinates, int[] rings, String[] properties);
     synchronized native void nativeAddGeoJson(long mapPtr, long sourcePtr, String geoJson);
+
+    synchronized native void nativeBeginChangeBlock(long mapPtr, long sourcePtr);
+    synchronized native void nativeEndChangeBlock(long mapPtr, long sourcePtr);
 
     native void nativeSetDebugFlag(int flag, boolean on);
 

--- a/android/tangram/src/com/mapzen/tangram/MapData.java
+++ b/android/tangram/src/com/mapzen/tangram/MapData.java
@@ -41,6 +41,26 @@ public class MapData {
     }
 
     /**
+     * Causes all feature changes ({@link #addPoint(LngLat, Map<String, String>)}, 
+     * {@link #addPolyline(List<LngLat>, Map<String, String>)}, etc.)
+     * to not be immediately rendered until {@link #endChangeBlock()} is called.
+     * Useful to prevent flickering when clearing and redrawing features.
+     */
+    public void beginChangeBlock()
+    {
+	map.beginChangeBlock(pointer);
+    }
+
+    /**
+     * All feature changes since {@link #beginChangeBlock()} will be placed
+     * in the rendered scene.
+     */
+    public void endChangeBlock()
+    {
+	map.endChangeBlock(pointer);
+    }
+
+    /**
      * Get the name of this {@code MapData}.
      * @return The name.
      */

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -59,6 +59,21 @@ ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::st
 
 ClientGeoJsonSource::~ClientGeoJsonSource() {}
 
+void ClientGeoJsonSource::beginChangeBlock()
+{
+    m_inChangeBlock = true;
+}
+  
+void ClientGeoJsonSource::endChangeBlock()
+{
+    m_inChangeBlock = false;
+
+    std::lock_guard<std::mutex> lock(m_mutexStore);
+    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
+    m_generation++;
+
+}
+  
 void ClientGeoJsonSource::addData(const std::string& _data) {
 
     auto features = geojsonvt::GeoJSONVT::convertFeatures(_data);
@@ -67,10 +82,11 @@ void ClientGeoJsonSource::addData(const std::string& _data) {
         m_features.push_back(std::move(f));
     }
 
-    std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
-    m_generation++;
-
+    if(!m_inChangeBlock) {
+      std::lock_guard<std::mutex> lock(m_mutexStore);
+      m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
+      m_generation++;
+    }
 }
 
 bool ClientGeoJsonSource::loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb) {
@@ -88,9 +104,11 @@ void ClientGeoJsonSource::clearData() {
 
     m_features.clear();
 
-    std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store.reset();
-    m_generation++;
+    if(!m_inChangeBlock) {
+      std::lock_guard<std::mutex> lock(m_mutexStore);
+      m_store.reset();
+      m_generation++;
+    }
 }
 
 void ClientGeoJsonSource::addPoint(const Properties& _tags, LngLat _point) {
@@ -105,9 +123,11 @@ void ClientGeoJsonSource::addPoint(const Properties& _tags, LngLat _point) {
 
     m_features.push_back(std::move(feature));
 
-    std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
-    m_generation++;
+    if(!m_inChangeBlock) {
+      std::lock_guard<std::mutex> lock(m_mutexStore);
+      m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
+      m_generation++;
+    }
 }
 
 void ClientGeoJsonSource::addLine(const Properties& _tags, const Coordinates& _line) {
@@ -121,9 +141,11 @@ void ClientGeoJsonSource::addLine(const Properties& _tags, const Coordinates& _l
 
     m_features.push_back(std::move(feature));
 
-    std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
-    m_generation++;
+    if(!m_inChangeBlock) {
+      std::lock_guard<std::mutex> lock(m_mutexStore);
+      m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
+      m_generation++;
+    }
 }
 
 void ClientGeoJsonSource::addPoly(const Properties& _tags, const std::vector<Coordinates>& _poly) {
@@ -140,9 +162,11 @@ void ClientGeoJsonSource::addPoly(const Properties& _tags, const std::vector<Coo
 
     m_features.push_back(std::move(feature));
 
-    std::lock_guard<std::mutex> lock(m_mutexStore);
-    m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
-    m_generation++;
+    if(!m_inChangeBlock) {
+      std::lock_guard<std::mutex> lock(m_mutexStore);
+      m_store = std::make_unique<GeoJSONVT>(m_features, m_maxZoom, m_maxZoom, indexMaxPoints, tolerance);
+      m_generation++;
+    }
 }
 
 std::shared_ptr<TileData> ClientGeoJsonSource::parse(const TileTask& _task,

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -26,6 +26,13 @@ public:
     ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
+    // after this is called, any call to add*() and clearData() will not take effect
+    // until commitChangeBlock() is called
+    void beginChangeBlock();
+
+    // commits changes after beginChangeBlock() was called
+    void endChangeBlock();
+
     // Add geometry from a GeoJSON string
     void addData(const std::string& _data);
     void addPoint(const Properties& _tags, LngLat _point);
@@ -47,6 +54,8 @@ protected:
     mutable std::mutex m_mutexStore;
     std::vector<mapbox::util::geojsonvt::ProjectedFeature> m_features;
     bool m_hasPendingData = false;
+
+    bool m_inChangeBlock = false;
 
 };
 


### PR DESCRIPTION
I'm converting my android app, Tiny Travel Tracker, to mapzen. It contains an database on the phone of gps points collected continuously tracking the users movements for later retrieval, which I'd like to add as a tile source (my idea is it would just loop back to the android app to query its database). Since my app can handle hundreds of thousands of points (personally I have over 500,000 stored tracking me over the last 6 years),

I've tried using addFeature() to display a subset of points (of what is on the screen currently) but it creates a lot of flickering as the points are deleted and redrawn.

I was able to change the source to fix my problem by adding two methods to MapData, beginChangeBlock(), which prevents feature changes from immediately being reflected in the rendered view, and endChangeBlock(), which commits the features after the beginChangeBlock() all at once. This successfully prevents flickering in my app and fixes my problem.

I hope this change is useful.
