### PR TITLE
Flip y coordinates of texture data from stb_image

### DIFF
--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -73,7 +73,7 @@ RasterSource::RasterSource(const std::string& _name, const std::string& _urlTemp
                            TextureOptions _options, bool _genMipmap)
     : DataSource(_name, _urlTemplate, _maxZoom), m_texOptions(_options), m_genMipmap(_genMipmap) {
 
-    m_emptyTexture = std::make_shared<Texture>(nullptr, 0, m_texOptions, m_genMipmap, true);
+    m_emptyTexture = std::make_shared<Texture>(nullptr, 0, m_texOptions, m_genMipmap);
 }
 
 std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _rawTileData) {
@@ -84,7 +84,7 @@ std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _r
         return m_emptyTexture;
     }
 
-    auto texture = std::make_shared<Texture>(udata, dataSize, m_texOptions, m_genMipmap, true);
+    auto texture = std::make_shared<Texture>(udata, dataSize, m_texOptions, m_genMipmap);
 
     return texture;
 }

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -23,20 +23,20 @@ Texture::Texture(unsigned int _width, unsigned int _height, TextureOptions _opti
     resize(_width, _height);
 }
 
-Texture::Texture(const unsigned char* data, size_t dataSize, TextureOptions options, bool generateMipmaps, bool _flipOnLoad)
+Texture::Texture(const unsigned char* data, size_t dataSize, TextureOptions options, bool generateMipmaps)
     : Texture(0u, 0u, options, generateMipmaps) {
 
-    loadImageFromMemory(data, dataSize, _flipOnLoad);
+    loadImageFromMemory(data, dataSize);
 }
 
-bool Texture::loadImageFromMemory(const unsigned char* blob, unsigned int size, bool flipOnLoad) {
+bool Texture::loadImageFromMemory(const unsigned char* blob, unsigned int size) {
     unsigned char* pixels = nullptr;
     int width, height, comp;
 
-    // stbi_load_from_memory loads the image as a serie of scanline starting from
-    // the top-left corner of the image. When shouldFlip is set to true, the image
-    // would be flipped vertically.
-    stbi_set_flip_vertically_on_load((int)flipOnLoad);
+    // stbi_load_from_memory loads the image as a series of scanlines starting from
+    // the top-left corner of the image. This call flips the output such that the data
+    // begins at the bottom-left corner, as required for OpenGL texture data.
+    stbi_set_flip_vertically_on_load(1);
 
     if (blob != nullptr && size != 0) {
         pixels = stbi_load_from_memory(blob, size, &width, &height, &comp, STBI_rgb_alpha);

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -41,7 +41,7 @@ public:
 
     Texture(const unsigned char* data, size_t dataSize,
             TextureOptions _options = DEFAULT_TEXTURE_OPTION},
-            bool _generateMipmaps = false, bool _flipOnLoad = false);
+            bool _generateMipmaps = false);
 
     Texture(Texture&& _other);
     Texture& operator=(Texture&& _other);
@@ -85,7 +85,7 @@ public:
 
     static bool isRepeatWrapping(TextureWrapping _wrapping);
 
-    bool loadImageFromMemory(const unsigned char* blob, unsigned int size, bool flipOnLoad);
+    bool loadImageFromMemory(const unsigned char* blob, unsigned int size);
 
 protected:
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -544,7 +544,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
                 std::lock_guard<std::mutex> lock(m_textureMutex);
 				auto texture = scene->getTexture(name);
                 if (texture) {
-                    if (!texture->loadImageFromMemory(ptr, dataSize, false)) {
+                    if (!texture->loadImageFromMemory(ptr, dataSize)) {
                         LOGE("Invalid texture data '%s'", url.c_str());
                     }
 
@@ -552,7 +552,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
                     scene->m_resourceLoad--;
                 }
             });
-        texture = std::make_shared<Texture>(nullptr, 0, options, generateMipmaps, true);
+        texture = std::make_shared<Texture>(nullptr, 0, options, generateMipmaps);
     } else {
 
         if (url.substr(0, 22) == "data:image/png;base64,") {
@@ -573,7 +573,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
             }
             texture = std::make_shared<Texture>(0, 0, options, generateMipmaps);
 
-            if (!texture->loadImageFromMemory(blob.data(), blob.size(), false)) {
+            if (!texture->loadImageFromMemory(blob.data(), blob.size())) {
                 LOGE("Invalid Base64 texture");
             }
 
@@ -587,7 +587,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
             }
             texture = std::make_shared<Texture>(0, 0, options, generateMipmaps);
 
-            if (!texture->loadImageFromMemory(blob, size, false)) {
+            if (!texture->loadImageFromMemory(blob, size)) {
                 LOGE("Invalid texture data '%s'", url.c_str());
             }
             free(blob);

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -7,11 +7,14 @@ SpriteAtlas::SpriteAtlas(std::shared_ptr<Texture> _texture) : m_texture(_texture
 
 void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size) {
 
-    glm::vec2 atlasSize = {m_texture->getWidth(), m_texture->getHeight()};
-    glm::vec2 uvBL = _origin / atlasSize;
-    glm::vec2 uvTR = (_origin + _size) / atlasSize;
+    float atlasWidth = m_texture->getWidth();
+    float atlasHeight = m_texture->getHeight();
+    float uvL = _origin.x / atlasWidth;
+    float uvR = uvL + _size.x / atlasWidth;
+    float uvB = 1.f - _origin.y / atlasHeight;
+    float uvT = uvB - _size.y / atlasHeight;
 
-    m_spritesNodes[_name] = SpriteNode { uvBL, uvTR, _size, _origin };
+    m_spritesNodes[_name] = SpriteNode { { uvL, uvB }, { uvR, uvT }, _size, _origin };
 }
 
 bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) const {


### PR DESCRIPTION
Resolves #869 

This could use a careful eye - texture y-coordinates get confusing very quickly.