### PR TITLE
Dynamic anchors

### DIFF
--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -60,7 +60,7 @@ public class MapController implements Renderer {
         TILE_INFOS,
         LABELS,
         TANGRAM_INFOS,
-        ALL_LABELS,
+        DRAW_ALL_LABELS,
         TANGRAM_STATS,
     }
 

--- a/core/src/labels/fadeEffect.h
+++ b/core/src/labels/fadeEffect.h
@@ -35,6 +35,13 @@ public:
         return st;
     }
 
+    void reset(bool _in, Interpolation _interpolation, float _duration) {
+        m_in = _in;
+        m_interpolation = _interpolation;
+        m_duration = _duration;
+        m_step = 0.f;
+    }
+
     bool isFinished() {
         return m_step > m_duration;
     }

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -3,6 +3,7 @@
 #include "util/geom.h"
 #include "glm/gtx/rotate_vector.hpp"
 #include "tangram.h"
+#include "platform.h"
 
 namespace Tangram {
 

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -10,13 +10,13 @@ namespace Tangram {
 const float Label::activation_distance_threshold = 2;
 
 Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, Options _options, LabelProperty::Anchor _anchor)
-    : m_type(_type),
+    : m_state(State::none),
+      m_type(_type),
       m_transform(_transform),
       m_dim(_size),
       m_options(_options),
       m_anchorType(_anchor) {
 
-    m_state = State::wait_occ;
     if (!m_options.collide || m_type == Type::debug){
         enterState(State::visible, 1.0);
     } else {
@@ -138,7 +138,7 @@ bool Label::canOcclude() {
     }
 
     int occludeFlags = (State::visible |
-                        State::wait_occ |
+                        State::none |
                         State::skip_transition |
                         State::fading_in |
                         State::sleep |
@@ -187,7 +187,7 @@ void Label::resetState() {
 
     m_occludedLastFrame = false;
     m_occluded = false;
-    enterState(State::wait_occ, 0.0);
+    enterState(State::none, 0.0);
 }
 
 bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract, bool _drawAllLabels) {
@@ -287,7 +287,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
             } else {
                 enterState(State::visible, 1.0);
             }
-            
+
             animate = true;
             break;
         case State::fading_in:
@@ -315,7 +315,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                 enterState(State::sleep, 0.0);
             }
             break;
-        case State::wait_occ:
+        case State::none:
             if (m_occluded) {
                 if (m_options.anchorFallbacks != 0) {
                     enterState(State::anchor_fallback, 0.0);

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -190,6 +190,26 @@ void Label::resetState() {
     enterState(State::none, 0.0);
 }
 
+void Label::print() const {
+    LOG("Label - %p", this);
+    LOG("\tm_occludedLastFrame: %d", m_occludedLastFrame);
+    LOG("\tm_occluded: %d", m_occluded);
+    std::string state;
+    switch (m_state) {
+        case State::none: state = "none"; break;
+        case State::visible: state = "visible"; break;
+        case State::anchor_fallback: state = "anchor_fallback"; break;
+        case State::fading_in: state = "fading_in"; break;
+        case State::fading_out: state = "fading_out"; break;
+        case State::skip_transition: state = "skip_transition"; break;
+        case State::sleep: state = "sleep"; break;
+        case State::dead: state = "dead"; break;
+        case State::out_of_screen: state = "out_of_screen"; break;
+    }
+    LOG("\tm_state: %s", state.c_str());
+    LOG("\tm_options.anchorFallback: %s", m_options.anchorFallbacks.to_string().c_str());
+}
+
 bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract, bool _drawAllLabels) {
 
     m_occludedLastFrame = m_occluded;

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -242,7 +242,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
 
     switch (m_state) {
         case State::visible:
-            if (m_occluded) {
+            if (m_occluded || m_occludedLastFrame) {
                 if (m_options.anchorFallback.size() > 0) {
                     enterState(State::anchor_fallback, 0.0);
                 } else {
@@ -274,7 +274,11 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                 m_anchorFallbackCount++;
             } else {
                 m_anchorFallbackCount = 0;
-                enterState(State::visible, 1.0);
+                if (!m_occludedLastFrame) {
+                    enterState(State::visible, 1.0);
+                } else {
+                    enterState(State::sleep, 0.0);
+                }
             }
             
             animate = true;

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -278,7 +278,7 @@ Label::EvalUpdate Label::evalState(float _dt) {
 
     switch (m_state) {
         case State::visible:
-            if (m_occluded || m_occludedLastFrame) {
+            if (m_occluded) {
                 if (m_options.anchors.count > 1) {
                     enterState(State::anchor_fallback, 0.0);
 
@@ -305,10 +305,10 @@ Label::EvalUpdate Label::evalState(float _dt) {
                     // Move to next one for upcoming frame
                     m_anchorIndex++;
                 }
-            } else {
-                enterState(State::visible, 1.0);
+                return EvalUpdate::relayout;
             }
-            return EvalUpdate::relayout;
+            enterState(State::visible, 1.0);
+            return EvalUpdate::none;
 
         case State::fading_in:
             if (m_occluded) {
@@ -343,12 +343,10 @@ Label::EvalUpdate Label::evalState(float _dt) {
                     enterState(State::sleep, 0.0);
                     return EvalUpdate::none;
                 }
-            } else {
-                m_fade.reset(true, m_options.showTransition.ease,
-                                   m_options.showTransition.time);
-
-                enterState(State::fading_in, 0.0);
             }
+            m_fade.reset(true, m_options.showTransition.ease,
+                         m_options.showTransition.time);
+            enterState(State::fading_in, 0.0);
             return EvalUpdate::animate;
 
         case State::skip_transition:

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -281,7 +281,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
     switch (m_state) {
         case State::visible:
             if (m_occluded || m_occludedLastFrame) {
-                if (m_options.anchorCount > 1) {
+                if (m_options.anchors.count > 1) {
                     enterState(State::anchor_fallback, 0.0);
                 } else {
                     m_fade.reset(false, m_options.hideTransition.ease,
@@ -295,7 +295,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
             break;
         case State::anchor_fallback:
             if (m_occluded) {
-                if (m_anchorIndex >= int(m_options.anchorCount)-1) {
+                if (m_anchorIndex >= int(m_options.anchors.count)-1) {
                     // Tried all anchors - deactivate label
                     m_fade.reset(false, m_options.hideTransition.ease,
                                         m_options.hideTransition.time);
@@ -337,7 +337,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
             break;
         case State::none:
             if (m_occluded) {
-                if (m_options.anchorCount > 1) {
+                if (m_options.anchors.count > 1) {
                     enterState(State::anchor_fallback, 0.0);
                     animate = true;
                 } else {

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -26,6 +26,7 @@ Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, Options _
     m_occluded = false;
     m_parent = nullptr;
     m_anchorFallbackCount = 0;
+    m_currentAnchorFallback = 0;
 }
 
 Label::~Label() {}
@@ -250,6 +251,8 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                     enterState(State::fading_out, 1.0);
                 }
                 animate = true;
+            } else if (m_currentAnchorFallback != 0) {
+                // TODO: try to place again to prefered fallback (0)
             }
             break;
         case State::anchor_fallback:
@@ -261,6 +264,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                     m_anchorFallbackCount = 0;
                 } else {
                     m_anchorType = m_options.anchorFallback[m_anchorFallbackCount];
+                    m_currentAnchorFallback = m_anchorFallbackCount;
                     if (m_parent) {
                         alignFromParent(*m_parent);
                     } else {

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -31,7 +31,7 @@ Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, Options _
 
 Label::~Label() {}
 
-bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize, bool _testVisibility) {
+bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize, bool _drawAllLabels) {
 
     glm::vec2 screenPosition;
     glm::vec2 rotation = {1, 0};
@@ -46,7 +46,7 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
             screenPosition = worldToScreenSpace(_mvp, glm::vec4(p0, 0.0, 1.0),
                                                 _screenSize, clipped);
 
-            if (_testVisibility && clipped) {
+            if (clipped) {
                 return false;
             }
 
@@ -68,7 +68,7 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
 
             // check whether the label is behind the camera using the
             // perspective division factor
-            if (_testVisibility && clipped) {
+            if (clipped) {
                 return false;
             }
 
@@ -77,7 +77,7 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
             // default heuristic : allow label to be 30% wider than segment
             float minLength = m_dim.x * 0.7;
 
-            if (_testVisibility && length < minLength) {
+            if (!_drawAllLabels && length < minLength) {
                 return false;
             }
 
@@ -200,7 +200,7 @@ bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _z
         }
     }
 
-    bool ruleSatisfied = updateScreenTransform(_mvp, _screenSize, !_drawAllLabels);
+    bool ruleSatisfied = updateScreenTransform(_mvp, _screenSize, _drawAllLabels);
 
     // one of the label rules has not been satisfied
     if (!ruleSatisfied) {

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -25,6 +25,7 @@ Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, Options _
     m_occludedLastFrame = false;
     m_occluded = false;
     m_parent = nullptr;
+    m_anchorFallbackCount = 0;
 }
 
 Label::~Label() {}
@@ -99,18 +100,22 @@ bool Label::updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _scree
     return true;
 }
 
+void Label::alignFromParent(const Label& _parent) {
+    glm::vec2 anchorDir = LabelProperty::anchorDirection(_parent.anchorType());
+    glm::vec2 anchorOrigin = anchorDir * _parent.dimension() * 0.5f;
+
+    applyAnchor(m_dim + _parent.dimension(), anchorOrigin, m_anchorType);
+    m_options.offset += _parent.options().offset;
+}
+
 void Label::setParent(const Label& _parent, bool _definePriority) {
     m_parent = &_parent;
 
-    glm::vec2 anchorDir = LabelProperty::anchorDirection(_parent.anchorType());
-    glm::vec2 anchorOrigin = anchorDir * _parent.dimension() * 0.5f;
-    applyAnchor(m_dim + _parent.dimension(), anchorOrigin, m_anchorType);
+    alignFromParent(_parent);
 
     if (_definePriority) {
         m_options.priority = _parent.options().priority + 0.5f;
     }
-
-    m_options.offset += _parent.options().offset;
 }
 
 bool Label::offViewport(const glm::vec2& _screenSize) {
@@ -136,6 +141,7 @@ bool Label::canOcclude() {
                         State::skip_transition |
                         State::fading_in |
                         State::sleep |
+                        State::anchor_fallback |
                         State::out_of_screen |
                         State::dead);
 
@@ -146,6 +152,7 @@ bool Label::visibleState() const {
     int visibleFlags = (State::visible |
                         State::fading_in |
                         State::fading_out |
+                        State::anchor_fallback |
                         State::skip_transition);
 
     return (visibleFlags & m_state);
@@ -171,6 +178,7 @@ void Label::setAlpha(float _alpha) {
 }
 
 void Label::resetState() {
+
     if (m_state == State::dead) { return; }
 
     m_occludedLastFrame = false;
@@ -232,11 +240,38 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
     switch (m_state) {
         case State::visible:
             if (m_occluded) {
-                m_fade = FadeEffect(false, m_options.hideTransition.ease,
-                                    m_options.hideTransition.time);
-                enterState(State::fading_out, 1.0);
+                if (m_options.anchorFallback.size() > 0) {
+                    enterState(State::anchor_fallback, 0.0);
+                } else {
+                    m_fade = FadeEffect(false, m_options.hideTransition.ease,
+                                        m_options.hideTransition.time);
+                    enterState(State::fading_out, 1.0);
+                }
                 animate = true;
             }
+            break;
+        case State::anchor_fallback:
+            if (m_occluded) {
+                if (m_anchorFallbackCount >= m_options.anchorFallback.size()) {
+                    m_fade = FadeEffect(false, m_options.hideTransition.ease,
+                                        m_options.hideTransition.time);
+                    enterState(State::fading_out, m_transform.state.alpha);
+                    m_anchorFallbackCount = 0;
+                } else {
+                    m_anchorType = m_options.anchorFallback[m_anchorFallbackCount];
+                    if (m_parent) {
+                        alignFromParent(*m_parent);
+                    } else {
+                        applyAnchor(m_dim, glm::vec2(0.0), m_anchorType);
+                    }
+                }
+                m_anchorFallbackCount++;
+            } else {
+                m_anchorFallbackCount = 0;
+                enterState(State::visible, 1.0);
+            }
+            
+            animate = true;
             break;
         case State::fading_in:
             if (m_occluded) {
@@ -265,7 +300,12 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
             break;
         case State::wait_occ:
             if (m_occluded) {
-                enterState(State::sleep, 0.0);
+                if (m_options.anchorFallback.size() > 0) {
+                    enterState(State::anchor_fallback, 0.0);
+                    animate = true;
+                } else {
+                    enterState(State::sleep, 0.0);
+                }
             } else {
                 m_fade = FadeEffect(true, m_options.showTransition.ease,
                                     m_options.showTransition.time);

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -300,9 +300,7 @@ Label::EvalUpdate Label::evalState(float _dt) {
             if (m_occluded) {
                 if (m_anchorIndex >= int(m_options.anchors.count)-1) {
                     // Tried all anchors - deactivate label
-                    m_fade.reset(false, m_options.hideTransition.ease,
-                                        m_options.hideTransition.time);
-                    enterState(State::fading_out, m_transform.state.alpha);
+                    enterState(State::sleep, 0.0);
                 } else {
                     // Move to next one for upcoming frame
                     m_anchorIndex++;

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -25,8 +25,7 @@ Label::Label(Label::Transform _transform, glm::vec2 _size, Type _type, Options _
     m_occludedLastFrame = false;
     m_occluded = false;
     m_parent = nullptr;
-    m_anchorFallbackCount = 0;
-    m_currentAnchorFallback = 0;
+    m_anchorFallbackIndex = 0;
 }
 
 Label::~Label() {}
@@ -172,6 +171,9 @@ void Label::enterState(const State& _state, float _alpha) {
 
     m_state = _state;
     setAlpha(_alpha);
+
+    // Reset anchor fallback index
+    m_anchorFallbackIndex = 0;
 }
 
 void Label::setAlpha(float _alpha) {
@@ -243,7 +245,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
     switch (m_state) {
         case State::visible:
             if (m_occluded || m_occludedLastFrame) {
-                if (m_options.anchorFallback.size() > 0) {
+                if (m_options.anchorFallbacks != 0) {
                     enterState(State::anchor_fallback, 0.0);
                 } else {
                     m_fade.reset(false, m_options.hideTransition.ease,
@@ -253,37 +255,36 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                 }
 
                 animate = true;
-            } else if (m_currentAnchorFallback != 0) {
-                // TODO: try to place again to prefered fallback (0)
             }
             break;
         case State::anchor_fallback:
             if (m_occluded) {
-                if (m_anchorFallbackCount >= m_options.anchorFallback.size()) {
+                if (m_anchorFallbackIndex >= m_options.anchorFallbacks.size()) {
                     m_fade.reset(false, m_options.hideTransition.ease,
                                         m_options.hideTransition.time);
 
                     enterState(State::fading_out, m_transform.state.alpha);
-                    m_anchorFallbackCount = 0;
                 } else {
-                    m_anchorType = m_options.anchorFallback[m_anchorFallbackCount];
-                    m_currentAnchorFallback = m_anchorFallbackCount;
+                    // Find next valid anchor
+                    for (; m_anchorFallbackIndex < m_options.anchorFallbacks.size(); ++m_anchorFallbackIndex) {
+                        if (m_options.anchorFallbacks.test(m_anchorFallbackIndex)) {
+                            m_anchorType = (LabelProperty::Anchor) m_anchorFallbackIndex;
 
-                    if (m_parent) {
-                        alignFromParent(*m_parent);
-                    } else {
-                        applyAnchor(m_dim, glm::vec2(0.0), m_anchorType);
+                            // Apply new alignment
+                            if (m_parent) {
+                                alignFromParent(*m_parent);
+                            } else {
+                                applyAnchor(m_dim, glm::vec2(0.0), m_anchorType);
+                            }
+
+                            // Move to next one for upcoming frame
+                            m_anchorFallbackIndex++;
+                            break;
+                        }
                     }
                 }
-                m_anchorFallbackCount++;
             } else {
-                m_anchorFallbackCount = 0;
-
-                if (!m_occludedLastFrame) {
-                    enterState(State::visible, 1.0);
-                } else {
-                    enterState(State::sleep, 0.0);
-                }
+                enterState(State::visible, 1.0);
             }
             
             animate = true;
@@ -315,7 +316,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
             break;
         case State::wait_occ:
             if (m_occluded) {
-                if (m_options.anchorFallback.size() > 0) {
+                if (m_options.anchorFallbacks.size() != 0) {
                     enterState(State::anchor_fallback, 0.0);
                     animate = true;
                 } else {

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -187,20 +187,20 @@ void Label::resetState() {
     enterState(State::wait_occ, 0.0);
 }
 
-bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract, bool _allLabels) {
+bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract, bool _drawAllLabels) {
 
     m_occludedLastFrame = m_occluded;
     m_occluded = false;
 
     if (m_state == State::dead) {
-        if (!_allLabels) {
-            return false;
-        } else {
+        if (_drawAllLabels) {
             m_occluded = true;
+        } else {
+            return false;
         }
     }
 
-    bool ruleSatisfied = updateScreenTransform(_mvp, _screenSize, !_allLabels);
+    bool ruleSatisfied = updateScreenTransform(_mvp, _screenSize, !_drawAllLabels);
 
     // one of the label rules has not been satisfied
     if (!ruleSatisfied) {
@@ -232,7 +232,7 @@ bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _z
 bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
 
 #ifdef DEBUG
-    if (Tangram::getDebugFlag(DebugFlags::all_labels)) {
+    if (Tangram::getDebugFlag(DebugFlags::draw_all_labels)) {
         enterState(State::visible, 1.0);
         return false;
     }

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -230,10 +230,12 @@ bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _z
 
 bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
 
-    // if (Tangram::getDebugFlag(DebugFlags::all_labels)) {
-    //     enterState(State::visible, 1.0);
-    //     return false;
-    // }
+#ifdef DEBUG
+    if (Tangram::getDebugFlag(DebugFlags::all_labels)) {
+        enterState(State::visible, 1.0);
+        return false;
+    }
+#endif
 
     bool animate = false;
 

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -317,7 +317,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
             break;
         case State::wait_occ:
             if (m_occluded) {
-                if (m_options.anchorFallbacks.size() != 0) {
+                if (m_options.anchorFallbacks != 0) {
                     enterState(State::anchor_fallback, 0.0);
                     animate = true;
                 } else {

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -246,10 +246,12 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                 if (m_options.anchorFallback.size() > 0) {
                     enterState(State::anchor_fallback, 0.0);
                 } else {
-                    m_fade = FadeEffect(false, m_options.hideTransition.ease,
+                    m_fade.reset(false, m_options.hideTransition.ease,
                                         m_options.hideTransition.time);
+
                     enterState(State::fading_out, 1.0);
                 }
+
                 animate = true;
             } else if (m_currentAnchorFallback != 0) {
                 // TODO: try to place again to prefered fallback (0)
@@ -258,13 +260,15 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
         case State::anchor_fallback:
             if (m_occluded) {
                 if (m_anchorFallbackCount >= m_options.anchorFallback.size()) {
-                    m_fade = FadeEffect(false, m_options.hideTransition.ease,
+                    m_fade.reset(false, m_options.hideTransition.ease,
                                         m_options.hideTransition.time);
+
                     enterState(State::fading_out, m_transform.state.alpha);
                     m_anchorFallbackCount = 0;
                 } else {
                     m_anchorType = m_options.anchorFallback[m_anchorFallbackCount];
                     m_currentAnchorFallback = m_anchorFallbackCount;
+
                     if (m_parent) {
                         alignFromParent(*m_parent);
                     } else {
@@ -274,6 +278,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                 m_anchorFallbackCount++;
             } else {
                 m_anchorFallbackCount = 0;
+
                 if (!m_occludedLastFrame) {
                     enterState(State::visible, 1.0);
                 } else {
@@ -286,10 +291,9 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
         case State::fading_in:
             if (m_occluded) {
                 enterState(State::sleep, 0.0);
-                // enterState(State::fading_out, m_transform.state.alpha);
-                // animate = true;
                 break;
             }
+
             setAlpha(m_fade.update(_dt));
             animate = true;
             if (m_fade.isFinished()) {
@@ -302,6 +306,7 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                 animate = true;
                 break;
             }
+
             setAlpha(m_fade.update(_dt));
             animate = true;
             if (m_fade.isFinished()) {
@@ -317,8 +322,9 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
                     enterState(State::sleep, 0.0);
                 }
             } else {
-                m_fade = FadeEffect(true, m_options.showTransition.ease,
-                                    m_options.showTransition.time);
+                m_fade.reset(true, m_options.showTransition.ease,
+                                   m_options.showTransition.time);
+
                 enterState(State::fading_in, 0.0);
                 animate = true;
             }
@@ -332,8 +338,9 @@ bool Label::evalState(const glm::vec2& _screenSize, float _dt) {
             break;
         case State::sleep:
             if (!m_occluded) {
-                m_fade = FadeEffect(true, m_options.showTransition.ease,
-                                    m_options.showTransition.time);
+                m_fade.reset(true, m_options.showTransition.ease,
+                                   m_options.showTransition.time);
+
                 enterState(State::fading_in, 0.0);
                 animate = true;
             }

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -254,13 +254,7 @@ bool Label::update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _z
             return false;
         }
     } else if (m_state == State::out_of_screen) {
-        if (m_occludedLastFrame) {
-            enterState(State::sleep, 0.0);
-        } else {
-            // Non-occluded out-of-screen label came into
-            // screen again. Skip fade-in transition.
-            enterState(State::visible, 1.0);
-        }
+        enterState(State::sleep, 0.0);
     }
 
     return true;

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -131,6 +131,7 @@ bool Label::canOcclude() {
                         State::none |
                         State::skip_transition |
                         State::fading_in |
+                        State::fading_out |
                         State::sleep |
                         State::out_of_screen |
                         State::dead);
@@ -298,10 +299,10 @@ bool Label::evalState(float _dt) {
             return true;
 
         case State::fading_out:
-            // if (!m_occluded) {
-            //     enterState(State::fading_in, m_transform.state.alpha);
-            //     return true;
-            // }
+            if (!m_occluded) {
+                enterState(State::fading_in, m_transform.state.alpha);
+                return true;
+            }
             setAlpha(m_fade.update(_dt));
             if (m_fade.isFinished()) {
                 enterState(State::sleep, 0.0);

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -270,15 +270,33 @@ bool Label::evalState(float _dt) {
 #endif
 
     switch (m_state) {
-        case State::visible:
+        case State::none:
+        case State::sleep:
             if (m_occluded) {
-                m_fade.reset(false, m_options.hideTransition.ease,
-                             m_options.hideTransition.time);
-
-                enterState(State::fading_out, 1.0);
-                return true;
+                enterState(State::sleep, 0.0);
+                return false;
             }
-            return false;
+            if (m_options.showTransition.time == 0.f) {
+                enterState(State::visible, 1.0);
+                return false;
+            }
+            m_fade.reset(true, m_options.showTransition.ease,
+                         m_options.showTransition.time);
+            enterState(State::fading_in, 0.0);
+            return true;
+
+        case State::visible:
+            if (!m_occluded) { return false; }
+
+            if (m_options.hideTransition.time == 0.f) {
+                enterState(State::sleep, 0.0);
+                return false;
+            }
+            m_fade.reset(false, m_options.hideTransition.ease,
+                         m_options.hideTransition.time);
+
+            enterState(State::fading_out, 1.0);
+            return true;
 
         case State::fading_in:
             if (m_occluded) {
@@ -304,16 +322,6 @@ bool Label::evalState(float _dt) {
             }
             return true;
 
-        case State::none:
-            if (m_occluded) {
-                enterState(State::sleep, 0.0);
-                return false;
-            }
-            m_fade.reset(true, m_options.showTransition.ease,
-                         m_options.showTransition.time);
-            enterState(State::fading_in, 0.0);
-            return true;
-
         case State::skip_transition:
             if (m_occluded) {
                 enterState(State::sleep, 0.0);
@@ -321,16 +329,6 @@ bool Label::evalState(float _dt) {
                 enterState(State::visible, 1.0);
             }
             return true;
-
-        case State::sleep:
-            if (!m_occluded) {
-                m_fade.reset(true, m_options.showTransition.ease,
-                                   m_options.showTransition.time);
-
-                enterState(State::fading_in, 0.0);
-                return true;
-            }
-            return false;
 
         case State::dead:
         case State::out_of_screen:

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -311,10 +311,12 @@ bool Label::evalState(float _dt) {
             return true;
 
         case State::fading_out:
-            if (!m_occluded) {
-                enterState(State::fading_in, m_transform.state.alpha);
-                return true;
-            }
+            // if (!m_occluded) {
+            //     enterState(State::fading_in, m_transform.state.alpha);
+            //     m_fade.reset(false, m_options.hideTransition.ease,
+            //                  m_options.showTransition.time);
+            //     return true;
+            // }
             setAlpha(m_fade.update(_dt));
             if (m_fade.isFinished()) {
                 enterState(State::sleep, 0.0);

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -37,9 +37,10 @@ public:
         visible         = 1 << 2,
         sleep           = 1 << 3,
         out_of_screen   = 1 << 4,
-        wait_occ        = 1 << 5, // state waiting for first occlusion result
-        skip_transition = 1 << 6,
-        dead            = 1 << 7,
+        anchor_fallback = 1 << 5,
+        wait_occ        = 1 << 6, // state waiting for first occlusion result
+        skip_transition = 1 << 7,
+        dead            = 1 << 8,
     };
 
     struct Transform {
@@ -76,6 +77,8 @@ public:
 
         // the label hash based on its styling parameters
         size_t paramHash = 0;
+
+        std::vector<LabelProperty::Anchor> anchorFallback;
     };
 
     static const float activation_distance_threshold;
@@ -124,7 +127,9 @@ public:
     bool occludedLastFrame() const { return m_occludedLastFrame; }
 
     const Label* parent() const { return m_parent; }
-    void setParent(const Label& parent, bool definePriority);
+    void setParent(const Label& _parent, bool _definePriority);
+
+    void alignFromParent(const Label& _parent);
 
     LabelProperty::Anchor anchorType() const { return m_anchorType; }
 
@@ -133,6 +138,7 @@ public:
     void enterState(const State& _state, float _alpha = 1.0f);
 
     Type type() const { return m_type; }
+
 private:
 
     virtual void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
@@ -146,6 +152,8 @@ private:
     State m_state;
     // the label fade effect
     FadeEffect m_fade;
+
+    int m_anchorFallbackCount;
 
 protected:
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -154,6 +154,7 @@ private:
     FadeEffect m_fade;
 
     int m_anchorFallbackCount;
+    int m_currentAnchorFallback;
 
 protected:
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -138,6 +138,8 @@ public:
 
     Type type() const { return m_type; }
 
+    void print() const;
+
 private:
 
     virtual void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -87,7 +87,7 @@ public:
 
     virtual ~Label();
 
-    bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract, bool _allLabels = false);
+    bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract, bool _drawAllLabels = false);
 
     /* Push the pending transforms to the vbo by updating the vertices */
     virtual void pushTransform() = 0;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -95,8 +95,7 @@ public:
     bool evalState(const glm::vec2& _screenSize, float _dt);
 
     /* Update the screen position of the label */
-    bool updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize,
-                               bool _testVisibility = true);
+    bool updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize, bool _drawAllLabels);
 
     virtual void updateBBoxes(float _zoomFract) = 0;
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <limits>
 #include <memory>
-
+#include <bitset>
 
 namespace Tangram {
 
@@ -78,7 +78,7 @@ public:
         // the label hash based on its styling parameters
         size_t paramHash = 0;
 
-        std::vector<LabelProperty::Anchor> anchorFallback;
+        std::bitset<9> anchorFallbacks = 0;
     };
 
     static const float activation_distance_threshold;
@@ -152,8 +152,7 @@ private:
     // the label fade effect
     FadeEffect m_fade;
 
-    int m_anchorFallbackCount;
-    int m_currentAnchorFallback;
+    int m_anchorFallbackIndex;
 
 protected:
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -14,7 +14,6 @@
 #include <string>
 #include <limits>
 #include <memory>
-#include <bitset>
 
 namespace Tangram {
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -77,8 +77,7 @@ public:
         // the label hash based on its styling parameters
         size_t paramHash = 0;
 
-        LabelProperty::AnchorFallback anchors;
-        int anchorCount = 0;
+        LabelProperty::Anchors anchors;
     };
 
     static const float activation_distance_threshold;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -28,17 +28,17 @@ public:
     enum class Type {
         point,
         line,
-        debug
+        debug,
     };
 
     enum State {
-        fading_in       = 1,
-        fading_out      = 1 << 1,
-        visible         = 1 << 2,
-        sleep           = 1 << 3,
-        out_of_screen   = 1 << 4,
-        anchor_fallback = 1 << 5,
-        wait_occ        = 1 << 6, // state waiting for first occlusion result
+        none            = 1 << 0,
+        fading_in       = 1 << 1,
+        fading_out      = 1 << 2,
+        visible         = 1 << 3,
+        sleep           = 1 << 4,
+        out_of_screen   = 1 << 5,
+        anchor_fallback = 1 << 6,
         skip_transition = 1 << 7,
         dead            = 1 << 8,
     };

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -77,8 +77,7 @@ public:
         // the label hash based on its styling parameters
         size_t paramHash = 0;
 
-        static const int max_anchors = 9;
-        std::array<LabelProperty::Anchor, max_anchors> anchors;
+        LabelProperty::AnchorFallback anchors;
         int anchorCount = 0;
     };
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -78,12 +78,14 @@ public:
         // the label hash based on its styling parameters
         size_t paramHash = 0;
 
-        std::bitset<9> anchorFallbacks = 0;
+        static const int max_anchors = 9;
+        std::array<LabelProperty::Anchor, max_anchors> anchors;
+        int anchorCount = 0;
     };
 
     static const float activation_distance_threshold;
 
-    Label(Transform _transform, glm::vec2 _size, Type _type, Options _options, LabelProperty::Anchor _anchor);
+    Label(Transform _transform, glm::vec2 _size, Type _type, Options _options);
 
     virtual ~Label();
 
@@ -130,7 +132,7 @@ public:
 
     void alignFromParent(const Label& _parent);
 
-    LabelProperty::Anchor anchorType() const { return m_anchorType; }
+    LabelProperty::Anchor anchorType() const { return m_options.anchors[0]; }
 
     virtual glm::vec2 center() const;
 
@@ -143,7 +145,7 @@ public:
 private:
 
     virtual void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
-        LabelProperty::Anchor _anchor) = 0;
+                             LabelProperty::Anchor _anchor) = 0;
 
     bool offViewport(const glm::vec2& _screenSize);
 
@@ -154,7 +156,7 @@ private:
     // the label fade effect
     FadeEffect m_fade;
 
-    int m_anchorFallbackIndex;
+    int m_anchorIndex;
 
 protected:
 
@@ -173,7 +175,6 @@ protected:
     // label options
     Options m_options;
 
-    LabelProperty::Anchor m_anchorType;
     glm::vec2 m_anchor;
 
     const Label* m_parent;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -42,6 +42,12 @@ public:
         dead            = 1 << 8,
     };
 
+    enum class EvalUpdate {
+        none,
+        animate,
+        relayout,
+    };
+
     struct Transform {
         Transform(glm::vec2 _pos) : modelPosition1(_pos), modelPosition2(_pos) {}
         Transform(glm::vec2 _pos1, glm::vec2 _pos2) : modelPosition1(_pos1), modelPosition2(_pos2) {}
@@ -91,7 +97,7 @@ public:
     /* Push the pending transforms to the vbo by updating the vertices */
     virtual void pushTransform() = 0;
 
-    bool evalState(const glm::vec2& _screenSize, float _dt);
+    EvalUpdate evalState(float _dt);
 
     /* Update the screen position of the label */
     bool updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize, bool _drawAllLabels);

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -130,7 +130,7 @@ public:
 
     void alignFromParent(const Label& _parent);
 
-    LabelProperty::Anchor anchorType() const { return m_options.anchors[0]; }
+    LabelProperty::Anchor anchorType() const { return m_options.anchors[m_anchorIndex]; }
 
     virtual glm::vec2 center() const;
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -50,7 +50,7 @@ public:
 
         struct {
             glm::vec2 screenPos;
-            glm::vec2 rotation;
+            glm::vec2 rotation = {1.f,0.f};
             float alpha = 0.f;
         } state;
     };
@@ -87,7 +87,7 @@ public:
 
     bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract, bool _drawAllLabels = false);
 
-    void nextAnchor();
+    bool nextAnchor();
     bool setAnchorIndex(int _index);
     int anchorIndex() { return m_anchorIndex; }
 
@@ -130,8 +130,6 @@ public:
     const Label* parent() const { return m_parent; }
     void setParent(const Label& _parent, bool _definePriority);
 
-    void alignFromParent(const Label& _parent);
-
     LabelProperty::Anchor anchorType() const { return m_options.anchors[m_anchorIndex]; }
 
     virtual glm::vec2 center() const;
@@ -146,8 +144,7 @@ public:
 
 private:
 
-    virtual void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
-                             LabelProperty::Anchor _anchor) = 0;
+    virtual void applyAnchor(LabelProperty::Anchor _anchor) = 0;
 
     void setAlpha(float _alpha);
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -37,15 +37,8 @@ public:
         visible         = 1 << 3,
         sleep           = 1 << 4,
         out_of_screen   = 1 << 5,
-        anchor_fallback = 1 << 6,
-        skip_transition = 1 << 7,
-        dead            = 1 << 8,
-    };
-
-    enum class EvalUpdate {
-        none,
-        animate,
-        relayout,
+        skip_transition = 1 << 6,
+        dead            = 1 << 7,
     };
 
     struct Transform {
@@ -94,10 +87,14 @@ public:
 
     bool update(const glm::mat4& _mvp, const glm::vec2& _screenSize, float _zoomFract, bool _drawAllLabels = false);
 
+    void nextAnchor();
+    bool setAnchorIndex(int _index);
+    int anchorIndex() { return m_anchorIndex; }
+
     /* Push the pending transforms to the vbo by updating the vertices */
     virtual void pushTransform() = 0;
 
-    EvalUpdate evalState(float _dt);
+    bool evalState(float _dt);
 
     /* Update the screen position of the label */
     bool updateScreenTransform(const glm::mat4& _mvp, const glm::vec2& _screenSize, bool _drawAllLabels);
@@ -145,12 +142,12 @@ public:
 
     void print() const;
 
+    bool offViewport(const glm::vec2& _screenSize);
+
 private:
 
     virtual void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
                              LabelProperty::Anchor _anchor) = 0;
-
-    bool offViewport(const glm::vec2& _screenSize);
 
     void setAlpha(float _alpha);
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -56,8 +56,8 @@ public:
     };
 
     struct Transition {
-        FadeEffect::Interpolation ease = FadeEffect::Interpolation::sine;
-        float time = 0.2;
+        FadeEffect::Interpolation ease = FadeEffect::Interpolation::linear;
+        float time = 0.0;
     };
 
     struct Options {

--- a/core/src/labels/labelCollider.cpp
+++ b/core/src/labels/labelCollider.cpp
@@ -210,7 +210,7 @@ void LabelCollider::process() {
         if (label->isOccluded()) {
             label->enterState(Label::State::dead, 0.0f);
         } else {
-            label->enterState(Label::State::wait_occ, 0.0f);
+            label->enterState(Label::State::none, 0.0f);
         }
     }
 

--- a/core/src/labels/labelCollider.cpp
+++ b/core/src/labels/labelCollider.cpp
@@ -166,6 +166,10 @@ void LabelCollider::process() {
             }
         }
 
+        // Dont let parents occlude their child
+        if (l1->parent() == l2 || l2->parent() == l1) {
+            continue;
+        }
         if (l1->parent() && l1->parent()->isOccluded()) {
             l1->occlude();
         }

--- a/core/src/labels/labelProperty.cpp
+++ b/core/src/labels/labelProperty.cpp
@@ -63,5 +63,22 @@ bool align(const std::string& _align, Align& _out) {
     return tryFind(s_AlignMap, _align, _out);
 }
 
+Align alignFromAnchor(LabelProperty::Anchor _anchor) {
+    switch(_anchor) {
+        case LabelProperty::Anchor::top_left:
+        case LabelProperty::Anchor::left:
+        case LabelProperty::Anchor::bottom_left:
+            return TextLabelProperty::Align::right;
+        case LabelProperty::Anchor::top_right:
+        case LabelProperty::Anchor::right:
+        case LabelProperty::Anchor::bottom_right:
+            return TextLabelProperty::Align::left;
+        case LabelProperty::Anchor::top:
+        case LabelProperty::Anchor::bottom:
+        case LabelProperty::Anchor::center:;
+    }
+    return TextLabelProperty::Align::center;
+}
+
 } // TextLabelProperty
 } // Tangram

--- a/core/src/labels/labelProperty.h
+++ b/core/src/labels/labelProperty.h
@@ -28,14 +28,15 @@ glm::vec2 anchorDirection(Anchor _anchor);
 
 namespace TextLabelProperty {
 
-enum Transform {
+enum class Transform {
     none,
     capitalize,
     uppercase,
     lowercase,
 };
 
-enum Align {
+enum class Align {
+    none,
     right,
     left,
     center,

--- a/core/src/labels/labelProperty.h
+++ b/core/src/labels/labelProperty.h
@@ -9,7 +9,7 @@ namespace Tangram {
 namespace LabelProperty {
 
 enum Anchor {
-    center,
+    center = 0,
     top,
     bottom,
     left,

--- a/core/src/labels/labelProperty.h
+++ b/core/src/labels/labelProperty.h
@@ -43,6 +43,7 @@ enum Align {
 
 bool transform(const std::string& _transform, Transform& _out);
 bool align(const std::string& _transform, Align& _out);
+Align alignFromAnchor(LabelProperty::Anchor _anchor);
 
 } // TextLabelProperty
 } // Tangram

--- a/core/src/labels/labelProperty.h
+++ b/core/src/labels/labelProperty.h
@@ -35,11 +35,6 @@ struct Anchors {
         return anchor == _other.anchor && count == _other.count;
     }
 
-    // For GCC<5
-    Anchors(std::array<LabelProperty::Anchor, LabelProperty::max_anchors> _anchor, int _count)
-        : anchor(_anchor), count(_count) {}
-
-    Anchors() : count(0) {}
 };
 
 bool anchor(const std::string& _transform, Anchor& _out);

--- a/core/src/labels/labelProperty.h
+++ b/core/src/labels/labelProperty.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <array>
 #include "util/util.h"
 #include "glm/vec2.hpp"
 
@@ -19,6 +20,10 @@ enum Anchor : uint8_t {
     bottom_left,
     bottom_right,
 };
+
+constexpr int max_anchors = 9;
+
+using AnchorFallback = std::array<LabelProperty::Anchor, LabelProperty::max_anchors>;
 
 bool anchor(const std::string& _transform, Anchor& _out);
 

--- a/core/src/labels/labelProperty.h
+++ b/core/src/labels/labelProperty.h
@@ -8,7 +8,7 @@ namespace Tangram {
 
 namespace LabelProperty {
 
-enum Anchor {
+enum Anchor : uint8_t {
     center = 0,
     top,
     bottom,

--- a/core/src/labels/labelProperty.h
+++ b/core/src/labels/labelProperty.h
@@ -23,7 +23,24 @@ enum Anchor : uint8_t {
 
 constexpr int max_anchors = 9;
 
-using AnchorFallback = std::array<LabelProperty::Anchor, LabelProperty::max_anchors>;
+struct Anchors {
+    std::array<LabelProperty::Anchor, LabelProperty::max_anchors> anchor;
+    int count = 0;
+
+    LabelProperty::Anchor operator[](size_t _pos) const {
+        return anchor[_pos];
+    }
+
+    bool operator==(const Anchors& _other) const {
+        return anchor == _other.anchor && count == _other.count;
+    }
+
+    // For GCC<5
+    Anchors(std::array<LabelProperty::Anchor, LabelProperty::max_anchors> _anchor, int _count)
+        : anchor(_anchor), count(_count) {}
+
+    Anchors() : count(0) {}
+};
 
 bool anchor(const std::string& _transform, Anchor& _out);
 
@@ -41,10 +58,10 @@ enum class Transform {
 };
 
 enum class Align {
-    none,
-    right,
-    left,
-    center,
+    none   = -1,
+    right  = 0,
+    left   = 1,
+    center = 2,
 };
 
 bool transform(const std::string& _transform, Transform& _out);

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -122,9 +122,9 @@ void Labels::skipTransitions(const std::vector<const Style*>& _styles, Tile& _ti
 
 std::shared_ptr<Tile> findProxy(int32_t _sourceID, const TileID& _proxyID,
                                 const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                std::unique_ptr<TileCache>& _cache) {
+                                TileCache& _cache) {
 
-    auto proxy = _cache->contains(_sourceID, _proxyID);
+    auto proxy = _cache.contains(_sourceID, _proxyID);
     if (proxy) { return proxy; }
 
     for (auto& tile : _tiles) {
@@ -137,7 +137,7 @@ std::shared_ptr<Tile> findProxy(int32_t _sourceID, const TileID& _proxyID,
 
 void Labels::skipTransitions(const std::vector<std::unique_ptr<Style>>& _styles,
                              const std::vector<std::shared_ptr<Tile>>& _tiles,
-                             std::unique_ptr<TileCache>& _cache, float _currentZoom) const {
+                             TileCache& _cache, float _currentZoom) const {
 
     std::vector<const Style*> styles;
 
@@ -277,7 +277,7 @@ bool Labels::withinRepeatDistance(Label *_label) {
 void Labels::updateLabelSet(const View& _view, float _dt,
                             const std::vector<std::unique_ptr<Style>>& _styles,
                             const std::vector<std::shared_ptr<Tile>>& _tiles,
-                            std::unique_ptr<TileCache>& _cache) {
+                            TileCache& _cache) {
 
     /// Collect and update labels from visible tiles
     updateLabels(_view, _dt, _styles, _tiles, false);

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -45,7 +45,7 @@ void Labels::updateLabels(const View& _view, float _dt,
     // int lodDiscard = LODDiscardFunc(View::s_maxZoom, _view.getZoom());
     float dz = _view.getZoom() - std::floor(_view.getZoom());
 
-    bool allLabels = Tangram::getDebugFlag(DebugFlags::all_labels);
+    bool drawAllLabels = Tangram::getDebugFlag(DebugFlags::draw_all_labels);
 
     for (const auto& tile : _tiles) {
 
@@ -65,7 +65,7 @@ void Labels::updateLabels(const View& _view, float _dt,
             auto labelMesh = dynamic_cast<const LabelSet*>(mesh.get());
             if (!labelMesh) { continue; }
             for (auto& label : labelMesh->getLabels()) {
-                if (!label->update(mvp, screenSize, dz, allLabels)) {
+                if (!label->update(mvp, screenSize, dz, drawAllLabels)) {
                     // skip dead labels
                     continue;
                 }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -80,6 +80,8 @@ void Labels::updateLabels(const View& _view, float _dt,
 
                 if (_onlyTransitions) {
                     if (!label->canOcclude() || label->visibleState()) {
+                        if (label->occludedLastFrame()) { label->occlude(); }
+
                         evalLabel(label.get(), _dt);
                         label->pushTransform();
                     }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -21,7 +21,7 @@
 namespace Tangram {
 
 Labels::Labels()
-    : m_needUpdate(Label::EvalUpdate::none),
+    : m_needUpdate(false),
       m_lastZoom(0.0f) {}
 
 Labels::~Labels() {}
@@ -29,14 +29,6 @@ Labels::~Labels() {}
 // int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
 //     return (int) MIN(floor(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5)), MAX_LOD);
 // }
-
-void Labels::evalLabel(Label* _label, float _dt) {
-    auto update = _label->evalState(_dt);
-    if (update == Label::EvalUpdate::relayout ||
-        m_needUpdate == Label::EvalUpdate::none) {
-        m_needUpdate = update;
-    }
-}
 
 void Labels::updateLabels(const View& _view, float _dt,
                           const std::vector<std::unique_ptr<Style>>& _styles,
@@ -46,7 +38,7 @@ void Labels::updateLabels(const View& _view, float _dt,
     // Keep labels for debugDraw
     if (!_onlyTransitions) { m_labels.clear(); }
 
-    m_needUpdate = Label::EvalUpdate::none;
+    m_needUpdate = false;
 
     glm::vec2 screenSize = glm::vec2(_view.getWidth(), _view.getHeight());
 
@@ -64,7 +56,7 @@ void Labels::updateLabels(const View& _view, float _dt,
 
         bool proxyTile = tile->isProxy();
 
-        glm::mat4 mvp = _view.getViewProjectionMatrix() * tile->getModelMatrix();
+        glm::mat4 mvp = tile->mvp();
 
         for (const auto& style : _styles) {
             const auto& mesh = tile->getMesh(*style);
@@ -82,13 +74,13 @@ void Labels::updateLabels(const View& _view, float _dt,
                     if (!label->canOcclude() || label->visibleState()) {
                         if (label->occludedLastFrame()) { label->occlude(); }
 
-                        evalLabel(label.get(), _dt);
+                        m_needUpdate |= label->evalState(_dt);
                         label->pushTransform();
                     }
                 } else if (label->canOcclude()) {
-                    m_labels.emplace_back(label.get(), proxyTile);
+                    m_labels.emplace_back(label.get(), tile.get(), proxyTile);
                 } else {
-                    evalLabel(label.get(), _dt);
+                    m_needUpdate |= label->evalState(_dt);
                     label->pushTransform();
                 }
             }
@@ -222,7 +214,9 @@ void Labels::sortLabels() {
     std::sort(m_labels.begin(), m_labels.end(), Labels::labelComparator);
 }
 
-void Labels::handleOcclusions() {
+void Labels::handleOcclusions(const View& _view) {
+
+    glm::vec2 screenSize = glm::vec2(_view.getWidth(), _view.getHeight());
 
     m_isect2d.clear();
     m_repeatGroups.clear();
@@ -246,22 +240,55 @@ void Labels::handleOcclusions() {
             }
         }
 
-        // Skip label if it intersects with a previous label.
-        auto aabb = l->aabb();
-        aabb.m_userData = static_cast<void*>(l);
+        int anchorIndex = l->anchorIndex();
 
-        m_isect2d.intersect(aabb, [](auto& a, auto& b) {
-                auto* l1 = static_cast<Label*>(a.m_userData);
-                auto* l2 = static_cast<Label*>(b.m_userData);
+        while (!l->isOccluded()) {
 
-                if (intersect(l1->obb(), l2->obb())) {
-                    l1->occlude();
-                    // Drop label
-                    return false;
+            // Skip label if it intersects with a previous label.
+            auto aabb = l->aabb();
+            aabb.m_userData = static_cast<void*>(l);
+
+            m_isect2d.intersect(aabb, [](auto& a, auto& b) {
+                    auto* l1 = static_cast<Label*>(a.m_userData);
+                    auto* l2 = static_cast<Label*>(b.m_userData);
+                    // Parents do not occlude their child
+                    if (l1->parent() == l2) {
+                        return true;
+                    }
+
+                    if (intersect(l1->obb(), l2->obb())) {
+                        l1->occlude();
+                        // Drop label
+                        return false;
+                    }
+                    // Continue
+                    return true;
+                });
+
+            if (!l->isOccluded()) { break; }
+
+            // Try next anchor
+            l->nextAnchor();
+            while (anchorIndex != l->anchorIndex()) {
+
+                if (l->updateScreenTransform(entry.tile->mvp(), screenSize, false)) {
+                    if (!l->offViewport(screenSize)) {
+                        l->occlude(false);
+                        l->updateBBoxes(0);
+                        break;
+                    }
                 }
-                // Continue
-                return true;
-            });
+                l->nextAnchor();
+            }
+        }
+
+        if (anchorIndex != l->anchorIndex() &&
+            l->isOccluded() && l->visibleState()) {
+            // Reset to original position for fade-out
+            l->setAnchorIndex(anchorIndex);
+            l->updateScreenTransform(entry.tile->mvp(), screenSize, false);
+            l->updateBBoxes(0);
+        }
 
         if (l->options().repeatDistance > 0.f) {
             m_repeatGroups[l->options().repeatGroup].push_back(l);
@@ -304,14 +331,14 @@ void Labels::updateLabelSet(const View& _view, float _dt,
     m_isect2d.resize({_view.getWidth() / 256, _view.getHeight() / 256},
                      {_view.getWidth(), _view.getHeight()});
 
-    handleOcclusions();
+    handleOcclusions(_view);
 
     /// Update label meshes
 
     for (auto& entry : m_labels) {
         Label* label = entry.label;
 
-        evalLabel(label, _dt);
+        m_needUpdate |= label->evalState(_dt);
         label->pushTransform();
     }
 }
@@ -335,7 +362,7 @@ const std::vector<TouchItem>& Labels::getFeaturesAtPoint(const View& _view, floa
 
     for (const auto& tile : _tiles) {
 
-        glm::mat4 mvp = _view.getViewProjectionMatrix() * tile->getModelMatrix();
+        glm::mat4 mvp = tile->mvp();
 
         for (const auto& style : _styles) {
             const auto& mesh = tile->getMesh(*style);

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -415,6 +415,12 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         // draw projected anchor point
         Primitives::setColor(rs, 0x0000ff);
         Primitives::drawRect(rs, sp - glm::vec2(1.f), sp + glm::vec2(1.f));
+
+        if (label->options().anchorFallback.size() != 0) {
+            Primitives::setColor(rs, 0xffffff);
+            Primitives::drawPoly(rs, &(label->obb().getQuad())[0], 4);
+        }
+
 #if 0
         if (label->options().repeatGroup != 0 && label->state() == Label::State::visible) {
             size_t seed = 0;

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -179,9 +179,11 @@ bool Labels::labelComparator(const LabelEntry& _a, const LabelEntry& _b) {
     if (_a.proxy != _b.proxy) {
         return _b.proxy;
     }
-
     if (_a.priority != _b.priority) {
         return _a.priority < _b.priority;
+    }
+    if (_a.tile->getID().z != _b.tile->getID().z) {
+        return _a.tile->getID().z > _b.tile->getID().z;
     }
 
     auto l1 = _a.label;
@@ -191,6 +193,11 @@ bool Labels::labelComparator(const LabelEntry& _a, const LabelEntry& _b) {
     // navigation history.
     if (l1->occludedLastFrame() != l2->occludedLastFrame()) {
         return l2->occludedLastFrame();
+    }
+    // This prefers labels within screen over out_of_screen.
+    // Important for repeat groups!
+    if (l1->visibleState() != l2->visibleState()) {
+        return l1->visibleState();
     }
 
     // if (l1->options().repeatGroup != l2->options().repeatGroup) {

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -416,7 +416,7 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         Primitives::setColor(rs, 0x0000ff);
         Primitives::drawRect(rs, sp - glm::vec2(1.f), sp + glm::vec2(1.f));
 
-        if (label->options().anchorCount > 1) {
+        if (label->options().anchors.count > 1) {
             Primitives::setColor(rs, 0xffffff);
             Primitives::drawPoly(rs, &(label->obb().getQuad())[0], 4);
         }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -416,7 +416,7 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         Primitives::setColor(rs, 0x0000ff);
         Primitives::drawRect(rs, sp - glm::vec2(1.f), sp + glm::vec2(1.f));
 
-        if (label->options().anchorFallback.size() != 0) {
+        if (label->options().anchorFallbacks != 0) {
             Primitives::setColor(rs, 0xffffff);
             Primitives::drawPoly(rs, &(label->obb().getQuad())[0], 4);
         }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -98,7 +98,7 @@ void Labels::skipTransitions(const std::vector<const Style*>& _styles, Tile& _ti
 
         for (auto& l0 : mesh0->getLabels()) {
             if (!l0->canOcclude()) { continue; }
-            if (l0->state() != Label::State::wait_occ) { continue; }
+            if (l0->state() != Label::State::none) { continue; }
 
             for (auto& l1 : mesh1->getLabels()) {
                 if (!l1->visibleState()) { continue; }
@@ -385,7 +385,7 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         case Label::State::visible:
             Primitives::setColor(rs, 0x000000);
             break;
-        case Label::State::wait_occ:
+        case Label::State::none:
             Primitives::setColor(rs, 0x0000ff);
             break;
         case Label::State::dead:

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -235,7 +235,7 @@ void Labels::handleOcclusions(const View& _view) {
         // Parent must have been processed earlier so at this point its
         // occlusion and anchor position is determined for the current frame.
         if (l->parent()) {
-            if (l->parent()->isOccluded() || !l->parent()->visibleState()) {
+            if (l->parent()->isOccluded()) {
                 l->occlude();
                 continue;
             }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -416,7 +416,7 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         Primitives::setColor(rs, 0x0000ff);
         Primitives::drawRect(rs, sp - glm::vec2(1.f), sp + glm::vec2(1.f));
 
-        if (label->options().anchorFallbacks != 0) {
+        if (label->options().anchorCount > 1) {
             Primitives::setColor(rs, 0xffffff);
             Primitives::drawPoly(rs, &(label->obb().getQuad())[0], 4);
         }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -71,9 +71,9 @@ void Labels::updateLabels(const View& _view, float _dt,
                 }
 
                 if (_onlyTransitions) {
-                    if (!label->canOcclude() || label->visibleState()) {
-                        if (label->occludedLastFrame()) { label->occlude(); }
+                    if (label->occludedLastFrame()) { label->occlude(); }
 
+                    if (label->visibleState() || !label->canOcclude()) {
                         m_needUpdate |= label->evalState(_dt);
                         label->pushTransform();
                     }
@@ -409,7 +409,7 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         // draw bounding box
         switch (label->state()) {
         case Label::State::sleep:
-            Primitives::setColor(rs, 0x00ff00);
+            Primitives::setColor(rs, 0xdddddd);
             break;
         case Label::State::visible:
             Primitives::setColor(rs, 0x000000);
@@ -421,12 +421,27 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
             Primitives::setColor(rs, 0xff00ff);
             break;
         case Label::State::fading_in:
-        case Label::State::fading_out:
             Primitives::setColor(rs, 0xffff00);
+            break;
+        case Label::State::fading_out:
+            Primitives::setColor(rs, 0xff0000);
             break;
         default:
             Primitives::setColor(rs, 0x999999);
         }
+
+#if DEBUG_OCCLUSION
+        if (label->isOccluded()) {
+            Primitives::setColor(rs, 0xff0000);
+            if (label->occludedLastFrame()) {
+                Primitives::setColor(rs, 0xffff00);
+            }
+        } else if (label->occludedLastFrame()) {
+            Primitives::setColor(rs, 0x00ff00);
+        } else {
+            Primitives::setColor(rs, 0x000000);
+        }
+#endif
 
         Primitives::drawPoly(rs, &(label->obb().getQuad())[0], 4);
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -45,7 +45,7 @@ public:
                                                      const std::vector<std::shared_ptr<Tile>>& _tiles,
                                                      float _x, float _y, bool _visibleOnly = true);
 
-    bool needUpdate() const { return m_needUpdate; }
+    Label::EvalUpdate needUpdate() const { return m_needUpdate; }
 
 private:
 
@@ -66,7 +66,9 @@ private:
 
     PERF_TRACE bool withinRepeatDistance(Label *_label);
 
-    bool m_needUpdate;
+    void evalLabel(Label* _label, float _dt);
+
+    Label::EvalUpdate m_needUpdate;
 
     isect2d::ISect2D<glm::vec2> m_isect2d;
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -45,7 +45,7 @@ public:
                                                      const std::vector<std::shared_ptr<Tile>>& _tiles,
                                                      float _x, float _y, bool _visibleOnly = true);
 
-    Label::EvalUpdate needUpdate() const { return m_needUpdate; }
+    bool needUpdate() const { return m_needUpdate; }
 
 private:
 
@@ -62,13 +62,11 @@ private:
 
     PERF_TRACE void sortLabels();
 
-    PERF_TRACE void handleOcclusions();
+    PERF_TRACE void handleOcclusions(const View& _view);
 
     PERF_TRACE bool withinRepeatDistance(Label *_label);
 
-    void evalLabel(Label* _label, float _dt);
-
-    Label::EvalUpdate m_needUpdate;
+    bool m_needUpdate;
 
     isect2d::ISect2D<glm::vec2> m_isect2d;
 
@@ -76,13 +74,14 @@ private:
 
     struct LabelEntry {
 
-        LabelEntry(Label* _label, bool _proxy)
+        LabelEntry(Label* _label, Tile* _tile, bool _proxy)
             : label(_label),
+              tile(_tile),
               priority(_label->options().priority),
               proxy(_proxy) {}
 
         Label* label;
-
+        Tile* tile;
         float priority;
         bool proxy;
     };

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -35,7 +35,7 @@ public:
     void drawDebug(RenderState& rs, const View& _view);
 
     void updateLabelSet(const View& _view, float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
-                        const std::vector<std::shared_ptr<Tile>>& _tiles, std::unique_ptr<TileCache>& _cache);
+                        const std::vector<std::shared_ptr<Tile>>& _tiles, TileCache& _cache);
 
     PERF_TRACE void updateLabels(const View& _view, float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
                                  const std::vector<std::shared_ptr<Tile>>& _tiles, bool _onlyTransitions = true);
@@ -56,7 +56,7 @@ private:
 
     void skipTransitions(const std::vector<std::unique_ptr<Style>>& _styles,
                          const std::vector<std::shared_ptr<Tile>>& _tiles,
-                         std::unique_ptr<TileCache>& _cache, float _currentZoom) const;
+                         TileCache& _cache, float _currentZoom) const;
 
     PERF_TRACE void skipTransitions(const std::vector<const Style*>& _styles, Tile& _tile, Tile& _proxy) const;
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -47,7 +47,7 @@ public:
 
     bool needUpdate() const { return m_needUpdate; }
 
-private:
+protected:
 
     using AABB = isect2d::AABB<glm::vec2>;
     using OBB = isect2d::OBB<glm::vec2>;

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -12,18 +12,18 @@ const float SpriteVertex::alpha_scale = 65535.0f;
 const float SpriteVertex::texture_scale = 65535.0f;
 
 SpriteLabel::SpriteLabel(Label::Transform _transform, glm::vec2 _size, Label::Options _options,
-                         float _extrudeScale, LabelProperty::Anchor _anchor,
-                         SpriteLabels& _labels, size_t _labelsPos)
-    : Label(_transform, _size, Label::Type::point, _options, _anchor),
+                         float _extrudeScale, SpriteLabels& _labels, size_t _labelsPos)
+    : Label(_transform, _size, Label::Type::point, _options),
       m_labels(_labels),
       m_labelsPos(_labelsPos),
       m_extrudeScale(_extrudeScale) {
 
-    applyAnchor(m_dim, glm::vec2(0.0), _anchor);
+    applyAnchor(m_dim, glm::vec2(0.0), m_options.anchors[0]);
 }
 
 void SpriteLabel::applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
                               LabelProperty::Anchor _anchor) {
+
     // _dimension is not applied to the sprite anchor since fractionnal zoom
     // level would result in scaling the sprite size dynamically, instead we
     // store a factor between 0..1 to scale the sprite accordingly

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -18,35 +18,21 @@ SpriteLabel::SpriteLabel(Label::Transform _transform, glm::vec2 _size, Label::Op
       m_labelsPos(_labelsPos),
       m_extrudeScale(_extrudeScale) {
 
-    applyAnchor(m_dim, glm::vec2(0.0), m_options.anchors[0]);
+    applyAnchor(m_options.anchors[0]);
 }
 
-void SpriteLabel::applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
-                              LabelProperty::Anchor _anchor) {
+void SpriteLabel::applyAnchor(LabelProperty::Anchor _anchor) {
 
-    // _dimension is not applied to the sprite anchor since fractionnal zoom
-    // level would result in scaling the sprite size dynamically, instead we
-    // store a factor between 0..1 to scale the sprite accordingly
-
-    glm::vec2 direction = LabelProperty::anchorDirection(_anchor);
-
-    // Transform anchor direction from anchor space (centered)
-    // to local sprite space (lower-left corner for the sprite)
-    m_anchor = direction * glm::vec2(-0.5, 0.5) + glm::vec2(0.5);
-
-    m_anchor.x = -(m_dim.x * m_anchor.x);
-    m_anchor.y =  (m_dim.y * m_anchor.y);
+    m_anchor = LabelProperty::anchorDirection(_anchor) * m_dim * 0.5f;
 }
 
 void SpriteLabel::updateBBoxes(float _zoomFract) {
-    glm::vec2 halfSize = m_dim * 0.5f;
     glm::vec2 sp = m_transform.state.screenPos;
     glm::vec2 dim = m_dim + glm::vec2(m_extrudeScale * 2.f * _zoomFract);
 
     if (m_occludedLastFrame) { dim += Label::activation_distance_threshold; }
 
-    m_obb = OBB({sp.x + halfSize.x, sp.y - halfSize.y},
-                m_transform.state.rotation, dim.x, dim.y);
+    m_obb = OBB(sp, m_transform.state.rotation, dim.x, dim.y);
 }
 
 void SpriteLabel::pushTransform() {

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -26,8 +26,7 @@ class SpriteLabel : public Label {
 public:
 
     SpriteLabel(Label::Transform _transform, glm::vec2 _size, Label::Options _options,
-                float _extrudeScale, LabelProperty::Anchor _anchor,
-                SpriteLabels& _labels, size_t _labelsPos);
+                float _extrudeScale, SpriteLabels& _labels, size_t _labelsPos);
 
     void updateBBoxes(float _zoomFract) override;
 
@@ -36,7 +35,7 @@ public:
 private:
 
     void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
-        LabelProperty::Anchor _anchor) override;
+                     LabelProperty::Anchor _anchor) override;
     
     // Back-pointer to owning container and position
     const SpriteLabels& m_labels;

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -34,8 +34,7 @@ public:
 
 private:
 
-    void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
-                     LabelProperty::Anchor _anchor) override;
+    void applyAnchor(LabelProperty::Anchor _anchor) override;
     
     // Back-pointer to owning container and position
     const SpriteLabels& m_labels;

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -14,10 +14,10 @@ const float TextVertex::alpha_scale = 65535.0f;
 
 TextLabel::TextLabel(Label::Transform _transform, Type _type, Label::Options _options,
                      Anchor _anchor, TextLabel::FontVertexAttributes _attrib,
-                     glm::vec2 _dim,  TextLabels& _labels, Range _vertexRange)
+                     glm::vec2 _dim,  TextLabels& _labels, std::vector<TextRange> _textRanges)
     : Label(_transform, _dim, _type, _options, _anchor),
       m_textLabels(_labels),
-      m_vertexRange(_vertexRange),
+      m_textRanges(_textRanges),
       m_fontAttrib(_attrib) {
 
     applyAnchor(_dim, glm::vec2(0.0), _anchor);
@@ -54,8 +54,10 @@ void TextLabel::pushTransform() {
         uint16_t(m_fontAttrib.fontScale),
     };
 
-    auto it = m_textLabels.quads.begin() + m_vertexRange.start;
-    auto end = it + m_vertexRange.length;
+    rangeindex = (rangeindex + 1) % m_textRanges.size();
+    auto it = m_textLabels.quads.begin() + m_textRanges[rangeindex].range.start;
+
+    auto end = it + m_textRanges[rangeindex].range.length;
     auto& style = m_textLabels.style;
 
     glm::i16vec2 sp = glm::i16vec2(m_transform.state.screenPos * TextVertex::position_scale);

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -35,6 +35,10 @@ void TextLabel::applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origi
         m_textRangeIndex = int(m_preferedAlignment);
     }
 
+    if (m_textRanges[m_textRangeIndex].length == 0) {
+        m_textRangeIndex = 0;
+    }
+
     m_anchor = _origin + LabelProperty::anchorDirection(_anchor) * _dimension * 0.5f;
 }
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -14,17 +14,17 @@ const float TextVertex::position_scale = 4.0f;
 const float TextVertex::alpha_scale = 65535.0f;
 
 TextLabel::TextLabel(Label::Transform _transform, Type _type, Label::Options _options,
-                     Anchor _anchor, TextLabel::FontVertexAttributes _attrib,
+                     TextLabel::FontVertexAttributes _attrib,
                      glm::vec2 _dim,  TextLabels& _labels, std::vector<TextRange> _textRanges,
                      Align _preferedAlignment)
-    : Label(_transform, _dim, _type, _options, _anchor),
+    : Label(_transform, _dim, _type, _options),
       m_textLabels(_labels),
       m_textRanges(_textRanges),
       m_fontAttrib(_attrib),
       m_preferedAlignment(_preferedAlignment) {
 
-    applyAnchor(_dim, glm::vec2(0.0), _anchor);
     m_textRangeIndex = 0;
+    applyAnchor(_dim, glm::vec2(0.0), m_options.anchors[0]);
 }
 
 void TextLabel::applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin, Anchor _anchor) {

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -15,7 +15,7 @@ const float TextVertex::alpha_scale = 65535.0f;
 
 TextLabel::TextLabel(Label::Transform _transform, Type _type, Label::Options _options,
                      TextLabel::FontVertexAttributes _attrib,
-                     glm::vec2 _dim,  TextLabels& _labels, std::vector<TextRange> _textRanges,
+                     glm::vec2 _dim,  TextLabels& _labels, TextRange _textRanges,
                      Align _preferedAlignment)
     : Label(_transform, _dim, _type, _options),
       m_textLabels(_labels),
@@ -23,7 +23,6 @@ TextLabel::TextLabel(Label::Transform _transform, Type _type, Label::Options _op
       m_fontAttrib(_attrib),
       m_preferedAlignment(_preferedAlignment) {
 
-    m_textRangeIndex = 0;
     applyAnchor(_dim, glm::vec2(0.0), m_options.anchors[0]);
 }
 
@@ -31,12 +30,9 @@ void TextLabel::applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origi
 
     if (m_preferedAlignment == Align::none) {
         Align newAlignment = alignFromAnchor(_anchor);
-        for (int i = 0; i < m_textRanges.size(); ++i) {
-            if (m_textRanges[i].align == newAlignment) {
-                m_textRangeIndex = i;
-                break;
-            }
-        }
+        m_textRangeIndex = int(newAlignment);
+    } else {
+        m_textRangeIndex = int(m_preferedAlignment);
     }
 
     m_anchor = _origin + LabelProperty::anchorDirection(_anchor) * _dimension * 0.5f;
@@ -69,16 +65,22 @@ void TextLabel::pushTransform() {
         uint16_t(m_fontAttrib.fontScale),
     };
 
-    auto it = m_textLabels.quads.begin() + m_textRanges[m_textRangeIndex].range.start;
-    auto end = it + m_textRanges[m_textRangeIndex].range.length;
+    auto it = m_textLabels.quads.begin() + m_textRanges[m_textRangeIndex].start;
+    auto end = it + m_textRanges[m_textRangeIndex].length;
     auto& style = m_textLabels.style;
 
     glm::i16vec2 sp = glm::i16vec2(m_transform.state.screenPos * TextVertex::position_scale);
+    auto& meshes = style.getMeshes();
 
     for (; it != end; ++it) {
         auto quad = *it;
 
-        auto* quadVertices = style.getMesh(it->atlas).pushQuad();
+        if (it->atlas >= meshes.size()) {
+            LOGE("Accesing inconsistent quad mesh (id:%u, size:%u)",
+                 it->atlas, meshes.size());
+            break;
+        }
+        auto* quadVertices = meshes[it->atlas]->pushQuad();
         for (int i = 0; i < 4; i++) {
             TextVertex& v = quadVertices[i];
             if (rotate) {

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -3,7 +3,6 @@
 #include "labels/label.h"
 
 #include <glm/glm.hpp>
-#include <limits>
 
 namespace Tangram {
 
@@ -52,8 +51,6 @@ public:
               glm::vec2 _dim, TextLabels& _labels, std::vector<TextRange> _textRanges);
 
     void updateBBoxes(float _zoomFract) override;
-
-    size_t allQuadRange() const;
 
     std::vector<TextRange>& textRanges() {
         return m_textRanges;

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -48,7 +48,8 @@ public:
 
     TextLabel(Label::Transform _transform, Type _type, Label::Options _options,
               LabelProperty::Anchor _anchor, TextLabel::FontVertexAttributes _attrib,
-              glm::vec2 _dim, TextLabels& _labels, std::vector<TextRange> _textRanges);
+              glm::vec2 _dim, TextLabels& _labels, std::vector<TextRange> _textRanges,
+              TextLabelProperty::Align _preferedAlignment);
 
     void updateBBoxes(float _zoomFract) override;
 
@@ -61,6 +62,7 @@ protected:
     void pushTransform() override;
 
 private:
+
     void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
                      LabelProperty::Anchor _anchor) override;
 
@@ -70,10 +72,14 @@ private:
     // first vertex and count in m_textLabels quads
     std::vector<TextRange> m_textRanges;
 
+    // TextRange currently used for drawing
+    int m_textRangeIndex;
+
     FontVertexAttributes m_fontAttrib;
 
-    // TODO: remove me
-    int rangeindex = 0;
+    // The text LAbel prefered alignment
+    TextLabelProperty::Align m_preferedAlignment;
+
 };
 
 }

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -3,6 +3,7 @@
 #include "labels/label.h"
 
 #include <glm/glm.hpp>
+#include <limits>
 
 namespace Tangram {
 
@@ -15,6 +16,11 @@ struct GlyphQuad {
         glm::i16vec2 pos;
         glm::u16vec2 uv;
     } quad[4];
+};
+
+struct TextRange {
+    TextLabelProperty::Align align;
+    Range range;
 };
 
 struct TextVertex {
@@ -43,11 +49,15 @@ public:
 
     TextLabel(Label::Transform _transform, Type _type, Label::Options _options,
               LabelProperty::Anchor _anchor, TextLabel::FontVertexAttributes _attrib,
-              glm::vec2 _dim, TextLabels& _labels, Range _vertexRange);
+              glm::vec2 _dim, TextLabels& _labels, std::vector<TextRange> _textRanges);
 
     void updateBBoxes(float _zoomFract) override;
 
-    Range& quadRange() { return m_vertexRange; }
+    size_t allQuadRange() const;
+
+    std::vector<TextRange>& textRanges() {
+        return m_textRanges;
+    }
 
 protected:
 
@@ -59,10 +69,14 @@ private:
 
     // Back-pointer to owning container
     const TextLabels& m_textLabels;
+
     // first vertex and count in m_textLabels quads
-    Range m_vertexRange;
+    std::vector<TextRange> m_textRanges;
 
     FontVertexAttributes m_fontAttrib;
+
+    // TODO: remove me
+    int rangeindex = 0;
 };
 
 }

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -47,7 +47,7 @@ public:
     };
 
     TextLabel(Label::Transform _transform, Type _type, Label::Options _options,
-              LabelProperty::Anchor _anchor, TextLabel::FontVertexAttributes _attrib,
+              TextLabel::FontVertexAttributes _attrib,
               glm::vec2 _dim, TextLabels& _labels, std::vector<TextRange> _textRanges,
               TextLabelProperty::Align _preferedAlignment);
 

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -17,10 +17,7 @@ struct GlyphQuad {
     } quad[4];
 };
 
-struct TextRange {
-    TextLabelProperty::Align align;
-    Range range;
-};
+using TextRange = std::array<Range, 3>;
 
 struct TextVertex {
     glm::i16vec2 pos;
@@ -48,12 +45,12 @@ public:
 
     TextLabel(Label::Transform _transform, Type _type, Label::Options _options,
               TextLabel::FontVertexAttributes _attrib,
-              glm::vec2 _dim, TextLabels& _labels, std::vector<TextRange> _textRanges,
+              glm::vec2 _dim, TextLabels& _labels, TextRange _textRanges,
               TextLabelProperty::Align _preferedAlignment);
 
     void updateBBoxes(float _zoomFract) override;
 
-    std::vector<TextRange>& textRanges() {
+    TextRange& textRanges() {
         return m_textRanges;
     }
 
@@ -69,8 +66,8 @@ private:
     // Back-pointer to owning container
     const TextLabels& m_textLabels;
 
-    // first vertex and count in m_textLabels quads
-    std::vector<TextRange> m_textRanges;
+    // first vertex and count in m_textLabels quads (left,right,center)
+    TextRange m_textRanges;
 
     // TextRange currently used for drawing
     int m_textRangeIndex;

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -60,8 +60,7 @@ protected:
 
 private:
 
-    void applyAnchor(const glm::vec2& _dimension, const glm::vec2& _origin,
-                     LabelProperty::Anchor _anchor) override;
+    void applyAnchor(LabelProperty::Anchor _anchor) override;
 
     // Back-pointer to owning container
     const TextLabels& m_textLabels;

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -84,7 +84,7 @@ struct SceneLoader {
 
     static void parseStyleParams(Node params, const std::shared_ptr<Scene>& scene, const std::string& propPrefix,
                                  std::vector<StyleParam>& out);
-    static void parseTransition(Node params, const std::shared_ptr<Scene>& scene, std::vector<StyleParam>& out);
+    static void parseTransition(Node params, const std::shared_ptr<Scene>& scene, std::string _prefix, std::vector<StyleParam>& out);
 
     static bool parseStyleUniforms(const Node& value, const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
 

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -213,9 +213,6 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
                 LOG("Invalid anchor %s", anchor.c_str());
             }
         }
-        if (anchors.count == 0) {
-            anchors = TextStyle::Parameters::defaultAnchorFallbacks();
-        }
         return anchors;
     }
     case StyleParamKey::text_align:

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "labels/labelProperty.h"
 #include "util/variant.h"
 #include "glm/vec2.hpp"
 #include <string>
@@ -130,7 +131,7 @@ struct StyleParam {
         }
     };
 
-    using Value = variant<none_type, bool, float, uint32_t, std::string, glm::vec2, Width>;
+    using Value = variant<none_type, bool, float, uint32_t, std::string, glm::vec2, Width, LabelProperty::Anchors>;
 
     StyleParam() :
         key(StyleParamKey::none),

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<StyledMesh> PointStyleBuilder::build() {
     if (m_quads.empty()) { return nullptr; }
 
 
-    if (Tangram::getDebugFlag(DebugFlags::all_labels)) {
+    if (Tangram::getDebugFlag(DebugFlags::draw_all_labels)) {
 
         m_iconMesh->setLabels(m_labels);
 

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -136,6 +136,9 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
 
     LabelProperty::anchor(anchor, p.anchor);
 
+    p.labelOptions.anchors[0] = p.anchor;
+    p.labelOptions.anchorCount = 1;
+
     if (p.labelOptions.interactive) {
         p.labelOptions.properties = std::make_shared<Properties>(_props);
     }
@@ -153,7 +156,6 @@ void PointStyleBuilder::addLabel(const Point& _point, const glm::vec4& _quad,
                                                      _params.size,
                                                      _params.labelOptions,
                                                      _params.extrudeScale,
-                                                     _params.anchor,
                                                      *m_spriteLabels,
                                                      m_quads.size()));
 

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -136,8 +136,8 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
 
     LabelProperty::anchor(anchor, p.anchor);
 
-    p.labelOptions.anchors[0] = p.anchor;
-    p.labelOptions.anchorCount = 1;
+    p.labelOptions.anchors.anchor[0] = p.anchor;
+    p.labelOptions.anchors.count = 1;
 
     if (p.labelOptions.interactive) {
         p.labelOptions.properties = std::make_shared<Properties>(_props);

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -270,7 +270,7 @@ void PointStyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) 
     bool textVisible = true;
     _rule.get(StyleParamKey::text_visible, textVisible);
 
-    if ( textVisible && _rule.contains(StyleParamKey::point_text) ) {
+    if (textVisible && _rule.contains(StyleParamKey::point_text)) {
         if (iconsCount == 0) { return; }
 
         auto& textStyleBuilder = static_cast<TextStyleBuilder&>(*m_textStyleBuilder);

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -278,7 +278,7 @@ void PointStyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) 
 
         size_t textStart = textLabels.size();
 
-        textStyleBuilder.addFeatureCommon(_feat, _rule, true);
+        if (!textStyleBuilder.addFeatureCommon(_feat, _rule, true)) { return; }
 
         size_t textCount = textLabels.size() - textStart;
 

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -165,14 +165,17 @@ void PointStyleBuilder::addLabel(const Point& _point, const glm::vec4& _quad,
     glm::vec2 uvTR = glm::vec2{_quad.z, _quad.w} * SpriteVertex::texture_scale;
     glm::vec2 uvBL = glm::vec2{_quad.x, _quad.y} * SpriteVertex::texture_scale;
 
+    float sx = size.x * 0.5f;
+    float sy = size.y * 0.5f;
+
     m_quads.push_back({
-            {{{0, 0},
+            {{{-sx, sy},
              {uvBL.x, uvTR.y}},
-            {{size.x, 0},
+            {{sx, sy},
              {uvTR.x, uvTR.y}},
-            {{0, -size.y},
+            {{-sx, -sy},
              {uvBL.x, uvBL.y}},
-            {{size.x, -size.y},
+            {{sx, -sy},
              {uvTR.x, uvBL.y}}},
             _params.color});
 }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -99,12 +99,6 @@ void TextStyle::onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _sce
     }
 }
 
-TextStyle::Parameters TextStyle::defaultUnifiedParams() const {
-    TextStyle::Parameters params;
-    params.anchor = LabelProperty::Anchor::bottom;
-    return params;
-}
-
 std::unique_ptr<StyleBuilder> TextStyle::createBuilder() const {
     return std::make_unique<TextStyleBuilder>(*this);
 }

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -34,7 +34,7 @@ public:
         uint32_t maxLineWidth = 15;
 
         TextLabelProperty::Transform transform = TextLabelProperty::Transform::none;
-        TextLabelProperty::Align align = TextLabelProperty::Align::center;
+        TextLabelProperty::Align align = TextLabelProperty::Align::none;
         LabelProperty::Anchor anchor = LabelProperty::Anchor::center;
 
         float fontScale = 1;

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -36,7 +36,6 @@ public:
         TextLabelProperty::Transform transform = TextLabelProperty::Transform::none;
         TextLabelProperty::Align align = TextLabelProperty::Align::center;
         LabelProperty::Anchor anchor = LabelProperty::Anchor::center;
-        std::vector<LabelProperty::Anchor> anchorFallback;
 
         float fontScale = 1;
         float lineSpacing = 0;

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -36,6 +36,7 @@ public:
         TextLabelProperty::Transform transform = TextLabelProperty::Transform::none;
         TextLabelProperty::Align align = TextLabelProperty::Align::center;
         LabelProperty::Anchor anchor = LabelProperty::Anchor::center;
+        std::vector<LabelProperty::Anchor> anchorFallback;
 
         float fontScale = 1;
         float lineSpacing = 0;

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -37,6 +37,20 @@ public:
         TextLabelProperty::Align align = TextLabelProperty::Align::none;
         LabelProperty::Anchor anchor = LabelProperty::Anchor::center;
 
+        static inline LabelProperty::AnchorFallback defaultAnchorFallbacks() {
+            static LabelProperty::AnchorFallback defaultFallbacks = {
+                {LabelProperty::Anchor::bottom,
+                 LabelProperty::Anchor::top,
+                 LabelProperty::Anchor::right,
+                 LabelProperty::Anchor::left,
+                 LabelProperty::Anchor::bottom_right,
+                 LabelProperty::Anchor::bottom_left,
+                 LabelProperty::Anchor::top_right,
+                 LabelProperty::Anchor::top_left}
+            };
+            return defaultFallbacks;
+        }
+
         float fontScale = 1;
         float lineSpacing = 0;
     };

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -37,16 +37,17 @@ public:
         TextLabelProperty::Align align = TextLabelProperty::Align::none;
         LabelProperty::Anchor anchor = LabelProperty::Anchor::center;
 
-        static inline LabelProperty::AnchorFallback defaultAnchorFallbacks() {
-            static LabelProperty::AnchorFallback defaultFallbacks = {
-                {LabelProperty::Anchor::bottom,
-                 LabelProperty::Anchor::top,
-                 LabelProperty::Anchor::right,
-                 LabelProperty::Anchor::left,
-                 LabelProperty::Anchor::bottom_right,
-                 LabelProperty::Anchor::bottom_left,
-                 LabelProperty::Anchor::top_right,
-                 LabelProperty::Anchor::top_left}
+        static inline LabelProperty::Anchors defaultAnchorFallbacks() {
+            static const LabelProperty::Anchors defaultFallbacks = {
+                {{LabelProperty::Anchor::bottom,
+                  LabelProperty::Anchor::top,
+                  LabelProperty::Anchor::right,
+                  LabelProperty::Anchor::left,
+                  LabelProperty::Anchor::bottom_right,
+                  LabelProperty::Anchor::bottom_left,
+                  LabelProperty::Anchor::top_right,
+                  LabelProperty::Anchor::top_left}},
+                8,
             };
             return defaultFallbacks;
         }
@@ -98,6 +99,8 @@ public:
     std::unique_ptr<StyleBuilder> createBuilder() const override;
 
     DynamicQuadMesh<TextVertex>& getMesh(size_t id) const;
+
+    auto& getMeshes() const { return m_meshes; }
 
     virtual size_t dynamicMeshSize() const override;
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -35,22 +35,6 @@ public:
 
         TextLabelProperty::Transform transform = TextLabelProperty::Transform::none;
         TextLabelProperty::Align align = TextLabelProperty::Align::none;
-        LabelProperty::Anchor anchor = LabelProperty::Anchor::center;
-
-        static inline LabelProperty::Anchors defaultAnchorFallbacks() {
-            static const LabelProperty::Anchors defaultFallbacks = {
-                {{LabelProperty::Anchor::bottom,
-                  LabelProperty::Anchor::top,
-                  LabelProperty::Anchor::right,
-                  LabelProperty::Anchor::left,
-                  LabelProperty::Anchor::bottom_right,
-                  LabelProperty::Anchor::bottom_left,
-                  LabelProperty::Anchor::top_right,
-                  LabelProperty::Anchor::top_left}},
-                8,
-            };
-            return defaultFallbacks;
-        }
 
         float fontScale = 1;
         float lineSpacing = 0;
@@ -106,8 +90,6 @@ public:
 
     virtual ~TextStyle() override;
 
-    Parameters defaultUnifiedParams() const;
-
 private:
 
     const std::string& applyTextSource(const Parameters& _parameters, const Properties& _props) const;
@@ -134,7 +116,6 @@ namespace std {
             hash_combine(seed, p.maxLineWidth);
             hash_combine(seed, int(p.transform));
             hash_combine(seed, int(p.align));
-            hash_combine(seed, int(p.anchor));
             hash_combine(seed, optionsHash(p.labelOptions));
             return seed;
         }

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -485,8 +485,7 @@ bool TextStyleBuilder::prepareLabel(TextStyle::Parameters& _params, Label::Type 
     m_attributes.fill = _params.fill;
     m_attributes.fontScale = _params.fontScale * 64.f;
     if (m_attributes.fontScale > 255) {
-        // FIXME: This warning should not be logged for every label
-        // LOGW("Too large font scale %f, maximal scale is 4", _params.fontScale);
+        LOGN("Too large font scale %f, maximal scale is 4", _params.fontScale);
         m_attributes.fontScale = 255;
     }
     m_attributes.quadsStart = m_quads.size();

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -516,6 +516,8 @@ bool TextStyleBuilder::prepareLabel(TextStyle::Parameters& _params, Label::Type 
     }
     m_attributes.quadsStart = m_quads.size();
 
+    m_attributes.textRanges.clear();
+
     glm::vec2 bbox(0);
     if (ctx->layoutText(_params, *renderText, m_quads, m_atlasRefs, bbox, m_attributes.textRanges)) {
         m_attributes.width = bbox.x;

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<StyledMesh> TextStyleBuilder::build() {
 
     if (m_quads.empty()) { return nullptr; }
 
-    if (Tangram::getDebugFlag(DebugFlags::all_labels)) {
+    if (Tangram::getDebugFlag(DebugFlags::draw_all_labels)) {
         m_textLabels->setLabels(m_labels);
 
         std::vector<GlyphQuad> quads(m_quads);

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -351,10 +351,10 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         std::vector<std::string> anchors = splitString(a, ',');
 
         if (anchors.size() > 1) {
-            for (int i = 1; i < anchors.size(); ++i) {
+            for (int i = 0; i < anchors.size(); ++i) {
                 LabelProperty::Anchor labelAnchor;
                 if (LabelProperty::anchor(anchors[i], labelAnchor)) {
-                    p.anchorFallback.push_back(labelAnchor);
+                    p.labelOptions.anchorFallback.push_back(labelAnchor);
                 } else {
                     LOG("Invalid anchor %s", anchors[i].c_str());
                 }

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -110,17 +110,20 @@ std::unique_ptr<StyledMesh> TextStyleBuilder::build() {
         for (auto& label : m_labels) {
             auto* textLabel = static_cast<TextLabel*>(label.get());
 
-            // Range range = textLabel->quadRange();
             std::vector<TextRange>& ranges = textLabel->textRanges();
             bool active = textLabel->state() != Label::State::dead;
 
-            for (auto& textRange : ranges) {
-                auto& range = textRange.range;
-                if (range.end() != quadPos) {
-                    quadStart = quadEnd;
-                    quadPos = range.end();
-                    added = false;
-                }
+            if (ranges.empty()) {
+                // FIXME when does this happen?
+                continue;
+            }
+
+
+            auto& range = ranges.back().range;
+            if (range.end() != quadPos) {
+                quadStart = quadEnd;
+                quadPos = range.end();
+                added = false;
             }
 
             if (!active) { continue; }

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -531,7 +531,8 @@ void TextStyleBuilder::addLabel(const TextStyle::Parameters& _params, Label::Typ
     m_labels.emplace_back(new TextLabel(_transform, _type, _params.labelOptions, _params.anchor,
                                         {m_attributes.fill, m_attributes.stroke, m_attributes.fontScale},
                                         {m_attributes.width, m_attributes.height},
-                                        *m_textLabels, std::move(m_attributes.textRanges)));
+                                        *m_textLabels, std::move(m_attributes.textRanges),
+                                        _params.align));
 }
 
 }

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -355,22 +355,7 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
     if (auto* align = _rule.get<std::string>(StyleParamKey::text_align)) {
         bool res = TextLabelProperty::align(*align, p.align);
         if (!res) {
-            switch(p.anchor) {
-            case LabelProperty::Anchor::top_left:
-            case LabelProperty::Anchor::left:
-            case LabelProperty::Anchor::bottom_left:
-                p.align = TextLabelProperty::Align::right;
-                break;
-            case LabelProperty::Anchor::top_right:
-            case LabelProperty::Anchor::right:
-            case LabelProperty::Anchor::bottom_right:
-                p.align = TextLabelProperty::Align::left;
-                break;
-            case LabelProperty::Anchor::top:
-            case LabelProperty::Anchor::bottom:
-            case LabelProperty::Anchor::center:
-                break;
-            }
+            p.align = TextLabelProperty::alignFromAnchor(p.anchor);
         }
     }
 

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -144,7 +144,7 @@ std::unique_ptr<StyledMesh> TextStyleBuilder::build() {
     return std::move(m_textLabels);
 }
 
-void TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _rule, bool _iconText) {
+bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _rule, bool _iconText) {
     TextStyle::Parameters params = applyRule(_rule, _feat.props, _iconText);
 
     Label::Type labelType;
@@ -159,7 +159,7 @@ void TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
     size_t quadsStart = m_quads.size();
     size_t numLabels = m_labels.size();
 
-    if (!prepareLabel(params, labelType)) { return; }
+    if (!prepareLabel(params, labelType)) { return false; }
 
     if (_feat.geometryType == GeometryType::points) {
         for (auto& point : _feat.points) {
@@ -200,6 +200,7 @@ void TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
         // Drop quads when no label was added
         m_quads.resize(quadsStart);
     }
+    return true;
 }
 
 void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::Parameters& _params) {

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -365,12 +365,10 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
                 LabelProperty::Anchor labelAnchor;
                 if (LabelProperty::anchor(anchors[i], labelAnchor)) {
                     p.labelOptions.anchorFallbacks.set(labelAnchor);
-                    LOG("Set label anchor, %d", (int)labelAnchor);
                 } else {
                     LOG("Invalid anchor %s", anchors[i].c_str());
                 }
             }
-            LOG("Label anchor %s", p.labelOptions.anchorFallbacks.to_string().c_str());
         }
 
         LabelProperty::anchor(anchors[0], p.anchor);

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -364,11 +364,13 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
             for (size_t i = 0; i < anchors.size(); ++i) {
                 LabelProperty::Anchor labelAnchor;
                 if (LabelProperty::anchor(anchors[i], labelAnchor)) {
-                    p.labelOptions.anchorFallback.push_back(labelAnchor);
+                    p.labelOptions.anchorFallbacks.set(labelAnchor);
+                    LOG("Set label anchor, %d", (int)labelAnchor);
                 } else {
                     LOG("Invalid anchor %s", anchors[i].c_str());
                 }
             }
+            LOG("Label anchor %s", p.labelOptions.anchorFallbacks.to_string().c_str());
         }
 
         LabelProperty::anchor(anchors[0], p.anchor);

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -357,7 +357,6 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
     if (anchor) {
         // TODO: cache in style param and optimize
         std::string a = *anchor;
-        a.erase(std::remove(a.begin(), a.end(), ' '), a.end());
         std::vector<std::string> anchors = splitString(a, ',');
 
         for (size_t i = 0; i < anchors.size() && i < Label::Options::max_anchors; ++i) {

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -360,18 +360,17 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         a.erase(std::remove(a.begin(), a.end(), ' '), a.end());
         std::vector<std::string> anchors = splitString(a, ',');
 
-        if (anchors.size() > 1) {
-            for (size_t i = 0; i < anchors.size(); ++i) {
-                LabelProperty::Anchor labelAnchor;
-                if (LabelProperty::anchor(anchors[i], labelAnchor)) {
-                    p.labelOptions.anchorFallbacks.set(labelAnchor);
-                } else {
-                    LOG("Invalid anchor %s", anchors[i].c_str());
-                }
+        for (size_t i = 0; i < anchors.size() && i < Label::Options::max_anchors; ++i) {
+            LabelProperty::Anchor labelAnchor;
+            if (LabelProperty::anchor(anchors[i], labelAnchor)) {
+                p.labelOptions.anchors[i] = labelAnchor;
+                p.labelOptions.anchorCount++;
+                //p.labelOptions.anchorFallbacks.set(labelAnchor);
+            } else {
+                LOG("Invalid anchor %s", anchors[i].c_str());
             }
         }
 
-        LabelProperty::anchor(anchors[0], p.anchor);
     }
 
     if (auto* transform = _rule.get<std::string>(StyleParamKey::text_transform)) {
@@ -514,7 +513,7 @@ bool TextStyleBuilder::prepareLabel(TextStyle::Parameters& _params, Label::Type 
 void TextStyleBuilder::addLabel(const TextStyle::Parameters& _params, Label::Type _type,
                                 Label::Transform _transform) {
 
-    m_labels.emplace_back(new TextLabel(_transform, _type, _params.labelOptions, _params.anchor,
+    m_labels.emplace_back(new TextLabel(_transform, _type, _params.labelOptions,
                                         {m_attributes.fill, m_attributes.stroke, m_attributes.fontScale},
                                         {m_attributes.width, m_attributes.height},
                                         *m_textLabels, m_attributes.textRanges,

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -359,17 +359,18 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         std::string a = *anchor;
         std::vector<std::string> anchors = splitString(a, ',');
 
-        for (size_t i = 0; i < anchors.size() && i < Label::Options::max_anchors; ++i) {
+        for (size_t i = 0; i < anchors.size() && i < LabelProperty::max_anchors; ++i) {
             LabelProperty::Anchor labelAnchor;
             if (LabelProperty::anchor(anchors[i], labelAnchor)) {
                 p.labelOptions.anchors[i] = labelAnchor;
                 p.labelOptions.anchorCount++;
-                //p.labelOptions.anchorFallbacks.set(labelAnchor);
             } else {
                 LOG("Invalid anchor %s", anchors[i].c_str());
             }
         }
-
+    } else if (_rule.contains(StyleParamKey::point_text)) { // text attached to point
+        p.labelOptions.anchors = TextStyle::Parameters::defaultAnchorFallbacks();
+        p.labelOptions.anchorCount = 8;
     }
 
     if (auto* transform = _rule.get<std::string>(StyleParamKey::text_transform)) {

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -296,8 +296,6 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
 
     _rule.get(StyleParamKey::text_font_fill, p.fill);
 
-    p.labelOptions.offset *= m_style.pixelScale();
-
     _rule.get(StyleParamKey::text_font_stroke_color, p.strokeColor);
     _rule.get(StyleParamKey::text_font_stroke_width, p.strokeWidth);
     p.strokeWidth *= m_style.pixelScale();
@@ -311,6 +309,7 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         _rule.get(StyleParamKey::text_collide, p.labelOptions.collide);
         _rule.get(StyleParamKey::text_interactive, p.interactive);
         _rule.get(StyleParamKey::text_offset, p.labelOptions.offset);
+        p.labelOptions.offset *= m_style.pixelScale();
 
         _rule.get(StyleParamKey::text_anchor, p.labelOptions.anchors);
         if (p.labelOptions.anchors.count == 0) {
@@ -331,6 +330,7 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         _rule.get(StyleParamKey::collide, p.labelOptions.collide);
         _rule.get(StyleParamKey::interactive, p.interactive);
         _rule.get(StyleParamKey::offset, p.labelOptions.offset);
+        p.labelOptions.offset *= m_style.pixelScale();
 
         _rule.get(StyleParamKey::anchor, p.labelOptions.anchors);
         if (p.labelOptions.anchors.count == 0) {
@@ -364,6 +364,7 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
     p.labelOptions.repeatDistance *= m_style.pixelScale();
 
     if (p.interactive) {
+        // TODO optimization: for icon-text use the parent's properties
         p.labelOptions.properties = std::make_shared<Properties>(_props);
     }
 

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -321,11 +321,7 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
                     {LabelProperty::Anchor::bottom,
                      LabelProperty::Anchor::top,
                      LabelProperty::Anchor::right,
-                     LabelProperty::Anchor::left,
-                     LabelProperty::Anchor::bottom_right,
-                     LabelProperty::Anchor::bottom_left,
-                     LabelProperty::Anchor::top_right,
-                     LabelProperty::Anchor::top_left}}, 8};
+                     LabelProperty::Anchor::left}}, 4};
         }
 
         _rule.get(StyleParamKey::text_transition_hide_time, p.labelOptions.hideTransition.time);

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -300,6 +300,10 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
     _rule.get(StyleParamKey::text_font_stroke_width, p.strokeWidth);
     p.strokeWidth *= m_style.pixelScale();
 
+    _rule.get(StyleParamKey::transition_hide_time, p.labelOptions.hideTransition.time);
+    _rule.get(StyleParamKey::transition_selected_time, p.labelOptions.selectTransition.time);
+    _rule.get(StyleParamKey::transition_show_time, p.labelOptions.showTransition.time);
+
     uint32_t priority;
     if (_iconText) {
 
@@ -323,6 +327,11 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
                      LabelProperty::Anchor::top_right,
                      LabelProperty::Anchor::top_left}}, 8};
         }
+
+        _rule.get(StyleParamKey::text_transition_hide_time, p.labelOptions.hideTransition.time);
+        _rule.get(StyleParamKey::text_transition_selected_time, p.labelOptions.selectTransition.time);
+        _rule.get(StyleParamKey::text_transition_show_time, p.labelOptions.showTransition.time);
+
     } else {
         if (_rule.get(StyleParamKey::priority, priority)) {
             p.labelOptions.priority = (float)priority;
@@ -339,9 +348,6 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         }
     }
 
-    _rule.get(StyleParamKey::text_transition_hide_time, p.labelOptions.hideTransition.time);
-    _rule.get(StyleParamKey::text_transition_selected_time, p.labelOptions.selectTransition.time);
-    _rule.get(StyleParamKey::text_transition_show_time, p.labelOptions.showTransition.time);
     _rule.get(StyleParamKey::text_wrap, p.maxLineWidth);
 
     size_t repeatGroupHash = 0;

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -73,7 +73,7 @@ protected:
         uint32_t fill = 0;
         uint32_t stroke = 0;
         uint8_t fontScale = 0;
-        std::vector<TextRange> textRanges;
+        TextRange textRanges;
     } m_attributes;
 
     float m_tileSize = 0;

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -24,7 +24,7 @@ public:
         addFeatureCommon(_feature, _rule, false);
     }
 
-    void addFeatureCommon(const Feature& _feature, const DrawRule& _rule, bool _iconText);
+    bool addFeatureCommon(const Feature& _feature, const DrawRule& _rule, bool _iconText);
 
     void setup(const Tile& _tile) override;
 

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -73,6 +73,7 @@ protected:
         uint32_t fill = 0;
         uint32_t stroke = 0;
         uint8_t fontScale = 0;
+        std::vector<TextRange> textRanges;
     } m_attributes;
 
     float m_tileSize = 0;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -293,7 +293,10 @@ bool Map::update(float _dt) {
 
         auto& tiles = impl->tileManager.getVisibleTiles();
 
-        if (impl->view.changedOnLastUpdate() ||
+        const bool mustUpdateLabels = true;
+
+        if (mustUpdateLabels ||
+            impl->view.changedOnLastUpdate() ||
             impl->tileManager.hasTileSetChanged()) {
 
             for (const auto& tile : tiles) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -304,7 +304,7 @@ bool Map::update(float _dt) {
             }
 
             impl->labels.updateLabelSet(impl->view, _dt, impl->scene->styles(), tiles,
-                                        impl->tileManager.getTileCache());
+                                        *impl->tileManager.getTileCache());
         } else {
             impl->labels.updateLabels(impl->view, _dt, impl->scene->styles(), tiles);
         }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -302,9 +302,9 @@ bool Map::update(float _dt) {
             for (const auto& tile : tiles) {
                 tile->update(_dt, impl->view);
             }
+
             impl->labels.updateLabelSet(impl->view, _dt, impl->scene->styles(), tiles,
                                         impl->tileManager.getTileCache());
-
         } else {
             impl->labels.updateLabels(impl->view, _dt, impl->scene->styles(), tiles);
         }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -293,9 +293,7 @@ bool Map::update(float _dt) {
 
         auto& tiles = impl->tileManager.getVisibleTiles();
 
-        const bool mustUpdateLabels = true;
-
-        if (mustUpdateLabels ||
+        if (impl->labels.needUpdate() == Label::EvalUpdate::relayout ||
             impl->view.changedOnLastUpdate() ||
             impl->tileManager.hasTileSetChanged()) {
 
@@ -315,7 +313,7 @@ bool Map::update(float _dt) {
     bool viewChanged = impl->view.changedOnLastUpdate();
     bool tilesChanged = impl->tileManager.hasTileSetChanged();
     bool tilesLoading = impl->tileManager.hasLoadingTiles();
-    bool labelsNeedUpdate = impl->labels.needUpdate();
+    bool labelsNeedUpdate = impl->labels.needUpdate() != Label::EvalUpdate::none;
     bool resourceLoading = (impl->scene->resourceLoad > 0);
     bool nextScene = bool(impl->nextScene);
 
@@ -324,7 +322,7 @@ bool Map::update(float _dt) {
     }
 
     // Request for render if labels are in fading in/out states
-    if (impl->labels.needUpdate()) { requestRender(); }
+    if (labelsNeedUpdate) { requestRender(); }
 
     return viewComplete;
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -685,6 +685,7 @@ void toggleDebugFlag(DebugFlags _flag) {
 
     // Rebuild tiles for debug modes that needs it
     // if (_flag == DebugFlags::proxy_colors
+    //  || _flag == DebugFlags::draw_all_labels
     //  || _flag == DebugFlags::tile_bounds
     //  || _flag == DebugFlags::tile_infos) {
     //     if (m_tileManager) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -293,8 +293,7 @@ bool Map::update(float _dt) {
 
         auto& tiles = impl->tileManager.getVisibleTiles();
 
-        if (impl->labels.needUpdate() == Label::EvalUpdate::relayout ||
-            impl->view.changedOnLastUpdate() ||
+        if (impl->view.changedOnLastUpdate() ||
             impl->tileManager.hasTileSetChanged()) {
 
             for (const auto& tile : tiles) {
@@ -313,7 +312,7 @@ bool Map::update(float _dt) {
     bool viewChanged = impl->view.changedOnLastUpdate();
     bool tilesChanged = impl->tileManager.hasTileSetChanged();
     bool tilesLoading = impl->tileManager.hasLoadingTiles();
-    bool labelsNeedUpdate = impl->labels.needUpdate() != Label::EvalUpdate::none;
+    bool labelsNeedUpdate = impl->labels.needUpdate();
     bool resourceLoading = (impl->scene->resourceLoad > 0);
     bool nextScene = bool(impl->nextScene);
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -193,7 +193,7 @@ enum DebugFlags {
     tile_infos,         // Debug tile infos
     labels,             // Debug label bounding boxes
     tangram_infos,      // Various text tangram debug info printed on the screen
-    all_labels,         // Draw all labels
+    draw_all_labels,    // Draw all labels
     tangram_stats,      // Tangram frame graph stats
 };
 

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -186,7 +186,7 @@ void FontContext::bindTexture(RenderState& rs, alfons::AtlasID _id, GLuint _unit
 
 bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& _text,
                              std::vector<GlyphQuad>& _quads, std::bitset<max_textures>& _refs,
-                             glm::vec2& _size, std::vector<TextRange>& _textRanges) {
+                             glm::vec2& _size, TextRange& _textRanges) {
 
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -207,40 +207,52 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
     size_t quadsStart = _quads.size();
     alfons::LineMetrics metrics;
 
-    // Collect possible alignment from anchor fallbacks
-    std::vector<TextLabelProperty::Align> alignments;
-    for (int i = 0; i < _params.labelOptions.anchorCount; ++i) {
-        // TODO only need center/right/left align once!
-        TextLabelProperty::Align alignmentFallback =
-            TextLabelProperty::alignFromAnchor(_params.labelOptions.anchors[i]);
-        alignments.push_back(alignmentFallback);
+    std::array<bool, 3> alignments = {};
+    if (_params.align != TextLabelProperty::Align::none) {
+        alignments[int(_params.align)] = true;
     }
 
-    if (alignments.empty()) {
-        alignments.push_back(TextLabelProperty::Align::center);
+    // Collect possible alignment from anchor fallbacks
+    for (int i = 0; i < _params.labelOptions.anchors.count; i++) {
+        auto anchor = _params.labelOptions.anchors[i];
+        TextLabelProperty::Align alignment = TextLabelProperty::alignFromAnchor(anchor);
+        if (alignment != TextLabelProperty::Align::none) {
+            alignments[int(alignment)] = true;
+        }
     }
 
     if (_params.wordWrap) {
         m_textWrapper.clearWraps();
 
-        float width = m_textWrapper.getShapeRangeWidth(line, MIN_LINE_WIDTH, _params.maxLineWidth);
+        float width = m_textWrapper.getShapeRangeWidth(line, MIN_LINE_WIDTH,
+                                                       _params.maxLineWidth);
 
-        for (auto& align : alignments) {
+        for (size_t i = 0; i < 3; i++) {
+
             int rangeStart = m_scratch.quads->size();
-            m_textWrapper.draw(m_batch, width, line, align, _params.lineSpacing, metrics);
+            if (!alignments[i]) {
+                _textRanges[i] = Range(rangeStart, 0);
+                continue;
+            }
+            m_textWrapper.draw(m_batch, width, line, TextLabelProperty::Align(i),
+                               _params.lineSpacing, metrics);
+
             int rangeEnd = m_scratch.quads->size();
 
-            _textRanges.push_back({align, {rangeStart, rangeEnd - rangeStart}});
+            _textRanges[i] = Range(rangeStart, rangeEnd - rangeStart);
         }
     } else {
-        glm::vec2 position(0);
-
-        for (auto& align : alignments) {
+        for (size_t i = 0; i < 3; i++) {
+            glm::vec2 position(0);
             int rangeStart = m_scratch.quads->size();
+            if (!alignments[i]) {
+                _textRanges[i] = Range(rangeStart, 0);
+                continue;
+            }
             m_batch.drawShapeRange(line, 0, line.shapes().size(), position, metrics);
             int rangeEnd = m_scratch.quads->size();
 
-            _textRanges.push_back({align, {rangeStart, rangeEnd - rangeStart}});
+            _textRanges[i] = Range(rangeStart, rangeEnd - rangeStart);
         }
     }
 

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -185,7 +185,8 @@ void FontContext::bindTexture(RenderState& rs, alfons::AtlasID _id, GLuint _unit
 }
 
 bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& _text,
-                             std::vector<GlyphQuad>& _quads, std::bitset<max_textures>& _refs, glm::vec2& _size) {
+                             std::vector<GlyphQuad>& _quads, std::bitset<max_textures>& _refs,
+                             glm::vec2& _size, std::vector<TextRange>& _textRanges) {
 
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -217,14 +218,27 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
         m_textWrapper.clearWraps();
         
         if (line.shapes().size() > 0) {
-            float width = m_textWrapper.getShapeRangeWidth(line,
-                MIN_LINE_WIDTH, _params.maxLineWidth);
-            m_textWrapper.draw(m_batch, width, line, alignments,
-                               _params.lineSpacing, metrics);
+            float width = m_textWrapper.getShapeRangeWidth(line, MIN_LINE_WIDTH, _params.maxLineWidth);
+
+            for (auto& align : alignments) {
+                int rangeStart = m_scratch.quads->size();
+                m_textWrapper.draw(m_batch, width, line, align, _params.lineSpacing, metrics);
+                int rangeEnd = m_scratch.quads->size();
+
+                _textRanges.push_back({align, {rangeStart, rangeEnd - rangeStart}});
+                LOGD("Text quad range {%d,%d} for label %s", rangeStart, rangEnd, _text.c_str());
+            }
         }
     } else {
         glm::vec2 position(0);
-        m_batch.drawShapeRange(line, 0, line.shapes().size(), position, metrics);
+
+        for (auto& align : alignments) {
+            int rangeStart = m_scratch.quads->size();
+            m_batch.drawShapeRange(line, 0, line.shapes().size(), position, metrics);
+            int rangeEnd = m_scratch.quads->size();
+
+            _textRanges.push_back({align, {rangeStart, rangeEnd - rangeStart}});
+        }
     }
 
     // TextLabel parameter: Dimension
@@ -331,6 +345,7 @@ void FontContext::ScratchBuffer::drawGlyph(const alfons::Rect& q, const alfons::
     if (atlasGlyph.atlas >= max_textures) { return; }
 
     auto& g = *atlasGlyph.glyph;
+
     quads->push_back({
             atlasGlyph.atlas,
             {{glm::vec2{q.x1, q.y1} * TextVertex::position_scale, {g.u1, g.v1}},

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -209,8 +209,11 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
 
     // Collect possible alignment from anchor fallbacks
     std::vector<TextLabelProperty::Align> alignments;
-    for (auto anchorFallback : _params.labelOptions.anchorFallback) {
-        TextLabelProperty::Align alignmentFallback = TextLabelProperty::alignFromAnchor(anchorFallback);
+    for (int i = 0; i < _params.labelOptions.anchorFallbacks.size(); ++i) {
+        if (!_params.labelOptions.anchorFallbacks[i]) {
+            continue;
+        }
+        TextLabelProperty::Align alignmentFallback = TextLabelProperty::alignFromAnchor((LabelProperty::Anchor)i);
         alignments.push_back(alignmentFallback);
     }
 

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -226,7 +226,7 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
                 int rangeEnd = m_scratch.quads->size();
 
                 _textRanges.push_back({align, {rangeStart, rangeEnd - rangeStart}});
-                LOGD("Text quad range {%d,%d} for label %s", rangeStart, rangEnd, _text.c_str());
+                LOGD("Text quad range {%d,%d} for label %s", rangeStart, rangeEnd, _text.c_str());
             }
         }
     } else {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -245,21 +245,23 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
         }
     }
 
-    // TextLabel parameter: Dimension
-    float width = metrics.aabb.z - metrics.aabb.x;
-    float height = metrics.aabb.w - metrics.aabb.y;
-
-    // Offset to center all glyphs around 0/0
-    glm::vec2 offset((metrics.aabb.x + width * 0.5) * TextVertex::position_scale,
-                     (metrics.aabb.y + height * 0.5) * TextVertex::position_scale);
-
     auto it = _quads.begin() + quadsStart;
     if (it == _quads.end()) {
         // No glyphs added
         return false;
     }
 
-    while (it != _quads.end()) {
+    // TextLabel parameter: Dimension
+    float width = metrics.aabb.z - metrics.aabb.x;
+    float height = metrics.aabb.w - metrics.aabb.y;
+    _size = glm::vec2(width, height);
+
+    // Offset to center all glyphs around 0/0
+    glm::vec2 offset((metrics.aabb.x + width * 0.5) * TextVertex::position_scale,
+                     (metrics.aabb.y + height * 0.5) * TextVertex::position_scale);
+
+
+    for (; it != _quads.end(); ++it) {
 
         if (!_refs[it->atlas]) {
             _refs[it->atlas] = true;
@@ -270,10 +272,7 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
         it->quad[1].pos -= offset;
         it->quad[2].pos -= offset;
         it->quad[3].pos -= offset;
-        ++it;
     }
-
-    _size = glm::vec2(width, height);
 
     return true;
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -221,17 +221,15 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
     if (_params.wordWrap) {
         m_textWrapper.clearWraps();
         
-        if (line.shapes().size() > 0) {
-            float width = m_textWrapper.getShapeRangeWidth(line, MIN_LINE_WIDTH, _params.maxLineWidth);
+        float width = m_textWrapper.getShapeRangeWidth(line, MIN_LINE_WIDTH, _params.maxLineWidth);
 
-            for (auto& align : alignments) {
-                int rangeStart = m_scratch.quads->size();
-                m_textWrapper.draw(m_batch, width, line, align, _params.lineSpacing, metrics);
-                int rangeEnd = m_scratch.quads->size();
+        for (auto& align : alignments) {
+            int rangeStart = m_scratch.quads->size();
+            m_textWrapper.draw(m_batch, width, line, align, _params.lineSpacing, metrics);
+            int rangeEnd = m_scratch.quads->size();
 
-                _textRanges.push_back({align, {rangeStart, rangeEnd - rangeStart}});
-                LOGD("Text quad range {%d,%d} for label %s", rangeStart, rangeEnd, _text.c_str());
-            }
+            _textRanges.push_back({align, {rangeStart, rangeEnd - rangeStart}});
+            LOGD("Text quad range {%d,%d} for label %s", rangeStart, rangeEnd, _text.c_str());
         }
     } else {
         glm::vec2 position(0);

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -214,6 +214,10 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
         alignments.push_back(alignmentFallback);
     }
 
+    if (alignments.empty()) {
+        alignments.push_back(TextLabelProperty::Align::center);
+    }
+
     if (_params.wordWrap) {
         m_textWrapper.clearWraps();
         

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -209,11 +209,10 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
 
     // Collect possible alignment from anchor fallbacks
     std::vector<TextLabelProperty::Align> alignments;
-    for (int i = 0; i < _params.labelOptions.anchorFallbacks.size(); ++i) {
-        if (!_params.labelOptions.anchorFallbacks[i]) {
-            continue;
-        }
-        TextLabelProperty::Align alignmentFallback = TextLabelProperty::alignFromAnchor((LabelProperty::Anchor)i);
+    for (int i = 0; i < _params.labelOptions.anchorCount; ++i) {
+        // TODO only need center/right/left align once!
+        TextLabelProperty::Align alignmentFallback =
+            TextLabelProperty::alignFromAnchor(_params.labelOptions.anchors[i]);
         alignments.push_back(alignmentFallback);
     }
 
@@ -223,7 +222,7 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
 
     if (_params.wordWrap) {
         m_textWrapper.clearWraps();
-        
+
         float width = m_textWrapper.getShapeRangeWidth(line, MIN_LINE_WIDTH, _params.maxLineWidth);
 
         for (auto& align : alignments) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -232,7 +232,6 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
             int rangeEnd = m_scratch.quads->size();
 
             _textRanges.push_back({align, {rangeStart, rangeEnd - rangeStart}});
-            LOGD("Text quad range {%d,%d} for label %s", rangeStart, rangeEnd, _text.c_str());
         }
     } else {
         glm::vec2 position(0);

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -206,10 +206,22 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
     size_t quadsStart = _quads.size();
     alfons::LineMetrics metrics;
 
+    // Collect possible alignment from anchor fallbacks
+    std::vector<TextLabelProperty::Align> alignments;
+    for (auto anchorFallback : _params.labelOptions.anchorFallback) {
+        TextLabelProperty::Align alignmentFallback = TextLabelProperty::alignFromAnchor(anchorFallback);
+        alignments.push_back(alignmentFallback);
+    }
+
     if (_params.wordWrap) {
-        m_textWrapper.draw(m_batch, line, MIN_LINE_WIDTH,
-                           _params.maxLineWidth, _params.align,
-                           _params.lineSpacing, metrics);
+        m_textWrapper.clearWraps();
+        
+        if (line.shapes().size() > 0) {
+            float width = m_textWrapper.getShapeRangeWidth(line,
+                MIN_LINE_WIDTH, _params.maxLineWidth);
+            m_textWrapper.draw(m_batch, width, line, alignments,
+                               _params.lineSpacing, metrics);
+        }
     } else {
         glm::vec2 position(0);
         m_batch.drawShapeRange(line, 0, line.shapes().size(), position, metrics);

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -234,26 +234,29 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
                 _textRanges[i] = Range(rangeStart, 0);
                 continue;
             }
-            m_textWrapper.draw(m_batch, width, line, TextLabelProperty::Align(i),
-                               _params.lineSpacing, metrics);
-
+            int numLines = m_textWrapper.draw(m_batch, width, line, TextLabelProperty::Align(i),
+                                              _params.lineSpacing, metrics);
             int rangeEnd = m_scratch.quads->size();
 
             _textRanges[i] = Range(rangeStart, rangeEnd - rangeStart);
+
+            // For single line text alignments are the same
+            if (i == 0 && numLines == 1) {
+                _textRanges[1] = Range(rangeEnd, 0);
+                _textRanges[2] = Range(rangeEnd, 0);
+                break;
+            }
         }
     } else {
-        for (size_t i = 0; i < 3; i++) {
-            glm::vec2 position(0);
-            int rangeStart = m_scratch.quads->size();
-            if (!alignments[i]) {
-                _textRanges[i] = Range(rangeStart, 0);
-                continue;
-            }
-            m_batch.drawShapeRange(line, 0, line.shapes().size(), position, metrics);
-            int rangeEnd = m_scratch.quads->size();
+        glm::vec2 position(0);
+        int rangeStart = m_scratch.quads->size();
+        m_batch.drawShapeRange(line, 0, line.shapes().size(), position, metrics);
+        int rangeEnd = m_scratch.quads->size();
 
-            _textRanges[i] = Range(rangeStart, rangeEnd - rangeStart);
-        }
+        _textRanges[0] = Range(rangeStart, rangeEnd - rangeStart);
+
+        _textRanges[1] = Range(rangeEnd, 0);
+        _textRanges[2] = Range(rangeEnd, 0);
     }
 
     auto it = _quads.begin() + quadsStart;

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -106,7 +106,7 @@ public:
 
     bool layoutText(TextStyle::Parameters& _params, const std::string& _text,
                     std::vector<GlyphQuad>& _quads, std::bitset<max_textures>& _refs,
-                    glm::vec2& _bbox, std::vector<TextRange>& _textRanges);
+                    glm::vec2& _bbox, TextRange& _textRanges);
 
     struct ScratchBuffer : public alfons::MeshCallback {
         void drawGlyph(const alfons::Quad& q, const alfons::AtlasGlyph& altasGlyph) override {}

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -105,7 +105,8 @@ public:
     float maxStrokeWidth() { return m_sdfRadius; }
 
     bool layoutText(TextStyle::Parameters& _params, const std::string& _text,
-                    std::vector<GlyphQuad>& _quads, std::bitset<max_textures>& _refs, glm::vec2& _bbox);
+                    std::vector<GlyphQuad>& _quads, std::bitset<max_textures>& _refs,
+                    glm::vec2& _bbox, std::vector<TextRange>& _textRanges);
 
     struct ScratchBuffer : public alfons::MeshCallback {
         void drawGlyph(const alfons::Quad& q, const alfons::AtlasGlyph& altasGlyph) override {}

--- a/core/src/text/textUtil.cpp
+++ b/core/src/text/textUtil.cpp
@@ -78,6 +78,7 @@ int TextWrapper::draw(alfons::TextBatch& _batch, float _maxWidth, const alfons::
 
         switch(_alignment) {
             case TextLabelProperty::Align::center:
+            case TextLabelProperty::Align::none:
                 position.x = (_maxWidth - wrap.second) * 0.5;
                 break;
             case TextLabelProperty::Align::right:

--- a/core/src/text/textUtil.cpp
+++ b/core/src/text/textUtil.cpp
@@ -2,7 +2,6 @@
 
 #include "platform.h"
 
-
 namespace Tangram {
 
 float TextWrapper::getShapeRangeWidth(const alfons::LineLayout& _line,
@@ -69,44 +68,40 @@ void TextWrapper::clearWraps() {
 }
 
 int TextWrapper::draw(alfons::TextBatch& _batch, float _maxWidth, const alfons::LineLayout& _line,
-                       std::vector<TextLabelProperty::Align> _alignments, float _lineSpacing,
-                       alfons::LineMetrics& _layoutMetrics) {
-    for (auto alignment : _alignments) {
-        size_t shapeStart = 0;
-        glm::vec2 position;
+                      TextLabelProperty::Align _alignment, float _lineSpacing,
+                      alfons::LineMetrics& _layoutMetrics) {
+    size_t shapeStart = 0;
+    glm::vec2 position;
 
-        for (auto wrap : m_lineWraps) {
-            alfons::LineMetrics lineMetrics;
-            
-            switch(alignment) {
-                case TextLabelProperty::Align::center:
-                    position.x = (_maxWidth - wrap.second) * 0.5;
-                    break;
-                case TextLabelProperty::Align::right:
-                    position.x = (_maxWidth - wrap.second);
-                    break;
-                default:
-                    position.x = 0;
-            }
-            
-            size_t shapeEnd = wrap.first;
-            
-            // Draw line quads
-            _batch.drawShapeRange(_line, shapeStart, shapeEnd, position, lineMetrics);
-            
-            shapeStart = shapeEnd;
-            
-            // FIXME hardcoded value for SDF radius 6
-            float height = lineMetrics.height();
-            height -= (2 * 6) * _line.scale(); // substract glyph padding
-            height += _lineSpacing; // add some custom line offset
-            
-            position.y += height;
-            
-            _layoutMetrics.addExtents(lineMetrics.aabb);
+    for (auto wrap : m_lineWraps) {
+        alfons::LineMetrics lineMetrics;
+
+        switch(_alignment) {
+            case TextLabelProperty::Align::center:
+                position.x = (_maxWidth - wrap.second) * 0.5;
+                break;
+            case TextLabelProperty::Align::right:
+                position.x = (_maxWidth - wrap.second);
+                break;
+            default:
+                position.x = 0;
         }
-        // TODO: remove me
-        break;
+
+        size_t shapeEnd = wrap.first;
+
+        // Draw line quads
+        _batch.drawShapeRange(_line, shapeStart, shapeEnd, position, lineMetrics);
+
+        shapeStart = shapeEnd;
+
+        // FIXME hardcoded value for SDF radius 6
+        float height = lineMetrics.height();
+        height -= (2 * 6) * _line.scale(); // substract glyph padding
+        height += _lineSpacing; // add some custom line offset
+
+        position.y += height;
+
+        _layoutMetrics.addExtents(lineMetrics.aabb);
     }
 
     return int(m_lineWraps.size());

--- a/core/src/text/textUtil.h
+++ b/core/src/text/textUtil.h
@@ -32,7 +32,7 @@ public:
      * _metrics out: text extents
      */
     int draw(alfons::TextBatch& _batch, float _maxWidth, const alfons::LineLayout& _line,
-             std::vector<TextLabelProperty::Align> _alignments, float _lineSpacing,
+             TextLabelProperty::Align _alignment, float _lineSpacing,
              alfons::LineMetrics& _metrics);
 
 private:

--- a/core/src/text/textUtil.h
+++ b/core/src/text/textUtil.h
@@ -6,12 +6,18 @@
 #include "alfons/textBatch.h"
 #include "alfons/lineLayout.h"
 
+#include <vector>
 
 namespace Tangram {
 
-struct TextWrapper {
+class TextWrapper {
 
-    std::vector<std::pair<int,float>> m_lineWraps;
+public:
+
+    float getShapeRangeWidth(const alfons::LineLayout& _line,
+        size_t _minLineChars, size_t _maxLineChars);
+
+    void clearWraps();
 
     /* Wrap an Alfons line layout, and draw the glyph quads to the TextBatch.
      *
@@ -25,10 +31,12 @@ struct TextWrapper {
      * _lineSpacing
      * _metrics out: text extents
      */
-    int draw(alfons::TextBatch& _batch, const alfons::LineLayout& _line,
-             size_t _minLineChars, size_t _maxLineChars,
-             TextLabelProperty::Align _alignment, float _lineSpacing,
+    int draw(alfons::TextBatch& _batch, float _maxWidth, const alfons::LineLayout& _line,
+             std::vector<TextLabelProperty::Align> _alignments, float _lineSpacing,
              alfons::LineMetrics& _metrics);
+
+private:
+    std::vector<std::pair<int,float>> m_lineWraps;
 };
 
 }

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -58,6 +58,7 @@ void Tile::update(float _dt, const View& _view) {
     m_modelMatrix[3][0] = m_tileOrigin.x - viewOrigin.x;
     m_modelMatrix[3][1] = m_tileOrigin.y - viewOrigin.y;
 
+    m_mvp = _view.getViewProjectionMatrix() * m_modelMatrix;
 }
 
 void Tile::resetState() {

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -60,6 +60,8 @@ public:
 
     const glm::mat4& getModelMatrix() const { return m_modelMatrix; }
 
+    const glm::mat4& mvp() const { return m_mvp; }
+
     void initGeometry(uint32_t _size);
 
     const std::unique_ptr<StyledMesh>& getMesh(const Style& _style) const;
@@ -112,6 +114,8 @@ private:
     // Note that this matrix does not contain the relative translation from the global origin to the tile origin.
     // Distances from the global origin are too large to represent precisely in 32-bit floats, so we only apply the
     // relative translation from the view origin to the model origin immediately before drawing the tile.
+
+    glm::mat4 m_mvp;
 
     // Map of <Style>s and their associated <Mesh>es
     std::vector<std::unique_ptr<StyledMesh>> m_geometry;

--- a/core/src/util/types.h
+++ b/core/src/util/types.h
@@ -9,11 +9,15 @@ struct Range {
     int length;
 
     int end() const { return start + length; }
+
+    Range(int _start, int _length) : start(_start), length(_length) {}
+
+    Range() : start(0), length(0) {}
 };
 
 struct LngLat {
     LngLat() {}
-    LngLat(double _lon, double _lat) : longitude(_lon), latitude(_lat){}
+    LngLat(double _lon, double _lat) : longitude(_lon), latitude(_lat) {}
 
     LngLat(const LngLat& _other) = default;
     LngLat(LngLat&& _other) = default;

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -184,7 +184,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 Tangram::toggleDebugFlag(Tangram::DebugFlags::labels);
                 break;
             case GLFW_KEY_6:
-                Tangram::toggleDebugFlag(Tangram::DebugFlags::all_labels);
+                Tangram::toggleDebugFlag(Tangram::DebugFlags::draw_all_labels);
                 break;
             case GLFW_KEY_7:
                 Tangram::toggleDebugFlag(Tangram::DebugFlags::tangram_infos);

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -236,6 +236,14 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             case GLFW_KEY_ESCAPE:
                 glfwSetWindowShouldClose(main_window, true);
                 break;
+            case GLFW_KEY_F1:
+                map->setPosition(-74.00976419448854, 40.70532700869127);
+                map->setZoom(16);
+                break;
+            case GLFW_KEY_F2:
+                map->setPosition(8.82, 53.08);
+                map->setZoom(14);
+                break;
             default:
                 break;
         }

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -189,7 +189,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
                 Tangram::toggleDebugFlag(Tangram::DebugFlags::labels);
                 break;
             case GLFW_KEY_6:
-                Tangram::toggleDebugFlag(Tangram::DebugFlags::all_labels);
+                Tangram::toggleDebugFlag(Tangram::DebugFlags::draw_all_labels);
                 break;
             case GLFW_KEY_7:
                 Tangram::toggleDebugFlag(Tangram::DebugFlags::tangram_infos);

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -245,6 +245,14 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             case GLFW_KEY_ESCAPE:
                 glfwSetWindowShouldClose(main_window, true);
                 break;
+            case GLFW_KEY_F1:
+                map->setPosition(-74.00976419448854, 40.70532700869127);
+                map->setZoom(16);
+                break;
+            case GLFW_KEY_F2:
+                map->setPosition(8.82, 53.08);
+                map->setZoom(14);
+                break;
         default:
                 break;
         }

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -18,9 +18,12 @@ TextLabels dummy(dummyStyle);
 TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
     Label::Options options;
     options.offset = {0.0f, 0.0f};
+    std::vector<TextRange> textRanges;
+    textRanges.push_back({TextLabelProperty::Align::none, {}});
+
     return TextLabel(_transform, _type, options,
-            LabelProperty::Anchor::center,
-            {}, {0, 0}, dummy, {});
+            LabelProperty::Anchor::center, {}, {0, 0}, dummy, textRanges,
+            TextLabelProperty::Align::none);
 }
 
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -29,10 +29,10 @@ TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
 TextLabel makeLabelWithAnchorFallbacks() {
     Label::Options options;
 
-    options.anchorFallback.push_back(LabelProperty::Anchor::right);
-    options.anchorFallback.push_back(LabelProperty::Anchor::bottom);
-    options.anchorFallback.push_back(LabelProperty::Anchor::left);
-    options.anchorFallback.push_back(LabelProperty::Anchor::top);
+    options.anchorFallbacks.set(LabelProperty::Anchor::right);
+    options.anchorFallbacks.set(LabelProperty::Anchor::bottom);
+    options.anchorFallbacks.set(LabelProperty::Anchor::left);
+    options.anchorFallbacks.set(LabelProperty::Anchor::top);
 
     options.offset = {0.0f, 0.0f};
 
@@ -240,7 +240,7 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
 
     // anchor_fallback -> fading_out (all anchor tested)
     {
-        for (int i = 0; i < 2; ++i) {
+        for (int i = 0; i < 3; ++i) {
             l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
             l.occlude(true);
             l.evalState(screenSize, 1.f);

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -47,11 +47,11 @@ TextLabel makeLabelWithAnchorFallbacks() {
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
-    REQUIRE(l.state() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::none);
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
 
     REQUIRE(l.state() != Label::State::sleep);
-    REQUIRE(l.state() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::none);
     REQUIRE(l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
@@ -64,7 +64,7 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
 TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
-    REQUIRE(l.state() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::none);
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
     l.occlude(false);
@@ -107,7 +107,7 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
 TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize*2.f}, Label::Type::point));
 
-    REQUIRE(l.state() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::none);
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
 
@@ -116,7 +116,7 @@ TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
 
     l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0);
     l.evalState(screenSize, 0);
-    REQUIRE(l.state() != Label::State::wait_occ);
+    REQUIRE(l.state() != Label::State::none);
 
     REQUIRE(l.state() == Label::State::visible);
     REQUIRE(l.canOcclude());
@@ -202,7 +202,7 @@ TEST_CASE( "Sine interpolation", "[Core][Label][Fade]" ) {
 TEST_CASE( "Ensure anchor fallback behavior on first fallback", "[Core][Label]" ) {
     TextLabel l = makeLabelWithAnchorFallbacks();
 
-    REQUIRE(l.state() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::none);
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
     l.occlude(true);
@@ -214,9 +214,9 @@ TEST_CASE( "Ensure anchor fallback behavior on first fallback", "[Core][Label]" 
 TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks without finding one", "[Core][Label]" ) {
     TextLabel l = makeLabelWithAnchorFallbacks();
 
-    // wait_occ -> anchor_fallback
+    // none -> anchor_fallback
     {
-        REQUIRE(l.state() == Label::State::wait_occ);
+        REQUIRE(l.state() == Label::State::none);
 
         l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
         l.occlude(true);
@@ -253,7 +253,7 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
 TEST_CASE( "Ensure anchor fallback behavior when looping over all fallback and finding one", "[Core][Label]" ) {
     TextLabel l = makeLabelWithAnchorFallbacks();
 
-    REQUIRE(l.state() == Label::State::wait_occ);
+    REQUIRE(l.state() == Label::State::none);
 
     // move to third anchor
     for (int i = 0; i < 3; ++i) {

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -201,6 +201,7 @@ TEST_CASE( "Sine interpolation", "[Core][Label][Fade]" ) {
     REQUIRE(fadeIn.isFinished());
 }
 
+#if 0
 TEST_CASE( "Ensure anchor fallback behavior on first fallback", "[Core][Label]" ) {
     TextLabel l = makeLabelWithAnchorFallbacks();
 
@@ -275,3 +276,4 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallback and f
     REQUIRE(l.anchorType() == LabelProperty::Anchor::left);
     REQUIRE(l.state() == Label::State::visible);
 }
+#endif

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -58,7 +58,7 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
     l.occlude(true);
-    l.evalState(screenSize, 0);
+    l.evalState(0);
 
     REQUIRE(l.state() == Label::State::sleep);
 }
@@ -70,13 +70,13 @@ TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
     l.occlude(false);
-    l.evalState(screenSize, 0);
+    l.evalState(0);
 
     REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
-    l.evalState(screenSize, 1.f);
+    l.evalState(1.f);
 
     REQUIRE(l.state() == Label::State::visible);
     REQUIRE(l.canOcclude());
@@ -87,14 +87,14 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
     l.occlude(false);
-    l.evalState(screenSize, 0);
+    l.evalState(0);
 
     REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
     l.occlude(true);
-    l.evalState(screenSize, 1.f);
+    l.evalState(1.f);
 
     // Depends whether fading-in labels fade out or set to sleep in evalState
     // REQUIRE(l.state() == Label::State::fading_out);
@@ -117,7 +117,7 @@ TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
     REQUIRE(l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), screenSize, 0);
-    l.evalState(screenSize, 0);
+    l.evalState(0);
     REQUIRE(l.state() != Label::State::none);
 
     REQUIRE(l.state() == Label::State::visible);
@@ -131,7 +131,7 @@ TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][
     REQUIRE(!l.canOcclude());
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
-    l.evalState(screenSize, 1.f);
+    l.evalState(1.f);
 
     REQUIRE(l.state() == Label::State::visible);
     REQUIRE(!l.canOcclude());
@@ -208,7 +208,7 @@ TEST_CASE( "Ensure anchor fallback behavior on first fallback", "[Core][Label]" 
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
     l.occlude(true);
-    l.evalState(screenSize, 1.f);
+    l.evalState(1.f);
 
     REQUIRE(l.state() == Label::State::anchor_fallback);
 }
@@ -222,7 +222,7 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
 
         l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
         l.occlude(true);
-        l.evalState(screenSize, 1.f);
+        l.evalState(1.f);
 
         REQUIRE(l.state() == Label::State::anchor_fallback);
     }
@@ -232,7 +232,7 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
         for (int i = 0; i < 3; ++i) {
             l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
             l.occlude(true);
-            l.evalState(screenSize, 1.f);
+            l.evalState(1.f);
 
             REQUIRE(l.state() == Label::State::anchor_fallback);
         }
@@ -244,12 +244,12 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
     {
         l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
         l.occlude(true);
-        l.evalState(screenSize, 1.f);
+        l.evalState(1.f);
         REQUIRE(l.state() == Label::State::fading_out);
 
         l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
         l.occlude(true);
-        l.evalState(screenSize, 1.f);
+        l.evalState(1.f);
         REQUIRE(l.state() == Label::State::sleep);
     }
 }
@@ -264,14 +264,14 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallback and f
     for (int i = 0; i < 3; ++i) {
         l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
         l.occlude(true);
-        l.evalState(screenSize, 1.f);
+        l.evalState(1.f);
 
         REQUIRE(l.state() == Label::State::anchor_fallback);
     }
 
     l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
     l.occlude(false);
-    l.evalState(screenSize, 1.f);
+    l.evalState(1.f);
 
     REQUIRE(l.anchorType() == LabelProperty::Anchor::left);
     REQUIRE(l.state() == Label::State::visible);

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -229,7 +229,7 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
         REQUIRE(l.state() == Label::State::anchor_fallback);
     }
 
-    // anchor_fallback -> anchor_fallback (move to third anchor)
+    // anchor_fallback -> anchor_fallback (move to fourth anchor)
     {
         for (int i = 0; i < 3; ++i) {
             l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
@@ -239,17 +239,20 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
             REQUIRE(l.state() == Label::State::anchor_fallback);
         }
 
-        REQUIRE(l.anchorType() == LabelProperty::Anchor::left);
+        REQUIRE(l.anchorType() == LabelProperty::Anchor::top);
     }
 
     // anchor_fallback -> fading_out (all anchor tested)
     {
-        for (int i = 0; i < 3; ++i) {
-            l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
-            l.occlude(true);
-            l.evalState(screenSize, 1.f);
-        }
+        l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+        l.occlude(true);
+        l.evalState(screenSize, 1.f);
         REQUIRE(l.state() == Label::State::fading_out);
+
+        l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
+        l.occlude(true);
+        l.evalState(screenSize, 1.f);
+        REQUIRE(l.state() == Label::State::sleep);
     }
 }
 

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -18,21 +18,26 @@ TextLabels dummy(dummyStyle);
 TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
     Label::Options options;
     options.offset = {0.0f, 0.0f};
+    options.anchors[0] = LabelProperty::Anchor::center;
+    options.anchorCount = 1;
+
     std::vector<TextRange> textRanges;
     textRanges.push_back({TextLabelProperty::Align::none, {}});
 
     return TextLabel(_transform, _type, options,
-            LabelProperty::Anchor::center, {}, {0, 0}, dummy, textRanges,
+            {}, {0, 0}, dummy, textRanges,
             TextLabelProperty::Align::none);
 }
 
 TextLabel makeLabelWithAnchorFallbacks() {
     Label::Options options;
 
-    options.anchorFallbacks.set(LabelProperty::Anchor::right);
-    options.anchorFallbacks.set(LabelProperty::Anchor::bottom);
-    options.anchorFallbacks.set(LabelProperty::Anchor::left);
-    options.anchorFallbacks.set(LabelProperty::Anchor::top);
+    options.anchors[0] = LabelProperty::Anchor::center;
+    options.anchors[1] = LabelProperty::Anchor::right;
+    options.anchors[2] = LabelProperty::Anchor::bottom;
+    options.anchors[3] = LabelProperty::Anchor::left;
+    options.anchors[4] = LabelProperty::Anchor::top;
+    options.anchorCount = 5;
 
     options.offset = {0.0f, 0.0f};
 
@@ -40,8 +45,7 @@ TextLabel makeLabelWithAnchorFallbacks() {
 
     textRanges.push_back({TextLabelProperty::Align::none, {}});
     return TextLabel({screenSize/2.f}, Label::Type::point, options,
-            LabelProperty::Anchor::right, {}, {0, 0},
-            dummy, textRanges, TextLabelProperty::Align::none);
+            {}, {0, 0}, dummy, textRanges, TextLabelProperty::Align::none);
 }
 
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
@@ -272,4 +276,3 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallback and f
     REQUIRE(l.state() == Label::State::visible);
 }
 #endif
-

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -18,11 +18,10 @@ TextLabels dummy(dummyStyle);
 TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
     Label::Options options;
     options.offset = {0.0f, 0.0f};
-    options.anchors[0] = LabelProperty::Anchor::center;
-    options.anchorCount = 1;
+    options.anchors.anchor[0] = LabelProperty::Anchor::center;
+    options.anchors.count = 1;
 
-    std::vector<TextRange> textRanges;
-    textRanges.push_back({TextLabelProperty::Align::none, {}});
+    TextRange textRanges;
 
     return TextLabel(_transform, _type, options,
             {}, {0, 0}, dummy, textRanges,
@@ -32,18 +31,17 @@ TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
 TextLabel makeLabelWithAnchorFallbacks() {
     Label::Options options;
 
-    options.anchors[0] = LabelProperty::Anchor::center;
-    options.anchors[1] = LabelProperty::Anchor::right;
-    options.anchors[2] = LabelProperty::Anchor::bottom;
-    options.anchors[3] = LabelProperty::Anchor::left;
-    options.anchors[4] = LabelProperty::Anchor::top;
-    options.anchorCount = 5;
+    options.anchors.anchor[0] = LabelProperty::Anchor::center;
+    options.anchors.anchor[1] = LabelProperty::Anchor::right;
+    options.anchors.anchor[2] = LabelProperty::Anchor::bottom;
+    options.anchors.anchor[3] = LabelProperty::Anchor::left;
+    options.anchors.anchor[4] = LabelProperty::Anchor::top;
+    options.anchors.count = 5;
 
     options.offset = {0.0f, 0.0f};
 
-    std::vector<TextRange> textRanges;
+    TextRange textRanges;
 
-    textRanges.push_back({TextLabelProperty::Align::none, {}});
     return TextLabel({screenSize/2.f}, Label::Type::point, options,
             {}, {0, 0}, dummy, textRanges, TextLabelProperty::Align::none);
 }

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -245,7 +245,7 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
         l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
         l.occlude(true);
         l.evalState(1.f);
-        REQUIRE(l.state() == Label::State::fading_out);
+        REQUIRE(l.state() == Label::State::sleep);
 
         l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), screenSize, 0);
         l.occlude(true);
@@ -254,7 +254,6 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallbacks with
     }
 }
 
-#if 0
 TEST_CASE( "Ensure anchor fallback behavior when looping over all fallback and finding one", "[Core][Label]" ) {
     TextLabel l = makeLabelWithAnchorFallbacks();
 
@@ -276,4 +275,3 @@ TEST_CASE( "Ensure anchor fallback behavior when looping over all fallback and f
     REQUIRE(l.anchorType() == LabelProperty::Anchor::left);
     REQUIRE(l.state() == Label::State::visible);
 }
-#endif

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -20,6 +20,8 @@ TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
     options.offset = {0.0f, 0.0f};
     options.anchors.anchor[0] = LabelProperty::Anchor::center;
     options.anchors.count = 1;
+    options.showTransition.time = 0.2;
+    options.hideTransition.time = 0.2;
 
     TextRange textRanges;
 

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -102,7 +102,7 @@ TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
     l.evalState(0);
     REQUIRE(l.state() != Label::State::none);
 
-    REQUIRE(l.state() == Label::State::visible);
+    REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 }
 

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -28,24 +28,6 @@ TextLabel makeLabel(Label::Transform _transform, Label::Type _type) {
             TextLabelProperty::Align::none);
 }
 
-TextLabel makeLabelWithAnchorFallbacks() {
-    Label::Options options;
-
-    options.anchors.anchor[0] = LabelProperty::Anchor::center;
-    options.anchors.anchor[1] = LabelProperty::Anchor::right;
-    options.anchors.anchor[2] = LabelProperty::Anchor::bottom;
-    options.anchors.anchor[3] = LabelProperty::Anchor::left;
-    options.anchors.anchor[4] = LabelProperty::Anchor::top;
-    options.anchors.count = 5;
-
-    options.offset = {0.0f, 0.0f};
-
-    TextRange textRanges;
-
-    return TextLabel({screenSize/2.f}, Label::Type::point, options,
-            {}, {0, 0}, dummy, textRanges, TextLabelProperty::Align::none);
-}
-
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -26,10 +26,12 @@ std::unique_ptr<TextLabel> makeLabel(Label::Transform _transform, Label::Type _t
     options.properties = std::make_shared<Properties>();
     options.properties->set("id", id);
     options.interactive = true;
+    std::vector<TextRange> textRanges;
+    textRanges.push_back({TextLabelProperty::Align::none, {}});
 
     return std::unique_ptr<TextLabel>(new TextLabel(_transform, _type, options,
-            LabelProperty::Anchor::center,
-            {}, {10, 10}, dummy, {}));
+            LabelProperty::Anchor::center, {}, {10, 10}, dummy, textRanges,
+            TextLabelProperty::Align::none));
 }
 
 TEST_CASE("Test getFeaturesAtPoint", "[Labels][FeaturePicking]") {

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -26,15 +26,12 @@ std::unique_ptr<TextLabel> makeLabel(Label::Transform _transform, Label::Type _t
     options.properties = std::make_shared<Properties>();
     options.properties->set("id", id);
     options.interactive = true;
-    options.anchors[0] = LabelProperty::Anchor::center;
-    options.anchorCount = 1;
-
-    std::vector<TextRange> textRanges;
-    textRanges.push_back({TextLabelProperty::Align::none, {}});
+    options.anchors.anchor[0] = LabelProperty::Anchor::center;
+    options.anchors.count = 1;
 
     return std::unique_ptr<TextLabel>(new TextLabel(_transform, _type, options,
-            {}, {10, 10}, dummy, textRanges,
-            TextLabelProperty::Align::none));
+                                                    {}, {10, 10}, dummy, {},
+                                                    TextLabelProperty::Align::none));
 }
 
 TEST_CASE("Test getFeaturesAtPoint", "[Labels][FeaturePicking]") {

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -26,11 +26,14 @@ std::unique_ptr<TextLabel> makeLabel(Label::Transform _transform, Label::Type _t
     options.properties = std::make_shared<Properties>();
     options.properties->set("id", id);
     options.interactive = true;
+    options.anchors[0] = LabelProperty::Anchor::center;
+    options.anchorCount = 1;
+
     std::vector<TextRange> textRanges;
     textRanges.push_back({TextLabelProperty::Align::none, {}});
 
     return std::unique_ptr<TextLabel>(new TextLabel(_transform, _type, options,
-            LabelProperty::Anchor::center, {}, {10, 10}, dummy, textRanges,
+            {}, {10, 10}, dummy, textRanges,
             TextLabelProperty::Align::none));
 }
 

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -16,7 +16,6 @@
 
 namespace Tangram {
 
-glm::vec2 screenSize(256.f, 256.f);
 TextStyle dummyStyle("textStyle", nullptr);
 TextLabels dummy(dummyStyle);
 
@@ -32,6 +31,24 @@ std::unique_ptr<TextLabel> makeLabel(Label::Transform _transform, Label::Type _t
     return std::unique_ptr<TextLabel>(new TextLabel(_transform, _type, options,
                                                     {}, {10, 10}, dummy, {},
                                                     TextLabelProperty::Align::none));
+}
+
+TextLabel makeLabelWithAnchorFallbacks(Label::Transform _transform, glm::vec2 _offset = {0, 0}) {
+    Label::Options options;
+
+    // options.anchors.anchor[0] = LabelProperty::Anchor::center;
+    options.anchors.anchor[0] = LabelProperty::Anchor::right;
+    options.anchors.anchor[1] = LabelProperty::Anchor::bottom;
+    options.anchors.anchor[2] = LabelProperty::Anchor::left;
+    options.anchors.anchor[3] = LabelProperty::Anchor::top;
+    options.anchors.count = 4;
+
+    options.offset = _offset;
+
+    TextRange textRanges;
+
+    return TextLabel(_transform, Label::Type::point, options,
+            {}, {10, 10}, dummy, textRanges, TextLabelProperty::Align::none);
 }
 
 TEST_CASE("Test getFeaturesAtPoint", "[Labels][FeaturePicking]") {
@@ -81,6 +98,111 @@ TEST_CASE("Test getFeaturesAtPoint", "[Labels][FeaturePicking]") {
         REQUIRE(items.size() == 1);
         REQUIRE(items[0].properties->getString("id") == "2");
     }
+}
+
+TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
+
+    View view(256, 256);
+    view.setPosition(0, 0);
+    view.setZoom(0);
+    view.update(false);
+
+    Tile tile({0,0,0}, view.getMapProjection());
+    tile.update(0, view);
+
+    glm::vec2 screenSize = glm::vec2(view.getWidth(), view.getHeight());
+
+    class TestLabels : public Labels {
+    public:
+        TestLabels(View& _v) {
+            m_isect2d.resize({1, 1}, {_v.getWidth(), _v.getHeight()});
+        }
+        void addLabel(Label* _l, Tile* _t) { m_labels.push_back({_l, _t, false}); }
+        void run(View& _v) { handleOcclusions(_v); }
+        void clear() { m_labels.clear(); }
+    };
+
+    TestLabels labels(view);
+
+    {
+        TextLabel l1 = makeLabelWithAnchorFallbacks(glm::vec2{0.5,0.5});
+        l1.update(tile.mvp(), screenSize, true);
+        labels.addLabel(&l1, &tile);
+
+        TextLabel l2 = makeLabelWithAnchorFallbacks(glm::vec2{0.5,0.5});
+        l2.update(tile.mvp(), screenSize, true);
+        labels.addLabel(&l2, &tile);
+
+        labels.run(view);
+        REQUIRE(l1.isOccluded() == false);
+        REQUIRE(l2.isOccluded() == true);
+
+        REQUIRE(l1.anchorType() == LabelProperty::Anchor::right);
+        REQUIRE(l2.anchorType() == LabelProperty::Anchor::right);
+    }
+    labels.clear();
+
+    {
+        TextLabel l1 = makeLabelWithAnchorFallbacks(glm::vec2{0.5,0.5});
+        l1.update(tile.mvp(), screenSize, true);
+        labels.addLabel(&l1, &tile);
+
+        // Second label is one pixel left of L1
+        TextLabel l2 = makeLabelWithAnchorFallbacks(glm::vec2{0.5 - 1./256,0.5});
+        l2.update(tile.mvp(), screenSize, true);
+        labels.addLabel(&l2, &tile);
+
+        labels.run(view);
+        // l1.print();
+        // l2.print();
+        REQUIRE(l1.isOccluded() == false);
+        REQUIRE(l2.isOccluded() == false);
+
+        REQUIRE(l1.anchorType() == LabelProperty::Anchor::right);
+        // Check that left-of anchor fallback is used
+        REQUIRE(l2.anchorType() == LabelProperty::Anchor::left);
+    }
+    labels.clear();
+
+    {
+        TextLabel l1 = makeLabelWithAnchorFallbacks(glm::vec2{0.5,0.5});
+        l1.update(tile.mvp(), screenSize, true);
+        labels.addLabel(&l1, &tile);
+
+        // Second label is 10 pixel top of L1
+        TextLabel l2 = makeLabelWithAnchorFallbacks(glm::vec2{0.5,0.5 + 10./256});
+        l2.update(tile.mvp(), screenSize, true);
+        labels.addLabel(&l2, &tile);
+
+        labels.run(view);
+        REQUIRE(l1.isOccluded() == false);
+        REQUIRE(l2.isOccluded() == false);
+
+        REQUIRE(l1.anchorType() == LabelProperty::Anchor::right);
+        // Check that anchor fallback is used
+        REQUIRE(l2.anchorType() == LabelProperty::Anchor::top);
+    }
+    labels.clear();
+
+    {
+        TextLabel l1 = makeLabelWithAnchorFallbacks(glm::vec2{0.5,0.5});
+        l1.update(tile.mvp(), screenSize, true);
+        labels.addLabel(&l1, &tile);
+
+        // Second label is 10 pixel below of L1
+        TextLabel l2 = makeLabelWithAnchorFallbacks(glm::vec2{0.5,0.5 - 10./256});
+        l2.update(tile.mvp(), screenSize, true);
+        labels.addLabel(&l2, &tile);
+
+        labels.run(view);
+        REQUIRE(l1.isOccluded() == false);
+        REQUIRE(l2.isOccluded() == false);
+
+        REQUIRE(l1.anchorType() == LabelProperty::Anchor::right);
+        // Check that anchor fallback is used
+        REQUIRE(l2.anchorType() == LabelProperty::Anchor::bottom);
+    }
+
 }
 
 }

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -43,7 +43,10 @@ void initFont(std::string _font = TEST_FONT) {
     font->addFace(face);
 }
 
+// TODO: Update
+
 TEST_CASE("Ensure empty line is given when giving empty shape to alfons", "[Core][Alfons]") {
+#if 0
     initFont();
     auto line = shaper.shape(font, "");
 
@@ -52,9 +55,11 @@ TEST_CASE("Ensure empty line is given when giving empty shape to alfons", "[Core
     alfons::LineMetrics metrics;
     int nbLines = textWrap.draw(batch, line, 10, 4, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 0);
+#endif
 }
 
 TEST_CASE() {
+#if 0
     initFont();
 
     auto line = shaper.shape(font, "The quick brown fox");
@@ -73,9 +78,11 @@ TEST_CASE() {
     REQUIRE(nbLines == 4);
     nbLines = textWrap.draw(batch, line, 2, 5, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 4);
+#endif
 }
 
 TEST_CASE() {
+#if 0
     initFont(TEST_FONT_AR);
 
     auto line = shaper.shape(font, "لعدم عليها كلّ.");
@@ -87,9 +94,11 @@ TEST_CASE() {
     REQUIRE(nbLines == 3);
     nbLines = textWrap.draw(batch, line, 0, 10, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 2);
+#endif
 }
 
 TEST_CASE() {
+#if 0
     initFont(TEST_FONT_JP);
 
     auto line = shaper.shape(font, "日本語のキーボード");
@@ -99,6 +108,7 @@ TEST_CASE() {
     alfons::LineMetrics metrics;
     int nbLines = textWrap.draw(batch, line, 0, 1, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 7);
+#endif
 }
 
 }

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -71,15 +71,23 @@ TEST_CASE() {
     float width = textWrap.getShapeRangeWidth(line, 4, 10);
     int nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 2);
+
+    textWrap.clearWraps();
     width = textWrap.getShapeRangeWidth(line, 4, 4);
     nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 3);
+
+    textWrap.clearWraps();
     width = textWrap.getShapeRangeWidth(line, 0, 1);
     nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 4);
+
+    textWrap.clearWraps();
     width = textWrap.getShapeRangeWidth(line, 0, 3);
     nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 4);
+
+    textWrap.clearWraps();
     width = textWrap.getShapeRangeWidth(line, 2, 5);
     nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 4);
@@ -97,6 +105,8 @@ TEST_CASE() {
     float width = textWrap.getShapeRangeWidth(line, 0, 1);
     int nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 3);
+
+    textWrap.clearWraps();
     width = textWrap.getShapeRangeWidth(line, 0, 10);
     nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 2);

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -43,8 +43,6 @@ void initFont(std::string _font = TEST_FONT) {
     font->addFace(face);
 }
 
-// TODO: Update
-
 TEST_CASE("Ensure empty line is given when giving empty shape to alfons", "[Core][Alfons]") {
     initFont();
     auto line = shaper.shape(font, "");

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -46,20 +46,20 @@ void initFont(std::string _font = TEST_FONT) {
 // TODO: Update
 
 TEST_CASE("Ensure empty line is given when giving empty shape to alfons", "[Core][Alfons]") {
-#if 0
     initFont();
     auto line = shaper.shape(font, "");
 
     REQUIRE(line.shapes().size() == 0);
     TextWrapper textWrap;
     alfons::LineMetrics metrics;
-    int nbLines = textWrap.draw(batch, line, 10, 4, TextLabelProperty::Align::center, 1.0, metrics);
+
+    float width = textWrap.getShapeRangeWidth(line, 10, 4);
+    int nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
+
     REQUIRE(nbLines == 0);
-#endif
 }
 
 TEST_CASE() {
-#if 0
     initFont();
 
     auto line = shaper.shape(font, "The quick brown fox");
@@ -68,21 +68,24 @@ TEST_CASE() {
 
     TextWrapper textWrap;
     alfons::LineMetrics metrics;
-    int nbLines = textWrap.draw(batch, line, 4, 10, TextLabelProperty::Align::center, 1.0, metrics);
+    float width = textWrap.getShapeRangeWidth(line, 4, 10);
+    int nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 2);
-    nbLines = textWrap.draw(batch, line, 4, 4, TextLabelProperty::Align::center, 1.0, metrics);
+    width = textWrap.getShapeRangeWidth(line, 4, 4);
+    nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 3);
-    nbLines = textWrap.draw(batch, line, 0, 1, TextLabelProperty::Align::center, 1.0, metrics);
+    width = textWrap.getShapeRangeWidth(line, 0, 1);
+    nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 4);
-    nbLines = textWrap.draw(batch, line, 0, 3, TextLabelProperty::Align::center, 1.0, metrics);
+    width = textWrap.getShapeRangeWidth(line, 0, 3);
+    nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 4);
-    nbLines = textWrap.draw(batch, line, 2, 5, TextLabelProperty::Align::center, 1.0, metrics);
+    width = textWrap.getShapeRangeWidth(line, 2, 5);
+    nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 4);
-#endif
 }
 
 TEST_CASE() {
-#if 0
     initFont(TEST_FONT_AR);
 
     auto line = shaper.shape(font, "لعدم عليها كلّ.");
@@ -90,15 +93,16 @@ TEST_CASE() {
 
     TextWrapper textWrap;
     alfons::LineMetrics metrics;
-    int nbLines = textWrap.draw(batch, line, 0, 1, TextLabelProperty::Align::center, 1.0, metrics);
+
+    float width = textWrap.getShapeRangeWidth(line, 0, 1);
+    int nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 3);
-    nbLines = textWrap.draw(batch, line, 0, 10, TextLabelProperty::Align::center, 1.0, metrics);
+    width = textWrap.getShapeRangeWidth(line, 0, 10);
+    nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 2);
-#endif
 }
 
 TEST_CASE() {
-#if 0
     initFont(TEST_FONT_JP);
 
     auto line = shaper.shape(font, "日本語のキーボード");
@@ -106,9 +110,9 @@ TEST_CASE() {
 
     TextWrapper textWrap;
     alfons::LineMetrics metrics;
-    int nbLines = textWrap.draw(batch, line, 0, 1, TextLabelProperty::Align::center, 1.0, metrics);
+    float width = textWrap.getShapeRangeWidth(line, 0, 1);
+    int nbLines = textWrap.draw(batch, width, line, TextLabelProperty::Align::center, 1.0, metrics);
     REQUIRE(nbLines == 7);
-#endif
 }
 
 }


### PR DESCRIPTION
Continuing https://github.com/tangrams/tangram-es/pull/842 

Since the changes of tile-label-placement branch introduced incremental collision testing it's possible to try fallback anchors directly instead of going through the fallbacks during multiple frames.

TODO
- [x] When the parent label has multiple anchors the child label must be updated() after the parent has been placed
- [x] Bug in alignFromParent where the parent's offset is constantly added to childs m_offset
- [x] Should offset for child labels be ignored since it conflicts the offset from the parent?

BUGS
- [x] ```icon:text:transition [show,hide] time:``` form is not parsed correctly (old bug) 