### PR TITLE
Cleanup platform dependent code in FontContext

### DIFF
--- a/android/tangram/src/com/mapzen/tangram/FontFileParser.java
+++ b/android/tangram/src/com/mapzen/tangram/FontFileParser.java
@@ -135,7 +135,14 @@ class FontFileParser {
                                 fallbackFontDict.put(weight, new Vector<String>());
                             }
 
-                            fallbackFontDict.get(weight).add(filename);
+                            // Don't use UI fonts
+                            if (filename.indexOf("UI-") >= 0) {
+                                continue;
+                            }
+
+                            String fullFileName = "system/fonts/" + filename;
+
+                            fallbackFontDict.get(weight).add(fullFileName);
                         } else {
                             skip(parser);
                         }
@@ -156,10 +163,10 @@ class FontFileParser {
                         styleStr = (styleStr == null) ? "normal" : styleStr;
 
                         String filename = parser.nextText();
-                        String fullFilename = "/system/fonts/" + filename;
+                        String fullFileName = "/system/fonts/" + filename;
 
                         String key = name + "_" + weightStr + "_" + styleStr;
-                        fontDict.put(key, fullFilename);
+                        fontDict.put(key, fullFileName);
                     } else {
                         skip(parser);
                     }

--- a/android/tangram/src/com/mapzen/tangram/FontFileParser.java
+++ b/android/tangram/src/com/mapzen/tangram/FontFileParser.java
@@ -21,6 +21,12 @@ class FontFileParser {
     private Map<String, String> fontDict = new HashMap<String, String>();
     private Map<Integer, Vector<String>> fallbackFontDict = new HashMap<Integer, Vector<String>>();
 
+    private static String systemFontPath = "/system/fonts/";
+    // Android version >= 5.0
+    private static String fontXMLPath = "/system/etc/fonts.xml";
+    // Android version < 5.0
+    private static String fontXMLFallbackPath = "/etc/system_fonts.xml";
+
     private void processDocumentFallback(XmlPullParser parser) throws XmlPullParserException, IOException {
         parser.nextTag();
         parser.require(XmlPullParser.START_TAG, null, "familyset");
@@ -69,7 +75,7 @@ class FontFileParser {
 
                     for (String file : filesets) {
                         for (String name : namesets) {
-                            String fullFilename = "/system/fonts/" + file;
+                            String fullFilename = systemFontPath + file;
                             String style = "normal";
 
                             // The file structure in `/etc/system_fonts.xml` is quite undescriptive
@@ -140,7 +146,7 @@ class FontFileParser {
                                 continue;
                             }
 
-                            String fullFileName = "system/fonts/" + filename;
+                            String fullFileName = systemFontPath + filename;
 
                             fallbackFontDict.get(weight).add(fullFileName);
                         } else {
@@ -163,7 +169,7 @@ class FontFileParser {
                         styleStr = (styleStr == null) ? "normal" : styleStr;
 
                         String filename = parser.nextText();
-                        String fullFileName = "/system/fonts/" + filename;
+                        String fullFileName = systemFontPath + filename;
 
                         String key = name + "_" + weightStr + "_" + styleStr;
                         fontDict.put(key, fullFileName);
@@ -215,11 +221,6 @@ class FontFileParser {
     }
 
     public void parse() {
-        // Android version >= 5.0
-        String fontXMLPath = "/system/etc/fonts.xml";
-        // Android version < 5.0
-        String fontXMLFallbackPath = "/etc/system_fonts.xml";
-
         InputStream in = null;
         boolean fallbackXML = false;
         final File fontFile = new File(fontXMLPath);

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -50,6 +50,8 @@ struct TestContext {
         }
         SceneLoader::applyConfig(sceneNode, scene);
 
+        scene->fontContext()->loadFonts();
+
         styleContext.initFunctions(*scene);
         styleContext.setKeywordZoom(0);
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -60,6 +60,9 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
     if ((root = sceneImporter.applySceneImports(_scene->path(), _scene->resourceRoot())) ) {
         applyConfig(root, _scene);
 
+        // Load font resources
+        _scene->fontContext()->loadFonts();
+
         return true;
     }
     return false;

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -25,12 +25,12 @@
 namespace Tangram {
 
 FontContext::FontContext() :
+    resourceLoad(0),
     m_sdfRadius(SDF_WIDTH),
     m_atlas(*this, GlyphTexture::size, m_sdfRadius),
-    m_batch(m_atlas, m_scratch) {
+    m_batch(m_atlas, m_scratch) {}
 
-    resourceLoad = 0;
-
+void FontContext::loadFonts() {
     std::string systemFont = systemFontPath("sans-serif", "400", "normal");
 
     // Load default font

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -14,9 +14,6 @@
 #define FONT_JA "fonts/DroidSansJapanese.ttf"
 #define FALLBACK "fonts/DroidSansFallback.ttf"
 
-#if defined(PLATFORM_ANDROID)
-#define ANDROID_FONT_PATH "/system/fonts/"
-#endif
 #define BASE_SIZE   16
 #define STEP_SIZE   12
 #define MAX_STEPS   3
@@ -50,17 +47,11 @@ FontContext::FontContext() :
     while (importance < 100) {
         fallback = systemFontFallbackPath(importance++, 400);
         if (fallback.empty()) { break; }
-
-        if (fallback.find("UI-") != std::string::npos) {
-            continue;
-        }
-        fontPath = ANDROID_FONT_PATH;
-        fontPath += fallback;
-        LOGD("FALLBACK %s", fontPath.c_str());
+        LOGD("FALLBACK %s", fallback.c_str());
 
         int size = BASE_SIZE;
         for (int i = 0; i < MAX_STEPS; i++, size += STEP_SIZE) {
-            m_font[i]->addFace(m_alfons.addFontFace(alfons::InputSource(fontPath), size));
+            m_font[i]->addFace(m_alfons.addFontFace(alfons::InputSource(fallback), size));
         }
     }
 #elif defined(PLATFORM_IOS)

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -25,9 +25,6 @@
 
 #define MIN_LINE_WIDTH 4
 
-// TODO: more flexibility on this
-#define BUNDLE_FONT_PATH "fonts/"
-
 namespace Tangram {
 
 FontContext::FontContext() :
@@ -394,7 +391,7 @@ std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, c
     unsigned char* data = nullptr;
 
     // Assuming bundled ttf file follows this convention
-    std::string bundleFontPath = BUNDLE_FONT_PATH + FontDescription::BundleAlias(_family, _weight, _style);
+    std::string bundleFontPath = m_bundlePath + FontDescription::BundleAlias(_family, _weight, _style);
 
     if (!loadFontAlloc(bundleFontPath, data, dataSize)) {
 

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -72,6 +72,8 @@ public:
 
     FontContext();
 
+    void loadFonts();
+
     /* Synchronized on m_mutex on tile-worker threads
      * Called from alfons when a texture atlas needs to be created
      * Triggered from TextStyleBuilder::prepareLabel

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -116,6 +116,8 @@ public:
 
     void setSceneResourceRoot(const std::string& sceneResourceRoot) { m_sceneResourceRoot = sceneResourceRoot; }
 
+    void setBundlePath(const std::string& _bundlePath) { m_bundlePath = _bundlePath; }
+
     void fetch(const FontDescription& _ft);
 
     std::atomic_ushort resourceLoad;
@@ -146,6 +148,8 @@ private:
     alfons::TextBatch m_batch;
     TextWrapper m_textWrapper;
     std::string m_sceneResourceRoot = "";
+
+    std::string m_bundlePath = "fonts/";
 
 };
 


### PR DESCRIPTION
- Remove platform dependent code from core library
- Don't load default font resources twice when loading a remote scene