### PR TITLE
Fix global property updates

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -70,6 +70,21 @@ Scene::Scene(const Scene& _other)
 
 Scene::~Scene() {}
 
+bool Scene::removeGlobalRef(const std::string& key) {
+    bool found = false;
+    for (auto& globalRef : m_referencedGlobals) {
+        if (globalRef.first == key) {
+            globalRef.swap(m_referencedGlobals.back());
+            m_referencedGlobals.pop_back();
+            LOG("Found keys: %s", key.c_str());
+            found = true;
+            break;
+        }
+    }
+
+    return found;
+}
+
 const Style* Scene::findStyle(const std::string& _name) const {
 
     for (auto& style : m_styles) {

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "util/color.h"
-#include "util/fastmap.h"
 #include "view/view.h"
 
 #include <atomic>
@@ -9,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <tuple>
 #include <unordered_map>
 
 #include "glm/vec2.hpp"
@@ -74,6 +74,8 @@ public:
     auto& background() { return m_background; }
     auto& fontContext() { return m_fontContext; }
     auto& globals() { return m_globals; }
+    auto& referencedGlobals() { return m_referencedGlobals; }
+    bool removeGlobalRef(const std::string& key);
     Style* findStyle(const std::string& _name);
 
     const auto& path() const { return m_path; }
@@ -87,6 +89,7 @@ public:
     const auto& mapProjection() const { return m_mapProjection; };
     const auto& fontContext() const { return m_fontContext; }
     const auto& globals() const { return m_globals; }
+    const auto& referencedGlobals() const { return m_referencedGlobals; }
 
     const Style* findStyle(const std::string& _name) const;
     const Light* findLight(const std::string& _name) const;
@@ -136,6 +139,8 @@ private:
     std::unordered_map<std::string, std::shared_ptr<Texture>> m_textures;
     std::unordered_map<std::string, std::shared_ptr<SpriteAtlas>> m_spriteAtlases;
     std::unordered_map<std::string, YAML::Node> m_globals;
+    // save the YAML Nodes for which global values have been swapped
+    std::vector<std::pair<std::string, YAML::Node>> m_referencedGlobals;
 
     // Container of all strings used in styling rules; these need to be
     // copied and compared frequently when applying styling, so rules use

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -78,31 +78,47 @@ bool SceneLoader::loadConfig(const std::string& _sceneString, Node& root) {
     return true;
 }
 
-void SceneLoader::applyUpdates(Node& root, const std::vector<SceneUpdate>& updates) {
+void SceneLoader::applyUpdate(Node& root, const std::vector<std::string>& keys, Node value) {
 
+    auto node = root;
+    std::string key;
+    for (auto it = keys.begin(); it != keys.end(); ++it) {
+        key = *it;
+        if (it + 1 == keys.end()) { break; } // Stop before last key.
+        node.reset(node[key]); // Node safely becomes invalid is key is not present.
+    }
+
+    if (node) {
+        try {
+            node[key] = value;
+        } catch (YAML::ParserException e) {
+            LOGW("Cannot update scene - value invalid: %s", e.what());
+        }
+    } else {
+        std::string path;
+        for (const auto& k : keys) { path += "." + k; }
+        LOGW("Cannot update scene - key not found: %s", path.c_str());
+    }
+}
+
+void SceneLoader::applyUpdates(Scene& scene, const std::vector<SceneUpdate>& updates) {
+    auto& root = scene.config();
     for (const auto& update : updates) {
-
+        scene.removeGlobalRef(update.keys);
         auto keys = splitString(update.keys, COMPONENT_PATH_DELIMITER);
-
-        auto node = root;
-        std::string key;
-        for (auto it = keys.begin(); it != keys.end(); ++it) {
-            key = *it;
-            if (it + 1 == keys.end()) { break; } // Stop before last key.
-            node.reset(node[key]); // Node safely becomes invalid is key is not present.
+        try {
+            auto valueNode = YAML::Load(update.value);
+            applyUpdate(root, keys, valueNode);
+        } catch (YAML::ParserException e) {
+            LOGE("Parsing scene update string failed. '%s'", e.what());
         }
+    }
+}
 
-        if (node) {
-            try {
-                node[key] = YAML::Load(update.value);
-            } catch (YAML::ParserException e) {
-                LOGW("Cannot update scene - value invalid: %s", e.what());
-            }
-        } else {
-            std::string path;
-            for (const auto& k : keys) { path += "." + k; }
-            LOGW("Cannot update scene - key not found: %s", path.c_str());
-        }
+void SceneLoader::applyGlobalRefUpdates(Node& root, const std::shared_ptr<Scene>& scene) {
+    for (const auto& referencedGlobal : scene->referencedGlobals()) {
+        auto keys = splitString(referencedGlobal.first, COMPONENT_PATH_DELIMITER);
+        applyUpdate(root, keys, referencedGlobal.second);
     }
 }
 
@@ -115,7 +131,7 @@ void printFilters(const SceneLayer& layer, int indent){
     }
 };
 
-void SceneLoader::applyGlobalProperties(Node& node, const std::shared_ptr<Scene>& scene) {
+void SceneLoader::applyGlobalProperties(Node& node, const std::shared_ptr<Scene>& scene, const std::string& keys) {
     switch(node.Type()) {
     case NodeType::Scalar:
         {
@@ -124,17 +140,25 @@ void SceneLoader::applyGlobalProperties(Node& node, const std::shared_ptr<Scene>
                 key.replace(0, 7, "");
                 std::replace(key.begin(), key.end(), '.', DELIMITER[0]);
                 node = scene->globals()[key];
+                scene->referencedGlobals().emplace_back(keys, scene->globals()[key]);
             }
         }
         break;
     case NodeType::Sequence:
-        for (auto n : node) {
-            applyGlobalProperties(n, scene);
+        {
+            int i = 0;
+            for (auto n : node) {
+                std::string k = keys + COMPONENT_PATH_DELIMITER + std::to_string(i);
+                applyGlobalProperties(n, scene, k);
+                i++;
+            }
+            break;
         }
-        break;
     case NodeType::Map:
         for (auto n : node) {
-            applyGlobalProperties(n.second, scene);
+            std::string k = (n.first.IsScalar()) ? n.first.Scalar() : "";
+            k = (keys.size() > 0) ? (keys + COMPONENT_PATH_DELIMITER + k) : k;
+            applyGlobalProperties(n.second, scene, k);
         }
         break;
     default:
@@ -176,6 +200,7 @@ bool SceneLoader::applyConfig(Node& config, const std::shared_ptr<Scene>& _scene
 
     if (Node globals = config["global"]) {
         parseGlobals(globals, _scene);
+        applyGlobalRefUpdates(config, _scene);
         applyGlobalProperties(config, _scene);
     }
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -43,8 +43,10 @@ struct SceneLoader {
     static bool loadScene(std::shared_ptr<Scene> _scene);
     static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, const std::shared_ptr<Scene>& scene);
-    static void applyUpdates(Node& root, const std::vector<SceneUpdate>& updates);
-    static void applyGlobalProperties(Node& node, const std::shared_ptr<Scene>& scene);
+    static void applyUpdates(Scene& scene, const std::vector<SceneUpdate>& updates);
+    static void applyUpdate(Node& root, const std::vector<std::string>& keys, Node value);
+    static void applyGlobalProperties(Node& node, const std::shared_ptr<Scene>& scene, const std::string& keys = "");
+    static void applyGlobalRefUpdates(Node& node, const std::shared_ptr<Scene>& scene);
 
     /*** all public for testing ***/
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -221,6 +221,7 @@ void Map::applySceneUpdates() {
         if (impl->sceneUpdates.empty()) { return; }
 
         impl->nextScene = std::make_shared<Scene>(*impl->scene);
+        impl->nextScene->referencedGlobals() = impl->scene->referencedGlobals();
         impl->nextScene->useScenePosition = false;
 
         updates = impl->sceneUpdates;
@@ -229,7 +230,7 @@ void Map::applySceneUpdates() {
 
     runAsyncTask([scene = impl->nextScene, updates = std::move(updates), &jobQueue = impl->jobQueue, this](){
 
-            SceneLoader::applyUpdates(scene->config(), updates);
+            SceneLoader::applyUpdates(*scene, updates);
 
             bool ok = SceneLoader::applyConfig(scene->config(), scene);
 

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -68,7 +68,7 @@ TEST_CASE("Scene update tests") {
     updates.push_back({"global.non_existing_property1.non_existing_property_deep", "true"});
 
     // Tangram apply scene updates, reload the scene
-    SceneLoader::applyUpdates(scene.config(), updates);
+    SceneLoader::applyUpdates(scene, updates);
 
     const Node& root = scene.config();
 
@@ -101,7 +101,7 @@ TEST_CASE("Scene update tests, ensure update ordering is preserved") {
     updates.push_back({"lights.light2.ambient", "0.0"});
 
     // Tangram apply scene updates, reload the scene
-    SceneLoader::applyUpdates(scene.config(), updates);
+    SceneLoader::applyUpdates(scene, updates);
 
     const Node& root = scene.config();
 

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -13,14 +13,16 @@ using namespace Tangram;
 const static std::string sceneString = R"END(
 global:
     default_order: function() { return feature.sort_key; }
+    isoactive: true
+    persactive: false
 
 cameras:
     iso-camera:
         type: isometric
-        active: false
+        active: global.isoactive
     perspective-camera:
         type: perspective
-        active: true
+        active: global.persactive
 
 lights:
     light1:
@@ -107,4 +109,50 @@ TEST_CASE("Scene update tests, ensure update ordering is preserved") {
 
     REQUIRE(!root["lights"]["light1"]);
     REQUIRE(!root["lights"]["light2"]);
+}
+
+TEST_CASE("Scene update tests, multiple updates with globals") {
+    std::shared_ptr<Scene> scene = std::make_shared<Scene>();
+    std::vector<SceneUpdate> updates;
+
+    REQUIRE(!sceneString.empty());
+
+    REQUIRE(SceneLoader::loadConfig(sceneString, scene->config()));
+
+    Node& root = scene->config();
+
+    SceneLoader::parseGlobals(root["global"], scene);
+    SceneLoader::applyGlobalRefUpdates(root, scene);
+    SceneLoader::applyGlobalProperties(root, scene);
+
+    REQUIRE(root["cameras"]["iso-camera"]["active"].Scalar() == "true");
+    REQUIRE(root["cameras"]["perspective-camera"]["active"].Scalar() == "false");
+
+    // Update 1 - change 1 of the global values and explicitly set a value for the other
+    updates.push_back({"global.isoactive", "false"});
+    updates.push_back({"cameras.perspective-camera.active", "true"});
+    // Tangram apply scene updates, reload the scene
+    SceneLoader::applyUpdates(*scene, updates);
+    root = scene->config();
+    SceneLoader::parseGlobals(root["global"], scene);
+    SceneLoader::applyGlobalRefUpdates(root, scene);
+    SceneLoader::applyGlobalProperties(root, scene);
+    REQUIRE(root["cameras"]["iso-camera"]["active"].Scalar() == "false");
+    REQUIRE(root["cameras"]["perspective-camera"]["active"].Scalar() == "true");
+
+    updates.clear();
+
+    // Update 2 - swap globals
+    updates.push_back({"global.persactive", "true"});
+    updates.push_back({"cameras.iso-camera.active", "global.persactive"});
+    updates.push_back({"cameras.perspective-camera.active", "global.isoactive"});
+    // Tangram apply scene updates, reload the scene
+    SceneLoader::applyUpdates(*scene, updates);
+    root = scene->config();
+    SceneLoader::parseGlobals(root["global"], scene);
+    SceneLoader::applyGlobalRefUpdates(root, scene);
+    SceneLoader::applyGlobalProperties(root, scene);
+    REQUIRE(root["cameras"]["iso-camera"]["active"].Scalar() == "true");
+    REQUIRE(root["cameras"]["perspective-camera"]["active"].Scalar() == "false");
+
 }


### PR DESCRIPTION
since global properties are substituded when parsing the yaml scene for the first time, there was no information of
where the global properties were applied when any of these globals were updated.

This fixes the issue, by keeping track of the path of the node(s) which were using the global properties to begin with
so that subsequent global property updates are applied.