### PR TITLE
Update Android build to API 24 and build-tools 24.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ matrix:
               sources: [ 'kubuntu-backports', 'george-edison55-precise-backports' ]
               packages: [ 'cmake', 'lib32z1-dev', 'lib32stdc++6', 's3cmd' ]
           android:
-            components: [ 'build-tools-21.1.2', 'extra-android-m2repository', 'android-23' ]
+            components: [ 'tools', 'build-tools-24.0.0', 'extra-android-m2repository', 'android-24' ]
+          jdk: oraclejdk8
 
 before_install:
     - git submodule update --init --recursive

--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -7,12 +7,12 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "21.1.2"
+  compileSdkVersion 24
+  buildToolsVersion "24.0.0"
 
   defaultConfig {
     minSdkVersion 15
-    targetSdkVersion 23
+    targetSdkVersion 24
   }
 
   sourceSets.main {

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -14,7 +14,7 @@ version = VERSION_NAME
 apply from: 'versioning.gradle'
 
 android {
-  compileSdkVersion 23
+  compileSdkVersion 24
 
   /*
    * Ubuntu can't run the aapt on 64 bit before installing this packages
@@ -22,11 +22,11 @@ android {
    *    sudo apt-get install lib32z1
    */
 
-  buildToolsVersion "21.1.2"
+  buildToolsVersion "24.0.0"
 
   defaultConfig {
     minSdkVersion 15
-    targetSdkVersion 23
+    targetSdkVersion 24
     versionCode buildVersionCode()
     versionName VERSION_NAME
   }
@@ -51,7 +51,7 @@ afterEvaluate {
 dependencies {
   compile 'com.squareup.okhttp:okhttp:2.5.0'
   compile 'xmlpull:xmlpull:1.1.3.1'
-  compile 'com.android.support:support-annotations:23.1.1'
+  compile 'com.android.support:support-annotations:24.1.1'
 }
 
 apply from: file('gradle-mvn-push.gradle')


### PR DESCRIPTION
New tools require JDK 8 instead of 7, make sure you have a suitable JDK installed and configured for use in Android Studio.

The 'tools' component is necessary for Travis to find the 'android-24' SDK, but it's kind of unclear exactly why: https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943