### PR TITLE
Unified selection buffer technique for all styles

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -162,9 +162,18 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
         if (name.isEmpty()) {
             name = "unnamed";
         }
-        Toast.makeText(getApplicationContext(),
-                "Selected: " + name + " at: " + positionX + ", " + positionY,
-                Toast.LENGTH_SHORT).show();
+
+        Log.d("Tangram", "Picked: " + name);
+        final String message = name;
+        runOnUiThread(new Runnable() {
+                          @Override
+                          public void run() {
+                              Toast.makeText(getApplicationContext(),
+                                      "Selected: " + message,
+                                      Toast.LENGTH_SHORT).show();
+                          }
+                      });
+
     }
 }
 

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -214,10 +214,12 @@ extern "C" {
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickFeature(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jobject listener) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto& items = map->pickFeatureLabelsAt(posX, posY);
-        if (!items.empty()) {
-            featurePickCallback(jniEnv, listener, items);
-        }
+        auto object = jniEnv->NewGlobalRef(listener);
+        map->pickFeaturesAt(posX, posY, [object](const auto& items) {
+            if (!items.empty()) {
+                featurePickCallback(object, items);
+            }
+        });
     }
 
     JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeAddDataSource(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring name) {

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -308,7 +308,9 @@ void setCurrentThreadPriority(int priority) {
     setpriority(PRIO_PROCESS, tid, priority);
 }
 
-void featurePickCallback(JNIEnv* jniEnv, jobject listener, const std::vector<Tangram::TouchItem>& items) {
+void featurePickCallback(jobject listener, const std::vector<Tangram::TouchItem>& items) {
+
+    JniThreadBinding jniEnv(jvm);
 
     auto result = items[0];
     auto properties = result.properties;
@@ -323,6 +325,7 @@ void featurePickCallback(JNIEnv* jniEnv, jobject listener, const std::vector<Tan
     }
 
     jniEnv->CallVoidMethod(listener, onFeaturePickMID, hashmap, position[0], position[1]);
+    jniEnv->DeleteGlobalRef(listener);
 }
 
 void initGLExtensions() {

--- a/android/tangram/jni/platform_android.h
+++ b/android/tangram/jni/platform_android.h
@@ -14,6 +14,6 @@ namespace Tangram {
 struct TouchItem;
 }
 
-void featurePickCallback(JNIEnv* jniEnv, jobject listener, const std::vector<Tangram::TouchItem>& items);
+void featurePickCallback(jobject listener, const std::vector<Tangram::TouchItem>& items);
 
 std::string stringFromJString(JNIEnv* jniEnv, jstring string);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -62,6 +62,7 @@ public class MapController implements Renderer {
         TANGRAM_INFOS,
         DRAW_ALL_LABELS,
         TANGRAM_STATS,
+        SELECTION_BUFFER,
     }
 
     /**

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -191,7 +191,9 @@ GLuint ShaderProgram::makeLinkedShaderProgram(GLint _fragShader, GLint _vertShad
         if (infoLength > 1) {
             std::vector<GLchar> infoLog(infoLength);
             GL_CHECK(glGetProgramInfoLog(program, infoLength, NULL, &infoLog[0]));
-            LOGE("linking program:\n%s", &infoLog[0]);
+            LOGE("Linking program:\n%s", &infoLog[0]);
+            LOGE("Fragment shader source:\n%s", m_fragmentShaderSource.c_str());
+            LOGE("Vertex shader source:\n%s", m_vertexShaderSource.c_str());
         }
 
         GL_CHECK(glDeleteProgram(program));

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -43,6 +43,8 @@ public:
     GLuint getGlFragmentShader() const { return m_glFragmentShader; };
     GLuint getGlVertexShader() const { return m_glVertexShader; };
 
+    std::string getDescription() const { return m_description; }
+
     const std::string& getFragmentShaderSource() const { return m_fragmentShaderSource; }
     const std::string& getVertexShaderSource() const { return m_vertexShaderSource; }
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -8,7 +8,6 @@
 #include "fadeEffect.h"
 #include "util/types.h"
 #include "util/hash.h"
-#include "data/properties.h"
 #include "labels/labelProperty.h"
 
 #include <string>
@@ -64,7 +63,6 @@ public:
         glm::vec2 offset;
         float priority = std::numeric_limits<float>::max();
         bool interactive = false;
-        std::shared_ptr<Properties> properties;
         bool collide = true;
         Transition selectTransition;
         Transition hideTransition;
@@ -72,6 +70,7 @@ public:
         size_t repeatGroup = 0;
         float repeatDistance = 0;
         float buffer = 0.f;
+        uint32_t selectionColor = 0;
 
         // the label hash based on its styling parameters
         size_t paramHash = 0;

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -47,11 +47,6 @@ public:
                                  const std::vector<std::unique_ptr<Marker>>& _markers,
                                  bool _onlyTransitions = true);
 
-    const std::vector<TouchItem>& getFeaturesAtPoint(const View& _view, float _dt,
-                                                     const std::vector<std::unique_ptr<Style>>& _styles,
-                                                     const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                                     float _x, float _y, bool _visibleOnly = true);
-
     bool needUpdate() const { return m_needUpdate; }
 
 protected:

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -63,6 +63,7 @@ void SpriteLabel::pushTransform() {
         SpriteVertex& v = quadVertices[i];
         v.pos = sp + quad.quad[i].pos;
         v.uv = quad.quad[i].uv;
+        v.selection = options().selectionColor;
         //v.extrude = quad.quad[i].extrude;
         v.state = state;
     }

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -11,6 +11,7 @@ class PointStyle;
 struct SpriteVertex {
     glm::i16vec2 pos;
     glm::u16vec2 uv;
+    uint32_t selection;
     struct State {
         uint32_t color;
         uint16_t alpha;

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -104,6 +104,7 @@ void TextLabel::pushTransform() {
             }
             v.uv = quad.quad[i].uv;
             v.state = state;
+            v.selection = options().selectionColor;
         }
     }
 }

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -22,6 +22,7 @@ using TextRange = std::array<Range, 3>;
 struct TextVertex {
     glm::i16vec2 pos;
     glm::u16vec2 uv;
+    uint32_t selection;
     struct State {
         uint32_t color;
         uint32_t stroke;

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -27,6 +27,7 @@ void PointStyle::constructVertexLayout() {
     m_vertexLayout = std::shared_ptr<VertexLayout>(new VertexLayout({
         {"a_position", 2, GL_SHORT, false, 0},
         {"a_uv", 2, GL_UNSIGNED_SHORT, true, 0},
+        {"a_selection_color", 4, GL_UNSIGNED_BYTE, true, 0},
         {"a_color", 4, GL_UNSIGNED_BYTE, true, 0},
         {"a_alpha", 1, GL_UNSIGNED_SHORT, true, 0},
         {"a_scale", 1, GL_UNSIGNED_SHORT, false, 0},
@@ -51,6 +52,7 @@ void PointStyle::constructShaderProgram() {
     m_mesh = std::make_unique<DynamicQuadMesh<SpriteVertex>>(m_vertexLayout, m_drawMode);
 
     m_textStyle->constructShaderProgram();
+    m_textStyle->constructSelectionShaderProgram();
 }
 
 void PointStyle::onBeginUpdate() {
@@ -76,12 +78,26 @@ void PointStyle::onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _sc
         m_texture->bind(rs, texUnit);
     }
 
-    m_shaderProgram->setUniformi(rs, m_uTex, texUnit);
-    m_shaderProgram->setUniformMatrix4f(rs, m_uOrtho, _view.getOrthoViewportMatrix());
+    m_shaderProgram->setUniformi(rs, m_uniforms[Style::mainShaderUniformBlock].uTex, texUnit);
+    m_shaderProgram->setUniformMatrix4f(rs, m_uniforms[Style::mainShaderUniformBlock].uOrtho,
+                                        _view.getOrthoViewportMatrix());
 
     m_mesh->draw(rs, *m_shaderProgram);
 
     m_textStyle->onBeginDrawFrame(rs, _view, _scene);
+}
+
+void PointStyle::onBeginDrawSelectionFrame(RenderState& rs, const View& _view, Scene& _scene) {
+    m_mesh->upload(rs);
+
+    Style::onBeginDrawSelectionFrame(rs, _view, _scene);
+
+    m_selectionProgram->setUniformMatrix4f(rs, m_uniforms[Style::selectionShaderUniformBlock].uOrtho,
+                                           _view.getOrthoViewportMatrix());
+
+    m_mesh->draw(rs, *m_selectionProgram);
+
+    m_textStyle->onBeginDrawSelectionFrame(rs, _view, _scene);
 }
 
 std::unique_ptr<StyleBuilder> PointStyle::createBuilder() const {

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -30,11 +30,12 @@ public:
     };
 
     PointStyle(std::string _name, std::shared_ptr<FontContext> _fontContext,
-               Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES, bool _selection = false);
+               Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES, bool _selection = true);
 
     virtual void onBeginUpdate() override;
     virtual void onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _scene) override;
     virtual void onBeginFrame(RenderState& rs) override;
+    virtual void onBeginDrawSelectionFrame(RenderState& rs, const View& _view, Scene& _scene) override;
 
     void setSpriteAtlas(std::shared_ptr<SpriteAtlas> _spriteAtlas) { m_spriteAtlas = _spriteAtlas; }
     void setTexture(std::shared_ptr<Texture> _texture) { m_texture = _texture; }
@@ -60,8 +61,10 @@ protected:
     std::shared_ptr<SpriteAtlas> m_spriteAtlas;
     std::shared_ptr<Texture> m_texture;
 
-    UniformLocation m_uTex{"u_tex"};
-    UniformLocation m_uOrtho{"u_ortho"};
+    struct UniformBlock {
+        UniformLocation uTex{"u_tex"};
+        UniformLocation uOrtho{"u_ortho"};
+    } m_uniforms[2];
 
     mutable std::unique_ptr<DynamicQuadMesh<SpriteVertex>> m_mesh;
 

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -147,12 +147,10 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
     p.labelOptions.anchors.anchor[0] = p.anchor;
     p.labelOptions.anchors.count = 1;
 
-    if (p.labelOptions.interactive) {
-        p.labelOptions.properties = std::make_shared<Properties>(_props);
-    }
-
     std::hash<PointStyle::Parameters> hash;
     p.labelOptions.paramHash = hash(p);
+
+    p.labelOptions.selectionColor = _rule.selectionColor;
 
     return p;
 }

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -40,6 +40,17 @@ const std::vector<std::string>& Style::builtInStyleNames() {
     return builtInStyleNames;
 }
 
+void Style::constructSelectionShaderProgram() {
+
+    if (m_selection) {
+        m_selectionProgram->setDescription("selection_program {style:" + m_name + "}");
+        m_selectionProgram->setSourceStrings(SHADER_SOURCE(selection_fs),
+                                             m_shaderProgram->getVertexShaderSource());
+
+        m_selectionProgram->addSourceBlock("defines", "#define TANGRAM_FEATURE_SELECTION\n", false);
+    }
+}
+
 void Style::build(const Scene& _scene) {
 
     constructVertexLayout();
@@ -79,13 +90,7 @@ void Style::build(const Scene& _scene) {
 
     setupRasters(_scene.dataSources());
 
-    if (m_selection) {
-        m_selectionProgram->setDescription("selection_program {style:" + m_name + "}");
-        m_selectionProgram->setSourceStrings(SHADER_SOURCE(selection_fs),
-                                             m_shaderProgram->getVertexShaderSource());
-
-        m_selectionProgram->addSourceBlock("defines", "#define TANGRAM_FEATURE_SELECTION\n", false);
-    }
+    constructSelectionShaderProgram();
 }
 
 void Style::setMaterial(const std::shared_ptr<Material>& _material) {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -143,6 +143,15 @@ protected:
     /* Whether the style should generate texture coordinates */
     bool m_texCoordsGeneration = false;
 
+    static constexpr int mainShaderUniformBlock = 0;
+    static constexpr int selectionShaderUniformBlock = 1;
+
+    RasterType m_rasterType = RasterType::none;
+
+    bool m_selection;
+
+private:
+
     struct UniformBlock {
         UniformLocation uTime{"u_time"};
         // View uniforms
@@ -164,15 +173,6 @@ protected:
 
         std::vector<StyleUniform> styleUniforms;
     } m_uniforms[2];
-
-    static constexpr int mainShaderUniformBlock = 0;
-    static constexpr int selectionShaderUniformBlock = 1;
-
-    RasterType m_rasterType = RasterType::none;
-
-    bool m_selection;
-
-private:
 
     /* Set uniform values when @_updateUniforms is true,
      */
@@ -252,12 +252,14 @@ public:
      */
     virtual void constructShaderProgram() = 0;
 
+    void constructSelectionShaderProgram();
+
     /* Perform any setup needed before drawing each frame
      * _textUnit is the next available texture unit
      */
     virtual void onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _scene);
 
-    void onBeginDrawSelectionFrame(RenderState& rs, const View& _view, Scene& _scene);
+    virtual void onBeginDrawSelectionFrame(RenderState& rs, const View& _view, Scene& _scene);
 
     /* Perform any unsetup needed after drawing each frame */
     virtual void onEndDrawFrame() {}

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -26,6 +26,7 @@ void TextStyle::constructVertexLayout() {
     m_vertexLayout = std::shared_ptr<VertexLayout>(new VertexLayout({
         {"a_position", 2, GL_SHORT, false, 0},
         {"a_uv", 2, GL_UNSIGNED_SHORT, false, 0},
+        {"a_selection_color", 4, GL_UNSIGNED_BYTE, true, 0},
         {"a_color", 4, GL_UNSIGNED_BYTE, true, 0},
         {"a_stroke", 4, GL_UNSIGNED_BYTE, true, 0},
         {"a_alpha", 1, GL_UNSIGNED_SHORT, true, 0},
@@ -74,13 +75,16 @@ void TextStyle::onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _sce
 
     auto texUnit = rs.nextAvailableTextureUnit();
 
-    m_shaderProgram->setUniformf(rs, m_uMaxStrokeWidth, m_context->maxStrokeWidth());
-    m_shaderProgram->setUniformf(rs, m_uTexScaleFactor, glm::vec2(1.0f / GlyphTexture::size));
-    m_shaderProgram->setUniformi(rs, m_uTex, texUnit);
-    m_shaderProgram->setUniformMatrix4f(rs, m_uOrtho, _view.getOrthoViewportMatrix());
+    m_shaderProgram->setUniformf(rs, m_uniforms[Style::mainShaderUniformBlock].uMaxStrokeWidth,
+                                 m_context->maxStrokeWidth());
+    m_shaderProgram->setUniformf(rs, m_uniforms[Style::mainShaderUniformBlock].uTexScaleFactor,
+                                 glm::vec2(1.0f / GlyphTexture::size));
+    m_shaderProgram->setUniformi(rs, m_uniforms[Style::mainShaderUniformBlock].uTex, texUnit);
+    m_shaderProgram->setUniformMatrix4f(rs, m_uniforms[Style::mainShaderUniformBlock].uOrtho,
+                                        _view.getOrthoViewportMatrix());
 
     if (m_sdf) {
-        m_shaderProgram->setUniformi(rs, m_uPass, 1);
+        m_shaderProgram->setUniformi(rs, m_uniforms[Style::mainShaderUniformBlock].uPass, 1);
 
         for (size_t i = 0; i < m_meshes.size(); i++) {
             if (m_meshes[i]->isReady()) {
@@ -88,13 +92,29 @@ void TextStyle::onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _sce
                 m_meshes[i]->draw(rs, *m_shaderProgram);
             }
         }
-        m_shaderProgram->setUniformi(rs, m_uPass, 0);
+        m_shaderProgram->setUniformi(rs, m_uniforms[Style::mainShaderUniformBlock].uPass, 0);
     }
 
     for (size_t i = 0; i < m_meshes.size(); i++) {
         if (m_meshes[i]->isReady()) {
             m_context->bindTexture(rs, i, texUnit);
             m_meshes[i]->draw(rs, *m_shaderProgram);
+        }
+    }
+}
+
+void TextStyle::onBeginDrawSelectionFrame(RenderState& rs, const View& _view, Scene& _scene) {
+
+    for (auto& mesh : m_meshes) { mesh->upload(rs); }
+
+    Style::onBeginDrawSelectionFrame(rs, _view, _scene);
+
+    m_selectionProgram->setUniformMatrix4f(rs, m_uniforms[Style::selectionShaderUniformBlock].uOrtho,
+                                           _view.getOrthoViewportMatrix());
+
+    for (size_t i = 0; i < m_meshes.size(); i++) {
+        if (m_meshes[i]->isReady()) {
+            m_meshes[i]->draw(rs, *m_selectionProgram);
         }
     }
 }

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -48,18 +48,20 @@ protected:
 
     std::shared_ptr<FontContext> m_context;
 
-    UniformLocation m_uTexScaleFactor{"u_uv_scale_factor"};
-    UniformLocation m_uTex{"u_tex"};
-    UniformLocation m_uOrtho{"u_ortho"};
-    UniformLocation m_uPass{"u_pass"};
-    UniformLocation m_uMaxStrokeWidth{"u_max_stroke_width"};
+    struct UniformBlock {
+        UniformLocation uTexScaleFactor{"u_uv_scale_factor"};
+        UniformLocation uTex{"u_tex"};
+        UniformLocation uOrtho{"u_ortho"};
+        UniformLocation uPass{"u_pass"};
+        UniformLocation uMaxStrokeWidth{"u_max_stroke_width"};
+    } m_uniforms[2];
 
     mutable std::vector<std::unique_ptr<DynamicQuadMesh<TextVertex>>> m_meshes;
 
 public:
 
     TextStyle(std::string _name, std::shared_ptr<FontContext> _fontContext, bool _sdf = false,
-              Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES, bool _selection = false);
+              Blending _blendMode = Blending::overlay, GLenum _drawMode = GL_TRIANGLES, bool _selection = true);
 
     void constructVertexLayout() override;
     void constructShaderProgram() override;
@@ -79,6 +81,8 @@ public:
      * - Second pass, draw the inner glyph pixels
      */
     void onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _scene) override;
+
+    void onBeginDrawSelectionFrame(RenderState& rs, const View& _view, Scene& _scene) override;
 
     std::unique_ptr<StyleBuilder> createBuilder() const override;
 

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -5,7 +5,6 @@
 #include "labels/textLabel.h"
 #include "labels/textLabels.h"
 
-#include "data/propertyItem.h" // Include wherever Properties is used!
 #include "marker/marker.h"
 #include "scene/drawRule.h"
 #include "tile/tile.h"
@@ -381,11 +380,6 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
     p.labelOptions.repeatGroup = repeatGroupHash;
     p.labelOptions.repeatDistance *= m_style.pixelScale();
 
-    if (p.interactive) {
-        // TODO optimization: for icon-text use the parent's properties
-        p.labelOptions.properties = std::make_shared<Properties>(_props);
-    }
-
     if (auto* transform = _rule.get<std::string>(StyleParamKey::text_transform)) {
         TextLabelProperty::transform(*transform, p.transform);
     }
@@ -406,6 +400,8 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
     p.labelOptions.paramHash = hash(p);
 
     p.lineSpacing = 2 * m_style.pixelScale();
+
+    p.labelOptions.selectionColor = _rule.selectionColor;
 
     return p;
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -70,7 +70,7 @@ public:
     InputHandler inputHandler{view};
     TileWorker tileWorker{MAX_WORKERS};
     std::shared_ptr<FeatureSelection> featureSelection = std::make_shared<FeatureSelection>();
-    TileManager tileManager{tileWorker, featureSelection};
+    TileManager tileManager{tileWorker};
     MarkerManager markerManager;
 
     std::vector<SceneUpdate> sceneUpdates;
@@ -407,7 +407,6 @@ void Map::render() {
         if (drawSelectionBuffer) { return; }
 
         for (const auto& query : impl->selectionQueries) {
-            LOG("Solving query %f %f", query.position[0], query.position[1]);
             std::vector<TouchItem> items;
 
             float x = query.position[0] / impl->view.getWidth();
@@ -420,6 +419,7 @@ void Map::render() {
             if (props) {
                 items.push_back({props, {x, y}, 0});
             }
+
             query.callback(items);
         }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -361,6 +361,8 @@ bool Map::update(float _dt) {
 
 void Map::pickFeaturesAt(float _x, float _y, std::function<void(const std::vector<TouchItem>&)> _onReadyCallback) {
     impl->selectionQueries.push_back({{_x, _y}, _onReadyCallback});
+
+    requestRender();
 }
 
 void Map::render() {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -394,6 +394,7 @@ void Map::render() {
         }
 
         for (const auto& query : impl->selectionQueries) {
+            LOG("Solving query %f %f", query.position[0], query.position[1]);
             std::vector<TouchItem> items;
 
             float x = query.position[0] / impl->view.getWidth();
@@ -782,12 +783,6 @@ void Map::setupGL() {
 
 void Map::useCachedGlState(bool _useCache) {
     impl->cacheGlState = _useCache;
-}
-
-const std::vector<TouchItem>& Map::pickFeatureLabelsAt(float _x, float _y) {
-    return impl->labels.getFeaturesAtPoint(impl->view, 0, impl->scene->styles(),
-                                           impl->tileManager.getVisibleTiles(),
-                                           _x, _y);
 }
 
 void Map::runAsyncTask(std::function<void()> _task) {

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -242,6 +242,7 @@ enum DebugFlags {
     tangram_infos,      // Various text tangram debug info printed on the screen
     draw_all_labels,    // Draw all labels
     tangram_stats,      // Tangram frame graph stats
+    selection_buffer,   // Render selection framebuffer
 };
 
 // Set debug features on or off using a boolean (see debug.h)

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -221,8 +221,6 @@ public:
     // efficiency, but can cause errors if your application code makes OpenGL calls (false by default)
     void useCachedGlState(bool _use);
 
-    const std::vector<TouchItem>& pickFeatureLabelsAt(float _x, float _y);
-
     void pickFeaturesAt(float _x, float _y, std::function<void(const std::vector<TouchItem>&)> _onReadyCallback);
 
     // Run this task asynchronously to Tangram's main update loop.

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -15,9 +15,8 @@
 
 namespace Tangram {
 
-TileManager::TileManager(TileTaskQueue& _tileWorker, std::shared_ptr<FeatureSelection> _featureSelection) :
-    m_workers(_tileWorker),
-    m_featureSelection(_featureSelection) {
+TileManager::TileManager(TileTaskQueue& _tileWorker) :
+    m_workers(_tileWorker) {
 
     m_tileCache = std::unique_ptr<TileCache>(new TileCache(DEFAULT_CACHE_SIZE));
 
@@ -517,8 +516,6 @@ void TileManager::removeTile(TileSet& _tileSet, std::map<TileID, TileEntry>::ite
     _tileIt = _tileSet.tiles.erase(_tileIt);
     // Remove rasters from this DataSource
     _tileSet.source->clearRaster(id);
-    // Remove stored feature properties
-    m_featureSelection->clearFeaturesForTile(id);
 }
 
 bool TileManager::updateProxyTile(TileSet& _tileSet, TileEntry& _tile,

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -40,7 +40,7 @@ class TileManager {
 
 public:
 
-    TileManager(TileTaskQueue& _tileWorker, std::shared_ptr<FeatureSelection> _featureSelection);
+    TileManager(TileTaskQueue& _tileWorker);
 
     virtual ~TileManager();
 
@@ -243,8 +243,6 @@ private:
 
     /* Temporary list of tiles that need to be loaded */
     std::vector<std::tuple<double, TileSet*, TileID>> m_loadTasks;
-
-    std::shared_ptr<FeatureSelection> m_featureSelection;
 
 };
 

--- a/core/src/util/featureSelection.cpp
+++ b/core/src/util/featureSelection.cpp
@@ -26,7 +26,7 @@ uint32_t FeatureSelection::colorIdentifier(const Feature& _feature, const TileID
     return m_entry;
 }
 
-bool FeatureSelection::clearFeaturesForTile(const TileID& _tileID) {
+bool FeatureSelection::clearFeaturesForTile(TileID _tileID) {
 
     auto it = m_tileFeatures.find(_tileID);
     if (it != m_tileFeatures.end()) {

--- a/core/src/util/featureSelection.h
+++ b/core/src/util/featureSelection.h
@@ -21,7 +21,7 @@ public:
 
     uint32_t colorIdentifier(const Feature& _feature, const TileID& _tileID);
 
-    bool clearFeaturesForTile(const TileID& _tileID);
+    bool clearFeaturesForTile(TileID _tileID);
 
     std::shared_ptr<Properties> featurePropertiesForEntry(uint32_t entry) const;
 

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -198,6 +198,9 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             case GLFW_KEY_8:
                 Tangram::toggleDebugFlag(Tangram::DebugFlags::tangram_stats);
                 break;
+            case GLFW_KEY_9:
+                Tangram::toggleDebugFlag(Tangram::DebugFlags::selection_buffer);
+                break;
             case GLFW_KEY_BACKSPACE:
                 recreate_context = true;
                 break;

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -84,27 +84,8 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
         LngLat p;
         map->screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
         map->setPositionEased(p.longitude, p.latitude, 1.f);
-
-        logMsg("pick feature\n");
         map->clearDataSource(*data_source, true, true);
 
-        auto picks = map->pickFeatureLabelsAt(x, y);
-        std::string name;
-        logMsg("picked %d features\n", picks.size());
-        for (const auto& it : picks) {
-            if (it.properties->getString("name", name)) {
-                logMsg(" - %f\t %s\n", it.distance, name.c_str());
-            }
-        }
-
-        map->pickFeaturesAt(x, y, [](const auto& items) {
-            std::string name;
-            for (const auto& item : items) {
-                if (item.properties->getString("name", name)) {
-                    LOGS("%s", name.c_str());
-                }
-            }
-        });
     } else if ((time - last_time_pressed) < single_tap_time) {
         // Single tap recognized
         LngLat p1;
@@ -124,6 +105,15 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
             map->markerSetPolyline(marker, taps.data(), taps.size());
         }
         last_point = p1;
+
+        map->pickFeaturesAt(x, y, [](const auto& items) {
+            std::string name;
+            for (const auto& item : items) {
+                if (item.properties->getString("name", name)) {
+                    LOGS("%s", name.c_str());
+                }
+            }
+        });
 
         // Tangram::clearDataSource(*data_source, false, true);
         // This updates the tiles (maybe we need a recalcTiles())


### PR DESCRIPTION
Remove old technique to select label with bounding boxes and use a single technique (render to framebuffer with selection ids)
- [x] Update JNI bindings

To go in https://github.com/tangrams/tangram-es/pull/948