### PR TITLE
Simply print the GL info log when a shader fails to compile

### DIFF
--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -223,28 +223,7 @@ GLuint ShaderProgram::makeCompiledShader(const std::string& _src, GLenum _type) 
             infoLog.resize(infoLength);
 
             GL_CHECK(glGetShaderInfoLog(shader, infoLength, NULL, static_cast<GLchar*>(&infoLog[0])));
-            LOGE("Shader compilation failed %s", m_description.c_str());
-
-            std::stringstream ss(source);
-            std::string item;
-            std::vector<std::string> sourceLines;
-            while (std::getline(ss, item, '\n')) { sourceLines.push_back(item); }
-
-            // Print errors with context
-            std::string line;
-            ss.str(infoLog);
-            while (std::getline(ss, line)) {
-                if (line.length() < 2) { continue; }
-
-                int lineNum = 0;
-                sscanf(line.c_str(), "%*d(%d)", &lineNum);
-                logMsg("\nError on line %d: %s\n", lineNum, line.c_str());
-
-                for (int i = std::max(0, lineNum-5); i < lineNum+5; i++) {
-                    if (size_t(i) >= sourceLines.size()) { break; }
-                    logMsg("%d: %s\n", i, sourceLines[i].c_str());
-                }
-            }
+            LOGE("Shader compilation failed for %s with log:\n%s", m_description.c_str(), infoLog.c_str());
 
             // Print full source with line numbers
             // logMsg("\n\n");


### PR DESCRIPTION
The previous parsing of the error log was unreliable because the logs generally don't conform to a single format.

Having more info about shader errors would still be nice, especially since the shaders get so large. Maybe next we could add an option to write failed shaders to a log file for later analysis.