### PR TITLE
fix label flickering/duplicate tiles with different source-zoom

### DIFF
--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -174,7 +174,19 @@ void TileManager::updateTileSet(TileSet& _tileSet, const ViewState& _view,
     std::set<TileID> mappedTiles;
     if (_view.zoom > _tileSet.source->maxZoom()) {
         for (const auto& id : _visibleTiles) {
-            mappedTiles.insert(id.withMaxSourceZoom(_tileSet.source->maxZoom()));
+            auto tile = id.withMaxSourceZoom(_tileSet.source->maxZoom());
+            // Replace tile with same coordinates and lower source zoom
+            auto other = std::find_if(mappedTiles.begin(), mappedTiles.end(),
+                             [&](auto& t) { return tile.x == t.x &&
+                                            tile.y == t.y &&
+                                            tile.z == t.z &&
+                                            tile.wrap == t.wrap; });
+            if (other == mappedTiles.end()) {
+                mappedTiles.insert(tile);
+            } else if (other->s < tile.s) {
+                mappedTiles.erase(other);
+                mappedTiles.insert(tile);
+            }
         }
         visibleTiles = &mappedTiles;
     }


### PR DESCRIPTION
When tiles are mapped to the maximum source zoom, tiles with the same coordinates (but different style-zoomlevels) can appear in the the visible-set.

This change puts only the tile with the higher style-zoomlevel to the visible-set. 