### PR TITLE
Use gcc-5 for Travis Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
           env: PLATFORM=osx
           compiler: clang
         - os: linux
-          env: PLATFORM=linux CXX=g++-4.9 CC=gcc-4.9
+          env: PLATFORM=linux CXX=g++-5 CC=gcc-5
           addons:
             apt:
               sources: [ 'kubuntu-backports', 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
-              packages: [ 'cmake', 'gcc-4.9', 'g++-4.9', 'xorg-dev', 'libglu1-mesa-dev' ]
+              packages: [ 'cmake', 'gcc-5', 'g++-5', 'xorg-dev', 'libglu1-mesa-dev' ]
         - os: osx
           env: PLATFORM=ios
           compiler: clang

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ open build/xcode/tangram.xcodeproj
 Note that any Xcode configuration change you make to the project won't be preserved when CMake runs again. Build configuration is defined only in the CMakeLists file(s).
 
 ### Ubuntu Linux ###
-To build on Ubuntu you will need a C++ toolchain with support for C++14. GCC 4.9 (or higher) and Clang 3.4 (or higher) are known to work.
+To build on Ubuntu you will need a C++ toolchain with support for C++14. GCC 5 (or higher) and Clang 3.4 (or higher) are known to work.
 
 You will also need to install development packages for libcurl, x11, and opengl:
 

--- a/README.md
+++ b/README.md
@@ -126,17 +126,17 @@ Then install to a connected device or emulator. You can (re)install and run the 
 ```
 
 ### Raspberry Pi ###
-To build on Rasberry Pi you will need a C++ toolchain with support for C++14. GCC 4.9 (or higher) is known to work (refer [here](https://solarianprogrammer.com/2015/01/13/raspberry-pi-raspbian-install-gcc-compile-cpp-14-programs/) for instructions on getting GCC 4.9).
+To build on Rasberry Pi you will need a C++ toolchain with support for C++14. Clang 3.5 (or higher) is known to work.
 
-First, install CMake and libcurl:
+First, install Clang, CMake, and libcurl:
 
 ```
-sudo apt-get install cmake libcurl4-openssl-dev
+sudo apt-get install clang-3.5 cmake libcurl4-openssl-dev
 ```
 
 Before compiling, choose which compiler to use:
 ```
-export CXX=/usr/bin/g++-4.9
+export CXX=/usr/bin/clang++-3.5
 ```
 
 Then compile and run:


### PR DESCRIPTION
GCC 5 is the first version to fully support the C++14 standard: https://gcc.gnu.org/projects/cxx-status.html

The ubuntu-toolchain-r-test PPA provides version 5.4.0-3 for Ubuntu 12.04: https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test