### PR TITLE
min_display_zoom & max_display_zoom

### DIFF
--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -32,8 +32,9 @@ Point transformPoint(geojsonvt::TilePoint pt) {
 }
 
 // TODO: pass scene's resourcePath to constructor to be used with `stringFromFile`
-ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _minDisplayZoom, int32_t _maxZoom)
-    : DataSource(_name, _url, _minDisplayZoom, _maxZoom) {
+ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url,
+                                         int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom)
+    : DataSource(_name, _url, _minDisplayZoom, _maxDisplayZoom, _maxZoom) {
 
     // TODO: handle network url for client datasource data
     // TODO: generic uri handling

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -32,8 +32,8 @@ Point transformPoint(geojsonvt::TilePoint pt) {
 }
 
 // TODO: pass scene's resourcePath to constructor to be used with `stringFromFile`
-ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _minZoom, int32_t _maxZoom)
-    : DataSource(_name, _url, _minZoom, _maxZoom) {
+ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _minDisplayZoom, int32_t _maxZoom)
+    : DataSource(_name, _url, _minDisplayZoom, _maxZoom) {
 
     // TODO: handle network url for client datasource data
     // TODO: generic uri handling

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -32,8 +32,8 @@ Point transformPoint(geojsonvt::TilePoint pt) {
 }
 
 // TODO: pass scene's resourcePath to constructor to be used with `stringFromFile`
-ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom)
-    : DataSource(_name, _url, _maxZoom) {
+ClientGeoJsonSource::ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _minZoom, int32_t _maxZoom)
+    : DataSource(_name, _url, _minZoom, _maxZoom) {
 
     // TODO: handle network url for client datasource data
     // TODO: generic uri handling

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -23,7 +23,7 @@ class ClientGeoJsonSource : public DataSource {
 
 public:
 
-    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _maxZoom = 18);
+    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _minZoom = 0, int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -23,7 +23,8 @@ class ClientGeoJsonSource : public DataSource {
 
 public:
 
-    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _minDisplayZoom = 0, int32_t _maxZoom = 18);
+    ClientGeoJsonSource(const std::string& _name, const std::string& _url,
+                        int32_t _minDisplayZoom = 0, int32_t _maxDisplayZoom = INT32_MAX, int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -23,7 +23,7 @@ class ClientGeoJsonSource : public DataSource {
 
 public:
 
-    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _minZoom = 0, int32_t _maxZoom = 18);
+    ClientGeoJsonSource(const std::string& _name, const std::string& _url, int32_t _minDisplayZoom = 0, int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/data/clientGeoJsonSource.h
+++ b/core/src/data/clientGeoJsonSource.h
@@ -24,7 +24,7 @@ class ClientGeoJsonSource : public DataSource {
 public:
 
     ClientGeoJsonSource(const std::string& _name, const std::string& _url,
-                        int32_t _minDisplayZoom = 0, int32_t _maxDisplayZoom = INT32_MAX, int32_t _maxZoom = 18);
+                        int32_t _minDisplayZoom = -1, int32_t _maxDisplayZoom = -1, int32_t _maxZoom = 18);
     ~ClientGeoJsonSource();
 
     // Add geometry from a GeoJSON string

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -88,8 +88,8 @@ struct RawCache {
     }
 };
 
-DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom) :
-    m_name(_name), m_minZoom(_minZoom), m_maxZoom(_maxZoom), m_urlTemplate(_urlTemplate),
+DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom) :
+    m_name(_name), m_urlTemplate(_urlTemplate), m_minDisplayZoom(_minDisplayZoom), m_maxZoom(_maxZoom),
     m_cache(std::make_unique<RawCache>()){
 
     static std::atomic<int32_t> s_serial;
@@ -143,7 +143,7 @@ void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const
 bool DataSource::equals(const DataSource& other) const {
     if (m_name != other.m_name) { return false; }
     if (m_urlTemplate != other.m_urlTemplate) { return false; }
-    if (m_minZoom != other.m_minZoom) { return false; }
+    if (m_minDisplayZoom != other.m_minDisplayZoom) { return false; }
     if (m_maxZoom != other.m_maxZoom) { return false; }
     if (m_rasterSources.size() != other.m_rasterSources.size()) { return false; }
     for (size_t i = 0, end = m_rasterSources.size(); i < end; ++i) {

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -88,8 +88,8 @@ struct RawCache {
     }
 };
 
-DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom) :
-    m_name(_name), m_maxZoom(_maxZoom), m_urlTemplate(_urlTemplate),
+DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom) :
+    m_name(_name), m_minZoom(_minZoom), m_maxZoom(_maxZoom), m_urlTemplate(_urlTemplate),
     m_cache(std::make_unique<RawCache>()){
 
     static std::atomic<int32_t> s_serial;

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -88,8 +88,10 @@ struct RawCache {
     }
 };
 
-DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom) :
-    m_name(_name), m_urlTemplate(_urlTemplate), m_minDisplayZoom(_minDisplayZoom), m_maxZoom(_maxZoom),
+DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate,
+                       int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom) :
+    m_name(_name), m_urlTemplate(_urlTemplate),
+    m_minDisplayZoom(_minDisplayZoom), m_maxDisplayZoom(_maxDisplayZoom), m_maxZoom(_maxZoom),
     m_cache(std::make_unique<RawCache>()){
 
     static std::atomic<int32_t> s_serial;

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -143,6 +143,7 @@ void DataSource::constructURL(const TileID& _tileCoord, std::string& _url) const
 bool DataSource::equals(const DataSource& other) const {
     if (m_name != other.m_name) { return false; }
     if (m_urlTemplate != other.m_urlTemplate) { return false; }
+    if (m_minZoom != other.m_minZoom) { return false; }
     if (m_maxZoom != other.m_maxZoom) { return false; }
     if (m_rasterSources.size() != other.m_rasterSources.size()) { return false; }
     for (size_t i = 0, end = m_rasterSources.size(); i < end; ++i) {

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -212,4 +212,19 @@ void DataSource::clearRaster(const TileID& id) {
     }
 }
 
+void DataSource::addRasterSource(std::shared_ptr<DataSource> _rasterSource) {
+    /*
+     * We limit the parent source by any attached raster source's min/max.
+     */
+    int32_t rasterMinDisplayZoom = _rasterSource->minDisplayZoom();
+    int32_t rasterMaxDisplayZoom = _rasterSource->maxDisplayZoom();
+    if (rasterMinDisplayZoom > m_minDisplayZoom) {
+        m_minDisplayZoom = rasterMinDisplayZoom;
+    }
+    if (rasterMaxDisplayZoom < m_maxDisplayZoom) {
+        m_maxDisplayZoom = rasterMaxDisplayZoom;
+    }
+    m_rasterSources.push_back(_rasterSource);
+}
+
 }

--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -146,6 +146,7 @@ bool DataSource::equals(const DataSource& other) const {
     if (m_name != other.m_name) { return false; }
     if (m_urlTemplate != other.m_urlTemplate) { return false; }
     if (m_minDisplayZoom != other.m_minDisplayZoom) { return false; }
+    if (m_maxDisplayZoom != other.m_maxDisplayZoom) { return false; }
     if (m_maxZoom != other.m_maxZoom) { return false; }
     if (m_rasterSources.size() != other.m_rasterSources.size()) { return false; }
     for (size_t i = 0, end = m_rasterSources.size(); i < end; ++i) {

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -72,6 +72,10 @@ public:
     int32_t minZoom() const { return m_minZoom; }
     int32_t maxZoom() const { return m_maxZoom; }
 
+    bool isActiveForZoom(const float _zoom) const {
+        return _zoom >= m_minZoom;
+    }
+
     /* assign/get raster datasources to this datasource */
     auto& rasterSources() { return m_rasterSources; }
     const auto& rasterSources() const { return m_rasterSources; }

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -27,7 +27,7 @@ public:
      * each of '{x}', '{y}', and '{z}' which will be replaced by the x index, y index,
      * and zoom level of tiles to produce their URL.
      */
-    DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom = 0, int32_t _maxZoom = 18);
+    DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom = 0, int32_t _maxZoom = 18);
 
     virtual ~DataSource();
 
@@ -69,11 +69,11 @@ public:
     /* Generation ID of DataSource state (incremented for each update, e.g. on clearData()) */
     int64_t generation() const { return m_generation; }
 
-    int32_t minZoom() const { return m_minZoom; }
+    int32_t minZoom() const { return m_minDisplayZoom; }
     int32_t maxZoom() const { return m_maxZoom; }
 
     bool isActiveForZoom(const float _zoom) const {
-        return _zoom >= m_minZoom;
+        return _zoom >= m_minDisplayZoom;
     }
 
     /* assign/get raster datasources to this datasource */
@@ -110,8 +110,8 @@ protected:
     // Name used to identify this source in the style sheet
     std::string m_name;
 
-    // Minimum zoom for which tiles will be requested
-    int32_t m_minZoom;
+    // Minimum zoom for which tiles will be displayed
+    int32_t m_minDisplayZoom;
 
     // Maximum zoom for which tiles will be requested
     int32_t m_maxZoom;

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -27,7 +27,7 @@ public:
      * each of '{x}', '{y}', and '{z}' which will be replaced by the x index, y index,
      * and zoom level of tiles to produce their URL.
      */
-    DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom = 18);
+    DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom = 0, int32_t _maxZoom = 18);
 
     virtual ~DataSource();
 
@@ -69,6 +69,7 @@ public:
     /* Generation ID of DataSource state (incremented for each update, e.g. on clearData()) */
     int64_t generation() const { return m_generation; }
 
+    int32_t minZoom() const { return m_minZoom; }
     int32_t maxZoom() const { return m_maxZoom; }
 
     /* assign/get raster datasources to this datasource */
@@ -104,6 +105,9 @@ protected:
 
     // Name used to identify this source in the style sheet
     std::string m_name;
+
+    // Minimum zoom for which tiles will be requested
+    int32_t m_minZoom;
 
     // Maximum zoom for which tiles will be requested
     int32_t m_maxZoom;

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -27,7 +27,8 @@ public:
      * each of '{x}', '{y}', and '{z}' which will be replaced by the x index, y index,
      * and zoom level of tiles to produce their URL.
      */
-    DataSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom = 0, int32_t _maxZoom = 18);
+    DataSource(const std::string& _name, const std::string& _urlTemplate,
+               int32_t _minDisplayZoom = 0, int32_t _maxDisplayZoom = INT32_MAX, int32_t _maxZoom = 18);
 
     virtual ~DataSource();
 
@@ -73,7 +74,7 @@ public:
     int32_t maxZoom() const { return m_maxZoom; }
 
     bool isActiveForZoom(const float _zoom) const {
-        return _zoom >= m_minDisplayZoom;
+        return _zoom >= m_minDisplayZoom && _zoom <= m_maxDisplayZoom;
     }
 
     /* assign/get raster datasources to this datasource */
@@ -112,6 +113,9 @@ protected:
 
     // Minimum zoom for which tiles will be displayed
     int32_t m_minDisplayZoom;
+
+    // Maximum zoom for which tiles will be displayed
+    int32_t m_maxDisplayZoom;
 
     // Maximum zoom for which tiles will be requested
     int32_t m_maxZoom;

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -7,6 +7,10 @@
 
 #include "tile/tileTask.h"
 
+#ifndef INT32_MAX
+#define INT32_MAX 2147483647
+#endif
+
 namespace Tangram {
 
 class MapProjection;

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -7,10 +7,6 @@
 
 #include "tile/tileTask.h"
 
-#ifndef INT32_MAX
-#define INT32_MAX 2147483647
-#endif
-
 namespace Tangram {
 
 class MapProjection;
@@ -32,7 +28,7 @@ public:
      * and zoom level of tiles to produce their URL.
      */
     DataSource(const std::string& _name, const std::string& _urlTemplate,
-               int32_t _minDisplayZoom = 0, int32_t _maxDisplayZoom = INT32_MAX, int32_t _maxZoom = 18);
+               int32_t _minDisplayZoom = -1, int32_t _maxDisplayZoom = -1, int32_t _maxZoom = 18);
 
     virtual ~DataSource();
 
@@ -78,7 +74,7 @@ public:
     int32_t maxZoom() const { return m_maxZoom; }
 
     bool isActiveForZoom(const float _zoom) const {
-        return _zoom >= m_minDisplayZoom && _zoom <= m_maxDisplayZoom;
+        return _zoom >= m_minDisplayZoom && (m_maxDisplayZoom == -1 || _zoom <= m_maxDisplayZoom);
     }
 
     /* assign/get raster datasources to this datasource */

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -74,7 +74,7 @@ public:
     /* Generation ID of DataSource state (incremented for each update, e.g. on clearData()) */
     int64_t generation() const { return m_generation; }
 
-    int32_t minZoom() const { return m_minDisplayZoom; }
+    int32_t minDisplayZoom() const { return m_minDisplayZoom; }
     int32_t maxZoom() const { return m_maxZoom; }
 
     bool isActiveForZoom(const float _zoom) const {

--- a/core/src/data/dataSource.h
+++ b/core/src/data/dataSource.h
@@ -71,6 +71,7 @@ public:
     int64_t generation() const { return m_generation; }
 
     int32_t minDisplayZoom() const { return m_minDisplayZoom; }
+    int32_t maxDisplayZoom() const { return m_maxDisplayZoom; }
     int32_t maxZoom() const { return m_maxZoom; }
 
     bool isActiveForZoom(const float _zoom) const {
@@ -78,6 +79,7 @@ public:
     }
 
     /* assign/get raster datasources to this datasource */
+    void addRasterSource(std::shared_ptr<DataSource> _dataSource);
     auto& rasterSources() { return m_rasterSources; }
     const auto& rasterSources() const { return m_rasterSources; }
 

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -10,8 +10,8 @@
 
 namespace Tangram {
 
-GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom) :
-    DataSource(_name, _urlTemplate, _minZoom, _maxZoom) {
+GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _minDisplayZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> GeoJsonSource::parse(const TileTask& _task,

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -10,8 +10,8 @@
 
 namespace Tangram {
 
-GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom) :
-    DataSource(_name, _urlTemplate, _maxZoom) {
+GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _minZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> GeoJsonSource::parse(const TileTask& _task,

--- a/core/src/data/geoJsonSource.cpp
+++ b/core/src/data/geoJsonSource.cpp
@@ -10,8 +10,9 @@
 
 namespace Tangram {
 
-GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom) :
-    DataSource(_name, _urlTemplate, _minDisplayZoom, _maxZoom) {
+GeoJsonSource::GeoJsonSource(const std::string& _name, const std::string& _urlTemplate,
+                             int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _minDisplayZoom, _maxDisplayZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> GeoJsonSource::parse(const TileTask& _task,

--- a/core/src/data/geoJsonSource.h
+++ b/core/src/data/geoJsonSource.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom);
+    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom);
 
 };
 

--- a/core/src/data/geoJsonSource.h
+++ b/core/src/data/geoJsonSource.h
@@ -13,7 +13,8 @@ protected:
 
 public:
 
-    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom);
+    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate,
+                  int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom);
 
 };
 

--- a/core/src/data/geoJsonSource.h
+++ b/core/src/data/geoJsonSource.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom);
+    GeoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom);
 
 };
 

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -10,8 +10,8 @@
 namespace Tangram {
 
 
-MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom) :
-    DataSource(_name, _urlTemplate, _minZoom, _maxZoom) {
+MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _minDisplayZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> MVTSource::parse(const TileTask& _task, const MapProjection& _projection) const {

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -10,8 +10,8 @@
 namespace Tangram {
 
 
-MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom) :
-    DataSource(_name, _urlTemplate, _maxZoom) {
+MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _minZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> MVTSource::parse(const TileTask& _task, const MapProjection& _projection) const {

--- a/core/src/data/mvtSource.cpp
+++ b/core/src/data/mvtSource.cpp
@@ -10,8 +10,9 @@
 namespace Tangram {
 
 
-MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom) :
-    DataSource(_name, _urlTemplate, _minDisplayZoom, _maxZoom) {
+MVTSource::MVTSource(const std::string& _name, const std::string& _urlTemplate,
+                     int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _minDisplayZoom, _maxDisplayZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> MVTSource::parse(const TileTask& _task, const MapProjection& _projection) const {

--- a/core/src/data/mvtSource.h
+++ b/core/src/data/mvtSource.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom);
+    MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom);
 
 };
 

--- a/core/src/data/mvtSource.h
+++ b/core/src/data/mvtSource.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom);
+    MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom);
 
 };
 

--- a/core/src/data/mvtSource.h
+++ b/core/src/data/mvtSource.h
@@ -13,7 +13,8 @@ protected:
 
 public:
 
-    MVTSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom);
+    MVTSource(const std::string& _name, const std::string& _urlTemplate,
+              int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom);
 
 };
 

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -172,6 +172,11 @@ bool RasterSource::loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _c
     return status;
 }
 
+void RasterSource::loadEmptyTexture(std::shared_ptr<TileTask>&& _task) {
+    auto& task = static_cast<RasterTileTask&>(*_task);
+    task.m_texture = m_emptyTexture;
+}
+
 Raster RasterSource::getRaster(const TileTask& _task) {
     TileID id(_task.tileId().x, _task.tileId().y, _task.tileId().z);
 

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -69,9 +69,9 @@ public:
 };
 
 
-RasterSource::RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom,
+RasterSource::RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom,
                            TextureOptions _options, bool _genMipmap)
-    : DataSource(_name, _urlTemplate, _maxZoom), m_texOptions(_options), m_genMipmap(_genMipmap) {
+    : DataSource(_name, _urlTemplate, _minZoom, _maxZoom), m_texOptions(_options), m_genMipmap(_genMipmap) {
 
     m_emptyTexture = std::make_shared<Texture>(nullptr, 0, m_texOptions, m_genMipmap);
 }

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -69,9 +69,9 @@ public:
 };
 
 
-RasterSource::RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom,
+RasterSource::RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom,
                            TextureOptions _options, bool _genMipmap)
-    : DataSource(_name, _urlTemplate, _minZoom, _maxZoom), m_texOptions(_options), m_genMipmap(_genMipmap) {
+    : DataSource(_name, _urlTemplate, _minDisplayZoom, _maxZoom), m_texOptions(_options), m_genMipmap(_genMipmap) {
 
     m_emptyTexture = std::make_shared<Texture>(nullptr, 0, m_texOptions, m_genMipmap);
 }

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -69,9 +69,10 @@ public:
 };
 
 
-RasterSource::RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom,
+RasterSource::RasterSource(const std::string& _name, const std::string& _urlTemplate,
+                           int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
                            TextureOptions _options, bool _genMipmap)
-    : DataSource(_name, _urlTemplate, _minDisplayZoom, _maxZoom), m_texOptions(_options), m_genMipmap(_genMipmap) {
+    : DataSource(_name, _urlTemplate, _minDisplayZoom, _maxDisplayZoom, _maxZoom), m_texOptions(_options), m_genMipmap(_genMipmap) {
 
     m_emptyTexture = std::make_shared<Texture>(nullptr, 0, m_texOptions, m_genMipmap);
 }

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -173,11 +173,6 @@ bool RasterSource::loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _c
     return status;
 }
 
-void RasterSource::loadEmptyTexture(std::shared_ptr<TileTask>&& _task) {
-    auto& task = static_cast<RasterTileTask&>(*_task);
-    task.m_texture = m_emptyTexture;
-}
-
 Raster RasterSource::getRaster(const TileTask& _task) {
     TileID id(_task.tileId().x, _task.tileId().y, _task.tileId().z);
 

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -39,7 +39,7 @@ public:
 
     virtual bool loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb) override;
 
-
+    void loadEmptyTexture(std::shared_ptr<TileTask>&& _task);
 
     virtual void clearRasters() override;
     virtual void clearRaster(const TileID& id) override;

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -32,7 +32,7 @@ protected:
 
 public:
 
-    RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _maxZoom,
+    RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom,
                  TextureOptions _options, bool genMipmap = false);
 
     virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask) override;

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -32,7 +32,7 @@ protected:
 
 public:
 
-    RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom,
+    RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom,
                  TextureOptions _options, bool genMipmap = false);
 
     virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask) override;

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -32,7 +32,8 @@ protected:
 
 public:
 
-    RasterSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minDisplayZoom, int32_t _maxZoom,
+    RasterSource(const std::string& _name, const std::string& _urlTemplate,
+                 int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
                  TextureOptions _options, bool genMipmap = false);
 
     virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask) override;

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -40,8 +40,6 @@ public:
 
     virtual bool loadTileData(std::shared_ptr<TileTask>&& _task, TileTaskCb _cb) override;
 
-    void loadEmptyTexture(std::shared_ptr<TileTask>&& _task);
-
     virtual void clearRasters() override;
     virtual void clearRaster(const TileID& id) override;
     virtual bool isRaster() const override { return true; }

--- a/core/src/data/topoJsonSource.cpp
+++ b/core/src/data/topoJsonSource.cpp
@@ -10,8 +10,8 @@
 
 namespace Tangram {
 
-TopoJsonSource::TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom) :
-    DataSource(_name, _urlTemplate, _minZoom, _maxZoom) {
+TopoJsonSource::TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t minDisplayZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, minDisplayZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> TopoJsonSource::parse(const TileTask& _task,

--- a/core/src/data/topoJsonSource.cpp
+++ b/core/src/data/topoJsonSource.cpp
@@ -10,8 +10,8 @@
 
 namespace Tangram {
 
-TopoJsonSource::TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t maxZoom) :
-    DataSource(_name, _urlTemplate, maxZoom) {
+TopoJsonSource::TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t _minZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, _minZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> TopoJsonSource::parse(const TileTask& _task,

--- a/core/src/data/topoJsonSource.cpp
+++ b/core/src/data/topoJsonSource.cpp
@@ -10,8 +10,9 @@
 
 namespace Tangram {
 
-TopoJsonSource::TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t minDisplayZoom, int32_t _maxZoom) :
-    DataSource(_name, _urlTemplate, minDisplayZoom, _maxZoom) {
+TopoJsonSource::TopoJsonSource(const std::string& _name, const std::string& _urlTemplate,
+                               int32_t minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom) :
+    DataSource(_name, _urlTemplate, minDisplayZoom, _maxDisplayZoom, _maxZoom) {
 }
 
 std::shared_ptr<TileData> TopoJsonSource::parse(const TileTask& _task,

--- a/core/src/data/topoJsonSource.h
+++ b/core/src/data/topoJsonSource.h
@@ -13,7 +13,8 @@ protected:
 
 public:
 
-    TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t minDisplayZoom, int32_t maxZoom);
+    TopoJsonSource(const std::string& _name, const std::string& _urlTemplate,
+                   int32_t minDisplayZoom, int32_t _maxDisplayZoom, int32_t maxZoom);
 
 };
 

--- a/core/src/data/topoJsonSource.h
+++ b/core/src/data/topoJsonSource.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t maxZoom);
+    TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t minZoom, int32_t maxZoom);
 
 };
 

--- a/core/src/data/topoJsonSource.h
+++ b/core/src/data/topoJsonSource.h
@@ -13,7 +13,7 @@ protected:
 
 public:
 
-    TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t minZoom, int32_t maxZoom);
+    TopoJsonSource(const std::string& _name, const std::string& _urlTemplate, int32_t minDisplayZoom, int32_t maxZoom);
 
 };
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -891,8 +891,12 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
 
     std::string type = source["type"].Scalar();
     std::string url = source["url"].Scalar();
+    int32_t minZoom = 0;
     int32_t maxZoom = 18;
 
+    if (auto minZoomNode = source["min_zoom"]) {
+        minZoom = minZoomNode.as<int32_t>(minZoom);
+    }
     if (auto maxZoomNode = source["max_zoom"]) {
         maxZoom = maxZoomNode.as<int32_t>(maxZoom);
     }
@@ -932,14 +936,14 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
 
     if (type == "GeoJSON") {
         if (tiled) {
-            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url, maxZoom));
+            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url, minZoom, maxZoom));
         } else {
-            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, maxZoom));
+            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, minZoom, maxZoom));
         }
     } else if (type == "TopoJSON") {
-        sourcePtr = std::shared_ptr<DataSource>(new TopoJsonSource(name, url, maxZoom));
+        sourcePtr = std::shared_ptr<DataSource>(new TopoJsonSource(name, url, minZoom, maxZoom));
     } else if (type == "MVT") {
-        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url, maxZoom));
+        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url, minZoom, maxZoom));
     } else if (type == "Raster") {
         TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
         bool generateMipmaps = false;
@@ -948,7 +952,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
                 generateMipmaps = true;
             }
         }
-        sourcePtr = std::shared_ptr<DataSource>(new RasterSource(name, url, maxZoom, options, generateMipmaps));
+        sourcePtr = std::shared_ptr<DataSource>(new RasterSource(name, url, minZoom, maxZoom, options, generateMipmaps));
     } else {
         LOGW("Unrecognized data source type '%s', skipping", type.c_str());
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -892,7 +892,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
     std::string type = source["type"].Scalar();
     std::string url = source["url"].Scalar();
     int32_t minDisplayZoom = 0;
-    int32_t maxDisplayZoom = 18;
+    int32_t maxDisplayZoom = INT32_MAX;
     int32_t maxZoom = 18;
 
     if (auto minDisplayZoomNode = source["min_display_zoom"]) {
@@ -940,14 +940,14 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
 
     if (type == "GeoJSON") {
         if (tiled) {
-            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url, minDisplayZoom, maxZoom));
+            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url, minDisplayZoom, maxDisplayZoom, maxZoom));
         } else {
-            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, minDisplayZoom, maxZoom));
+            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, minDisplayZoom, maxDisplayZoom, maxZoom));
         }
     } else if (type == "TopoJSON") {
-        sourcePtr = std::shared_ptr<DataSource>(new TopoJsonSource(name, url, minDisplayZoom, maxZoom));
+        sourcePtr = std::shared_ptr<DataSource>(new TopoJsonSource(name, url, minDisplayZoom, maxDisplayZoom, maxZoom));
     } else if (type == "MVT") {
-        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url, minDisplayZoom, maxZoom));
+        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url, minDisplayZoom, maxDisplayZoom, maxZoom));
     } else if (type == "Raster") {
         TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
         bool generateMipmaps = false;
@@ -956,7 +956,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
                 generateMipmaps = true;
             }
         }
-        sourcePtr = std::shared_ptr<DataSource>(new RasterSource(name, url, minDisplayZoom, maxZoom, options, generateMipmaps));
+        sourcePtr = std::shared_ptr<DataSource>(new RasterSource(name, url, minDisplayZoom, maxDisplayZoom, maxZoom, options, generateMipmaps));
     } else {
         LOGW("Unrecognized data source type '%s', skipping", type.c_str());
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -891,11 +891,15 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
 
     std::string type = source["type"].Scalar();
     std::string url = source["url"].Scalar();
-    int32_t minZoom = 0;
+    int32_t minDisplayZoom = 0;
+    int32_t maxDisplayZoom = 18;
     int32_t maxZoom = 18;
 
-    if (auto minZoomNode = source["min_zoom"]) {
-        minZoom = minZoomNode.as<int32_t>(minZoom);
+    if (auto minDisplayZoomNode = source["min_display_zoom"]) {
+        minDisplayZoom = minDisplayZoomNode.as<int32_t>(minDisplayZoom);
+    }
+    if (auto maxDisplayZoomNode = source["max_display_zoom"]) {
+        maxDisplayZoom = maxDisplayZoomNode.as<int32_t>(maxDisplayZoom);
     }
     if (auto maxZoomNode = source["max_zoom"]) {
         maxZoom = maxZoomNode.as<int32_t>(maxZoom);
@@ -936,14 +940,14 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
 
     if (type == "GeoJSON") {
         if (tiled) {
-            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url, minZoom, maxZoom));
+            sourcePtr = std::shared_ptr<DataSource>(new GeoJsonSource(name, url, minDisplayZoom, maxZoom));
         } else {
-            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, minZoom, maxZoom));
+            sourcePtr = std::shared_ptr<DataSource>(new ClientGeoJsonSource(name, url, minDisplayZoom, maxZoom));
         }
     } else if (type == "TopoJSON") {
-        sourcePtr = std::shared_ptr<DataSource>(new TopoJsonSource(name, url, minZoom, maxZoom));
+        sourcePtr = std::shared_ptr<DataSource>(new TopoJsonSource(name, url, minDisplayZoom, maxZoom));
     } else if (type == "MVT") {
-        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url, minZoom, maxZoom));
+        sourcePtr = std::shared_ptr<DataSource>(new MVTSource(name, url, minDisplayZoom, maxZoom));
     } else if (type == "Raster") {
         TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
         bool generateMipmaps = false;
@@ -952,7 +956,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
                 generateMipmaps = true;
             }
         }
-        sourcePtr = std::shared_ptr<DataSource>(new RasterSource(name, url, minZoom, maxZoom, options, generateMipmaps));
+        sourcePtr = std::shared_ptr<DataSource>(new RasterSource(name, url, minDisplayZoom, maxZoom, options, generateMipmaps));
     } else {
         LOGW("Unrecognized data source type '%s', skipping", type.c_str());
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -983,7 +983,7 @@ void SceneLoader::loadSourceRasters(std::shared_ptr<DataSource> &source, Node ra
                 LOGNode("Parsing sources: '%s'", sources[srcName], e.what());
                 return;
             }
-            source->rasterSources().push_back(scene->getDataSource(srcName));
+            source->addRasterSource(scene->getDataSource(srcName));
         }
     }
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -43,10 +43,6 @@ using YAML::BadConversion;
 
 #define LOGNode(fmt, node, ...) LOGW(fmt ":\n'%s'\n", ## __VA_ARGS__, Dump(node).c_str())
 
-#ifndef INT32_MAX
-#define INT32_MAX 2147483647
-#endif
-
 namespace Tangram {
 
 const std::string DELIMITER = ":";
@@ -895,8 +891,8 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, const 
 
     std::string type = source["type"].Scalar();
     std::string url = source["url"].Scalar();
-    int32_t minDisplayZoom = 0;
-    int32_t maxDisplayZoom = INT32_MAX;
+    int32_t minDisplayZoom = -1;
+    int32_t maxDisplayZoom = -1;
     int32_t maxZoom = 18;
 
     if (auto minDisplayZoomNode = source["min_display_zoom"]) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -43,6 +43,10 @@ using YAML::BadConversion;
 
 #define LOGNode(fmt, node, ...) LOGW(fmt ":\n'%s'\n", ## __VA_ARGS__, Dump(node).c_str())
 
+#ifndef INT32_MAX
+#define INT32_MAX 2147483647
+#endif
+
 namespace Tangram {
 
 const std::string DELIMITER = ":";

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -568,11 +568,15 @@ void TileManager::updateProxyTiles(TileSet& _tileSet, const TileID& _tileID, Til
 
     // Try parent proxy
     auto parentID = _tileID.getParent();
-    if (updateProxyTile(_tileSet, _tile, parentID, ProxyID::parent)) {
+    auto minZoom = _tileSet.source->minZoom();
+    if (minZoom <= parentID.z
+            && updateProxyTile(_tileSet, _tile, parentID, ProxyID::parent)) {
         return;
     }
     // Try grandparent
-    if (updateProxyTile(_tileSet, _tile, parentID.getParent(), ProxyID::parent2)) {
+    auto grandparentID = parentID.getParent();
+    if (minZoom <= grandparentID.z
+            && updateProxyTile(_tileSet, _tile, grandparentID, ProxyID::parent2)) {
         return;
     }
     // Try children

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -123,7 +123,9 @@ void TileManager::updateTileSets(const ViewState& _view,
     m_tileSetChanged = false;
 
     for (auto& tileSet : m_tileSets) {
-        updateTileSet(tileSet, _view, _visibleTiles);
+        if (tileSet.source->isActiveForZoom(_view.zoom)) {
+            updateTileSet(tileSet, _view, _visibleTiles);
+        }
     }
 
     loadTiles();
@@ -384,6 +386,9 @@ void TileManager::loadSubTasks(std::vector<std::shared_ptr<DataSource>>& _subSou
         if (it != subTasks.end() && (*it)->subTaskId() == int(index)) { continue; }
 
         TileID subTileID = tileID;
+//        if (!subSource->isActiveForZoom((float)subTileID.z)) {
+//            continue;
+//        }
         if (subTileID.z > subSource->maxZoom()) {
             subTileID = subTileID.withMaxSourceZoom(subSource->maxZoom());
         }

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -585,7 +585,7 @@ void TileManager::updateProxyTiles(TileSet& _tileSet, const TileID& _tileID, Til
 
     // Try parent proxy
     auto parentID = _tileID.getParent();
-    auto minZoom = _tileSet.source->minZoom();
+    auto minZoom = _tileSet.source->minDisplayZoom();
     if (minZoom <= parentID.z
             && updateProxyTile(_tileSet, _tile, parentID, ProxyID::parent)) {
         return;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -9,7 +9,6 @@
 #include "glm/gtx/norm.hpp"
 
 #include <algorithm>
-#include <data/rasterSource.h>
 
 #define DBG(...) // LOGD(__VA_ARGS__)
 

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -394,18 +394,7 @@ void TileManager::loadSubTasks(std::vector<std::shared_ptr<DataSource>>& _subSou
             subTileID = subTileID.withMaxSourceZoom(subSource->maxZoom());
         }
         auto subTask = subSource->createTask(subTileID, index);
-        // check if we are at valid zoom for source
-        if (!subSource->isActiveForZoom((float)subTileID.z)) {
-            // Right now all subSources are raster, but let's check anyway...
-            if (RasterSource* rasterSubSource = dynamic_cast<RasterSource*>(subSource.get())) {
-                subTasks.insert(it, subTask);
-                // If the subSource isn't active for the zoom, we should just
-                // load an empty texture and move on.
-                rasterSubSource->loadEmptyTexture(std::move(subTask));
-                assert(subTask->isReady());
-                requestRender();
-            }
-        } else if (subTask->isReady()) {
+        if (subTask->isReady()) {
             subTasks.insert(it, subTask);
             requestRender();
 


### PR DESCRIPTION
This PR allows you to set a `min_zoom` parameter in your sources block of your scene.yaml.

When a source is given a `min_zoom` parameter, it does not fetch tiles below that min zoom. This includes the raster sub-sources we see with normals, as found in Walkabout and other terrain styles.

As @bcamper mentioned, we might actually want to call this parameter `min_display_zoom`, since we don't under-zoom data at lower zooms--we simply don't provide it.

I'm happy to re-factor that into this PR. Also, we could take a similar approach found here to implement `max_display_zoom`. 

https://github.com/tangrams/tangram/pull/394

Thinking about also implementing `bounds`, we could build that into [`DataSource#isActiveForZoom`](https://github.com/hallahan/tangram-es/blob/f7f2dbfbf60da54a3d085fac2e346e91269f9a2f/core/src/data/dataSource.h#L75-L77), calling it `isActive` instead. 

cc/ @tallytalwar @blair1618 @bcamper 