### PR TITLE
Add configurable 'max_tilt' for cameras

### DIFF
--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -37,6 +37,9 @@ public:
     struct Camera {
         CameraType type;
 
+        float maxTilt = 90.f;
+        std::shared_ptr<Stops> maxTiltStops;
+
         // perspective
         glm::vec2 vanishingPoint = {0, 0};
         float fieldOfView = 0.25 * PI;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1176,6 +1176,14 @@ void SceneLoader::loadCamera(const Node& _camera, const std::shared_ptr<Scene>& 
         z = zoom.as<float>();
     }
 
+    if (Node maxTilt = _camera["max_tilt"]) {
+        if (maxTilt.IsSequence()) {
+            camera.maxTiltStops = std::make_shared<Stops>(Stops::Numbers(maxTilt));
+        } else if (maxTilt.IsScalar()) {
+            camera.maxTilt = maxTilt.as<float>(PI);
+        }
+    }
+
     _scene->startPosition = glm::dvec2(x, y);
     _scene->startZoom = z;
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -123,6 +123,12 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
         break;
     }
 
+    if (camera.maxTiltStops) {
+        view.setMaxPitchStops(camera.maxTiltStops);
+    } else {
+        view.setMaxPitch(camera.maxTilt);
+    }
+
     if (scene->useScenePosition) {
         glm::dvec2 projPos = view.getMapProjection().LonLatToMeters(scene->startPosition);
         view.setPosition(projPos.x, projPos.y);

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -127,6 +127,32 @@ float View::getFocalLength() const {
 
 }
 
+
+void View::setMaxPitch(float degrees) {
+
+    m_maxPitch = degrees;
+    m_maxPitchStops = nullptr;
+    setPitch(m_pitch);
+
+}
+
+void View::setMaxPitchStops(std::shared_ptr<Stops> stops) {
+
+    m_maxPitchStops = stops;
+    setPitch(m_pitch);
+
+}
+
+float View::getMaxPitch() const {
+
+    if (m_maxPitchStops) {
+        return m_maxPitchStops->evalFloat(m_zoom);
+    }
+    return m_maxPitch;
+
+}
+
+
 void View::setPosition(double _x, double _y) {
 
     m_pos.x = _x;
@@ -152,12 +178,12 @@ void View::setRoll(float _roll) {
 
 void View::setPitch(float _pitch) {
 
-    float max_pitch = HALF_PI;
+    float maxPitchRadians = glm::radians(getMaxPitch());
     if (m_type != CameraType::perspective) {
         // Prevent projection plane from intersecting ground plane
-        max_pitch = atan2(m_pos.z, m_height * .5f);
+        maxPitchRadians = atan2(m_pos.z, m_height * .5f);
     }
-    m_pitch = glm::clamp(_pitch, 0.f, max_pitch);
+    m_pitch = glm::clamp(_pitch, 0.f, maxPitchRadians);
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
 
@@ -198,10 +224,11 @@ void View::update(bool _constrainToWorldBounds) {
         m_zoom -= std::log(m_constraint.getConstrainedScale()) / std::log(2);
     }
 
+    setPitch(m_pitch); // Ensure pitch is still valid for viewport
+
     if (m_dirtyMatrices) {
 
         updateMatrices(); // Resets dirty flag
-        setPitch(m_pitch); // Ensure pitch is still valid for viewport
         m_changed = true;
 
     }

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -71,6 +71,15 @@ public:
     // field-of-view angle.
     float getFocalLength() const;
 
+    // Set the maximum pitch angle in degrees.
+    void setMaxPitch(float degrees);
+
+    // Set the maximum pitch angle in degrees as a series of stops over zooms.
+    void setMaxPitchStops(std::shared_ptr<Stops> stops);
+
+    // Get the maximum pitch angle for the current zoom.
+    float getMaxPitch() const;
+
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
      * If unset, default is 1.0
      */
@@ -182,6 +191,7 @@ protected:
 
     std::shared_ptr<MapProjection> m_projection;
     std::shared_ptr<Stops> m_fovStops;
+    std::shared_ptr<Stops> m_maxPitchStops;
     std::set<TileID> m_visibleTiles;
 
     ViewConstraint m_constraint;
@@ -212,6 +222,7 @@ protected:
     float m_aspect;
     float m_pixelScale = 1.0f;
     float m_fov = 0.25 * PI;
+    float m_maxPitch = 0.5 * PI;
 
     CameraType m_type;
 

--- a/scenes/scene.yaml
+++ b/scenes/scene.yaml
@@ -26,6 +26,7 @@ cameras:
         position: [-74.00976419448854, 40.70532700869127, 16]
         type: perspective
         fov: 45
+        max_tilt: [[2, 0], [16, 90]]
         active: true
 
 lights:


### PR DESCRIPTION
This enables a new parameter for the `camera` or `cameras` block of a scene file:  a `max_tilt` value given in degrees from vertical.
```yaml
camera:
  position: [-74.010, 40.705, 16]
  type: perspective
  max_tilt: 60 # Limits camera tilt to 60 degrees from vertical
```
The `max_tilt` parameter can also be given as a series of 'stops':
```yaml
camera:
  position: [-74.010, 40.705, 16]
  type: perspective
  max_tilt: [[2, 0], [16, 70]] # Max tilt goes from 0 degrees at zoom 2 to 70 at zoom 16
```
The default value for `max_tilt` is 90 degrees, but for `isometric` cameras the tilt is further constrained at high zooms to prevent the viewing plane from intersecting the ground. 

Resolves https://github.com/tangrams/tangram-es/issues/934.