### PR TITLE
Fix conversion of a sequence of filters to an implicit 'any' filter

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1268,7 +1268,7 @@ Filter SceneLoader::generateFilter(Node _filter, Scene& scene) {
             } else if (key == "any") {
                 filters.push_back(generateAnyFilter(node, scene));
             } else if (key == "all") {
-                filters.push_back(generateFilter(node, scene));
+                filters.push_back(generateAllFilter(node, scene));
             } else {
                 filters.push_back(generatePredicate(node, key));
             }
@@ -1282,6 +1282,7 @@ Filter SceneLoader::generateFilter(Node _filter, Scene& scene) {
 
     if (filters.size() == 0) { return Filter(); }
     if (filters.size() == 1) { return std::move(filters.front()); }
+    if (_filter.IsSequence()) { return Filter::MatchAny(std::move(filters)); }
     return (Filter::MatchAll(std::move(filters)));
 }
 
@@ -1360,6 +1361,19 @@ Filter SceneLoader::generateAnyFilter(Node _filter, Scene& scene) {
         filters.emplace_back(generateFilter(filt, scene));
     }
     return Filter::MatchAny(std::move(filters));
+}
+
+Filter SceneLoader::generateAllFilter(Node _filter, Scene& scene) {
+    std::vector<Filter> filters;
+
+    if (!_filter.IsSequence()) {
+        LOGW("Invalid filter. 'All' expects a list.");
+        return Filter();
+    }
+    for (const auto& filt : _filter) {
+        filters.emplace_back(generateFilter(filt, scene));
+    }
+    return Filter::MatchAll(std::move(filters));
 }
 
 Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -66,6 +66,7 @@ struct SceneLoader {
     static SceneLayer loadSublayer(Node layer, const std::string& name, const std::shared_ptr<Scene>& scene);
     static Filter generateFilter(Node filter, Scene& scene);
     static Filter generateAnyFilter(Node filter, Scene& scene);
+    static Filter generateAllFilter(Node filter, Scene& scene);
     static Filter generateNoneFilter(Node filter, Scene& scene);
     static Filter generatePredicate(Node filter, std::string _key);
     /* loads a texture with default texture properties */

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -238,3 +238,12 @@ TEST_CASE("Filters specified as a javascript function evaluate correctly", "[fil
     REQUIRE(!filter.eval(bmw1, ctx));
     REQUIRE(!filter.eval(bike, ctx));
 }
+
+TEST_CASE("Sequences in filters implicitly create an 'any' filter", "[filters][core][yaml]") {
+    init();
+    Filter filter = load("filter: [ { brand: 'bmw' }, { type: 'car' } ]");
+
+    REQUIRE(filter.eval(civic, ctx));
+    REQUIRE(filter.eval(bmw1, ctx));
+    REQUIRE(!filter.eval(bike, ctx));
+}


### PR DESCRIPTION
Previously a sequence of filters, like this:
```yaml
filter:
  - { $zoom: 13, height: { min: 250 } }
  - { $zoom: 13, area: { min: 50000 } }
  - { $zoom: 13, volume: { min: 200000 } }
  - { $zoom: 14, height: { min: 190 } }
```
would be converted into an 'all' filter. These should instead be 'any' filters, as documented here: https://mapzen.com/documentation/tangram/Filters-Overview/#lists-imply-any-mappings-imply-all