### PR TITLE
'Marker' interface to create and manipulate individual geometries

### DIFF
--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -19,6 +19,7 @@
 namespace Tangram {
 
 class FontContext;
+class Marker;
 class Tile;
 class View;
 class Style;
@@ -34,11 +35,17 @@ public:
 
     void drawDebug(RenderState& rs, const View& _view);
 
-    void updateLabelSet(const View& _view, float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
-                        const std::vector<std::shared_ptr<Tile>>& _tiles, TileCache& _cache);
+    void updateLabelSet(const View& _view, float _dt,
+                        const std::vector<std::unique_ptr<Style>>& _styles,
+                        const std::vector<std::shared_ptr<Tile>>& _tiles,
+                        const std::vector<std::unique_ptr<Marker>>& _markers,
+                        TileCache& _cache);
 
-    PERF_TRACE void updateLabels(const View& _view, float _dt, const std::vector<std::unique_ptr<Style>>& _styles,
-                                 const std::vector<std::shared_ptr<Tile>>& _tiles, bool _onlyTransitions = true);
+    PERF_TRACE void updateLabels(const View& _view, float _dt,
+                                 const std::vector<std::unique_ptr<Style>>& _styles,
+                                 const std::vector<std::shared_ptr<Tile>>& _tiles,
+                                 const std::vector<std::unique_ptr<Marker>>& _markers,
+                                 bool _onlyTransitions = true);
 
     const std::vector<TouchItem>& getFeaturesAtPoint(const View& _view, float _dt,
                                                      const std::vector<std::unique_ptr<Style>>& _styles,
@@ -65,6 +72,11 @@ protected:
     PERF_TRACE void handleOcclusions(const View& _view);
 
     PERF_TRACE bool withinRepeatDistance(Label *_label);
+
+    void processLabelUpdate(StyledMesh* mesh, Tile* tile,
+                            const glm::mat4& mvp, const glm::vec2& screen,
+                            float dt, float dz, bool drawAll,
+                            bool onlyTransitions, bool isProxy);
 
     bool m_needUpdate;
 

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -1,0 +1,77 @@
+#include "marker/marker.h"
+#include "data/tileData.h"
+#include "scene/drawRule.h"
+#include "scene/scene.h"
+
+#include "style/style.h"
+#include "view/view.h"
+#include "glm/gtc/matrix_transform.hpp"
+
+namespace Tangram {
+
+Marker::Marker() {
+}
+
+Marker::~Marker() {
+}
+
+void Marker::setBounds(BoundingBox bounds) {
+    m_bounds = bounds;
+    m_origin = { bounds.min.x, bounds.max.y }; // South-West corner
+    m_modelMatrix = glm::scale(glm::mat4(), glm::vec3(bounds.width()));
+}
+
+void Marker::setFeature(std::unique_ptr<Feature> feature) {
+    m_feature = std::move(feature);
+}
+
+void Marker::setStyling(std::unique_ptr<DrawRuleData> drawRuleData) {
+    m_drawRuleData = std::move(drawRuleData);
+    m_drawRule = std::make_unique<DrawRule>(*m_drawRuleData, "anonymous_marker_layer", 0);
+}
+
+void Marker::setMesh(uint32_t styleId, std::unique_ptr<StyledMesh> mesh) {
+    m_mesh = std::move(mesh);
+    m_styleId = styleId;
+}
+
+void Marker::update(float dt, const View& view) {
+    // Apply tile-view translation to the model matrix
+    const auto& viewOrigin = view.getPosition();
+    m_modelMatrix[3][0] = m_origin.x - viewOrigin.x;
+    m_modelMatrix[3][1] = m_origin.y - viewOrigin.y;
+}
+
+uint32_t Marker::styleId() const {
+    return m_styleId;
+}
+
+Feature* Marker::feature() const {
+    return m_feature.get();
+}
+
+DrawRule* Marker::drawRule() {
+    return m_drawRule.get();
+}
+
+StyledMesh* Marker::mesh() const {
+    return m_mesh.get();
+}
+
+// MapProjection* Marker::mapProjection() const {
+//     return m_mapProjection;
+// }
+
+const BoundingBox& Marker::bounds() const {
+    return m_bounds;
+}
+
+const glm::dvec2& Marker::origin() const {
+    return m_origin;
+}
+
+const glm::mat4& Marker::modelMatrix() const {
+    return m_modelMatrix;
+}
+
+} // namespace Tangram

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -6,6 +6,7 @@
 #include "style/style.h"
 #include "view/view.h"
 #include "glm/gtc/matrix_transform.hpp"
+#include "glm/gtx/transform.hpp"
 
 namespace Tangram {
 
@@ -17,8 +18,7 @@ Marker::~Marker() {
 
 void Marker::setBounds(BoundingBox bounds) {
     m_bounds = bounds;
-    m_origin = { bounds.min.x, bounds.max.y }; // South-West corner
-    m_modelMatrix = glm::scale(glm::mat4(), glm::vec3(bounds.width()));
+    m_origin = bounds.min; // South-West corner
 }
 
 void Marker::setFeature(std::unique_ptr<Feature> feature) {
@@ -36,10 +36,11 @@ void Marker::setMesh(uint32_t styleId, std::unique_ptr<StyledMesh> mesh) {
 }
 
 void Marker::update(float dt, const View& view) {
-    // Apply tile-view translation to the model matrix
+    // Apply marker-view translation to the model matrix
     const auto& viewOrigin = view.getPosition();
-    m_modelMatrix[3][0] = m_origin.x - viewOrigin.x;
-    m_modelMatrix[3][1] = m_origin.y - viewOrigin.y;
+    auto scaling = glm::scale(glm::vec3(m_bounds.width(), m_bounds.height(), 1.f));
+    auto translation = glm::translate(glm::vec3(m_origin.x - viewOrigin.x, m_origin.y - viewOrigin.y, 0.f));
+    m_modelMatrix = translation * scaling;
 }
 
 uint32_t Marker::styleId() const {

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -35,7 +35,15 @@ void Marker::setMesh(uint32_t styleId, std::unique_ptr<StyledMesh> mesh) {
     m_styleId = styleId;
 }
 
+void Marker::setEase(const glm::dvec2& dest, float duration, EaseType e) {
+    auto origin = m_origin;
+    auto cb = [=](float t) { m_origin = { ease(origin.x, dest.x, t, e), ease(origin.y, dest.y, t, e) }; };
+    m_ease = { duration, cb };
+}
+
 void Marker::update(float dt, const View& view) {
+    // Update easing
+    if (!m_ease.finished()) { m_ease.update(dt); }
     // Apply marker-view translation to the model matrix
     const auto& viewOrigin = view.getPosition();
     auto scaling = glm::scale(glm::vec3(m_bounds.width(), m_bounds.height(), 1.f));
@@ -73,6 +81,10 @@ const glm::dvec2& Marker::origin() const {
 
 const glm::mat4& Marker::modelMatrix() const {
     return m_modelMatrix;
+}
+
+bool Marker::isEasing() const {
+    return !m_ease.finished();
 }
 
 } // namespace Tangram

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -52,6 +52,10 @@ void Marker::update(float dt, const View& view) {
     m_modelMatrix = translation * scaling;
 }
 
+void Marker::setVisible(bool visible) {
+    m_visible = visible;
+}
+
 int Marker::builtZoomLevel() const {
     return m_builtZoomLevel;
 }
@@ -94,6 +98,10 @@ const glm::mat4& Marker::modelMatrix() const {
 
 bool Marker::isEasing() const {
     return !m_ease.finished();
+}
+
+bool Marker::isVisible() const {
+    return m_visible;
 }
 
 } // namespace Tangram

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -30,9 +30,10 @@ void Marker::setStyling(std::unique_ptr<DrawRuleData> drawRuleData) {
     m_drawRule = std::make_unique<DrawRule>(*m_drawRuleData, "anonymous_marker_layer", 0);
 }
 
-void Marker::setMesh(uint32_t styleId, std::unique_ptr<StyledMesh> mesh) {
+void Marker::setMesh(uint32_t styleId, uint32_t zoom, std::unique_ptr<StyledMesh> mesh) {
     m_mesh = std::move(mesh);
     m_styleId = styleId;
+    m_builtZoomLevel = zoom;
 }
 
 void Marker::setEase(const glm::dvec2& dest, float duration, EaseType e) {
@@ -51,8 +52,16 @@ void Marker::update(float dt, const View& view) {
     m_modelMatrix = translation * scaling;
 }
 
+int Marker::builtZoomLevel() const {
+    return m_builtZoomLevel;
+}
+
 uint32_t Marker::styleId() const {
     return m_styleId;
+}
+
+float Marker::extent() const {
+    return glm::max(m_bounds.width(), m_bounds.height());
 }
 
 Feature* Marker::feature() const {

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -25,9 +25,13 @@ void Marker::setFeature(std::unique_ptr<Feature> feature) {
     m_feature = std::move(feature);
 }
 
-void Marker::setStyling(std::unique_ptr<DrawRuleData> drawRuleData) {
+void Marker::setStylingString(std::string stylingString) {
+    m_stylingString = stylingString;
+}
+
+void Marker::setDrawRule(std::unique_ptr<DrawRuleData> drawRuleData) {
     m_drawRuleData = std::move(drawRuleData);
-    m_drawRule = std::make_unique<DrawRule>(*m_drawRuleData, "anonymous_marker_layer", 0);
+    m_drawRule = std::make_unique<DrawRule>(*m_drawRuleData, "", 0);
 }
 
 void Marker::setMesh(uint32_t styleId, uint32_t zoom, std::unique_ptr<StyledMesh> mesh) {
@@ -94,6 +98,10 @@ const glm::dvec2& Marker::origin() const {
 
 const glm::mat4& Marker::modelMatrix() const {
     return m_modelMatrix;
+}
+
+const std::string& Marker::stylingString() const {
+    return m_stylingString;
 }
 
 bool Marker::isEasing() const {

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -10,7 +10,7 @@
 
 namespace Tangram {
 
-Marker::Marker() {
+Marker::Marker(MarkerID id) : m_id(id) {
 }
 
 Marker::~Marker() {
@@ -58,6 +58,10 @@ void Marker::setVisible(bool visible) {
 
 int Marker::builtZoomLevel() const {
     return m_builtZoomLevel;
+}
+
+MarkerID Marker::id() const {
+    return m_id;
 }
 
 uint32_t Marker::styleId() const {

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -84,10 +84,6 @@ StyledMesh* Marker::mesh() const {
     return m_mesh.get();
 }
 
-// MapProjection* Marker::mapProjection() const {
-//     return m_mapProjection;
-// }
-
 const BoundingBox& Marker::bounds() const {
     return m_bounds;
 }

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -47,7 +47,7 @@ void Marker::update(float dt, const View& view) {
     if (!m_ease.finished()) { m_ease.update(dt); }
     // Apply marker-view translation to the model matrix
     const auto& viewOrigin = view.getPosition();
-    auto scaling = glm::scale(glm::vec3(m_bounds.width(), m_bounds.height(), 1.f));
+    auto scaling = glm::scale(glm::vec3(extent()));
     auto translation = glm::translate(glm::vec3(m_origin.x - viewOrigin.x, m_origin.y - viewOrigin.y, 0.f));
     m_modelMatrix = translation * scaling;
 }

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "glm/mat4x4.hpp"
+#include "glm/vec2.hpp"
+#include "util/geom.h"
+#include <memory>
+#include <string>
+
+namespace Tangram {
+
+class MapProjection;
+class Scene;
+class View;
+struct DrawRule;
+struct DrawRuleData;
+struct Feature;
+struct StyledMesh;
+
+class Marker {
+
+public:
+
+    Marker();
+
+    ~Marker();
+
+    void setBounds(BoundingBox bounds);
+
+    void setFeature(std::unique_ptr<Feature> feature);
+
+    void setStyling(std::unique_ptr<DrawRuleData> drawRuleData);
+
+    void setMesh(uint32_t styleId, std::unique_ptr<StyledMesh> mesh);
+
+    void update(float dt, const View& view);
+
+    uint32_t styleId() const;
+
+    StyledMesh* mesh() const;
+
+    // MapProjection* mapProjection() const;
+
+    DrawRule* drawRule();
+
+    Feature* feature() const;
+
+    const BoundingBox& bounds() const;
+
+    const glm::dvec2& origin() const;
+
+    const glm::mat4& modelMatrix() const;
+
+protected:
+
+    std::unique_ptr<Feature> m_feature;
+    std::unique_ptr<StyledMesh> m_mesh;
+    std::unique_ptr<DrawRuleData> m_drawRuleData;
+    std::unique_ptr<DrawRule> m_drawRule;
+
+    MapProjection* m_mapProjection = nullptr;
+
+    uint32_t m_styleId = 0;
+
+    // Origin of marker geometry relative to global projection space.
+    glm::dvec2 m_origin;
+
+    // Bounding box in global projection space which describes the origin and extent of the coordinates in the Feature
+    BoundingBox m_bounds;
+
+    // Matrix relating marker-local coordinates to global projection space coordinates;
+    // Note that this matrix does not contain the relative translation from the global origin to the marker origin.
+    // Distances from the global origin are too large to represent precisely in 32-bit floats, so we only apply the
+    // relative translation from the view origin to the model origin immediately before drawing the marker.
+    glm::mat4 m_modelMatrix;
+
+};
+
+} // namespace Tangram

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -2,6 +2,7 @@
 
 #include "glm/mat4x4.hpp"
 #include "glm/vec2.hpp"
+#include "util/ease.h"
 #include "util/geom.h"
 #include <memory>
 #include <string>
@@ -32,6 +33,8 @@ public:
 
     void setMesh(uint32_t styleId, std::unique_ptr<StyledMesh> mesh);
 
+    void setEase(const glm::dvec2& destination, float duration, EaseType ease);
+
     void update(float dt, const View& view);
 
     uint32_t styleId() const;
@@ -49,6 +52,8 @@ public:
     const glm::dvec2& origin() const;
 
     const glm::mat4& modelMatrix() const;
+
+    bool isEasing() const;
 
 protected:
 
@@ -72,6 +77,8 @@ protected:
     // Distances from the global origin are too large to represent precisely in 32-bit floats, so we only apply the
     // relative translation from the view origin to the model origin immediately before drawing the marker.
     glm::mat4 m_modelMatrix;
+
+    Ease m_ease;
 
 };
 

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -31,13 +31,17 @@ public:
 
     void setStyling(std::unique_ptr<DrawRuleData> drawRuleData);
 
-    void setMesh(uint32_t styleId, std::unique_ptr<StyledMesh> mesh);
+    void setMesh(uint32_t styleId, uint32_t zoom, std::unique_ptr<StyledMesh> mesh);
 
     void setEase(const glm::dvec2& destination, float duration, EaseType ease);
 
     void update(float dt, const View& view);
 
     uint32_t styleId() const;
+
+    int builtZoomLevel() const;
+
+    float extent() const;
 
     StyledMesh* mesh() const;
 
@@ -65,6 +69,8 @@ protected:
     MapProjection* m_mapProjection = nullptr;
 
     uint32_t m_styleId = 0;
+
+    int m_builtZoomLevel = 0;
 
     // Origin of marker geometry relative to global projection space.
     glm::dvec2 m_origin;

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -37,6 +37,8 @@ public:
 
     void update(float dt, const View& view);
 
+    void setVisible(bool visible);
+
     uint32_t styleId() const;
 
     int builtZoomLevel() const;
@@ -58,6 +60,8 @@ public:
     const glm::mat4& modelMatrix() const;
 
     bool isEasing() const;
+
+    bool isVisible() const;
 
 protected:
 
@@ -85,6 +89,8 @@ protected:
     glm::mat4 m_modelMatrix;
 
     Ease m_ease;
+
+    bool m_visible = true;
 
 };
 

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -36,8 +36,11 @@ public:
     // Set the feature whose geometry will be used to build the marker.
     void setFeature(std::unique_ptr<Feature> feature);
 
+    // Set the string of YAML that will be used to style the marker.
+    void setStylingString(std::string stylingString);
+
     // Set the draw rule that will be used to build the marker.
-    void setStyling(std::unique_ptr<DrawRuleData> drawRuleData);
+    void setDrawRule(std::unique_ptr<DrawRuleData> drawRuleData);
 
     // Set the styled mesh for this marker with the associated style id and zoom level.
     void setMesh(uint32_t styleId, uint32_t zoom, std::unique_ptr<StyledMesh> mesh);
@@ -78,6 +81,8 @@ public:
 
     const glm::mat4& modelMatrix() const;
 
+    const std::string& stylingString() const;
+
     bool isEasing() const;
 
     bool isVisible() const;
@@ -89,7 +94,7 @@ protected:
     std::unique_ptr<DrawRuleData> m_drawRuleData;
     std::unique_ptr<DrawRule> m_drawRule;
 
-    MapProjection* m_mapProjection = nullptr;
+    std::string m_stylingString;
 
     MarkerID m_id = 0;
 

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -4,6 +4,7 @@
 #include "glm/vec2.hpp"
 #include "util/ease.h"
 #include "util/geom.h"
+#include "util/types.h"
 #include <memory>
 #include <string>
 
@@ -21,7 +22,7 @@ class Marker {
 
 public:
 
-    Marker();
+    Marker(MarkerID id);
 
     ~Marker();
 
@@ -38,6 +39,8 @@ public:
     void update(float dt, const View& view);
 
     void setVisible(bool visible);
+
+    MarkerID id() const;
 
     uint32_t styleId() const;
 
@@ -71,6 +74,8 @@ protected:
     std::unique_ptr<DrawRule> m_drawRule;
 
     MapProjection* m_mapProjection = nullptr;
+
+    MarkerID m_id = 0;
 
     uint32_t m_styleId = 0;
 

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -22,35 +22,49 @@ class Marker {
 
 public:
 
+    // Create an empty marker with the given ID. An ID of 0 indicates an invalid marker.
     Marker(MarkerID id);
 
     ~Marker();
 
+    // Set the axis-aligned bounding box for the feature geometry in Mercator meters;
+    // The points in the feature for this Marker should be made relative to a coordinate system
+    // whose origin is the South-West corner of the bounds and whose unit length is the
+    // maximum dimension (extent) of the bounds.
     void setBounds(BoundingBox bounds);
 
+    // Set the feature whose geometry will be used to build the marker.
     void setFeature(std::unique_ptr<Feature> feature);
 
+    // Set the draw rule that will be used to build the marker.
     void setStyling(std::unique_ptr<DrawRuleData> drawRuleData);
 
+    // Set the styled mesh for this marker with the associated style id and zoom level.
     void setMesh(uint32_t styleId, uint32_t zoom, std::unique_ptr<StyledMesh> mesh);
 
+    // Set an ease for the origin of this marker in Mercator meters.
     void setEase(const glm::dvec2& destination, float duration, EaseType ease);
 
+    // Set the model matrix for the marker using the current view and update any eases.
     void update(float dt, const View& view);
 
+    // Set whether this marker should be visible.
     void setVisible(bool visible);
 
+    // Get the unique identifier for this marker. An ID of 0 indicates an invalid marker.
     MarkerID id() const;
 
+    // Get the ID of the style that should draw the mesh for this marker.
     uint32_t styleId() const;
 
+    // Get the zoom level at which the mesh for this marker was built.
     int builtZoomLevel() const;
 
+    // Get the length of the maximum dimension of the bounds of this marker. This is used as
+    // the scale in the model matrix.
     float extent() const;
 
     StyledMesh* mesh() const;
-
-    // MapProjection* mapProjection() const;
 
     DrawRule* drawRule();
 
@@ -58,6 +72,8 @@ public:
 
     const BoundingBox& bounds() const;
 
+    // Get the origin of the geometry for this marker, i.e. the South-West corner of the bounds.
+    // This is used as the origin in the model matrix.
     const glm::dvec2& origin() const;
 
     const glm::mat4& modelMatrix() const;

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -76,6 +76,20 @@ bool MarkerManager::setPoint(Marker* marker, LngLat lngLat) {
     return true;
 }
 
+bool MarkerManager::setPointEased(Marker* marker, LngLat lngLat, float duration, EaseType ease) {
+    if (!marker || !contains(marker)) { return false; }
+
+    // If the marker does not have a 'point' feature built, we can't ease it.
+    if (!marker->mesh() || !marker->feature() || marker->feature()->geometryType != GeometryType::points) {
+        return false;
+    }
+
+    auto dest = m_mapProjection->LonLatToMeters({ lngLat.longitude, lngLat.latitude });
+    marker->setEase(dest, duration, ease);
+
+    return true;
+}
+
 bool MarkerManager::setPolyline(Marker* marker, LngLat* coordinates, int count) {
     if (!marker || !contains(marker)) { return false; }
     if (!coordinates || count < 2) { return false; }

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -1,0 +1,215 @@
+#include "data/tileData.h"
+#include "marker/markerManager.h"
+#include "marker/marker.h"
+#include "scene/sceneLoader.h"
+#include "style/style.h"
+
+namespace Tangram {
+
+void MarkerManager::setScene(std::shared_ptr<Scene> scene) {
+
+    m_scene = scene;
+    m_mapProjection = scene->mapProjection().get();
+    m_styleContext.initFunctions(*scene);
+
+    // Initialize StyleBuilders
+    for (auto& style : scene->styles()) {
+        m_styleBuilders[style->getName()] = style->createBuilder();
+    }
+
+}
+
+Marker* MarkerManager::add(const char* styling) {
+
+    // Add a new empty marker object to the list of markers.
+    m_markers.push_back(std::make_unique<Marker>());
+
+    // Create a draw rule from the given styling string.
+    auto marker = m_markers.back().get();
+    setStyling(marker, styling);
+
+    // Return a pointer to the marker.
+    return marker;
+
+}
+
+bool MarkerManager::remove(Marker* marker) {
+    for (auto it = m_markers.begin(), end = m_markers.end(); it != end; ++it) {
+        if (it->get() == marker) {
+            m_markers.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool MarkerManager::setStyling(Marker* marker, const char* styling) {
+    if (!marker || !contains(marker)) { return false; }
+
+    // Update the draw rule for the marker.
+    YAML::Node node = YAML::Load(styling);
+    std::vector<StyleParam> params;
+    SceneLoader::parseStyleParams(node, m_scene, "", params);
+    marker->setStyling(std::make_unique<DrawRuleData>("anonymous_marker_rule", 0, std::move(params)));
+
+    // Build the feature mesh for the marker's current geometry.
+    build(*marker);
+    return true;
+}
+
+bool MarkerManager::setPoint(Marker* marker, double lng, double lat) {
+    if (!marker || !contains(marker)) { return false; }
+
+    // If the marker does not have a 'point' feature mesh built, build it.
+    if (!marker->mesh() || !marker->feature() || marker->feature()->geometryType != GeometryType::points) {
+        auto feature = std::make_unique<Feature>();
+        feature->geometryType = GeometryType::points;
+        feature->points.emplace_back();
+        marker->setFeature(std::move(feature));
+        build(*marker);
+    }
+
+    // Update the marker's bounds to the given coordinates.
+    auto origin = m_mapProjection->LonLatToMeters({ lng, lat });
+    marker->setBounds({ origin, origin });
+
+    return true;
+}
+
+bool MarkerManager::setPolyline(Marker* marker, double* coordinates, int count) {
+    if (!marker || !contains(marker)) { return false; }
+    if (!coordinates || count < 2) { return false; }
+
+    // Build a feature for the new set of polyline points.
+    auto feature = std::make_unique<Feature>();
+    feature->geometryType = GeometryType::lines;
+    feature->lines.emplace_back();
+    auto& line = feature->lines.back();
+
+    // Determine the bounds of the polyline.
+    BoundingBox bounds;
+    bounds.min = { coordinates[0], coordinates[1] };
+    bounds.max = bounds.min;
+    for (int i = 0; i < count; ++i) {
+        bounds.expand(coordinates[2 * i], coordinates[2 * i + 1]);
+    }
+    bounds.min = m_mapProjection->LonLatToMeters(bounds.min);
+    bounds.max = m_mapProjection->LonLatToMeters(bounds.max);
+
+    // Project and offset the coordinates into the marker-local coordinate system.
+    auto origin = glm::dvec2(bounds.min.x, bounds.max.y); // SW corner.
+    for (int i = 0; i < count; ++i) {
+        auto degrees = glm::dvec2(coordinates[2 * i], coordinates[2 * i + 1]);
+        auto meters = m_mapProjection->LonLatToMeters(degrees);
+        line.emplace_back(meters.x - origin.x, meters.y - origin.y, 0.f);
+    }
+
+    // Update the feature data for the marker.
+    marker->setFeature(std::move(feature));
+
+    // Update the marker's bounds
+    marker->setBounds(bounds);
+
+    // Build a new mesh for the marker.
+    build(*marker);
+
+    return true;
+}
+
+bool MarkerManager::setPolygon(Marker* marker, double** coordinates, int* counts, int rings) {
+    if (!marker || !contains(marker)) { return false; }
+    if (!coordinates || !counts || rings < 1) { return false; }
+
+    // Build a feature for the new set of polygon points.
+    auto feature = std::make_unique<Feature>();
+    feature->geometryType = GeometryType::polygons;
+    feature->polygons.emplace_back();
+    auto& polygon = feature->polygons.back();
+
+    // Determine the bounds of the polygon.
+    BoundingBox bounds;
+    for (int i = 0; i < rings; ++i) {
+        int count = counts[i];
+        double* ring = coordinates[i];
+        for (int j = 0; j < count; ++j) {
+            if (i == 0 && j == 0) {
+                bounds.min = { ring[0], ring[1] };
+                bounds.max = bounds.min;
+            }
+            bounds.expand(ring[2 * j], ring[2 * j + 1]);
+        }
+    }
+    bounds.min = m_mapProjection->LonLatToMeters(bounds.min);
+    bounds.max = m_mapProjection->LonLatToMeters(bounds.max);
+
+    // Project and offset the coordinates into the marker-local coordinate system.
+    auto origin = glm::dvec2(bounds.min.x, bounds.max.y); // SW corner.
+    for (int i = 0; i < rings; ++i) {
+        int count = counts[i];
+        double* ring = coordinates[i];
+        polygon.emplace_back();
+        auto& line = polygon.back();
+        for (int j = 0; j < count; ++j) {
+            auto degrees = glm::dvec2(ring[2 * j], ring[2 * j + 1]);
+            auto meters = m_mapProjection->LonLatToMeters(degrees);
+            line.emplace_back(meters.x - origin.x, meters.y - origin.y, 0.f);
+        }
+    }
+
+    // Update the feature data for the marker.
+    marker->setFeature(std::move(feature));
+
+    // Update the marker's bounds
+    marker->setBounds(bounds);
+
+    // Build a new mesh for the marker.
+    build(*marker);
+
+    return true;
+}
+
+const std::vector<std::unique_ptr<Marker>>& MarkerManager::markers() const {
+    return m_markers;
+}
+
+void MarkerManager::build(Marker& marker) {
+
+    auto rule = marker.drawRule();
+    auto feature = marker.feature();
+
+    if (!rule || !feature) { return; }
+
+    StyleBuilder* styler = nullptr;
+    {
+        auto name = rule->getStyleName();
+        auto it = m_styleBuilders.find(name);
+        if (it != m_styleBuilders.end()) {
+            styler = it->second.get();
+        } else {
+            LOGN("Invalid style %s", name.c_str());
+            return;
+        }
+    }
+
+    // TODO: setup geometry dimensions for style builder as in setup(Tile&)
+
+    m_styleContext.setKeywordZoom(0); // TODO: use a meaningful zoom value
+
+    bool valid = m_ruleSet.evaluateRuleForContext(*rule, m_styleContext);
+
+    if (valid) {
+        styler->setup(marker);
+        styler->addFeature(*feature, *rule);
+        marker.setMesh(styler->style().getID(), styler->build());
+    }
+
+}
+
+bool MarkerManager::contains(Marker* marker) {
+    for (auto it = m_markers.begin(), end = m_markers.end(); it != end; ++it) {
+        if (it->get() == marker) { return true; }
+    }
+    return false;
+}
+
+} // namespace Tangram

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -96,12 +96,15 @@ bool MarkerManager::setPolyline(Marker* marker, LngLat* coordinates, int count) 
     bounds.min = m_mapProjection->LonLatToMeters(bounds.min);
     bounds.max = m_mapProjection->LonLatToMeters(bounds.max);
 
+    float scaleX = 1. / bounds.width();
+    float scaleY = 1. / bounds.height();
+
     // Project and offset the coordinates into the marker-local coordinate system.
     auto origin = bounds.min; // glm::dvec2(bounds.min.x, bounds.max.y); // SW corner.
     for (int i = 0; i < count; ++i) {
         auto degrees = glm::dvec2(coordinates[i].longitude, coordinates[i].latitude);
         auto meters = m_mapProjection->LonLatToMeters(degrees);
-        line.emplace_back(meters.x - origin.x, meters.y - origin.y, 0.f);
+        line.emplace_back((meters.x - origin.x) * scaleX, (meters.y - origin.y) * scaleY, 0.f);
     }
 
     // Update the feature data for the marker.
@@ -143,6 +146,9 @@ bool MarkerManager::setPolygon(Marker* marker, LngLat* coordinates, int* counts,
     bounds.min = m_mapProjection->LonLatToMeters(bounds.min);
     bounds.max = m_mapProjection->LonLatToMeters(bounds.max);
 
+    float scaleX = 1. / bounds.width();
+    float scaleY = 1. / bounds.height();
+
     // Project and offset the coordinates into the marker-local coordinate system.
     auto origin = glm::dvec2(bounds.min.x, bounds.max.y); // SW corner.
     ring = coordinates;
@@ -153,7 +159,7 @@ bool MarkerManager::setPolygon(Marker* marker, LngLat* coordinates, int* counts,
         for (int j = 0; j < count; ++j) {
             auto degrees = glm::dvec2(ring[j].longitude, ring[j].latitude);
             auto meters = m_mapProjection->LonLatToMeters(degrees);
-            line.emplace_back(meters.x - origin.x, meters.y - origin.y, 0.f);
+            line.emplace_back((meters.x - origin.x) * scaleX, (meters.y - origin.y) * scaleY, 0.f);
         }
         ring += count;
     }

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -215,6 +215,12 @@ bool MarkerManager::update(int zoom) {
     return rebuilt;
 }
 
+void MarkerManager::removeAll() {
+
+    m_markers.clear();
+
+}
+
 const std::vector<std::unique_ptr<Marker>>& MarkerManager::markers() const {
     return m_markers;
 }

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -44,8 +44,8 @@ bool MarkerManager::remove(MarkerID markerID) {
 }
 
 bool MarkerManager::setStyling(MarkerID markerID, const char* styling) {
-    Marker* marker = nullptr;
-    if (!markerID || !(marker = tryGet(markerID))) { return false; }
+    Marker* marker = getMarkerOrNull(markerID);
+    if (!marker) { return false; }
 
     // Update the draw rule for the marker.
     YAML::Node node = YAML::Load(styling);
@@ -67,8 +67,8 @@ bool MarkerManager::setStyling(MarkerID markerID, const char* styling) {
 }
 
 bool MarkerManager::setVisible(MarkerID markerID, bool visible) {
-    Marker* marker = nullptr;
-    if (!markerID || !(marker = tryGet(markerID))) { return false; }
+    Marker* marker = getMarkerOrNull(markerID);
+    if (!marker) { return false; }
 
     marker->setVisible(visible);
     return true;
@@ -76,8 +76,8 @@ bool MarkerManager::setVisible(MarkerID markerID, bool visible) {
 }
 
 bool MarkerManager::setPoint(MarkerID markerID, LngLat lngLat) {
-    Marker* marker = nullptr;
-    if (!markerID || !(marker = tryGet(markerID))) { return false; }
+    Marker* marker = getMarkerOrNull(markerID);
+    if (!marker) { return false; }
 
     // If the marker does not have a 'point' feature mesh built, build it.
     if (!marker->mesh() || !marker->feature() || marker->feature()->geometryType != GeometryType::points) {
@@ -96,8 +96,8 @@ bool MarkerManager::setPoint(MarkerID markerID, LngLat lngLat) {
 }
 
 bool MarkerManager::setPointEased(MarkerID markerID, LngLat lngLat, float duration, EaseType ease) {
-    Marker* marker = nullptr;
-    if (!markerID || !(marker = tryGet(markerID))) { return false; }
+    Marker* marker = getMarkerOrNull(markerID);
+    if (!marker) { return false; }
 
     // If the marker does not have a 'point' feature built, we can't ease it.
     if (!marker->mesh() || !marker->feature() || marker->feature()->geometryType != GeometryType::points) {
@@ -111,8 +111,8 @@ bool MarkerManager::setPointEased(MarkerID markerID, LngLat lngLat, float durati
 }
 
 bool MarkerManager::setPolyline(MarkerID markerID, LngLat* coordinates, int count) {
-    Marker* marker = nullptr;
-    if (!markerID || !(marker = tryGet(markerID))) { return false; }
+    Marker* marker = getMarkerOrNull(markerID);
+    if (!marker) { return false; }
     if (!coordinates || count < 2) { return false; }
 
     // Build a feature for the new set of polyline points.
@@ -154,8 +154,8 @@ bool MarkerManager::setPolyline(MarkerID markerID, LngLat* coordinates, int coun
 }
 
 bool MarkerManager::setPolygon(MarkerID markerID, LngLat* coordinates, int* counts, int rings) {
-    Marker* marker = nullptr;
-    if (!markerID || !(marker = tryGet(markerID))) { return false; }
+    Marker* marker = getMarkerOrNull(markerID);
+    if (!marker) { return false; }
     if (!coordinates || !counts || rings < 1) { return false; }
 
     // Build a feature for the new set of polygon points.
@@ -267,9 +267,10 @@ void MarkerManager::build(Marker& marker, int zoom) {
 
 }
 
-Marker* MarkerManager::tryGet(MarkerID markerID) {
-    for (auto it = m_markers.begin(), end = m_markers.end(); it != end; ++it) {
-        if (it->get()->id() == markerID) { return it->get(); }
+Marker* MarkerManager::getMarkerOrNull(MarkerID markerID) {
+    if (!markerID) { return nullptr; }
+    for (const auto& entry : m_markers) {
+        if (entry->id() == markerID) { return entry.get(); }
     }
     return nullptr;
 }

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -68,6 +68,14 @@ bool MarkerManager::setStyling(Marker* marker, const char* styling) {
     return true;
 }
 
+bool MarkerManager::setVisible(Marker* marker, bool visible) {
+    if (!marker || !contains(marker)) { return false; }
+
+    marker->setVisible(visible);
+    return true;
+
+}
+
 bool MarkerManager::setPoint(Marker* marker, LngLat lngLat) {
     if (!marker || !contains(marker)) { return false; }
 

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -110,22 +110,21 @@ bool MarkerManager::setPolyline(Marker* marker, LngLat* coordinates, int count) 
     bounds.min = m_mapProjection->LonLatToMeters(bounds.min);
     bounds.max = m_mapProjection->LonLatToMeters(bounds.max);
 
-    float scaleX = 1. / bounds.width();
-    float scaleY = 1. / bounds.height();
+    // Update the marker's bounds.
+    marker->setBounds(bounds);
+
+    float scale = 1.f / marker->extent();
 
     // Project and offset the coordinates into the marker-local coordinate system.
-    auto origin = bounds.min; // glm::dvec2(bounds.min.x, bounds.max.y); // SW corner.
+    auto origin = marker->origin(); // SW corner.
     for (int i = 0; i < count; ++i) {
         auto degrees = glm::dvec2(coordinates[i].longitude, coordinates[i].latitude);
         auto meters = m_mapProjection->LonLatToMeters(degrees);
-        line.emplace_back((meters.x - origin.x) * scaleX, (meters.y - origin.y) * scaleY, 0.f);
+        line.emplace_back((meters.x - origin.x) * scale, (meters.y - origin.y) * scale, 0.f);
     }
 
     // Update the feature data for the marker.
     marker->setFeature(std::move(feature));
-
-    // Update the marker's bounds
-    marker->setBounds(bounds);
 
     // Build a new mesh for the marker.
     build(*marker, m_zoom);
@@ -160,11 +159,13 @@ bool MarkerManager::setPolygon(Marker* marker, LngLat* coordinates, int* counts,
     bounds.min = m_mapProjection->LonLatToMeters(bounds.min);
     bounds.max = m_mapProjection->LonLatToMeters(bounds.max);
 
-    float scaleX = 1. / bounds.width();
-    float scaleY = 1. / bounds.height();
+    // Update the marker's bounds.
+    marker->setBounds(bounds);
+
+    float scale = 1.f / marker->extent();
 
     // Project and offset the coordinates into the marker-local coordinate system.
-    auto origin = glm::dvec2(bounds.min.x, bounds.max.y); // SW corner.
+    auto origin = marker->origin(); // SW corner.
     ring = coordinates;
     for (int i = 0; i < rings; ++i) {
         int count = counts[i];
@@ -173,16 +174,13 @@ bool MarkerManager::setPolygon(Marker* marker, LngLat* coordinates, int* counts,
         for (int j = 0; j < count; ++j) {
             auto degrees = glm::dvec2(ring[j].longitude, ring[j].latitude);
             auto meters = m_mapProjection->LonLatToMeters(degrees);
-            line.emplace_back((meters.x - origin.x) * scaleX, (meters.y - origin.y) * scaleY, 0.f);
+            line.emplace_back((meters.x - origin.x) * scale, (meters.y - origin.y) * scale, 0.f);
         }
         ring += count;
     }
 
     // Update the feature data for the marker.
     marker->setFeature(std::move(feature));
-
-    // Update the marker's bounds
-    marker->setBounds(bounds);
 
     // Build a new mesh for the marker.
     build(*marker, m_zoom);

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -99,9 +99,9 @@ bool MarkerManager::setPointEased(MarkerID markerID, LngLat lngLat, float durati
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
 
-    // If the marker does not have a 'point' feature built, we can't ease it.
+    // If the marker does not have a 'point' feature built, set that point immediately.
     if (!marker->mesh() || !marker->feature() || marker->feature()->geometryType != GeometryType::points) {
-        return false;
+        return setPoint(markerID, lngLat);
     }
 
     auto dest = m_mapProjection->LonLatToMeters({ lngLat.longitude, lngLat.latitude });

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -22,15 +22,11 @@ void MarkerManager::setScene(std::shared_ptr<Scene> scene) {
 
 }
 
-MarkerID MarkerManager::add(const char* styling) {
+MarkerID MarkerManager::add() {
 
     // Add a new empty marker object to the list of markers.
     auto id = ++m_idCounter;
     m_markers.push_back(std::make_unique<Marker>(id));
-
-    // Create a draw rule from the given styling string.
-    auto marker = m_markers.back().get();
-    setStyling(id, styling);
 
     // Return a handle for the marker.
     return id;

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -2,6 +2,7 @@
 
 #include "scene/styleContext.h"
 #include "scene/drawRule.h"
+#include "util/ease.h"
 #include "util/fastmap.h"
 #include "util/types.h"
 #include <memory>
@@ -27,6 +28,8 @@ public:
     bool setStyling(Marker* marker, const char* styling);
 
     bool setPoint(Marker* marker, LngLat lngLat);
+
+    bool setPointEased(Marker* marker, LngLat lngLat, float duration, EaseType ease);
 
     bool setPolyline(Marker* marker, LngLat* coordinates, int count);
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -3,6 +3,7 @@
 #include "scene/styleContext.h"
 #include "scene/drawRule.h"
 #include "util/fastmap.h"
+#include "util/types.h"
 #include <memory>
 #include <vector>
 
@@ -25,11 +26,11 @@ public:
 
     bool setStyling(Marker* marker, const char* styling);
 
-    bool setPoint(Marker* marker, double lng, double lat);
+    bool setPoint(Marker* marker, LngLat lngLat);
 
-    bool setPolyline(Marker* marker, double* coordinates, int count);
+    bool setPolyline(Marker* marker, LngLat* coordinates, int count);
 
-    bool setPolygon(Marker* marker, double** coordinates, int* counts, int rings);
+    bool setPolygon(Marker* marker, LngLat* coordinates, int* counts, int rings);
 
     const std::vector<std::unique_ptr<Marker>>& markers() const;
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "scene/styleContext.h"
+#include "scene/drawRule.h"
+#include "util/fastmap.h"
+#include <memory>
+#include <vector>
+
+namespace Tangram {
+
+class MapProjection;
+class Marker;
+class Scene;
+class StyleBuilder;
+
+class MarkerManager {
+
+public:
+
+    void setScene(std::shared_ptr<Scene> scene);
+
+    Marker* add(const char* styling);
+
+    bool remove(Marker* marker);
+
+    bool setStyling(Marker* marker, const char* styling);
+
+    bool setPoint(Marker* marker, double lng, double lat);
+
+    bool setPolyline(Marker* marker, double* coordinates, int count);
+
+    bool setPolygon(Marker* marker, double** coordinates, int* counts, int rings);
+
+    const std::vector<std::unique_ptr<Marker>>& markers() const;
+
+private:
+
+    bool contains(Marker* marker);
+
+    void build(Marker& _marker);
+
+    DrawRuleMergeSet m_ruleSet;
+    StyleContext m_styleContext;
+    std::shared_ptr<Scene> m_scene;
+    std::vector<std::unique_ptr<Marker>> m_markers;
+    fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilders;
+    MapProjection* m_mapProjection = nullptr;
+
+};
+
+} // namespace Tangram

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -35,13 +35,15 @@ public:
 
     bool setPolygon(Marker* marker, LngLat* coordinates, int* counts, int rings);
 
+    bool update(int zoom);
+
     const std::vector<std::unique_ptr<Marker>>& markers() const;
 
 private:
 
     bool contains(Marker* marker);
 
-    void build(Marker& _marker);
+    void build(Marker& _marker, int zoom);
 
     DrawRuleMergeSet m_ruleSet;
     StyleContext m_styleContext;
@@ -49,6 +51,7 @@ private:
     std::vector<std::unique_ptr<Marker>> m_markers;
     fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilders;
     MapProjection* m_mapProjection = nullptr;
+    int m_zoom = 0;
 
 };
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -21,7 +21,7 @@ public:
 
     void setScene(std::shared_ptr<Scene> scene);
 
-    MarkerID add(const char* styling);
+    MarkerID add();
 
     bool remove(MarkerID markerID);
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -61,7 +61,8 @@ private:
 
     Marker* getMarkerOrNull(MarkerID markerID);
 
-    void build(Marker& marker, int zoom);
+    void buildStyling(Marker& marker);
+    void buildGeometry(Marker& marker, int zoom);
 
     DrawRuleMergeSet m_ruleSet;
     StyleContext m_styleContext;

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -21,21 +21,21 @@ public:
 
     void setScene(std::shared_ptr<Scene> scene);
 
-    Marker* add(const char* styling);
+    MarkerID add(const char* styling);
 
-    bool remove(Marker* marker);
+    bool remove(MarkerID markerID);
 
-    bool setStyling(Marker* marker, const char* styling);
+    bool setStyling(MarkerID markerID, const char* styling);
 
-    bool setVisible(Marker* marker, bool visible);
+    bool setVisible(MarkerID markerID, bool visible);
 
-    bool setPoint(Marker* marker, LngLat lngLat);
+    bool setPoint(MarkerID markerID, LngLat lngLat);
 
-    bool setPointEased(Marker* marker, LngLat lngLat, float duration, EaseType ease);
+    bool setPointEased(MarkerID markerID, LngLat lngLat, float duration, EaseType ease);
 
-    bool setPolyline(Marker* marker, LngLat* coordinates, int count);
+    bool setPolyline(MarkerID markerID, LngLat* coordinates, int count);
 
-    bool setPolygon(Marker* marker, LngLat* coordinates, int* counts, int rings);
+    bool setPolygon(MarkerID markerID, LngLat* coordinates, int* counts, int rings);
 
     bool update(int zoom);
 
@@ -45,9 +45,9 @@ public:
 
 private:
 
-    bool contains(Marker* marker);
+    Marker* tryGet(MarkerID markerID);
 
-    void build(Marker& _marker, int zoom);
+    void build(Marker& marker, int zoom);
 
     DrawRuleMergeSet m_ruleSet;
     StyleContext m_styleContext;
@@ -57,6 +57,7 @@ private:
     fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilders;
     MapProjection* m_mapProjection = nullptr;
     size_t m_jsFnIndex = 0;
+    uint32_t m_idCounter = 0;
     int m_zoom = 0;
 
 };

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -27,6 +27,8 @@ public:
 
     bool setStyling(Marker* marker, const char* styling);
 
+    bool setVisible(Marker* marker, bool visible);
+
     bool setPoint(Marker* marker, LngLat lngLat);
 
     bool setPointEased(Marker* marker, LngLat lngLat, float duration, EaseType ease);

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -45,7 +45,7 @@ public:
 
 private:
 
-    Marker* tryGet(MarkerID markerID);
+    Marker* getMarkerOrNull(MarkerID markerID);
 
     void build(Marker& marker, int zoom);
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -19,26 +19,40 @@ class MarkerManager {
 
 public:
 
+    // Set the Scene object whose styling information will be used to build markers.
     void setScene(std::shared_ptr<Scene> scene);
 
+    // Create a new, empty marker and return its ID. An ID of 0 indicates an invalid marker.
     MarkerID add();
 
+    // Try to remove the marker with the given ID; returns true if the marker was found and removed.
     bool remove(MarkerID markerID);
 
+    // Set the styling string for a marker; returns true if the marker was found and updated.
     bool setStyling(MarkerID markerID, const char* styling);
 
+    // Set whether a marker should be visible; returns true if the marker was found and updated.
     bool setVisible(MarkerID markerID, bool visible);
 
+    // Set a marker to a point feature at the given position; returns true if the marker was found and updated.
     bool setPoint(MarkerID markerID, LngLat lngLat);
 
+    // Set a marker to a point feature at the given position; if the marker was previously set to a point, this
+    // eases from the old position to the new one over the given duration with the given ease type; returns true if
+    // the marker was found and updated.
     bool setPointEased(MarkerID markerID, LngLat lngLat, float duration, EaseType ease);
 
+    // Set a marker to a polyline feature at the given position; returns true if the marker was found and updated.
     bool setPolyline(MarkerID markerID, LngLat* coordinates, int count);
 
+    // Set a marker to a polygon feature at the given position; returns true if the marker was found and updated.
     bool setPolygon(MarkerID markerID, LngLat* coordinates, int* counts, int rings);
 
+    // Update the zoom level for all markers; markers are built for one zoom level at a time so when the current zoom
+    // changes, all marker meshes are rebuilt.
     bool update(int zoom);
 
+    // Remove and destroy all markers.
     void removeAll();
 
     const std::vector<std::unique_ptr<Marker>>& markers() const;

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -37,6 +37,8 @@ public:
 
     bool update(int zoom);
 
+    void removeAll();
+
     const std::vector<std::unique_ptr<Marker>>& markers() const;
 
 private:

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -49,8 +49,10 @@ private:
     StyleContext m_styleContext;
     std::shared_ptr<Scene> m_scene;
     std::vector<std::unique_ptr<Marker>> m_markers;
+    std::vector<std::string> m_jsFnList;
     fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilders;
     MapProjection* m_mapProjection = nullptr;
+    size_t m_jsFnIndex = 0;
     int m_zoom = 0;
 
 };

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -248,7 +248,7 @@ void DrawRuleMergeSet::mergeRules(const SceneLayer& _layer) {
         }
 
         if (pos == end) {
-            m_matchedRules.emplace_back(rule, _layer.name(), 0);
+            m_matchedRules.emplace_back(rule, _layer.name(), _layer.depth());
         } else {
             m_matchedRules[pos].merge(rule, _layer);
         }

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -76,7 +76,7 @@ struct DrawRule {
     int id;
     bool isOutlineOnly = false;
 
-    DrawRule(const DrawRuleData& _ruleData, const SceneLayer& _layer);
+    DrawRule(const DrawRuleData& _ruleData, const std::string& _layerName, size_t _layerDepth);
 
     void merge(const DrawRuleData& _ruleData, const SceneLayer& _layer);
 
@@ -121,6 +121,8 @@ public:
      */
     void apply(const Feature& _feature, const SceneLayer& _sceneLayer,
                StyleContext& _ctx, TileBuilder& _builder);
+
+    bool evaluateRuleForContext(DrawRule& rule, StyleContext& ctx);
 
     // internal
     bool match(const Feature& _feature, const SceneLayer& _layer, StyleContext& _ctx);

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -194,7 +194,39 @@ bool StyleContext::setFunctions(const std::vector<std::string>& _functions) {
         LOGE("'fns' object not set");
     }
 
+    m_functionCount = id;
+
     DUMP("setFunctions\n");
+    return ok;
+}
+
+bool StyleContext::addFunction(const std::string& _function) {
+    // Get all functions (array) in context
+    if (!duk_get_global_string(m_ctx, FUNC_ID)) {
+        LOGE("AddFunction - functions array not initialized");
+        duk_pop(m_ctx); // pop [undefined] sitting at stack top
+        return false;
+    }
+
+    int id = m_functionCount;
+    bool ok = true;
+
+    duk_push_string(m_ctx, _function.c_str());
+    duk_push_string(m_ctx, "");
+
+    if (duk_pcompile(m_ctx, DUK_COMPILE_FUNCTION) == 0) {
+        duk_put_prop_index(m_ctx, -2, id);
+    } else {
+        LOGW("Compile failed: %s\n%s\n---",
+             duk_safe_to_string(m_ctx, -1),
+             _function.c_str());
+        duk_pop(m_ctx);
+        ok = false;
+    }
+
+    // Pop the functions array off the stack
+    duk_pop(m_ctx);
+
     return ok;
 }
 

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -69,6 +69,7 @@ public:
     void clear();
 
     bool setFunctions(const std::vector<std::string>& _functions);
+    bool addFunction(const std::string& _function);
     void setSceneGlobals(const std::unordered_map<std::string, YAML::Node>& sceneGlobals);
 
     void setKeyword(const std::string& _key, Value _value);
@@ -85,6 +86,8 @@ private:
     std::array<Value, 4> m_keywords;
     int m_keywordGeom= -1;
     int m_keywordZoom = -1;
+
+    int m_functionCount = 0;
 
     int32_t m_sceneId = -1;
 

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -48,6 +48,7 @@ struct DebugStyleBuilder : public StyleBuilder {
     const DebugStyle& m_style;
 
     void setup(const Tile& _tile) override {}
+    void setup(const Marker& _marker) override {}
 
     std::unique_ptr<StyledMesh> build() override {
         if (!Tangram::getDebugFlag(Tangram::DebugFlags::tile_bounds)) {

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -48,7 +48,7 @@ struct DebugStyleBuilder : public StyleBuilder {
     const DebugStyle& m_style;
 
     void setup(const Tile& _tile) override {}
-    void setup(const Marker& _marker) override {}
+    void setup(const Marker& _marker, int zoom) override {}
 
     std::unique_ptr<StyledMesh> build() override {
         if (!Tangram::getDebugFlag(Tangram::DebugFlags::tile_bounds)) {

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -16,6 +16,7 @@ public:
         : TextStyleBuilder(_style) {}
 
     void setup(const Tile& _tile) override;
+    void setup(const Marker& _marker) override;
 
     std::unique_ptr<StyledMesh> build() override;
 
@@ -32,6 +33,16 @@ void DebugTextStyleBuilder::setup(const Tile& _tile) {
     m_tileID = _tile.getID().toString();
 
     TextStyleBuilder::setup(_tile);
+}
+
+void DebugTextStyleBuilder::setup(const Marker& _marker) {
+    if (!Tangram::getDebugFlag(Tangram::DebugFlags::tile_infos)) {
+        return;
+    }
+
+    m_tileID = "I AM A MARKER";
+
+    TextStyleBuilder::setup(_marker);
 }
 
 std::unique_ptr<StyledMesh> DebugTextStyleBuilder::build() {

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -16,7 +16,7 @@ public:
         : TextStyleBuilder(_style) {}
 
     void setup(const Tile& _tile) override;
-    void setup(const Marker& _marker) override;
+    void setup(const Marker& _marker, int zoom) override;
 
     std::unique_ptr<StyledMesh> build() override;
 
@@ -35,14 +35,14 @@ void DebugTextStyleBuilder::setup(const Tile& _tile) {
     TextStyleBuilder::setup(_tile);
 }
 
-void DebugTextStyleBuilder::setup(const Marker& _marker) {
+void DebugTextStyleBuilder::setup(const Marker& _marker, int zoom) {
     if (!Tangram::getDebugFlag(Tangram::DebugFlags::tile_infos)) {
         return;
     }
 
     m_tileID = "I AM A MARKER";
 
-    TextStyleBuilder::setup(_marker);
+    TextStyleBuilder::setup(_marker, zoom);
 }
 
 std::unique_ptr<StyledMesh> DebugTextStyleBuilder::build() {

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -83,6 +83,14 @@ void PointStyleBuilder::setup(const Tile& _tile) {
     m_iconMesh = std::make_unique<IconMesh>();
 }
 
+void PointStyleBuilder::setup(const Marker& _marker) {
+    m_zoom = 0;
+    m_spriteLabels = std::make_unique<SpriteLabels>(m_style);
+
+    m_textStyleBuilder->setup(_marker);
+    m_iconMesh = std::make_unique<IconMesh>();
+}
+
 bool PointStyleBuilder::checkRule(const DrawRule& _rule) const {
     uint32_t checkColor;
     // require a color or texture atlas/texture to be valid

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -83,11 +83,11 @@ void PointStyleBuilder::setup(const Tile& _tile) {
     m_iconMesh = std::make_unique<IconMesh>();
 }
 
-void PointStyleBuilder::setup(const Marker& _marker) {
-    m_zoom = 0;
+void PointStyleBuilder::setup(const Marker& _marker, int zoom) {
+    m_zoom = zoom;
     m_spriteLabels = std::make_unique<SpriteLabels>(m_style);
 
-    m_textStyleBuilder->setup(_marker);
+    m_textStyleBuilder->setup(_marker, zoom);
     m_iconMesh = std::make_unique<IconMesh>();
 }
 

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -22,6 +22,7 @@ struct PointStyleBuilder : public StyleBuilder {
 
 
     void setup(const Tile& _tile) override;
+    void setup(const Marker& _marker) override;
 
     bool checkRule(const DrawRule& _rule) const override;
 

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -22,7 +22,7 @@ struct PointStyleBuilder : public StyleBuilder {
 
 
     void setup(const Tile& _tile) override;
-    void setup(const Marker& _marker) override;
+    void setup(const Marker& _marker, int zoom) override;
 
     bool checkRule(const DrawRule& _rule) const override;
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -98,6 +98,12 @@ public:
         m_meshData.clear();
     }
 
+    void setup(const Marker& _marker) override {
+        // m_tileUnitsPerMeter = _tile.getInverseScale();
+        m_zoom = 0;
+        m_meshData.clear();
+    }
+
     void addPolygon(const Polygon& _polygon, const Properties& _props, const DrawRule& _rule) override;
 
     const Style& style() const override { return m_style; }

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -9,7 +9,7 @@
 #include "gl/mesh.h"
 #include "tile/tile.h"
 #include "scene/drawRule.h"
-
+#include "marker/marker.h"
 #include "glm/vec2.hpp"
 #include "glm/vec3.hpp"
 #include "glm/gtc/type_precision.hpp"
@@ -98,9 +98,9 @@ public:
         m_meshData.clear();
     }
 
-    void setup(const Marker& _marker) override {
-        // m_tileUnitsPerMeter = _tile.getInverseScale();
-        m_zoom = 0;
+    void setup(const Marker& _marker, int zoom) override {
+        m_zoom = zoom;
+        m_tileUnitsPerMeter = 1.f / _marker.extent();
         m_meshData.clear();
     }
 

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -7,6 +7,7 @@
 #include "gl/mesh.h"
 #include "gl/texture.h"
 #include "gl/renderState.h"
+#include "marker/marker.h"
 #include "scene/stops.h"
 #include "scene/drawRule.h"
 #include "tile/tile.h"
@@ -160,6 +161,7 @@ public:
     };
 
     void setup(const Tile& _tile) override;
+    void setup(const Marker& _marker) override;
 
     const Style& style() const override { return m_style; }
 
@@ -205,6 +207,21 @@ void PolylineStyleBuilder<V>::setup(const Tile& tile) {
     m_overzoom2 = powf(2.f, id.s - id.z);
     m_tileUnitsPerMeter = tile.getInverseScale();
     m_tileSizePixels = tile.getProjection()->TileSize();
+
+    // When a tile is overzoomed, we are actually styling the area of its
+    // 'source' tile, which will have a larger effective pixel size at the
+    // 'style' zoom level. This scaling is performed in the vertex shader to
+    // prevent loss of precision for small dimensions in packed attributes.
+}
+
+template <class V>
+void PolylineStyleBuilder<V>::setup(const Marker& marker) {
+
+    // Use the 'style zoom' to evaluate style parameters.
+    m_zoom = 0;
+    m_overzoom2 = 0;
+    m_tileUnitsPerMeter = 1; // FIXME
+    m_tileSizePixels = 256; //FIXME
 
     // When a tile is overzoomed, we are actually styling the area of its
     // 'source' tile, which will have a larger effective pixel size at the

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -161,7 +161,7 @@ public:
     };
 
     void setup(const Tile& _tile) override;
-    void setup(const Marker& _marker) override;
+    void setup(const Marker& _marker, int zoom) override;
 
     const Style& style() const override { return m_style; }
 
@@ -215,18 +215,14 @@ void PolylineStyleBuilder<V>::setup(const Tile& tile) {
 }
 
 template <class V>
-void PolylineStyleBuilder<V>::setup(const Marker& marker) {
+void PolylineStyleBuilder<V>::setup(const Marker& marker, int zoom) {
 
-    // Use the 'style zoom' to evaluate style parameters.
-    m_zoom = 0;
+    m_zoom = zoom;
     m_overzoom2 = 0;
-    m_tileUnitsPerMeter = 1; // FIXME
-    m_tileSizePixels = 256; //FIXME
+    m_tileUnitsPerMeter = 1.f / marker.extent();
+    float metersPerTile = MapProjection::HALF_CIRCUMFERENCE / (1 << zoom);
+    m_tileSizePixels = 256 * (marker.extent() / metersPerTile);
 
-    // When a tile is overzoomed, we are actually styling the area of its
-    // 'source' tile, which will have a larger effective pixel size at the
-    // 'style' zoom level. This scaling is performed in the vertex shader to
-    // prevent loss of precision for small dimensions in packed attributes.
 }
 
 template <class V>

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -204,7 +204,7 @@ void PolylineStyleBuilder<V>::setup(const Tile& tile) {
 
     // Use the 'style zoom' to evaluate style parameters.
     m_zoom = id.s;
-    m_overzoom2 = powf(2.f, id.s - id.z);
+    m_overzoom2 = exp2(id.s - id.z);
     m_tileUnitsPerMeter = tile.getInverseScale();
     m_tileSizePixels = tile.getProjection()->TileSize();
 
@@ -218,9 +218,13 @@ template <class V>
 void PolylineStyleBuilder<V>::setup(const Marker& marker, int zoom) {
 
     m_zoom = zoom;
-    m_overzoom2 = 0;
+    m_overzoom2 = 1.f;
     m_tileUnitsPerMeter = 1.f / marker.extent();
-    float metersPerTile = MapProjection::HALF_CIRCUMFERENCE / (1 << zoom);
+    float metersPerTile = 2.f * MapProjection::HALF_CIRCUMFERENCE * exp2(-zoom);
+
+    // In general, a Marker won't cover the same area as a tile, so the effective
+    // "tile size" for building a Marker is the size of a tile in pixels multiplied
+    // by the ratio of the Marker's extent to the length of a tile side at this zoom.
     m_tileSizePixels = 256 * (marker.extent() / metersPerTile);
 
 }

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -12,6 +12,7 @@
 #include "tile/tile.h"
 #include "data/dataSource.h"
 #include "view/view.h"
+#include "marker/marker.h"
 #include "tangram.h"
 
 #include "shaders/rasters_glsl.h"
@@ -305,6 +306,23 @@ void Style::draw(RenderState& rs, const Tile& _tile) {
             }
         }
     }
+}
+
+void Style::draw(RenderState& rs, const Marker& marker) {
+
+    if (marker.styleId() != m_id) { return; }
+
+    auto* mesh = marker.mesh();
+
+    if (!mesh) { return; }
+
+    m_shaderProgram->setUniformMatrix4f(rs, m_uModel, marker.modelMatrix());
+    m_shaderProgram->setUniformf(rs, m_uTileOrigin, marker.origin().x, marker.origin().y, 0, 0);
+
+    if (!mesh->draw(rs, *m_shaderProgram)) {
+        LOGN("Mesh built by style %s cannot be drawn", m_name.c_str());
+    }
+
 }
 
 bool StyleBuilder::checkRule(const DrawRule& _rule) const {

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -317,7 +317,8 @@ void Style::draw(RenderState& rs, const Marker& marker) {
     if (!mesh) { return; }
 
     m_shaderProgram->setUniformMatrix4f(rs, m_uModel, marker.modelMatrix());
-    m_shaderProgram->setUniformf(rs, m_uTileOrigin, marker.origin().x, marker.origin().y, 0, 0);
+    m_shaderProgram->setUniformf(rs, m_uTileOrigin, marker.origin().x, marker.origin().y,
+                                 marker.builtZoomLevel(), marker.builtZoomLevel());
 
     if (!mesh->draw(rs, *m_shaderProgram)) {
         LOGN("Mesh built by style %s cannot be drawn", m_name.c_str());

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -316,6 +316,8 @@ void Style::draw(RenderState& rs, const Marker& marker) {
 
     if (!mesh) { return; }
 
+    if (!marker.isVisible()) { return; }
+
     m_shaderProgram->setUniformMatrix4f(rs, m_uModel, marker.modelMatrix());
     m_shaderProgram->setUniformf(rs, m_uTileOrigin, marker.origin().x, marker.origin().y,
                                  marker.builtZoomLevel(), marker.builtZoomLevel());

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -20,6 +20,7 @@ class Tile;
 class MapProjection;
 class Material;
 struct MaterialUniforms;
+class Marker;
 class VertexLayout;
 class View;
 class Scene;
@@ -64,6 +65,8 @@ public:
     virtual ~StyleBuilder() = default;
 
     virtual void setup(const Tile& _tile) = 0;
+
+    virtual void setup(const Marker& _marker) = 0;
 
     virtual void addFeature(const Feature& _feat, const DrawRule& _rule);
 
@@ -241,6 +244,8 @@ public:
 
     /* Draws the geometry associated with this <Style> */
     virtual void draw(RenderState& rs, const Tile& _tile);
+
+    virtual void draw(RenderState& rs, const Marker& _marker);
 
     virtual void setLightingType(LightingType _lType);
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -66,7 +66,7 @@ public:
 
     virtual void setup(const Tile& _tile) = 0;
 
-    virtual void setup(const Marker& _marker) = 0;
+    virtual void setup(const Marker& _marker, int zoom) = 0;
 
     virtual void addFeature(const Feature& _feat, const DrawRule& _rule);
 

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -6,6 +6,7 @@
 #include "labels/textLabels.h"
 
 #include "data/propertyItem.h" // Include wherever Properties is used!
+#include "marker/marker.h"
 #include "scene/drawRule.h"
 #include "tile/tile.h"
 #include "util/geom.h"
@@ -32,6 +33,18 @@ void TextStyleBuilder::setup(const Tile& _tile){
 
     float tileScale = pow(2, _tile.getID().s - _tile.getID().z);
     m_tileSize *= tileScale;
+
+    // add scale factor to the next zoom-level
+    m_tileSize *= 2;
+
+    m_atlasRefs.reset();
+
+    m_textLabels = std::make_unique<TextLabels>(m_style);
+}
+
+void TextStyleBuilder::setup(const Marker& marker){
+    m_tileSize = 256; //FIXME
+    m_tileSize *= m_style.pixelScale();
 
     // add scale factor to the next zoom-level
     m_tileSize *= 2;

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -42,8 +42,9 @@ void TextStyleBuilder::setup(const Tile& _tile){
     m_textLabels = std::make_unique<TextLabels>(m_style);
 }
 
-void TextStyleBuilder::setup(const Marker& marker){
-    m_tileSize = 256; //FIXME
+void TextStyleBuilder::setup(const Marker& marker, int zoom) {
+    float metersPerTile = MapProjection::HALF_CIRCUMFERENCE / (1 << zoom);
+    m_tileSize = 256 * (marker.extent() / metersPerTile);
     m_tileSize *= m_style.pixelScale();
 
     // add scale factor to the next zoom-level

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -43,11 +43,15 @@ void TextStyleBuilder::setup(const Tile& _tile){
 }
 
 void TextStyleBuilder::setup(const Marker& marker, int zoom) {
-    float metersPerTile = MapProjection::HALF_CIRCUMFERENCE / (1 << zoom);
-    m_tileSize = 256 * (marker.extent() / metersPerTile);
-    m_tileSize *= m_style.pixelScale();
+    float metersPerTile = 2.f * MapProjection::HALF_CIRCUMFERENCE * exp2(-zoom);
 
-    // add scale factor to the next zoom-level
+    // In general, a Marker won't cover the same area as a tile, so the effective
+    // "tile size" for building a Marker is the size of a tile in pixels multiplied
+    // by the ratio of the Marker's extent to the length of a tile side at this zoom.
+    m_tileSize = 256 * (marker.extent() / metersPerTile);
+
+    // (Copied from Tile setup function above, purpose unclear)
+    m_tileSize *= m_style.pixelScale();
     m_tileSize *= 2;
 
     m_atlasRefs.reset();

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -27,6 +27,7 @@ public:
     bool addFeatureCommon(const Feature& _feature, const DrawRule& _rule, bool _iconText);
 
     void setup(const Tile& _tile) override;
+    void setup(const Marker& _marker) override;
 
     std::unique_ptr<StyledMesh> build() override;
 

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -27,7 +27,7 @@ public:
     bool addFeatureCommon(const Feature& _feature, const DrawRule& _rule, bool _iconText);
 
     void setup(const Tile& _tile) override;
-    void setup(const Marker& _marker) override;
+    void setup(const Marker& _marker, int zoom) override;
 
     std::unique_ptr<StyledMesh> build() override;
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -274,6 +274,7 @@ bool Map::update(float _dt) {
     impl->scene->updateTime(_dt);
 
     bool viewComplete = true;
+    bool markersNeedUpdate = false;
 
     for (auto& ease : impl->eases) {
         if (!ease.finished()) {
@@ -306,6 +307,7 @@ bool Map::update(float _dt) {
 
         for (const auto& marker : markers) {
             marker->update(_dt, impl->view);
+            markersNeedUpdate |= marker->isEasing();
         }
 
         if (impl->view.changedOnLastUpdate() ||
@@ -334,8 +336,8 @@ bool Map::update(float _dt) {
         viewComplete = false;
     }
 
-    // Request for render if labels are in fading in/out states
-    if (labelsNeedUpdate) { requestRender(); }
+    // Request render if labels are in fading states or markers are easing.
+    if (labelsNeedUpdate || markersNeedUpdate) { requestRender(); }
 
     return viewComplete;
 }
@@ -615,6 +617,10 @@ bool Map::markerRemove(Marker* _marker) {
 
 bool Map::markerSetPoint(Marker* _marker, LngLat _lngLat) {
     return impl->markerManager.setPoint(_marker, _lngLat);
+}
+
+bool Map::markerSetPointEased(Marker* _marker, LngLat _lngLat, float _duration, EaseType ease) {
+    return impl->markerManager.setPointEased(_marker, _lngLat, _duration, ease);
 }
 
 bool Map::markerSetPolyline(Marker* _marker, LngLat* _coordinates, int _count) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -609,8 +609,8 @@ void Map::clearDataSource(DataSource& _source, bool _data, bool _tiles) {
     requestRender();
 }
 
-MarkerID Map::markerAdd(const char* _styling) {
-    return impl->markerManager.add(_styling);
+MarkerID Map::markerAdd() {
+    return impl->markerManager.add();
 }
 
 bool Map::markerRemove(MarkerID _marker) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -609,47 +609,47 @@ void Map::clearDataSource(DataSource& _source, bool _data, bool _tiles) {
     requestRender();
 }
 
-Marker* Map::markerAdd(const char* _styling) {
+MarkerID Map::markerAdd(const char* _styling) {
     return impl->markerManager.add(_styling);
 }
 
-bool Map::markerRemove(Marker* _marker) {
+bool Map::markerRemove(MarkerID _marker) {
     bool success = impl->markerManager.remove(_marker);
     requestRender();
     return success;
 }
 
-bool Map::markerSetPoint(Marker* _marker, LngLat _lngLat) {
+bool Map::markerSetPoint(MarkerID _marker, LngLat _lngLat) {
     bool success = impl->markerManager.setPoint(_marker, _lngLat);
     requestRender();
     return success;
 }
 
-bool Map::markerSetPointEased(Marker* _marker, LngLat _lngLat, float _duration, EaseType ease) {
+bool Map::markerSetPointEased(MarkerID _marker, LngLat _lngLat, float _duration, EaseType ease) {
     bool success = impl->markerManager.setPointEased(_marker, _lngLat, _duration, ease);
     requestRender();
     return success;
 }
 
-bool Map::markerSetPolyline(Marker* _marker, LngLat* _coordinates, int _count) {
+bool Map::markerSetPolyline(MarkerID _marker, LngLat* _coordinates, int _count) {
     bool success = impl->markerManager.setPolyline(_marker, _coordinates, _count);
     requestRender();
     return success;
 }
 
-bool Map::markerSetPolygon(Marker* _marker, LngLat* _coordinates, int* _counts, int _rings) {
+bool Map::markerSetPolygon(MarkerID _marker, LngLat* _coordinates, int* _counts, int _rings) {
     bool success = impl->markerManager.setPolygon(_marker, _coordinates, _counts, _rings);
     requestRender();
     return success;
 }
 
-bool Map::markerSetStyling(Marker* _marker, const char* _styling) {
+bool Map::markerSetStyling(MarkerID _marker, const char* _styling) {
     bool success = impl->markerManager.setStyling(_marker, _styling);
     requestRender();
     return success;
 }
 
-bool Map::markerSetVisible(Marker* _marker, bool _visible) {
+bool Map::markerSetVisible(MarkerID _marker, bool _visible) {
     bool success = impl->markerManager.setVisible(_marker, _visible);
     requestRender();
     return success;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -611,15 +611,15 @@ bool Map::markerRemove(Marker* _marker) {
     return impl->markerManager.remove(_marker);
 }
 
-bool Map::markerSetPoint(Marker* _marker, double _lng, double _lat) {
-    return impl->markerManager.setPoint(_marker, _lng, _lat);
+bool Map::markerSetPoint(Marker* _marker, LngLat _lngLat) {
+    return impl->markerManager.setPoint(_marker, _lngLat);
 }
 
-bool Map::markerSetPolyline(Marker* _marker, double* _coordinates, int _count) {
+bool Map::markerSetPolyline(Marker* _marker, LngLat* _coordinates, int _count) {
     return impl->markerManager.setPolyline(_marker, _coordinates, _count);
 }
 
-bool Map::markerSetPolygon(Marker* _marker, double** _coordinates, int* _counts, int _rings) {
+bool Map::markerSetPolygon(Marker* _marker, LngLat* _coordinates, int* _counts, int _rings) {
     return impl->markerManager.setPolygon(_marker, _coordinates, _counts, _rings);
 }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -614,27 +614,39 @@ Marker* Map::markerAdd(const char* _styling) {
 }
 
 bool Map::markerRemove(Marker* _marker) {
-    return impl->markerManager.remove(_marker);
+    bool success = impl->markerManager.remove(_marker);
+    requestRender();
+    return success;
 }
 
 bool Map::markerSetPoint(Marker* _marker, LngLat _lngLat) {
-    return impl->markerManager.setPoint(_marker, _lngLat);
+    bool success = impl->markerManager.setPoint(_marker, _lngLat);
+    requestRender();
+    return success;
 }
 
 bool Map::markerSetPointEased(Marker* _marker, LngLat _lngLat, float _duration, EaseType ease) {
-    return impl->markerManager.setPointEased(_marker, _lngLat, _duration, ease);
+    bool success = impl->markerManager.setPointEased(_marker, _lngLat, _duration, ease);
+    requestRender();
+    return success;
 }
 
 bool Map::markerSetPolyline(Marker* _marker, LngLat* _coordinates, int _count) {
-    return impl->markerManager.setPolyline(_marker, _coordinates, _count);
+    bool success = impl->markerManager.setPolyline(_marker, _coordinates, _count);
+    requestRender();
+    return success;
 }
 
 bool Map::markerSetPolygon(Marker* _marker, LngLat* _coordinates, int* _counts, int _rings) {
-    return impl->markerManager.setPolygon(_marker, _coordinates, _counts, _rings);
+    bool success = impl->markerManager.setPolygon(_marker, _coordinates, _counts, _rings);
+    requestRender();
+    return success;
 }
 
 bool Map::markerSetStyling(Marker* _marker, const char* _styling) {
-    return impl->markerManager.setStyling(_marker, _styling);
+    bool success = impl->markerManager.setStyling(_marker, _styling);
+    requestRender();
+    return success;
 }
 
 void Map::handleTapGesture(float _posX, float _posY) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -649,6 +649,11 @@ bool Map::markerSetStyling(Marker* _marker, const char* _styling) {
     return success;
 }
 
+void Map::markerRemoveAll() {
+    impl->markerManager.removeAll();
+    requestRender();
+}
+
 void Map::handleTapGesture(float _posX, float _posY) {
 
     impl->inputHandler.handleTapGesture(_posX, _posY);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -304,14 +304,15 @@ bool Map::update(float _dt) {
         auto& tiles = impl->tileManager.getVisibleTiles();
         auto& markers = impl->markerManager.markers();
 
+        for (const auto& marker : markers) {
+            marker->update(_dt, impl->view);
+        }
+
         if (impl->view.changedOnLastUpdate() ||
             impl->tileManager.hasTileSetChanged()) {
 
             for (const auto& tile : tiles) {
                 tile->update(_dt, impl->view);
-            }
-            for (const auto& marker : markers) {
-                marker->update(_dt, impl->view);
             }
             impl->labels.updateLabelSet(impl->view, _dt, impl->scene->styles(), tiles, markers,
                                         *impl->tileManager.getTileCache());

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -287,6 +287,8 @@ bool Map::update(float _dt) {
 
     impl->view.update();
 
+    impl->markerManager.update(static_cast<int>(impl->view.getZoom()));
+
     for (const auto& style : impl->scene->styles()) {
         style->onBeginUpdate();
     }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -649,6 +649,12 @@ bool Map::markerSetStyling(Marker* _marker, const char* _styling) {
     return success;
 }
 
+bool Map::markerSetVisible(Marker* _marker, bool _visible) {
+    bool success = impl->markerManager.setVisible(_marker, _visible);
+    requestRender();
+    return success;
+}
+
 void Map::markerRemoveAll() {
     impl->markerManager.removeAll();
     requestRender();

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -302,6 +302,7 @@ bool Map::update(float _dt) {
         impl->tileManager.updateTileSets(viewState, impl->view.getVisibleTiles());
 
         auto& tiles = impl->tileManager.getVisibleTiles();
+        auto& markers = impl->markerManager.markers();
 
         if (impl->view.changedOnLastUpdate() ||
             impl->tileManager.hasTileSetChanged()) {
@@ -309,13 +310,13 @@ bool Map::update(float _dt) {
             for (const auto& tile : tiles) {
                 tile->update(_dt, impl->view);
             }
-            for (const auto& marker : impl->markerManager.markers()) {
+            for (const auto& marker : markers) {
                 marker->update(_dt, impl->view);
             }
-            impl->labels.updateLabelSet(impl->view, _dt, impl->scene->styles(), tiles,
+            impl->labels.updateLabelSet(impl->view, _dt, impl->scene->styles(), tiles, markers,
                                         *impl->tileManager.getTileCache());
         } else {
-            impl->labels.updateLabels(impl->view, _dt, impl->scene->styles(), tiles);
+            impl->labels.updateLabels(impl->view, _dt, impl->scene->styles(), tiles, markers);
         }
     }
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -9,6 +9,7 @@
 namespace Tangram {
 
 class DataSource;
+class Marker;
 
 struct TouchItem {
     std::shared_ptr<Properties> properties;
@@ -147,6 +148,18 @@ public:
     bool removeDataSource(DataSource& _source);
 
     void clearDataSource(DataSource& _source, bool _data, bool _tiles);
+
+    Marker* markerAdd(const char* _styling);
+
+    bool markerRemove(Marker* _marker);
+
+    bool markerSetPoint(Marker* _marker, double _lng, double _lat);
+
+    bool markerSetPolyline(Marker* _marker, double* _coordinates, int _count);
+
+    bool markerSetPolygon(Marker* _marker, double** _coordinates, int* _counts, int _rings);
+
+    bool markerSetStyling(Marker* _marker, const char* _styling);
 
     // Respond to a tap at the given screen coordinates (x right, y down)
     void handleTapGesture(float _posX, float _posY);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -150,18 +150,43 @@ public:
 
     void clearDataSource(DataSource& _source, bool _data, bool _tiles);
 
+    // Add a marker object to the map and return a handle to it; _styling is a string of YAML
+    // that specifies a 'draw rule' according to the scene file syntax; The marker will not be
+    // drawn until it a point, line, or polygon is set for it with one of the functions below.
     Marker* markerAdd(const char* _styling);
 
+    // Remove a marker object from the map; returns true if the marker handle was found and
+    // successfully removed, otherwise returns false.
     bool markerRemove(Marker* _marker);
 
+    // Set the geometry of a marker to a point at the given coordinates; markers can have their
+    // geometry set multiple times with possibly different geometry types; returns true if the
+    // marker handle was found and successfully updated, otherwise returns false.
     bool markerSetPoint(Marker* _marker, LngLat _lngLat);
 
+    // Set the position of a marker with point geometry to ease to a new location over a duration
+    // in seconds with the given EaseType; returns true if the marker handle was found and has a
+    // point geometry, otherwise returns false.
     bool markerSetPointEased(Marker* _marker, LngLat _lngLat, float _duration, EaseType _ease);
 
+    // Set the geometry of a marker to a polyline along the given coordinates; _coordinates is a
+    // pointer to a sequence of _count LngLats; markers can have their geometry set multiple times
+    // with possibly different geometry types; returns true if the marker handle was found and
+    // successfully updated, otherwise returns false.
     bool markerSetPolyline(Marker* _marker, LngLat* _coordinates, int _count);
 
+    // Set the geometry of a marker to a polygon with the given coordinates; _counts is a pointer
+    // to a sequence of _rings integers and _coordinates is a pointer to a sequence of LngLats with
+    // a total length equal to the sum of _counts; for each integer n in _counts, a polygon is created
+    // by taking the next n LngLats from _coordinates, with winding order and internal polygons
+    // behaving according to the GeoJSON specification; markers can have their geometry set multiple
+    // times with possibly different geometry types; returns true if the marker handle was found and
+    // successfully updated, otherwise returns false.
     bool markerSetPolygon(Marker* _marker, LngLat* _coordinates, int* _counts, int _rings);
 
+    // Set the styling for a marker object; _styling is a string of YAML that specifies a 'draw rule'
+    // according to the scene file syntax; returns true if the marker handle was found and successfully
+    // updated, otherwise returns false.
     bool markerSetStyling(Marker* _marker, const char* _styling);
 
     // Respond to a tap at the given screen coordinates (x right, y down)

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -156,6 +156,8 @@ public:
 
     bool markerSetPoint(Marker* _marker, LngLat _lngLat);
 
+    bool markerSetPointEased(Marker* _marker, LngLat _lngLat, float _duration, EaseType _ease);
+
     bool markerSetPolyline(Marker* _marker, LngLat* _coordinates, int _count);
 
     bool markerSetPolygon(Marker* _marker, LngLat* _coordinates, int* _counts, int _rings);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "data/properties.h"
+#include "util/types.h"
 #include <functional>
 #include <memory>
 #include <string>
@@ -153,11 +154,11 @@ public:
 
     bool markerRemove(Marker* _marker);
 
-    bool markerSetPoint(Marker* _marker, double _lng, double _lat);
+    bool markerSetPoint(Marker* _marker, LngLat _lngLat);
 
-    bool markerSetPolyline(Marker* _marker, double* _coordinates, int _count);
+    bool markerSetPolyline(Marker* _marker, LngLat* _coordinates, int _count);
 
-    bool markerSetPolygon(Marker* _marker, double** _coordinates, int* _counts, int _rings);
+    bool markerSetPolygon(Marker* _marker, LngLat* _coordinates, int* _counts, int _rings);
 
     bool markerSetStyling(Marker* _marker, const char* _styling);
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -189,6 +189,10 @@ public:
     // updated, otherwise returns false.
     bool markerSetStyling(Marker* _marker, const char* _styling);
 
+    // Remove all marker objects from the map; Any marker handles previously returned from 'markerAdd'
+    // are invalidated after this.
+    void markerRemoveAll();
+
     // Respond to a tap at the given screen coordinates (x right, y down)
     void handleTapGesture(float _posX, float _posY);
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -167,9 +167,9 @@ public:
     // marker handle was found and successfully updated, otherwise returns false.
     bool markerSetPoint(MarkerID _marker, LngLat _lngLat);
 
-    // Set the position of a marker with point geometry to ease to a new location over a duration
-    // in seconds with the given EaseType; returns true if the marker handle was found and has a
-    // point geometry, otherwise returns false.
+    // Set the geometry of a marker to a point at the given coordinates; if the marker was previously
+    // set to a point, this eases the position over the given duration in seconds with the given EaseType;
+    // returns true if the marker handle was found and successfully updated, otherwise returns false.
     bool markerSetPointEased(MarkerID _marker, LngLat _lngLat, float _duration, EaseType _ease);
 
     // Set the geometry of a marker to a polyline along the given coordinates; _coordinates is a

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -10,7 +10,6 @@
 namespace Tangram {
 
 class DataSource;
-class Marker;
 
 struct TouchItem {
     std::shared_ptr<Properties> properties;
@@ -153,27 +152,27 @@ public:
     // Add a marker object to the map and return a handle to it; _styling is a string of YAML
     // that specifies a 'draw rule' according to the scene file syntax; The marker will not be
     // drawn until it a point, line, or polygon is set for it with one of the functions below.
-    Marker* markerAdd(const char* _styling);
+    MarkerID markerAdd(const char* _styling);
 
     // Remove a marker object from the map; returns true if the marker handle was found and
     // successfully removed, otherwise returns false.
-    bool markerRemove(Marker* _marker);
+    bool markerRemove(MarkerID _marker);
 
     // Set the geometry of a marker to a point at the given coordinates; markers can have their
     // geometry set multiple times with possibly different geometry types; returns true if the
     // marker handle was found and successfully updated, otherwise returns false.
-    bool markerSetPoint(Marker* _marker, LngLat _lngLat);
+    bool markerSetPoint(MarkerID _marker, LngLat _lngLat);
 
     // Set the position of a marker with point geometry to ease to a new location over a duration
     // in seconds with the given EaseType; returns true if the marker handle was found and has a
     // point geometry, otherwise returns false.
-    bool markerSetPointEased(Marker* _marker, LngLat _lngLat, float _duration, EaseType _ease);
+    bool markerSetPointEased(MarkerID _marker, LngLat _lngLat, float _duration, EaseType _ease);
 
     // Set the geometry of a marker to a polyline along the given coordinates; _coordinates is a
     // pointer to a sequence of _count LngLats; markers can have their geometry set multiple times
     // with possibly different geometry types; returns true if the marker handle was found and
     // successfully updated, otherwise returns false.
-    bool markerSetPolyline(Marker* _marker, LngLat* _coordinates, int _count);
+    bool markerSetPolyline(MarkerID _marker, LngLat* _coordinates, int _count);
 
     // Set the geometry of a marker to a polygon with the given coordinates; _counts is a pointer
     // to a sequence of _rings integers and _coordinates is a pointer to a sequence of LngLats with
@@ -182,16 +181,16 @@ public:
     // behaving according to the GeoJSON specification; markers can have their geometry set multiple
     // times with possibly different geometry types; returns true if the marker handle was found and
     // successfully updated, otherwise returns false.
-    bool markerSetPolygon(Marker* _marker, LngLat* _coordinates, int* _counts, int _rings);
+    bool markerSetPolygon(MarkerID _marker, LngLat* _coordinates, int* _counts, int _rings);
 
     // Set the styling for a marker object; _styling is a string of YAML that specifies a 'draw rule'
     // according to the scene file syntax; returns true if the marker handle was found and successfully
     // updated, otherwise returns false.
-    bool markerSetStyling(Marker* _marker, const char* _styling);
+    bool markerSetStyling(MarkerID _marker, const char* _styling);
 
     // Set the visibility of a marker object; returns true if the marker handle was found and successfully
     // updated, otherwise returns false.
-    bool markerSetVisible(Marker* _marker, bool _visible);
+    bool markerSetVisible(MarkerID _marker, bool _visible);
 
     // Remove all marker objects from the map; Any marker handles previously returned from 'markerAdd'
     // are invalidated after this.

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -149,14 +149,18 @@ public:
 
     void clearDataSource(DataSource& _source, bool _data, bool _tiles);
 
-    // Add a marker object to the map and return a handle to it; _styling is a string of YAML
-    // that specifies a 'draw rule' according to the scene file syntax; The marker will not be
-    // drawn until it a point, line, or polygon is set for it with one of the functions below.
-    MarkerID markerAdd(const char* _styling);
+    // Add a marker object to the map and return a handle to it; the marker will not be
+    // drawn until both styling and geometry are set using the functions below.
+    MarkerID markerAdd();
 
     // Remove a marker object from the map; returns true if the marker handle was found and
     // successfully removed, otherwise returns false.
     bool markerRemove(MarkerID _marker);
+
+    // Set the styling for a marker object; _styling is a string of YAML that specifies a 'draw rule'
+    // according to the scene file syntax; returns true if the marker handle was found and successfully
+    // updated, otherwise returns false.
+    bool markerSetStyling(MarkerID _marker, const char* _styling);
 
     // Set the geometry of a marker to a point at the given coordinates; markers can have their
     // geometry set multiple times with possibly different geometry types; returns true if the
@@ -182,11 +186,6 @@ public:
     // times with possibly different geometry types; returns true if the marker handle was found and
     // successfully updated, otherwise returns false.
     bool markerSetPolygon(MarkerID _marker, LngLat* _coordinates, int* _counts, int _rings);
-
-    // Set the styling for a marker object; _styling is a string of YAML that specifies a 'draw rule'
-    // according to the scene file syntax; returns true if the marker handle was found and successfully
-    // updated, otherwise returns false.
-    bool markerSetStyling(MarkerID _marker, const char* _styling);
 
     // Set the visibility of a marker object; returns true if the marker handle was found and successfully
     // updated, otherwise returns false.

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -149,32 +149,32 @@ public:
 
     void clearDataSource(DataSource& _source, bool _data, bool _tiles);
 
-    // Add a marker object to the map and return a handle to it; the marker will not be
-    // drawn until both styling and geometry are set using the functions below.
+    // Add a marker object to the map and return an ID for it; an ID of 0 indicates an invalid marker;
+    // the marker will not be drawn until both styling and geometry are set using the functions below.
     MarkerID markerAdd();
 
-    // Remove a marker object from the map; returns true if the marker handle was found and
-    // successfully removed, otherwise returns false.
+    // Remove a marker object from the map; returns true if the marker ID was found and successfully
+    // removed, otherwise returns false.
     bool markerRemove(MarkerID _marker);
 
     // Set the styling for a marker object; _styling is a string of YAML that specifies a 'draw rule'
-    // according to the scene file syntax; returns true if the marker handle was found and successfully
+    // according to the scene file syntax; returns true if the marker ID was found and successfully
     // updated, otherwise returns false.
     bool markerSetStyling(MarkerID _marker, const char* _styling);
 
     // Set the geometry of a marker to a point at the given coordinates; markers can have their
     // geometry set multiple times with possibly different geometry types; returns true if the
-    // marker handle was found and successfully updated, otherwise returns false.
+    // marker ID was found and successfully updated, otherwise returns false.
     bool markerSetPoint(MarkerID _marker, LngLat _lngLat);
 
     // Set the geometry of a marker to a point at the given coordinates; if the marker was previously
     // set to a point, this eases the position over the given duration in seconds with the given EaseType;
-    // returns true if the marker handle was found and successfully updated, otherwise returns false.
+    // returns true if the marker ID was found and successfully updated, otherwise returns false.
     bool markerSetPointEased(MarkerID _marker, LngLat _lngLat, float _duration, EaseType _ease);
 
     // Set the geometry of a marker to a polyline along the given coordinates; _coordinates is a
     // pointer to a sequence of _count LngLats; markers can have their geometry set multiple times
-    // with possibly different geometry types; returns true if the marker handle was found and
+    // with possibly different geometry types; returns true if the marker ID was found and
     // successfully updated, otherwise returns false.
     bool markerSetPolyline(MarkerID _marker, LngLat* _coordinates, int _count);
 
@@ -183,15 +183,15 @@ public:
     // a total length equal to the sum of _counts; for each integer n in _counts, a polygon is created
     // by taking the next n LngLats from _coordinates, with winding order and internal polygons
     // behaving according to the GeoJSON specification; markers can have their geometry set multiple
-    // times with possibly different geometry types; returns true if the marker handle was found and
+    // times with possibly different geometry types; returns true if the marker ID was found and
     // successfully updated, otherwise returns false.
     bool markerSetPolygon(MarkerID _marker, LngLat* _coordinates, int* _counts, int _rings);
 
-    // Set the visibility of a marker object; returns true if the marker handle was found and successfully
+    // Set the visibility of a marker object; returns true if the marker ID was found and successfully
     // updated, otherwise returns false.
     bool markerSetVisible(MarkerID _marker, bool _visible);
 
-    // Remove all marker objects from the map; Any marker handles previously returned from 'markerAdd'
+    // Remove all marker objects from the map; Any marker IDs previously returned from 'markerAdd'
     // are invalidated after this.
     void markerRemoveAll();
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -189,6 +189,10 @@ public:
     // updated, otherwise returns false.
     bool markerSetStyling(Marker* _marker, const char* _styling);
 
+    // Set the visibility of a marker object; returns true if the marker handle was found and successfully
+    // updated, otherwise returns false.
+    bool markerSetVisible(Marker* _marker, bool _visible);
+
     // Remove all marker objects from the map; Any marker handles previously returned from 'markerAdd'
     // are invalidated after this.
     void markerRemoveAll();

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -66,6 +66,10 @@ struct BoundingBox {
     bool containsX(double x) const { return x >= min.x && x <= max.x; }
     bool containsY(double y) const { return y >= min.y && y <= max.y; }
     bool contains(double x, double y) const { return containsX(x) && containsY(y); }
+    void expand(double x, double y) {
+        min = { glm::min(min.x, x), glm::min(min.y, y) };
+        max = { glm::max(max.x, x), glm::max(max.y, y) };
+    }
 };
 
 template<class InputIt>

--- a/core/src/util/types.h
+++ b/core/src/util/types.h
@@ -35,4 +35,6 @@ struct LngLat {
 
 typedef std::vector<LngLat> Coordinates;
 
+typedef uint32_t MarkerID;
+
 }

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -12,6 +12,8 @@ void init_main_window(bool recreate);
 
 std::string sceneFile = "scene.yaml";
 
+std::string markerStyling = "{ style: 'lines', color: 'purple', width: 10px, order: 100 }";
+
 GLFWwindow* main_window = nullptr;
 Tangram::Map* map = nullptr;
 int width = 800;
@@ -41,6 +43,8 @@ using namespace Tangram;
 
 std::shared_ptr<ClientGeoJsonSource> data_source;
 LngLat last_point;
+std::vector<LngLat> taps;
+Marker* marker = nullptr;
 
 template<typename T>
 static constexpr T clamp(T val, T min, T max) {
@@ -96,21 +100,18 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
         // Single tap recognized
         LngLat p1;
         map->screenPositionToLngLat(x, y, &p1.longitude, &p1.latitude);
+        taps.push_back(p1);
 
         if (!(last_point == LngLat{0, 0})) {
             LngLat p2 = last_point;
-            logMsg("add line %f %f - %f %f\n",
+            logMsg("add line (%f, %f)  (%f, %f)\n",
                    p1.longitude, p1.latitude,
                    p2.longitude, p2.latitude);
 
-            // data_source->addLine(Properties{{"type", "line" }}, {p1, p2});
-            // data_source->addPoint(Properties{{"type", "point" }}, p2);
-            Properties prop1;
-            prop1.set("type", "line");
-            data_source->addLine(prop1, {p1, p2});
-            Properties prop2;
-            prop2.set("type", "point");
-            data_source->addPoint(prop2, p2);
+            if (!marker) {
+                marker = map->markerAdd(markerStyling.c_str());
+            }
+            map->markerSetPolyline(marker, taps.data(), taps.size());
         }
         last_point = p1;
 

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -109,7 +109,8 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
                    p2.longitude, p2.latitude);
 
             if (!marker) {
-                marker = map->markerAdd(markerStyling.c_str());
+                marker = map->markerAdd();
+                map->markerSetStyling(marker, markerStyling.c_str());
             }
             map->markerSetPolyline(marker, taps.data(), taps.size());
         }

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -44,7 +44,7 @@ using namespace Tangram;
 std::shared_ptr<ClientGeoJsonSource> data_source;
 LngLat last_point;
 std::vector<LngLat> taps;
-Marker* marker = nullptr;
+MarkerID marker = 0;
 
 template<typename T>
 static constexpr T clamp(T val, T min, T max) {


### PR DESCRIPTION
This adds the concept of 'Markers' to the tangram-es C++ interface. A Marker represents a single feature on the map that can be programmatically added, removed, and manipulated. Markers can be either point, polyline, or polygon geometries. These geometries can be styled using the same options available in the scene file syntax. Users will interact with Markers through new functions in the `Map` class (defined in `tangram.h`): https://github.com/tangrams/tangram-es/blob/marker/core/src/tangram.h#L153-L190

TODO:

 - [x] Compile JS functions defined in marker draw rules
 - [x] ~~Allow user-defined data to be associated with markers~~ (not needed now)
 - [x] ~~Define an ordering among marker labels~~ (`blend_order` is sufficient for current needs)
 - [x] Document Marker and MarkerManager classes
 - [x] Add `markerRemoveAll()` to allow removal of markers whose handles are lost
 - [x] Add `markerSetVisible(Marker* marker, bool visible)` to conveniently toggle marker visibility.

Design questions:

 - Should users get and retain a `Marker*` (currently the case) or an integer handle? An integer handle would remove all concern of holding a pointer to a freed object, but we'd have think about whether integers are recycled and whether that would be confusing. *Resolved: We now use non-decreasing integer handles.*

 - Should location easing be enabled for polyline and polygon Markers? Currently I've only enabled location easing for point Markers, since it's unambiguous what it means to move a point geometry to a destination coordinate. For polylines and polygons, this would currently move the 'origin' of the geometry (the SW corner of the bounding box) to the destination coordinate, which might be more confusing than useful. *Resolved: We only allow easing for point markers, and setting a point ease for a marker with no point geometry will create a point geometry*.

Follow-up work:

 - Add a convenience method for adding custom bitmap data to a Marker
 - Add Android interface for Markers
 - Add iOS interface for Markers
