### PR TITLE
Fix desktop application to destroy map on context destroy

### DIFF
--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -269,10 +269,12 @@ void window_size_callback(GLFWwindow* window, int width, int height) {
 void init_main_window(bool recreate) {
 
     // Setup tangram
-    if (!map) {
-        map = new Tangram::Map();
-        map->loadSceneAsync(sceneFile.c_str(), true);
+    if (map) {
+        delete map;
     }
+
+    map = new Tangram::Map();
+    map->loadSceneAsync(sceneFile.c_str(), true);
 
     if (!recreate) {
         // Destroy old window

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -288,10 +288,12 @@ void framebuffer_size_callback(GLFWwindow* window, int fWidth, int fHeight) {
 void init_main_window(bool recreate) {
 
     // Setup tangram
-    if (!map) {
-        map = new Tangram::Map();
-        map->loadSceneAsync(sceneFile.c_str(), true);
+    if (map) {
+        delete map;
     }
+
+    map = new Tangram::Map();
+    map->loadSceneAsync(sceneFile.c_str(), true);
 
     if (!recreate) {
         // Destroy old window


### PR DESCRIPTION
So we don't retain the map instance memory when simulating loss of context on desktop apps.