### PR TITLE
Blend mode 'none' -> 'opaque'

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -747,7 +747,7 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, const std::shared
 
     if (Node blendNode = styleNode["blend"]) {
         const std::string& blendMode = blendNode.Scalar();
-        if      (blendMode == "none")     { style.setBlendMode(Blending::none); }
+        if      (blendMode == "opaque")   { style.setBlendMode(Blending::opaque); }
         else if (blendMode == "add")      { style.setBlendMode(Blending::add); }
         else if (blendMode == "multiply") { style.setBlendMode(Blending::multiply); }
         else if (blendMode == "overlay")  { style.setBlendMode(Blending::overlay); }

--- a/core/src/style/polygonStyle.h
+++ b/core/src/style/polygonStyle.h
@@ -11,7 +11,7 @@ class PolygonStyle : public Style {
 
 public:
 
-    PolygonStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
+    PolygonStyle(std::string _name, Blending _blendMode = Blending::opaque, GLenum _drawMode = GL_TRIANGLES);
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -10,7 +10,7 @@ class PolylineStyle : public Style {
 
 public:
 
-    PolylineStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
+    PolylineStyle(std::string _name, Blending _blendMode = Blending::opaque, GLenum _drawMode = GL_TRIANGLES);
 
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;

--- a/core/src/style/rasterStyle.h
+++ b/core/src/style/rasterStyle.h
@@ -15,7 +15,7 @@ protected:
 
 public:
 
-    RasterStyle(std::string _name, Blending _blendMode = Blending::none, GLenum _drawMode = GL_TRIANGLES);
+    RasterStyle(std::string _name, Blending _blendMode = Blending::opaque, GLenum _drawMode = GL_TRIANGLES);
 
 };
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -207,7 +207,7 @@ void Style::onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _scene) 
 
     // Configure render state
     switch (m_blend) {
-        case Blending::none:
+        case Blending::opaque:
             rs.blending(GL_FALSE);
             rs.blendingFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             rs.depthTest(GL_TRUE);

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -35,7 +35,7 @@ enum class LightingType : char {
 };
 
 enum class Blending : int8_t {
-    none = 0,
+    opaque = 0,
     add,
     multiply,
     inlay,
@@ -121,7 +121,7 @@ protected:
     /* <LightingType> to determine how lighting will be calculated for this style */
     LightingType m_lightingType = LightingType::fragment;
 
-    Blending m_blend = Blending::none;
+    Blending m_blend = Blending::opaque;
     int m_blendOrder = -1;
 
     /* Draw mode to pass into <Mesh>es created with this style */
@@ -192,7 +192,7 @@ public:
         const auto& orderA = a->blendOrder();
         const auto& orderB = b->blendOrder();
 
-        if (modeA != Blending::none && modeB != Blending::none) {
+        if (modeA != Blending::opaque && modeB != Blending::opaque) {
             if (orderA != orderB) {
                 return orderA < orderB;
             }


### PR DESCRIPTION
The default blend mode is actually denoted "opaque", as we now indicate in the docs: https://github.com/tangrams/tangram-docs/commit/9e96eaf154adb6c180a10fb31df1e1cf62c3db67