### PR TITLE
Initializing m_resourceLoad seams to fix the problem w Tangram:update…

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -24,6 +24,7 @@ static std::atomic<int32_t> s_serial;
 
 Scene::Scene(const std::string& _path)
     : id(s_serial++),
+      m_resourceLoad(0),
       m_path(_path),
       m_fontContext(std::make_shared<FontContext>()) {
 


### PR DESCRIPTION
Hi! This seams to be the `ushort` responsable of the inconsistency on on `tangram::update()`

Thanks