### PR TITLE
Updates, Fixes, and Changes for iOS 10 and Xcode 8 framework

### DIFF
--- a/ios/src/TGMapViewController.h
+++ b/ios/src/TGMapViewController.h
@@ -7,8 +7,6 @@
 //  Copyright (c) 2016 Mapzen. All rights reserved.
 //
 
-#include "tangram.h"
-
 #import <UIKit/UIKit.h>
 #import <GLKit/GLKit.h>
 
@@ -47,7 +45,6 @@ NS_ASSUME_NONNULL_END
 struct TileID;
 @interface TGMapViewController : GLKViewController <UIGestureRecognizerDelegate>
 
-@property (assign, nonatomic, nullable) Tangram::Map* map;
 @property (assign, nonatomic) BOOL continuous;
 @property (weak, nonatomic, nullable) id<TangramGestureRecognizerDelegate> gestureDelegate;
 

--- a/ios/src/TGMapViewController.mm
+++ b/ios/src/TGMapViewController.mm
@@ -6,6 +6,7 @@
 //  Updated by Matt Smollinger on 7/29/16.
 //  Copyright (c) 2016 Mapzen. All rights reserved.
 //
+#include "tangram.h"
 
 #import "TGMapViewController.h"
 #include "platform_ios.h"
@@ -15,6 +16,7 @@
 @property (nullable, strong, nonatomic) EAGLContext *context;
 @property (assign, nonatomic) CGFloat pixelScale;
 @property (assign, nonatomic) BOOL renderRequested;
+@property (assign, nonatomic, nullable) Tangram::Map* map;
 
 @end
 

--- a/ios/tangram_framework/tangram_framework.h
+++ b/ios/tangram_framework/tangram_framework.h
@@ -16,4 +16,4 @@ FOUNDATION_EXPORT const unsigned char tangram_frameworkVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <tangram_framework/PublicHeader.h>
 
-#import <tangram_framework/ViewController.h>
+#import <tangram_framework/TGMapViewController.h>

--- a/ios/xcodeproj/tangram.xcodeproj/project.pbxproj
+++ b/ios/xcodeproj/tangram.xcodeproj/project.pbxproj
@@ -346,18 +346,14 @@
 		0D900D1CC8CD4C8EBB6166BA /* ucharstrie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC4A65A098B245138F8730E1 /* ucharstrie.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		0DA5408B79254FCCBA0A33C1 /* topoJson.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D66E9480AD248458034D302 /* topoJson.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		0E323A51A480468381E21291 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2FFF787455874C2B9BD7508D /* util.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		0E4D388D8FDD425AB842DB88 /* hb-ft.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6E09F660736C4CE68EB076BF /* hb-ft.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		0ED45B1D21E44993ADEAB1A1 /* loclikely.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8DA56675286A4E1B9E2BE242 /* loclikely.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		0FACCF0F79AF437895937407 /* unistr_case_locale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A4F108EC23A8434A8C5CB026 /* unistr_case_locale.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		0FDC1BB2896D4B3A90C08CCA /* patternprops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5DDB357BC72A4913960E448A /* patternprops.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		112559A149EA4DEE9D284727 /* cross.png in CopyFiles */ = {isa = PBXBuildFile; fileRef = D48060EFA1CC45CB9FD02DCA /* cross.png */; settings = {COMPILER_FLAGS = ""; }; };
-		129F817BECA2442B847240A1 /* hb-shape-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = BACAAEFD426C4E3CAEEEC729 /* hb-shape-plan.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		12D9E8370DF745CDA25385EC /* polylineStyle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62C8E94A497F423E9D7C9C11 /* polylineStyle.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		13E0EA1D17764690B108B5E4 /* test.yaml in Copy Files */ = {isa = PBXBuildFile; fileRef = BE80AF0E1C6F404A8CF00D04 /* test.yaml */; settings = {COMPILER_FLAGS = ""; }; };
 		14D4DBF7B6AC4088944EFF62 /* bytestrie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B0D6DA605D8F4F9CA978B5C4 /* bytestrie.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		156612B0394B47209CF10D33 /* platform_ios.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1608DCBC5BAC421BB71A2708 /* platform_ios.mm */; settings = {COMPILER_FLAGS = ""; }; };
-		157EE348F99D456380D30F16 /* hb-ot-shape-complex-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = C8B4627E31904B50BBB5E613 /* hb-ot-shape-complex-myanmar.cc */; settings = {COMPILER_FLAGS = ""; }; };
-		16DFF4AB21E24FDB992F9284 /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6949653E52D84329BC42BFC6 /* hb-font.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		17BAAAC664FF4B969CC21347 /* unistr_props.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BA04C8801190431DB4CB250A /* unistr_props.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		1991920179FF4AE0BE730AFC /* psnames.c in Sources */ = {isa = PBXBuildFile; fileRef = 970DE29C2B1A4AEC96CAD2CB /* psnames.c */; settings = {COMPILER_FLAGS = ""; }; };
 		19F7C9999DCA4826B53F2316 /* ftlzw.c in Sources */ = {isa = PBXBuildFile; fileRef = 0CE29FF4D2C34513A207A0D9 /* ftlzw.c */; settings = {COMPILER_FLAGS = ""; }; };
@@ -409,20 +405,16 @@
 		37C94011204649C4A92775DA /* raster.c in Sources */ = {isa = PBXBuildFile; fileRef = 6DAB67174F8B41B5A0E0C710 /* raster.c */; settings = {COMPILER_FLAGS = ""; }; };
 		37E6A8214F0541028E2EDBDA /* schriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8A7D13E34C9646848DF0BA6E /* schriter.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		38A084318AD3404A9EFE6BE3 /* uinit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADFA48762B824B9A8B1588DD /* uinit.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		3948B5C298DB404AAFD5E820 /* hb-shaper.cc in Sources */ = {isa = PBXBuildFile; fileRef = B29164703DEF4128B962221E /* hb-shaper.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		399BC570B1BC43068C6B2AC6 /* ustrcase_locale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 824D6B3D70B547C5A25B2F37 /* ustrcase_locale.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		3A4DE9FB7A5346F6B7F160FD /* hb-set.cc in Sources */ = {isa = PBXBuildFile; fileRef = FA4A99F528B74DB7AA98BD7D /* hb-set.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		3A9376433BF1406F9EB0A127 /* bytestream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D0B88738F30942C698B8A844 /* bytestream.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		3B78159356484CB388A6DC9A /* dataLayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5D2C74FEEE74E4989D63342 /* dataLayer.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		3BF3B8D33ABC4269ABEB82B3 /* geoJson.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 788DAE8D6AEE472EBD49DD27 /* geoJson.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		3C3214C46FF34A6B9E70AC56 /* DroidSansJapanese.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = BC4F78BEC5654CDCB906283C /* DroidSansJapanese.ttf */; settings = {COMPILER_FLAGS = ""; }; };
 		3C66E8CE39DE4C47B1639C77 /* geojsonvt_clip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0D9F7FD3657547CDAED14E89 /* geojsonvt_clip.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		3CB448B4A45947FB8A2F103D /* hb-unicode.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B10C7CB7E454D708D806F4C /* hb-unicode.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		3CD39CA66C09467DBF9126E6 /* frameInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7501AD4AE844FFD9579BB6E /* frameInfo.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		3D21BAA14E0346F69DBACA5D /* ushape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9439A77FC5ED4437BC471CD3 /* ushape.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		3DD97EB7749F4E2685223A2B /* emit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DAFEC74411BD434BA5EBFAC6 /* emit.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		3DDDACC58F514CAB88A4193C /* uidna.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AEBC5C36E4B491C9A4B6905 /* uidna.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		3F5343F1EBA94323A1BDE204 /* hb-ot-shape-complex-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = F3F8DF3A93B7408284DC25A3 /* hb-ot-shape-complex-thai.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		4194C5A01B1B4B188B91DA7D /* rasterize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 081166BD702F4AE4B48CB86C /* rasterize.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		42456AAAAE7346B28386FB2A /* unisetspan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9FF69F09F9B846C3BAC096C4 /* unisetspan.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		440AD24A08854D60A393ECEE /* singledocparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 581BC2F498A24AB78BBAB720 /* singledocparser.cpp */; settings = {COMPILER_FLAGS = ""; }; };
@@ -446,15 +438,12 @@
 		509A42A33A934991AAC18869 /* geojsonvt_simplify.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 862A94978C0C444D8AB70316 /* geojsonvt_simplify.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		524989C171EF4FF89711E3A1 /* pbfParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB4437A0D285482D9E3DC284 /* pbfParser.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		52A77036069548E39A3821FA /* ucnv_u16.c in Sources */ = {isa = PBXBuildFile; fileRef = A2F01B0632FA43FBADDDA13B /* ucnv_u16.c */; settings = {COMPILER_FLAGS = ""; }; };
-		52AE6341CD824BE3909E7C39 /* hb-ot-shape-complex-arabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = A300BA04863A448786767B5C /* hb-ot-shape-complex-arabic.cc */; settings = {COMPILER_FLAGS = ""; }; };
-		53951EBC618F4ABFA6652DB3 /* hb-buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = D88EAA2A88384EB5985B036D /* hb-buffer.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		54348338FA6F4E11BED08673 /* arrow-3.png in CopyFiles */ = {isa = PBXBuildFile; fileRef = A59930103F7848F89278D200 /* arrow-3.png */; settings = {COMPILER_FLAGS = ""; }; };
 		54CEF9CE737F4A66A43F7AB6 /* utrie2_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A24E284E1D149119A3638C3 /* utrie2_builder.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		54D0A45CB8BD473B91562F1D /* poi_icons_32.png in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2608BC035969494AA2D19828 /* poi_icons_32.png */; settings = {COMPILER_FLAGS = ""; }; };
 		55112242AFCC4806B21C92BA /* dtintrv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EF41347D818540FB919CED53 /* dtintrv.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		552B8B011A1447B0B407C554 /* ubidiwrt.c in Sources */ = {isa = PBXBuildFile; fileRef = A0A90AA1033544E9B5789B0A /* ubidiwrt.c */; settings = {COMPILER_FLAGS = ""; }; };
 		5616E88128684CB5905191C0 /* nodebuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7DAE507977D34508AA769413 /* nodebuilder.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		562AFC2E1E004CECA5384C8F /* hb-ot-shape-complex-hangul.cc in Sources */ = {isa = PBXBuildFile; fileRef = B7A27565DEDB4C72A8C9CE31 /* hb-ot-shape-complex-hangul.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		564E0D665FCA40B2988409DB /* convert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFE2D30C68654306B2E56B5C /* convert.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		567D4192A1624ABA9B80E032 /* uniset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D554D63C2EED4DE487BA1BE7 /* uniset.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		5773918D74B945FD88F6B8AC /* ucnv_set.c in Sources */ = {isa = PBXBuildFile; fileRef = 981ACF92DFD8423EA9D32310 /* ucnv_set.c */; settings = {COMPILER_FLAGS = ""; }; };
@@ -463,22 +452,18 @@
 		58BCC6DD987A4C64BD983024 /* scrptrun.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8FE448F514A644ED91B34871 /* scrptrun.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		58EBFD7196364BFEBDC6D928 /* type42.c in Sources */ = {isa = PBXBuildFile; fileRef = 198ACE5ECC7D40579F1098FC /* type42.c */; settings = {COMPILER_FLAGS = ""; }; };
 		598A4C2F371346E7AEBEC905 /* polygonStyle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0989D46033394DA1998B06A1 /* polygonStyle.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		59DDE5EF15D74D8CB519F842 /* hb-ot-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = 899C8D0BD75E4F7BA8FF2B90 /* hb-ot-layout.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		5A340C59233143DA96D545EB /* ustring.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D5FB75672774BB68C957281 /* ustring.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		5AD6799AAD5E4F3E8CCF9536 /* emitter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A6CAF3713C24A4FAA8ACBD0 /* emitter.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		5B875457BD464CD0BF377FCB /* ustrtrns.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE49F19E1FB34A9EA2F24696 /* ustrtrns.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		5C40601B5580414B965252E6 /* uscript.c in Sources */ = {isa = PBXBuildFile; fileRef = 3441011F320A4DF189D42404 /* uscript.c */; settings = {COMPILER_FLAGS = ""; }; };
 		5CF2F79237ED40FE808DC6A7 /* ucasemap_titlecase_brkiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F0FD715275634CD2AC796E2A /* ucasemap_titlecase_brkiter.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		5D066900C1B34A5B819381F9 /* ucdn.c in Sources */ = {isa = PBXBuildFile; fileRef = 41397A6A6016411A9F0CCC94 /* ucdn.c */; settings = {COMPILER_FLAGS = ""; }; };
 		5DB2208F3B4440BAB359C077 /* umutex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42B3A35E2DBC438BA06958E7 /* umutex.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		5DC33CD9744640ECAF592700 /* hb-ot-shape-complex-tibetan.cc in Sources */ = {isa = PBXBuildFile; fileRef = C4BE61150055463B8B4B9638 /* hb-ot-shape-complex-tibetan.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		5DC51B1B93C84F20883C305D /* uloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F32B5C4A88FD4E6C8261DBE1 /* uloc.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		5ED23E0BDE2F4119A6D47FB9 /* extrude.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72AFE7E66F444EBEBE103034 /* extrude.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		61DBC68B5D4E492FBA6D0A03 /* mapzen-logo.png in CopyFiles */ = {isa = PBXBuildFile; fileRef = 59256EC81CE94328BD2A4E9A /* mapzen-logo.png */; settings = {COMPILER_FLAGS = ""; }; };
 		621322EDC7FF4B9D9A9F117B /* raster-simple.yaml in CopyFiles */ = {isa = PBXBuildFile; fileRef = C3E57C445FA34A04ACCB1829 /* raster-simple.yaml */; settings = {COMPILER_FLAGS = ""; }; };
 		62510704551A4DF48296889B /* raster-terrain.yaml in CopyFiles */ = {isa = PBXBuildFile; fileRef = 40086463238F4C1B90479B85 /* raster-terrain.yaml */; settings = {COMPILER_FLAGS = ""; }; };
 		629B0582A03547949BB55AF0 /* usetiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2429235BBAED4CE69991AD3E /* usetiter.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		62BD16CF79154060888C9540 /* hb-ot-shape-complex-default.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0FF14C75A77449ECABDBEBC4 /* hb-ot-shape-complex-default.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		62C6828FE7C84C55854294D3 /* dictionarydata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B07E4CBD073F4339BF398AD5 /* dictionarydata.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		62CC02BD53A548868C72BE04 /* ucnv_ct.c in Sources */ = {isa = PBXBuildFile; fileRef = 28C910BD5193446098DB13C4 /* ucnv_ct.c */; settings = {COMPILER_FLAGS = ""; }; };
 		63ACB19CFD274ABF9D022C77 /* uset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9EB1B87FE85442988DEB996A /* uset.cpp */; settings = {COMPILER_FLAGS = ""; }; };
@@ -494,7 +479,6 @@
 		69DBAEEBC8824113964C3F3E /* ambientLight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 13BF85316D3E4F2CBAE0DAEC /* ambientLight.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		6B27C97C329F453F993C98AD /* ucasemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9308428BB35E4BFD95439EF8 /* ucasemap.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		6B7F1B33D0F74B3E8456D03F /* normalizer2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 61F4E61ABDA14CD89ED0C4BA /* normalizer2.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		6BA4AA3D89B04041B64BD0EB /* hb-ucdn.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5BC0F7EFAADA403BAF6B4E1A /* hb-ucdn.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		6BB1181398BF480EBC239FF0 /* truetype.c in Sources */ = {isa = PBXBuildFile; fileRef = 9323D9BDA8744039BA985786 /* truetype.c */; settings = {COMPILER_FLAGS = ""; }; };
 		6C829761C40347C1B362A17C /* ftbase.c in Sources */ = {isa = PBXBuildFile; fileRef = D977F6B0C0D74C8CA3E27A71 /* ftbase.c */; settings = {COMPILER_FLAGS = ""; }; };
 		6CC2D85250AC419CB8F0AE29 /* cff.c in Sources */ = {isa = PBXBuildFile; fileRef = 24E343F4833E4820868B65E1 /* cff.c */; settings = {COMPILER_FLAGS = ""; }; };
@@ -513,7 +497,6 @@
 		751239537DE84E569371C318 /* udata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 928E759186DB46149875E3DA /* udata.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		7778FEF94A1C4CB9B94048F2 /* ftmm.c in Sources */ = {isa = PBXBuildFile; fileRef = 50F1CDCCFDBE43BFABF3AE80 /* ftmm.c */; settings = {COMPILER_FLAGS = ""; }; };
 		77A6AAF04DF2467DB82FB64F /* duktape.c in Sources */ = {isa = PBXBuildFile; fileRef = EA49785D8C05485D84BBB146 /* duktape.c */; settings = {COMPILER_FLAGS = ""; }; };
-		7858581B008449679A86728B /* hb-ot-shape-complex-use-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 83CC810132814F04B27C35D6 /* hb-ot-shape-complex-use-table.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		78C479CF7A2D46C8BDAEDB0B /* rbbiscan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A0225090A204FBE8C17FCBF /* rbbiscan.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		796CDD4710844FB8B33A565E /* binary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6606D1827F36410FBDCC5B43 /* binary.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		7980405F5E63468BBC2C2303 /* type1.c in Sources */ = {isa = PBXBuildFile; fileRef = 31B07E51BBF44E71B63B5783 /* type1.c */; settings = {COMPILER_FLAGS = ""; }; };
@@ -533,29 +516,24 @@
 		805533205BCE438C98D10240 /* unistr_case.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 706F4BBA1EF844F3B823523D /* unistr_case.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		809949AD041A4779B2242D3B /* locavailable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F4B43236B0D48189F8B7018 /* locavailable.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		839BE5EC789C4ED6A993DE7B /* ucat.c in Sources */ = {isa = PBXBuildFile; fileRef = 55AEA1083A4847A59AB97478 /* ucat.c */; settings = {COMPILER_FLAGS = ""; }; };
-		83A2DE91DD894885A2D0E8CF /* hb-ot-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 80F40CBDA8F34358A34F9419 /* hb-ot-map.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		84EF47F091644FDA97F843A3 /* quadMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 860773F593ED40BBBC1613B5 /* quadMatrix.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		85C6AAE09BC74906A642F597 /* propname.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 76A85B97F292445EBE56E5F6 /* propname.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		8687377400AE4D45918B692B /* pointStyle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4B4743A65AE4697A030E0BD /* pointStyle.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		88397C0578864CD985F5946E /* scanscalar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45583B673B9B4BEB93135488 /* scanscalar.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		8928828C82D74479B8835949 /* ubidiln.c in Sources */ = {isa = PBXBuildFile; fileRef = EF117E971CC84998991E721E /* ubidiln.c */; settings = {COMPILER_FLAGS = ""; }; };
 		89641180B2E342768CEF4D7F /* textBatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 435E064411DF498B8ECB55B5 /* textBatch.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		89B9A524A49147E3A2037D7F /* hb-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9E358A80543F488197A93F1F /* hb-common.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		8A43F08920694AEF8ACC209F /* unormcmp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1665EE1221CA4099BA45EF79 /* unormcmp.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		8CF28DE460774DB98FB5D920 /* ucnvmbcs.c in Sources */ = {isa = PBXBuildFile; fileRef = DF9AA05BB1684BA9A34F6D3F /* ucnvmbcs.c */; settings = {COMPILER_FLAGS = ""; }; };
 		8DD55C534C694BD394DA339E /* NotoNaskh-Regular.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 668D0363F9B84A6CA84E1C0E /* NotoNaskh-Regular.ttf */; settings = {COMPILER_FLAGS = ""; }; };
 		8E222B9B7E864BC493AEE7CB /* normlzr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F11B988C8EBB4ADDBA03C5C6 /* normlzr.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		8EE996AB1A5742F7BD8CA8F6 /* ucnv_bld.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2E3B7447B66442B9414E3DC /* ucnv_bld.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		90A3150FDB3544328CD67916 /* debugTextStyle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C504B1A2746E4E49A7BBD140 /* debugTextStyle.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		9189CD96735F468CA3F9B6DB /* hb-ot-shape-fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = AF25A489B1DB4864AFB80635 /* hb-ot-shape-fallback.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		92025C75A27F45D4B893159B /* ucnv_ext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29E1042C80A6449394AA3C86 /* ucnv_ext.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		93EF32E9B9EC46458375B08E /* node_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3781A5CC46B4B97BC62C25A /* node_data.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		94262C6447384CAE9124AF5D /* filterednormalizer2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0E0BF5C088824D2FB20EA627 /* filterednormalizer2.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		94E1014752384DC5B0482246 /* uhash.c in Sources */ = {isa = PBXBuildFile; fileRef = D8B6016F6E0C4C3EB9418B04 /* uhash.c */; settings = {COMPILER_FLAGS = ""; }; };
-		951DEA3CB3F743E694E9BD12 /* hb-face.cc in Sources */ = {isa = PBXBuildFile; fileRef = E08983525AE24CBEA77AEB36 /* hb-face.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		95F40E0E2FD94FE2AA6A83D0 /* lineSampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 916A778142A244D78F55FE3F /* lineSampler.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		9673CE5410E4499181745C24 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C88EC1FF3F945DAAE931700 /* main.m */; settings = {COMPILER_FLAGS = ""; }; };
-		98D8D465AAA949CE8064B107 /* hb-ot-shape-complex-indic.cc in Sources */ = {isa = PBXBuildFile; fileRef = 72DABCE405E94F879F04EF01 /* hb-ot-shape-complex-indic.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		998D2695769B4B8E9F5CE8D7 /* pointLight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B85FE04BC1F34C468C8BDEFD /* pointLight.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		9A6F587C5AA24EB3934F0A42 /* serv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A167CD84C937483C80AC0EBE /* serv.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		9A9EB1CD9965488EB284B8E4 /* ftlcdfil.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DE2787CC43F4D2CA16474AA /* ftlcdfil.c */; settings = {COMPILER_FLAGS = ""; }; };
@@ -568,7 +546,6 @@
 		A06C4B7948444FC89C1954C4 /* ucnvscsu.c in Sources */ = {isa = PBXBuildFile; fileRef = B00AA657D2CB49168258FA5D /* ucnvscsu.c */; settings = {COMPILER_FLAGS = ""; }; };
 		A0940ECEC24941B2B2222B24 /* tile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C214B88965C4E49BDAB8F5F /* tile.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		A0CC04E47FAC40A68C57E5F1 /* ftdebug.c in Sources */ = {isa = PBXBuildFile; fileRef = E445A15182C245F79D86E010 /* ftdebug.c */; settings = {COMPILER_FLAGS = ""; }; };
-		A0F3E7B0FBD14AC5A41D5F02 /* hb-ot-shape-normalize.cc in Sources */ = {isa = PBXBuildFile; fileRef = 686BCC96C74C4FD79F01D4FA /* hb-ot-shape-normalize.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		A132E217DCEE46BFB088A364 /* ustack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7FE738C6284C4F2DA573FED8 /* ustack.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		A1561C7153D5436586443C7A /* rbbistbl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6DB4C5A8978A4DE4AAF43386 /* rbbistbl.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		A1AB2A329DF04C7CAA28FF37 /* bmpset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FB3260C1B8B849EA8742E5FD /* bmpset.cpp */; settings = {COMPILER_FLAGS = ""; }; };
@@ -590,7 +567,6 @@
 		AC65B631A86A49C199571CBD /* parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AF6017075F214CDC906894C5 /* parser.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		ACBE1ADF7BFC48829BC7FDCD /* emitterstate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5F580663BA048F79A613B80 /* emitterstate.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		ACD215C6EF774742AE72D97F /* ubrk.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A35E5B416314D47B83456A6 /* ubrk.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		AD1407F8CA8B48E2A3850098 /* hb-ot-shape-complex-hebrew.cc in Sources */ = {isa = PBXBuildFile; fileRef = 562CD690A6C846B581ECFE16 /* hb-ot-shape-complex-hebrew.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		AD338F76539A421BA097B029 /* labelSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03D371F06B354E3CA37EF9D4 /* labelSet.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		AE3DFEAEB6294664ADF2A3D4 /* ftbdf.c in Sources */ = {isa = PBXBuildFile; fileRef = E4D884C7B2024DEF985667CD /* ftbdf.c */; settings = {COMPILER_FLAGS = ""; }; };
 		AE608C9E7CCD44CCA3D8F672 /* charstr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F2A3101ACE12434E833A281E /* charstr.cpp */; settings = {COMPILER_FLAGS = ""; }; };
@@ -602,7 +578,6 @@
 		B21B3C5692F24DEBBCD12F86 /* ostream_wrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2E1C13C1F1554BD2AA8435BB /* ostream_wrapper.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		B228367D82084A8DADE13080 /* smooth.c in Sources */ = {isa = PBXBuildFile; fileRef = 7DCB220339F34CF5B25008B0 /* smooth.c */; settings = {COMPILER_FLAGS = ""; }; };
 		B2B5AB9E906843758DD2238C /* sfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = 693A4ABB57EA4DD88EC78F7F /* sfnt.c */; settings = {COMPILER_FLAGS = ""; }; };
-		B39F082FF8BA478C985B9F0A /* hb-warning.cc in Sources */ = {isa = PBXBuildFile; fileRef = C50FBC0483A6416B95571164 /* hb-warning.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		B3BD8850A7374B7D99125617 /* ftinit.c in Sources */ = {isa = PBXBuildFile; fileRef = 66393AC62849411D9868B7D9 /* ftinit.c */; settings = {COMPILER_FLAGS = ""; }; };
 		B4085BE8B8054175B7AF7ABB /* roboto-regular.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0C9A2400B104452A80709E65 /* roboto-regular.ttf */; settings = {COMPILER_FLAGS = ""; }; };
 		B4A0FE582B7444FDB0D2115B /* servnotf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E32703E6994B4379819CC00B /* servnotf.cpp */; settings = {COMPILER_FLAGS = ""; }; };
@@ -611,7 +586,6 @@
 		B5E7D48AA85D40558D77C93C /* ucnv_io.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6607E78C239A4A8FA58C3675 /* ucnv_io.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		B5FB0E4FC7134AE5B18BB8BA /* inputHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA7CF1E74BE04DEBB54B2D77 /* inputHandler.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		B86BC56ADD334FD98F457FCD /* ruleiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E6597AC3EA4425A0006AB7 /* ruleiter.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		B88F25DCA8804803ADB0FAEB /* lineWrap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 934966E99587479C8C3C46C4 /* lineWrap.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		B8D235C3999447468BC3594E /* umapfile.c in Sources */ = {isa = PBXBuildFile; fileRef = FEDDB95F164D4A168C66F3F0 /* umapfile.c */; settings = {COMPILER_FLAGS = ""; }; };
 		B8DC93E83C844D0DAB96B7C4 /* shaderProgram.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CF928D77C4848249CBF43DE /* shaderProgram.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		BB6D4D5E4763499CB3B4DA49 /* uarrsort.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C55DFDC945F4902A55F253D /* uarrsort.c */; settings = {COMPILER_FLAGS = ""; }; };
@@ -627,7 +601,6 @@
 		BE91BEB3BB8E4C5991331E91 /* unorm_it.c in Sources */ = {isa = PBXBuildFile; fileRef = E5D22799B9D2428CA0F9875D /* unorm_it.c */; settings = {COMPILER_FLAGS = ""; }; };
 		BED807D233EA470980A0A5E6 /* uobject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DA2FDBE3A4D49CF92B30855 /* uobject.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		C043E91DE59D4E1BA3D62E32 /* tangram-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DF4D6FD16EB541108E39676F /* tangram-Info.plist */; settings = {COMPILER_FLAGS = ""; }; };
-		C198AA6DF50F48FA9B139172 /* hb-blob.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3D7EE01226884E699C85D35E /* hb-blob.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		C1D2FF25255B4AEDB578C08B /* pointStyleBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C5C54FBE92C4AC3B1DFF7E8 /* pointStyleBuilder.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		C21FBF2463DC4CD59CBD8357 /* textureCube.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72CC9730D0F9437D9B8CE91E /* textureCube.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		C2566F1DB11148BABA286219 /* geojsonvt_convert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF64F4981E9B4B2C904DF290 /* geojsonvt_convert.cpp */; settings = {COMPILER_FLAGS = ""; }; };
@@ -638,7 +611,6 @@
 		C3764C494EC24331A95A4B21 /* uvector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9062234BC5F348B7981B52AE /* uvector.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		C405187492464056AB326000 /* normals.jpg in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBA9BBDF50D0411DAF29F275 /* normals.jpg */; settings = {COMPILER_FLAGS = ""; }; };
 		C5A4019BD1D44B07BCF16767 /* labelProperty.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8206994BB689434896596EE9 /* labelProperty.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		C6275F1B1AC54EE7942AA512 /* hb-ot-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = CF8DAE04F3934E6384311CC2 /* hb-ot-font.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		C63223D65AC4468AA56DEF54 /* utf_impl.c in Sources */ = {isa = PBXBuildFile; fileRef = 8F56C8E4FCE44395A96AC1DE /* utf_impl.c */; settings = {COMPILER_FLAGS = ""; }; };
 		C6BC6E6A96184C0685E5A5C6 /* node.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEFE0FD19E9C4CF7841AAAE9 /* node.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		C83C088C70EA4ADA812211BD /* cubemap.png in CopyFiles */ = {isa = PBXBuildFile; fileRef = FED00CAC627A49DF80F86641 /* cubemap.png */; settings = {COMPILER_FLAGS = ""; }; };
@@ -661,11 +633,9 @@
 		D6AEC9E2E46244A2AC36980B /* locmap.c in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CB074EFA4464A5605488 /* locmap.c */; settings = {COMPILER_FLAGS = ""; }; };
 		D763175EAF434EF5B072DC3B /* uhash_us.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2F891A6E32B4B4AA007A06C /* uhash_us.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		D7B945B859C04F6ABF865700 /* ucnv_cb.c in Sources */ = {isa = PBXBuildFile; fileRef = D28B7ACB1CCF4BB3BE28FA17 /* ucnv_cb.c */; settings = {COMPILER_FLAGS = ""; }; };
-		D7B973A8B4FB43BEA3C056C5 /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = 023E9B0FDFC74C8BAB1CBDF8 /* hb-ot-shape-complex-indic-table.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		D83621B9246940C796A8831C /* textStyle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 931911F85C274E39A490EB61 /* textStyle.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		D9CFE8E11F434D7C869C793B /* scantag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AB2AC9F9C0F445F95913A66 /* scantag.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		D9DBF0E483B54C3CBE5C668D /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = F2A536EB751342AABB298001 /* LaunchScreen.xib */; settings = {COMPILER_FLAGS = ""; }; };
-		DA329467AD5E41B1A5AEA2B0 /* hb-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = A85FD3396A87458F8576E8BD /* hb-shape.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		DA3BDFCB299D4298AFB35367 /* linebreakdef.c in Sources */ = {isa = PBXBuildFile; fileRef = 948B79370581424BAAC00539 /* linebreakdef.c */; settings = {COMPILER_FLAGS = ""; }; };
 		DA421623DA7046EDA2515218 /* unistr_titlecase_brkiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 30943BEF56DB4DC3A8BE3A43 /* unistr_titlecase_brkiter.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		DA7340830CB845EB81208013 /* grid.jpg in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8DAA8B5D3CB045EB827CA073 /* grid.jpg */; settings = {COMPILER_FLAGS = ""; }; };
@@ -674,6 +644,42 @@
 		DB3C117A1D4BBE2600534CA9 /* TGMapViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = DB3C11791D4BBE2600534CA9 /* TGMapViewController.mm */; };
 		DB3C117B1D4BC11900534CA9 /* TGMapViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = DB3C11771D4BBE1F00534CA9 /* TGMapViewController.h */; };
 		DB3C117C1D4BC14800534CA9 /* TGMapViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = DB3C11791D4BBE2600534CA9 /* TGMapViewController.mm */; };
+		DB44A83A1D996EFD00719BFB /* hb-blob.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A80D1D996EFD00719BFB /* hb-blob.cc */; };
+		DB44A83C1D996EFD00719BFB /* hb-buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A80F1D996EFD00719BFB /* hb-buffer.cc */; };
+		DB44A83D1D996EFD00719BFB /* hb-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8101D996EFD00719BFB /* hb-common.cc */; };
+		DB44A8401D996EFD00719BFB /* hb-face.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8131D996EFD00719BFB /* hb-face.cc */; };
+		DB44A8421D996EFD00719BFB /* hb-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8151D996EFD00719BFB /* hb-font.cc */; };
+		DB44A8431D996EFD00719BFB /* hb-ft.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8161D996EFD00719BFB /* hb-ft.cc */; };
+		DB44A8481D996EFD00719BFB /* hb-ot-font.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A81B1D996EFD00719BFB /* hb-ot-font.cc */; };
+		DB44A8491D996EFD00719BFB /* hb-ot-layout.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A81C1D996EFD00719BFB /* hb-ot-layout.cc */; };
+		DB44A84A1D996EFD00719BFB /* hb-ot-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A81D1D996EFD00719BFB /* hb-ot-map.cc */; };
+		DB44A84B1D996EFD00719BFB /* hb-ot-shape-complex-arabic.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A81E1D996EFD00719BFB /* hb-ot-shape-complex-arabic.cc */; };
+		DB44A84C1D996EFD00719BFB /* hb-ot-shape-complex-default.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A81F1D996EFD00719BFB /* hb-ot-shape-complex-default.cc */; };
+		DB44A84D1D996EFD00719BFB /* hb-ot-shape-complex-hangul.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8201D996EFD00719BFB /* hb-ot-shape-complex-hangul.cc */; };
+		DB44A84E1D996EFD00719BFB /* hb-ot-shape-complex-hebrew.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8211D996EFD00719BFB /* hb-ot-shape-complex-hebrew.cc */; };
+		DB44A84F1D996EFD00719BFB /* hb-ot-shape-complex-indic-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8221D996EFD00719BFB /* hb-ot-shape-complex-indic-table.cc */; };
+		DB44A8501D996EFD00719BFB /* hb-ot-shape-complex-indic.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8231D996EFD00719BFB /* hb-ot-shape-complex-indic.cc */; };
+		DB44A8511D996EFD00719BFB /* hb-ot-shape-complex-myanmar.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8241D996EFD00719BFB /* hb-ot-shape-complex-myanmar.cc */; };
+		DB44A8521D996EFD00719BFB /* hb-ot-shape-complex-thai.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8251D996EFD00719BFB /* hb-ot-shape-complex-thai.cc */; };
+		DB44A8531D996EFD00719BFB /* hb-ot-shape-complex-tibetan.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8261D996EFD00719BFB /* hb-ot-shape-complex-tibetan.cc */; };
+		DB44A8541D996EFD00719BFB /* hb-ot-shape-complex-use-table.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8271D996EFD00719BFB /* hb-ot-shape-complex-use-table.cc */; };
+		DB44A8551D996EFD00719BFB /* hb-ot-shape-complex-use.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8281D996EFD00719BFB /* hb-ot-shape-complex-use.cc */; };
+		DB44A8561D996EFD00719BFB /* hb-ot-shape-fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8291D996EFD00719BFB /* hb-ot-shape-fallback.cc */; };
+		DB44A8571D996EFD00719BFB /* hb-ot-shape-normalize.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A82A1D996EFD00719BFB /* hb-ot-shape-normalize.cc */; };
+		DB44A8581D996EFD00719BFB /* hb-ot-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A82B1D996EFD00719BFB /* hb-ot-shape.cc */; };
+		DB44A8591D996EFD00719BFB /* hb-ot-tag.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A82C1D996EFD00719BFB /* hb-ot-tag.cc */; };
+		DB44A85A1D996EFD00719BFB /* hb-set.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A82D1D996EFD00719BFB /* hb-set.cc */; };
+		DB44A85B1D996EFD00719BFB /* hb-shape-plan.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A82E1D996EFD00719BFB /* hb-shape-plan.cc */; };
+		DB44A85C1D996EFD00719BFB /* hb-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A82F1D996EFD00719BFB /* hb-shape.cc */; };
+		DB44A85D1D996EFD00719BFB /* hb-shaper.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8301D996EFD00719BFB /* hb-shaper.cc */; };
+		DB44A85E1D996EFD00719BFB /* hb-ucdn.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8311D996EFD00719BFB /* hb-ucdn.cc */; };
+		DB44A85F1D996EFD00719BFB /* hb-unicode.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8321D996EFD00719BFB /* hb-unicode.cc */; };
+		DB44A8611D996EFD00719BFB /* hb-warning.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8341D996EFD00719BFB /* hb-warning.cc */; };
+		DB44A89C1D99770000719BFB /* ucdn.c in Sources */ = {isa = PBXBuildFile; fileRef = DB44A89B1D99770000719BFB /* ucdn.c */; };
+		DB44A8A51D99818E00719BFB /* marker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8A11D99818E00719BFB /* marker.cpp */; };
+		DB44A8A71D99818E00719BFB /* markerManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8A31D99818E00719BFB /* markerManager.cpp */; };
+		DB44A8AA1D9982C600719BFB /* platform_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8A91D9982C600719BFB /* platform_gl.cpp */; };
+		DB44A8AB1D9982C600719BFB /* platform_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DB44A8A91D9982C600719BFB /* platform_gl.cpp */; };
 		DB4F2B421D2FCCA300813AAA /* DroidSansFallback.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7000A79E2D56438ABDC3A1E1 /* DroidSansFallback.ttf */; };
 		DB4F2B431D2FCCA300813AAA /* DroidSansJapanese.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = BC4F78BEC5654CDCB906283C /* DroidSansJapanese.ttf */; };
 		DB4F2B441D2FCCA300813AAA /* NotoNaskh-Regular.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 668D0363F9B84A6CA84E1C0E /* NotoNaskh-Regular.ttf */; };
@@ -686,12 +692,10 @@
 		DBD889621D2FC0EF00D05B1F /* tangram_framework.h in Headers */ = {isa = PBXBuildFile; fileRef = DBD889611D2FC0EF00D05B1F /* tangram_framework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBD8896A1D2FC15700D05B1F /* platform_ios.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1608DCBC5BAC421BB71A2708 /* platform_ios.mm */; };
 		DBD889841D2FC36500D05B1F /* platform_ios.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1608DCBC5BAC421BB71A2708 /* platform_ios.mm */; };
-		DBE8AA5457204CB7B92F2857 /* hb-ot-shape.cc in Sources */ = {isa = PBXBuildFile; fileRef = E0E275C4FCA2489E86AEF353 /* hb-ot-shape.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		DC06A5B7C75A45E6A6A28C73 /* putil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC321E5836D34A029CAE59AC /* putil.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		DD7FA10AABE740C38B7D6A98 /* ulist.c in Sources */ = {isa = PBXBuildFile; fileRef = 5BCD4B4F4F0248E997DDBE67 /* ulist.c */; settings = {COMPILER_FLAGS = ""; }; };
 		DD9024C0440D4146A8F55A5E /* textDisplay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C5C53779B05641EC9D23568B /* textDisplay.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		DE5489EF2CEA4104AB7ED4F7 /* ftpatent.c in Sources */ = {isa = PBXBuildFile; fileRef = F8A6511865A143AE8F21F2FF /* ftpatent.c */; settings = {COMPILER_FLAGS = ""; }; };
-		DE7E3658F5B84014B3D907E9 /* hb-ot-tag.cc in Sources */ = {isa = PBXBuildFile; fileRef = 644ED745E5F84F4D99665C57 /* hb-ot-tag.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		DF60D2A019084A85A65DD345 /* normalizer2impl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 824E57702F9F43798AE4FC9A /* normalizer2impl.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		E01F2780B65944A5B3362AD8 /* udatamem.c in Sources */ = {isa = PBXBuildFile; fileRef = FE62FEBCEBCF419FB8C92D94 /* udatamem.c */; settings = {COMPILER_FLAGS = ""; }; };
 		E164C99B192A4DD0B3868B3B /* uresbund.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AEDD3930A6D34D3185C584DF /* uresbund.cpp */; settings = {COMPILER_FLAGS = ""; }; };
@@ -704,7 +708,6 @@
 		E60A7D591E184D2BB028105F /* uloc_tag.c in Sources */ = {isa = PBXBuildFile; fileRef = 079179108CD84A7E90960711 /* uloc_tag.c */; settings = {COMPILER_FLAGS = ""; }; };
 		E6EC15BAEF574B0CA0FC63FF /* ftwinfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D44A8364E794AB182FD209A /* ftwinfnt.c */; settings = {COMPILER_FLAGS = ""; }; };
 		E72CECF661E543678E9537E4 /* exp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8779D61B29794A6BACFF5108 /* exp.cpp */; settings = {COMPILER_FLAGS = ""; }; };
-		E793B7E0B95F438D8D0CAE30 /* hb-ot-shape-complex-use.cc in Sources */ = {isa = PBXBuildFile; fileRef = 876D4FD59AFF4A2286849D26 /* hb-ot-shape-complex-use.cc */; settings = {COMPILER_FLAGS = ""; }; };
 		E7D861E1338D46D1B2494E8D /* ucnv2022.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE9F0EF933BD42C790E94C1E /* ucnv2022.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		E931B7715E9E4B14BF31DDD1 /* chariter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8B290E826E3E4F4896DFD97C /* chariter.cpp */; settings = {COMPILER_FLAGS = ""; }; };
 		E94C323B37B645E0A21BBEA7 /* ubidi.c in Sources */ = {isa = PBXBuildFile; fileRef = 12518614C760420D87B59F56 /* ubidi.c */; settings = {COMPILER_FLAGS = ""; }; };
@@ -1418,50 +1421,47 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		002011213D394F0BB0F9ED2C /* brkeng.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = brkeng.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/brkeng.cpp"; sourceTree = SOURCE_ROOT; };
+		002011213D394F0BB0F9ED2C /* brkeng.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = brkeng.cpp; path = "external/harfbuzz-icu-freetype/icu/common/brkeng.cpp"; sourceTree = SOURCE_ROOT; };
 		0034DCD86BFA4ACBA36A551B /* json.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = json.h; path = core/src/util/json.h; sourceTree = SOURCE_ROOT; };
 		0064909A0C474CD3BDDA9240 /* node.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = node.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/node.h"; sourceTree = SOURCE_ROOT; };
 		016FD6D5D597452AAE138F72 /* nodeevents.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = nodeevents.h; path = "external/yaml-cpp/src/nodeevents.h"; sourceTree = SOURCE_ROOT; };
 		017E0C82ED1F4723A7960419 /* anchor.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = anchor.h; path = "external/yaml-cpp/include/yaml-cpp/anchor.h"; sourceTree = SOURCE_ROOT; };
 		0198081BE7774FF4A7D92C64 /* geoJsonSource.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geoJsonSource.cpp; path = core/src/data/geoJsonSource.cpp; sourceTree = SOURCE_ROOT; };
-		01A0E8B37B5E4A9FAAA0E39F /* ucnv_u32.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_u32.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_u32.c"; sourceTree = SOURCE_ROOT; };
+		01A0E8B37B5E4A9FAAA0E39F /* ucnv_u32.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_u32.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_u32.c"; sourceTree = SOURCE_ROOT; };
 		02087AFA57DB4768BB4D9805 /* vertexLayout.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = vertexLayout.cpp; path = core/src/gl/vertexLayout.cpp; sourceTree = SOURCE_ROOT; };
-		023E9B0FDFC74C8BAB1CBDF8 /* hb-ot-shape-complex-indic-table.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-indic-table.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-indic-table.cc"; sourceTree = SOURCE_ROOT; };
-		0332844145F34D3798E470C7 /* pshinter.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = pshinter.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/pshinter/pshinter.c"; sourceTree = SOURCE_ROOT; };
+		0332844145F34D3798E470C7 /* pshinter.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = pshinter.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/pshinter/pshinter.c"; sourceTree = SOURCE_ROOT; };
 		03D371F06B354E3CA37EF9D4 /* labelSet.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = labelSet.cpp; path = core/src/labels/labelSet.cpp; sourceTree = SOURCE_ROOT; };
 		0472E4FF8D064F2092FEFD4B /* labels.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = labels.h; path = core/src/labels/labels.h; sourceTree = SOURCE_ROOT; };
 		0528A7714FB24009A1FA1D62 /* topoJsonSource.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = topoJsonSource.h; path = core/src/data/topoJsonSource.h; sourceTree = SOURCE_ROOT; };
-		064394EAC04443FC82EDEE51 /* ftbbox.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbbox.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftbbox.c"; sourceTree = SOURCE_ROOT; };
-		06B2C8DCD9A54F52B3B54B54 /* servslkf.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servslkf.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/servslkf.cpp"; sourceTree = SOURCE_ROOT; };
+		064394EAC04443FC82EDEE51 /* ftbbox.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbbox.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftbbox.c"; sourceTree = SOURCE_ROOT; };
+		06B2C8DCD9A54F52B3B54B54 /* servslkf.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servslkf.cpp; path = "external/harfbuzz-icu-freetype/icu/common/servslkf.cpp"; sourceTree = SOURCE_ROOT; };
 		06EB06458D944EEA919AEAC4 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		079179108CD84A7E90960711 /* uloc_tag.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uloc_tag.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uloc_tag.c"; sourceTree = SOURCE_ROOT; };
+		079179108CD84A7E90960711 /* uloc_tag.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uloc_tag.c; path = "external/harfbuzz-icu-freetype/icu/common/uloc_tag.c"; sourceTree = SOURCE_ROOT; };
 		081166BD702F4AE4B48CB86C /* rasterize.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rasterize.cpp; path = core/src/util/rasterize.cpp; sourceTree = SOURCE_ROOT; };
 		08CDEFA6755B4C27AF893BA3 /* libgeojson-vt-cpp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libgeojson-vt-cpp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		08F5328E8B5147B5AE773A36 /* type1cid.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = type1cid.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/cid/type1cid.c"; sourceTree = SOURCE_ROOT; };
+		08F5328E8B5147B5AE773A36 /* type1cid.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = type1cid.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/cid/type1cid.c"; sourceTree = SOURCE_ROOT; };
 		08FDD74C3A4C4905BF488D7F /* labels.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = labels.cpp; path = core/src/labels/labels.cpp; sourceTree = SOURCE_ROOT; };
 		097DF87A670F4250B26198D7 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		0989D46033394DA1998B06A1 /* polygonStyle.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = polygonStyle.cpp; path = core/src/style/polygonStyle.cpp; sourceTree = SOURCE_ROOT; };
-		0A46FE797CD643D2BEFAC6FB /* wintz.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = wintz.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/wintz.c"; sourceTree = SOURCE_ROOT; };
+		0A46FE797CD643D2BEFAC6FB /* wintz.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = wintz.c; path = "external/harfbuzz-icu-freetype/icu/common/wintz.c"; sourceTree = SOURCE_ROOT; };
 		0ABEAB234DC7475B8886CA9F /* spriteAtlas.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = spriteAtlas.cpp; path = core/src/scene/spriteAtlas.cpp; sourceTree = SOURCE_ROOT; };
 		0B007AE4AD9545079C3959BF /* fastmap.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fastmap.h; path = core/src/util/fastmap.h; sourceTree = SOURCE_ROOT; };
 		0B604C28C7614AF3BF54B2C5 /* types.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = types.h; path = core/src/util/types.h; sourceTree = SOURCE_ROOT; };
-		0B9B8FE1F8EE4F5F9C7F36D0 /* ftstdlib.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftstdlib.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftstdlib.h"; sourceTree = SOURCE_ROOT; };
 		0BA5DC042F9640FFA77BDF79 /* AppDelegate.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; name = AppDelegate.m; path = ios/src/AppDelegate.m; sourceTree = SOURCE_ROOT; };
 		0BBB456DB9A54776A25E8D10 /* NotoSansHebrew-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = "NotoSansHebrew-Regular.ttf"; path = "scenes/fonts/NotoSansHebrew-Regular.ttf"; sourceTree = SOURCE_ROOT; };
-		0C331854DC0149569C6FF5FC /* stringpiece.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = stringpiece.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/stringpiece.cpp"; sourceTree = SOURCE_ROOT; };
+		0C331854DC0149569C6FF5FC /* stringpiece.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = stringpiece.cpp; path = "external/harfbuzz-icu-freetype/icu/common/stringpiece.cpp"; sourceTree = SOURCE_ROOT; };
 		0C9A2400B104452A80709E65 /* roboto-regular.ttf */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = "roboto-regular.ttf"; path = "scenes/fonts/roboto-regular.ttf"; sourceTree = SOURCE_ROOT; };
-		0CE29FF4D2C34513A207A0D9 /* ftlzw.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftlzw.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/lzw/ftlzw.c"; sourceTree = SOURCE_ROOT; };
+		0CE29FF4D2C34513A207A0D9 /* ftlzw.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftlzw.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/lzw/ftlzw.c"; sourceTree = SOURCE_ROOT; };
 		0D1C9A56C81C42AB92E728B3 /* exceptions.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = exceptions.h; path = "external/yaml-cpp/include/yaml-cpp/exceptions.h"; sourceTree = SOURCE_ROOT; };
 		0D9F7FD3657547CDAED14E89 /* geojsonvt_clip.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geojsonvt_clip.cpp; path = "external/geojson-vt-cpp/src/geojsonvt_clip.cpp"; sourceTree = SOURCE_ROOT; };
-		0E0BF5C088824D2FB20EA627 /* filterednormalizer2.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = filterednormalizer2.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/filterednormalizer2.cpp"; sourceTree = SOURCE_ROOT; };
+		0E0BF5C088824D2FB20EA627 /* filterednormalizer2.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = filterednormalizer2.cpp; path = "external/harfbuzz-icu-freetype/icu/common/filterednormalizer2.cpp"; sourceTree = SOURCE_ROOT; };
 		0E1B77C5BEB94072B64CC80B /* mark.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = mark.h; path = "external/yaml-cpp/include/yaml-cpp/mark.h"; sourceTree = SOURCE_ROOT; };
-		0E3A56E6152043A0B7BA65CD /* utypes.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = utypes.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/utypes.c"; sourceTree = SOURCE_ROOT; };
-		0E4E819B1875424DA899ACEF /* ucase.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucase.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucase.cpp"; sourceTree = SOURCE_ROOT; };
+		0E3A56E6152043A0B7BA65CD /* utypes.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = utypes.c; path = "external/harfbuzz-icu-freetype/icu/common/utypes.c"; sourceTree = SOURCE_ROOT; };
+		0E4E819B1875424DA899ACEF /* ucase.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucase.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucase.cpp"; sourceTree = SOURCE_ROOT; };
 		0F0E32255C6B41B8A3E19FA7 /* textUtil.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = textUtil.h; path = core/src/text/textUtil.h; sourceTree = SOURCE_ROOT; };
-		0FF14C75A77449ECABDBEBC4 /* hb-ot-shape-complex-default.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-default.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-default.cc"; sourceTree = SOURCE_ROOT; };
-		10629A2D3C9D4BC1B1BEBF52 /* servls.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servls.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/servls.cpp"; sourceTree = SOURCE_ROOT; };
+		10629A2D3C9D4BC1B1BEBF52 /* servls.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servls.cpp; path = "external/harfbuzz-icu-freetype/icu/common/servls.cpp"; sourceTree = SOURCE_ROOT; };
 		109E4C68A6F2450EBF9F399A /* tile.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tile.h; path = core/src/tile/tile.h; sourceTree = SOURCE_ROOT; };
-		12518614C760420D87B59F56 /* ubidi.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ubidi.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ubidi.c"; sourceTree = SOURCE_ROOT; };
+		12518614C760420D87B59F56 /* ubidi.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ubidi.c; path = "external/harfbuzz-icu-freetype/icu/common/ubidi.c"; sourceTree = SOURCE_ROOT; };
 		12D8991EA1D1462792BAE671 /* styleContext.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = styleContext.cpp; path = core/src/scene/styleContext.cpp; sourceTree = SOURCE_ROOT; };
 		1353A189B7484D8D97BB4C72 /* binary.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = binary.h; path = "external/yaml-cpp/include/yaml-cpp/binary.h"; sourceTree = SOURCE_ROOT; };
 		13BF85316D3E4F2CBAE0DAEC /* ambientLight.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ambientLight.cpp; path = core/src/scene/ambientLight.cpp; sourceTree = SOURCE_ROOT; };
@@ -1469,101 +1469,80 @@
 		150973962EB04C1D960AED8C /* textDisplay.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = textDisplay.h; path = core/src/debug/textDisplay.h; sourceTree = SOURCE_ROOT; };
 		156BE7863FDB4A26B821905D /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		1608DCBC5BAC421BB71A2708 /* platform_ios.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; name = platform_ios.mm; path = ios/src/platform_ios.mm; sourceTree = SOURCE_ROOT; };
-		1665EE1221CA4099BA45EF79 /* unormcmp.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unormcmp.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unormcmp.cpp"; sourceTree = SOURCE_ROOT; };
-		1674BD0E595E4ACEBF2E0D66 /* ftsynth.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftsynth.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftsynth.c"; sourceTree = SOURCE_ROOT; };
+		1665EE1221CA4099BA45EF79 /* unormcmp.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unormcmp.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unormcmp.cpp"; sourceTree = SOURCE_ROOT; };
+		1674BD0E595E4ACEBF2E0D66 /* ftsynth.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftsynth.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftsynth.c"; sourceTree = SOURCE_ROOT; };
 		1686DFECA046463CAE381834 /* emittermanip.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = emittermanip.h; path = "external/yaml-cpp/include/yaml-cpp/emittermanip.h"; sourceTree = SOURCE_ROOT; };
-		176486E188AB464AA5A993B7 /* ftlist.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftlist.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftlist.h"; sourceTree = SOURCE_ROOT; };
-		176990C6063243D3A824F414 /* t1tables.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = t1tables.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/t1tables.h"; sourceTree = SOURCE_ROOT; };
 		179C3C2841D14A06824D2CB3 /* textUtil.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = textUtil.cpp; path = core/src/text/textUtil.cpp; sourceTree = SOURCE_ROOT; };
-		17A3016425C14777B3C14089 /* ftgloadr.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftgloadr.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftgloadr.h"; sourceTree = SOURCE_ROOT; };
-		17A82B625B7F4EF29FD36CC6 /* ftotval.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftotval.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftotval.c"; sourceTree = SOURCE_ROOT; };
-		17EFA1E668B943AFBAC3B650 /* cmemory.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = cmemory.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/cmemory.c"; sourceTree = SOURCE_ROOT; };
-		188C57F8138D4CF89FA40EC9 /* ftheader.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftheader.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftheader.h"; sourceTree = SOURCE_ROOT; };
-		19607CD2D93647FC86003EE8 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
-		198ACE5ECC7D40579F1098FC /* type42.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = type42.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/type42/type42.c"; sourceTree = SOURCE_ROOT; };
+		17A82B625B7F4EF29FD36CC6 /* ftotval.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftotval.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftotval.c"; sourceTree = SOURCE_ROOT; };
+		17EFA1E668B943AFBAC3B650 /* cmemory.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = cmemory.c; path = "external/harfbuzz-icu-freetype/icu/common/cmemory.c"; sourceTree = SOURCE_ROOT; };
+		19607CD2D93647FC86003EE8 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/harfbuzz-icu-freetype/freetype-2.6/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
+		198ACE5ECC7D40579F1098FC /* type42.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = type42.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/type42/type42.c"; sourceTree = SOURCE_ROOT; };
 		19A69D2D3E764A30BE380CB0 /* viewConstraint.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = viewConstraint.h; path = core/src/view/viewConstraint.h; sourceTree = SOURCE_ROOT; };
-		19D13E69EFC94C23B219D313 /* freetype.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = freetype.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/freetype.h"; sourceTree = SOURCE_ROOT; };
 		19E602B255BD42D3979F941F /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = external/alfons/src/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		1A0B62567C16456FAA685835 /* scanscalar.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = scanscalar.h; path = "external/yaml-cpp/src/scanscalar.h"; sourceTree = SOURCE_ROOT; };
-		1A19607F600D40069B6889D1 /* ftsnames.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftsnames.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftsnames.h"; sourceTree = SOURCE_ROOT; };
-		1A69EB15AAD8438881CAD282 /* rbbitblb.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbitblb.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/rbbitblb.cpp"; sourceTree = SOURCE_ROOT; };
-		1ABBA628FC7545178CE83E8B /* ftimage.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftimage.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftimage.h"; sourceTree = SOURCE_ROOT; };
-		1AF5DC9526354571854691EF /* uresdata.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uresdata.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uresdata.c"; sourceTree = SOURCE_ROOT; };
-		1B10C7CB7E454D708D806F4C /* hb-unicode.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-unicode.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-unicode.cc"; sourceTree = SOURCE_ROOT; };
+		1A69EB15AAD8438881CAD282 /* rbbitblb.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbitblb.cpp; path = "external/harfbuzz-icu-freetype/icu/common/rbbitblb.cpp"; sourceTree = SOURCE_ROOT; };
+		1AF5DC9526354571854691EF /* uresdata.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uresdata.c; path = "external/harfbuzz-icu-freetype/icu/common/uresdata.c"; sourceTree = SOURCE_ROOT; };
 		1BB281B89CAF40549608B501 /* yamlHelper.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = yamlHelper.h; path = core/src/util/yamlHelper.h; sourceTree = SOURCE_ROOT; };
 		1BDF2C8FCACA4DF6B0F8A980 /* fadeEffect.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fadeEffect.h; path = core/src/labels/fadeEffect.h; sourceTree = SOURCE_ROOT; };
-		1C7D70567ADF40289D61D5D6 /* ucnvhz.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvhz.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnvhz.c"; sourceTree = SOURCE_ROOT; };
+		1C7D70567ADF40289D61D5D6 /* ucnvhz.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvhz.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnvhz.c"; sourceTree = SOURCE_ROOT; };
 		1D66E9480AD248458034D302 /* topoJson.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = topoJson.cpp; path = core/src/util/topoJson.cpp; sourceTree = SOURCE_ROOT; };
-		1D8EAEDF74144A19B00A0FB7 /* ubidi_props.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ubidi_props.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ubidi_props.c"; sourceTree = SOURCE_ROOT; };
+		1D8EAEDF74144A19B00A0FB7 /* ubidi_props.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ubidi_props.c; path = "external/harfbuzz-icu-freetype/icu/common/ubidi_props.c"; sourceTree = SOURCE_ROOT; };
 		1DA986BFCEDC4AAAA218CC68 /* mvtSource.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = mvtSource.cpp; path = core/src/data/mvtSource.cpp; sourceTree = SOURCE_ROOT; };
 		1DF5127AA6DC434B9343B6DF /* polygon.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = polygon.fs; path = core/shaders/polygon.fs; sourceTree = SOURCE_ROOT; };
-		1E23A077E3724B5198EFBD76 /* locdispnames.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locdispnames.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/locdispnames.cpp"; sourceTree = SOURCE_ROOT; };
-		1E4E3CE27DAC413CA29416E0 /* usc_impl.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = usc_impl.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/usc_impl.c"; sourceTree = SOURCE_ROOT; };
-		1EA20290CE3C41D8933195E5 /* ftglyph.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftglyph.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftglyph.h"; sourceTree = SOURCE_ROOT; };
-		1EBD14B913354A5C9171222B /* ures_cnv.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ures_cnv.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ures_cnv.c"; sourceTree = SOURCE_ROOT; };
+		1E23A077E3724B5198EFBD76 /* locdispnames.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locdispnames.cpp; path = "external/harfbuzz-icu-freetype/icu/common/locdispnames.cpp"; sourceTree = SOURCE_ROOT; };
+		1E4E3CE27DAC413CA29416E0 /* usc_impl.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = usc_impl.c; path = "external/harfbuzz-icu-freetype/icu/common/usc_impl.c"; sourceTree = SOURCE_ROOT; };
+		1EBD14B913354A5C9171222B /* ures_cnv.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ures_cnv.c; path = "external/harfbuzz-icu-freetype/icu/common/ures_cnv.c"; sourceTree = SOURCE_ROOT; };
 		1F4E1D6398B74642815286BD /* stlemitter.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = stlemitter.h; path = "external/yaml-cpp/include/yaml-cpp/stlemitter.h"; sourceTree = SOURCE_ROOT; };
-		1FB0F1DD8CF2472CBAFB3692 /* autohint.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = autohint.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/autohint.h"; sourceTree = SOURCE_ROOT; };
-		20A885321A614B8B96E15AC3 /* ftglyph.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftglyph.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftglyph.c"; sourceTree = SOURCE_ROOT; };
-		20E0296423684E389250384A /* ftrfork.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftrfork.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftrfork.h"; sourceTree = SOURCE_ROOT; };
+		20A885321A614B8B96E15AC3 /* ftglyph.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftglyph.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftglyph.c"; sourceTree = SOURCE_ROOT; };
 		21C8E5AEEF1447E2AA1E45B4 /* parser.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = parser.h; path = "external/yaml-cpp/include/yaml-cpp/parser.h"; sourceTree = SOURCE_ROOT; };
-		2265F6BEE92940979DCB247B /* ft2build.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ft2build.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/ft2build.h"; sourceTree = SOURCE_ROOT; };
 		22E4E32AB18E4E7EB7AF5389 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		235AB71148ED4FAB90E89A8F /* atlas.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = atlas.cpp; path = external/alfons/src/alfons/atlas.cpp; sourceTree = SOURCE_ROOT; };
 		23D4B32469D7446A80F9B1A5 /* platform.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = platform.h; path = core/src/platform.h; sourceTree = SOURCE_ROOT; };
-		2429235BBAED4CE69991AD3E /* usetiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = usetiter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/usetiter.cpp"; sourceTree = SOURCE_ROOT; };
-		24E343F4833E4820868B65E1 /* cff.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = cff.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/cff/cff.c"; sourceTree = SOURCE_ROOT; };
-		251DE69AF832448F9A3820C2 /* fttrace.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fttrace.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/fttrace.h"; sourceTree = SOURCE_ROOT; };
-		253B46759EF94D14981B11B9 /* ftdebug.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftdebug.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftdebug.h"; sourceTree = SOURCE_ROOT; };
+		2429235BBAED4CE69991AD3E /* usetiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = usetiter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/usetiter.cpp"; sourceTree = SOURCE_ROOT; };
+		24E343F4833E4820868B65E1 /* cff.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = cff.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/cff/cff.c"; sourceTree = SOURCE_ROOT; };
 		2608BC035969494AA2D19828 /* poi_icons_32.png */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = image; name = poi_icons_32.png; path = scenes/img/poi_icons_32.png; sourceTree = SOURCE_ROOT; };
-		261A75845FB54795BC903F9B /* ftcid.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftcid.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftcid.h"; sourceTree = SOURCE_ROOT; };
-		26DD77823ECC496CAB6FDF59 /* unistr_cnv.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_cnv.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unistr_cnv.cpp"; sourceTree = SOURCE_ROOT; };
-		273D169246FA498C904D290E /* ftfntfmt.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftfntfmt.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftfntfmt.h"; sourceTree = SOURCE_ROOT; };
-		273EB10A30B844DCBAF4E743 /* ftsystem.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftsystem.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftsystem.h"; sourceTree = SOURCE_ROOT; };
+		26DD77823ECC496CAB6FDF59 /* unistr_cnv.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_cnv.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unistr_cnv.cpp"; sourceTree = SOURCE_ROOT; };
 		288DBEE8CA2348DDBB0C2700 /* skybox.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = skybox.h; path = core/src/scene/skybox.h; sourceTree = SOURCE_ROOT; };
-		28C910BD5193446098DB13C4 /* ucnv_ct.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_ct.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_ct.c"; sourceTree = SOURCE_ROOT; };
+		28C910BD5193446098DB13C4 /* ucnv_ct.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_ct.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_ct.c"; sourceTree = SOURCE_ROOT; };
 		28F5109FEF4142A1A6D1DF69 /* directives.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = directives.cpp; path = "external/yaml-cpp/src/directives.cpp"; sourceTree = SOURCE_ROOT; };
-		290FA8D317AC43518054EE51 /* errorcode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = errorcode.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/errorcode.cpp"; sourceTree = SOURCE_ROOT; };
-		29874B69FB8841B5A323508F /* resbund_cnv.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = resbund_cnv.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/resbund_cnv.cpp"; sourceTree = SOURCE_ROOT; };
-		29E1042C80A6449394AA3C86 /* ucnv_ext.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnv_ext.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_ext.cpp"; sourceTree = SOURCE_ROOT; };
-		2A24E284E1D149119A3638C3 /* utrie2_builder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = utrie2_builder.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/utrie2_builder.cpp"; sourceTree = SOURCE_ROOT; };
+		290FA8D317AC43518054EE51 /* errorcode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = errorcode.cpp; path = "external/harfbuzz-icu-freetype/icu/common/errorcode.cpp"; sourceTree = SOURCE_ROOT; };
+		29874B69FB8841B5A323508F /* resbund_cnv.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = resbund_cnv.cpp; path = "external/harfbuzz-icu-freetype/icu/common/resbund_cnv.cpp"; sourceTree = SOURCE_ROOT; };
+		29E1042C80A6449394AA3C86 /* ucnv_ext.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnv_ext.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_ext.cpp"; sourceTree = SOURCE_ROOT; };
+		2A24E284E1D149119A3638C3 /* utrie2_builder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = utrie2_builder.cpp; path = "external/harfbuzz-icu-freetype/icu/common/utrie2_builder.cpp"; sourceTree = SOURCE_ROOT; };
 		2AA2DA9566F449A68AEA4129 /* linebreak.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = linebreak.c; path = external/alfons/src/linebreak/linebreak.c; sourceTree = SOURCE_ROOT; };
 		2AB2AC9F9C0F445F95913A66 /* scantag.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = scantag.cpp; path = "external/yaml-cpp/src/scantag.cpp"; sourceTree = SOURCE_ROOT; };
 		2AB9EAD790314C62B33760D6 /* asyncWorker.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = asyncWorker.h; path = core/src/util/asyncWorker.h; sourceTree = SOURCE_ROOT; };
 		2ABCFDE00ED7444D9AC55BFE /* textLabel.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = textLabel.h; path = core/src/labels/textLabel.h; sourceTree = SOURCE_ROOT; };
-		2B606A300CCD4DC0BA7E9618 /* stubdata.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = stubdata.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata/stubdata.c"; sourceTree = SOURCE_ROOT; };
+		2B606A300CCD4DC0BA7E9618 /* stubdata.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = stubdata.c; path = "external/harfbuzz-icu-freetype/icu/stubdata/stubdata.c"; sourceTree = SOURCE_ROOT; };
 		2B6E1028F83F4E7AADDE152E /* AppDelegate.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = AppDelegate.h; path = ios/src/AppDelegate.h; sourceTree = SOURCE_ROOT; };
 		2B8FEB4C11764ABB9A0CFC4E /* lights.glsl */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = lights.glsl; path = core/shaders/lights.glsl; sourceTree = SOURCE_ROOT; };
-		2BEC817C8E4E4994A697F19A /* bytestrieiterator.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bytestrieiterator.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/bytestrieiterator.cpp"; sourceTree = SOURCE_ROOT; };
+		2BEC817C8E4E4994A697F19A /* bytestrieiterator.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bytestrieiterator.cpp; path = "external/harfbuzz-icu-freetype/icu/common/bytestrieiterator.cpp"; sourceTree = SOURCE_ROOT; };
 		2C00DC9CA9C14F38A29F06AC /* sdf.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = sdf.fs; path = core/shaders/sdf.fs; sourceTree = SOURCE_ROOT; };
-		2C0C38C552804CD3812F8C74 /* ucmndata.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucmndata.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucmndata.c"; sourceTree = SOURCE_ROOT; };
-		2C55DFDC945F4902A55F253D /* uarrsort.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uarrsort.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uarrsort.c"; sourceTree = SOURCE_ROOT; };
+		2C0C38C552804CD3812F8C74 /* ucmndata.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucmndata.c; path = "external/harfbuzz-icu-freetype/icu/common/ucmndata.c"; sourceTree = SOURCE_ROOT; };
+		2C55DFDC945F4902A55F253D /* uarrsort.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uarrsort.c; path = "external/harfbuzz-icu-freetype/icu/common/uarrsort.c"; sourceTree = SOURCE_ROOT; };
 		2C9DEB4886F143D6A6EE746D /* scantoken.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = scantoken.cpp; path = "external/yaml-cpp/src/scantoken.cpp"; sourceTree = SOURCE_ROOT; };
-		2CAF194E2CBC49C6BE3DF836 /* cstring.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = cstring.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/cstring.c"; sourceTree = SOURCE_ROOT; };
+		2CAF194E2CBC49C6BE3DF836 /* cstring.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = cstring.c; path = "external/harfbuzz-icu-freetype/icu/common/cstring.c"; sourceTree = SOURCE_ROOT; };
 		2D3F727504D141B98174691E /* view.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = view.cpp; path = core/src/view/view.cpp; sourceTree = SOURCE_ROOT; };
 		2E1C13C1F1554BD2AA8435BB /* ostream_wrapper.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ostream_wrapper.cpp; path = "external/yaml-cpp/src/ostream_wrapper.cpp"; sourceTree = SOURCE_ROOT; };
 		2E7064B9117E4C72AADDBAFB /* memory.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = memory.cpp; path = "external/yaml-cpp/src/memory.cpp"; sourceTree = SOURCE_ROOT; };
-		2F9BED304C45498A9734B16D /* udataswp.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = udataswp.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/udataswp.c"; sourceTree = SOURCE_ROOT; };
-		2FFF787455874C2B9BD7508D /* util.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = util.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/util.cpp"; sourceTree = SOURCE_ROOT; };
-		30943BEF56DB4DC3A8BE3A43 /* unistr_titlecase_brkiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_titlecase_brkiter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unistr_titlecase_brkiter.cpp"; sourceTree = SOURCE_ROOT; };
+		2F9BED304C45498A9734B16D /* udataswp.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = udataswp.c; path = "external/harfbuzz-icu-freetype/icu/common/udataswp.c"; sourceTree = SOURCE_ROOT; };
+		2FFF787455874C2B9BD7508D /* util.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = util.cpp; path = "external/harfbuzz-icu-freetype/icu/common/util.cpp"; sourceTree = SOURCE_ROOT; };
+		30943BEF56DB4DC3A8BE3A43 /* unistr_titlecase_brkiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_titlecase_brkiter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unistr_titlecase_brkiter.cpp"; sourceTree = SOURCE_ROOT; };
 		30FD556B47914EEE8E465B95 /* graphbuilder.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = graphbuilder.h; path = "external/yaml-cpp/include/yaml-cpp/contrib/graphbuilder.h"; sourceTree = SOURCE_ROOT; };
-		31B07E51BBF44E71B63B5783 /* type1.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = type1.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/type1/type1.c"; sourceTree = SOURCE_ROOT; };
+		31B07E51BBF44E71B63B5783 /* type1.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = type1.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/type1/type1.c"; sourceTree = SOURCE_ROOT; };
 		327A7D6D4B494DC7AF84B208 /* textLabels.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = textLabels.h; path = core/src/labels/textLabels.h; sourceTree = SOURCE_ROOT; };
 		32AE4E27D5014DB48E670C25 /* stops.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = stops.cpp; path = core/src/scene/stops.cpp; sourceTree = SOURCE_ROOT; };
 		331C1335023245F690D73E8B /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = external/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		3320F551947146AA9FE72894 /* rasterSource.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = rasterSource.h; path = core/src/data/rasterSource.h; sourceTree = SOURCE_ROOT; };
 		33EBD0B4ABEE4F4BB1BBE9E9 /* libfreetyped.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libfreetyped.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3418AADB97104A90BD0A4063 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		3441011F320A4DF189D42404 /* uscript.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uscript.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uscript.c"; sourceTree = SOURCE_ROOT; };
+		3441011F320A4DF189D42404 /* uscript.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uscript.c; path = "external/harfbuzz-icu-freetype/icu/common/uscript.c"; sourceTree = SOURCE_ROOT; };
 		34A120DD463049C0B4DC441B /* libalfons_wrap.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libalfons_wrap.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		35353C9387E14DD880274974 /* gl.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = gl.h; path = core/src/gl.h; sourceTree = SOURCE_ROOT; };
 		3663EF19BAA44F6890BB0B72 /* point.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = point.fs; path = core/shaders/point.fs; sourceTree = SOURCE_ROOT; };
-		36EB54BF5BCD4EF09D34FC5B /* ftbbox.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftbbox.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftbbox.h"; sourceTree = SOURCE_ROOT; };
-		3798346A289F4EEB854D0AD8 /* ftchapters.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftchapters.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftchapters.h"; sourceTree = SOURCE_ROOT; };
 		3847B717150243DCA53207A3 /* Main_iPhone.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main_iPhone.storyboard; path = ios/resources/Main_iPhone.storyboard; sourceTree = SOURCE_ROOT; };
-		38777A89A64A46D6AF7AC2BB /* ucnv_u8.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_u8.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_u8.c"; sourceTree = SOURCE_ROOT; };
-		3879E6A3DC52440CB88FFD4D /* ftlzw.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftlzw.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftlzw.h"; sourceTree = SOURCE_ROOT; };
+		38777A89A64A46D6AF7AC2BB /* ucnv_u8.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_u8.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_u8.c"; sourceTree = SOURCE_ROOT; };
 		399C21F345004E3EB7369CFF /* tileManager.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = tileManager.cpp; path = core/src/tile/tileManager.cpp; sourceTree = SOURCE_ROOT; };
-		3A3AEC05FD6145AF9620A9BD /* ttunpat.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ttunpat.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ttunpat.h"; sourceTree = SOURCE_ROOT; };
 		3A7D8C1D9E344B24B6508EB2 /* styleParam.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = styleParam.cpp; path = core/src/scene/styleParam.cpp; sourceTree = SOURCE_ROOT; };
 		3B71313AA5F74D63A592724E /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		3B7FC0E0D7484A0FB15E0228 /* traits.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = traits.h; path = "external/yaml-cpp/include/yaml-cpp/traits.h"; sourceTree = SOURCE_ROOT; };
@@ -1571,163 +1550,140 @@
 		3C88EC1FF3F945DAAE931700 /* main.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; name = main.m; path = ios/src/main.m; sourceTree = SOURCE_ROOT; };
 		3C9196F938B1477385F27FE7 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		3D281C4C25D34EBDBA2EE9CC /* nodebuilder.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = nodebuilder.h; path = "external/yaml-cpp/src/nodebuilder.h"; sourceTree = SOURCE_ROOT; };
-		3D479C79AEB745B1A343BE6B /* ftbzip2.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbzip2.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/bzip2/ftbzip2.c"; sourceTree = SOURCE_ROOT; };
-		3D5FB75672774BB68C957281 /* ustring.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustring.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustring.cpp"; sourceTree = SOURCE_ROOT; };
-		3D7EE01226884E699C85D35E /* hb-blob.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-blob.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-blob.cc"; sourceTree = SOURCE_ROOT; };
+		3D479C79AEB745B1A343BE6B /* ftbzip2.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbzip2.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/bzip2/ftbzip2.c"; sourceTree = SOURCE_ROOT; };
+		3D5FB75672774BB68C957281 /* ustring.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustring.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ustring.cpp"; sourceTree = SOURCE_ROOT; };
 		3E4E85A4782B41B984D5B297 /* ptr.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ptr.h; path = "external/yaml-cpp/include/yaml-cpp/node/ptr.h"; sourceTree = SOURCE_ROOT; };
 		3ED77B7A24B34274B96428CA /* libalfons.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libalfons.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3ED9E24149F54CDB89EE7CAB /* labelSet.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = labelSet.h; path = core/src/labels/labelSet.h; sourceTree = SOURCE_ROOT; };
 		3F6176DCB7744DD5BA8D3E40 /* libyaml-cpp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libyaml-cpp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3F8FCA53F3954CE0B4668489 /* servrbf.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servrbf.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/servrbf.cpp"; sourceTree = SOURCE_ROOT; };
+		3F8FCA53F3954CE0B4668489 /* servrbf.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servrbf.cpp; path = "external/harfbuzz-icu-freetype/icu/common/servrbf.cpp"; sourceTree = SOURCE_ROOT; };
 		40086463238F4C1B90479B85 /* raster-terrain.yaml */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = "raster-terrain.yaml"; path = "scenes/raster-terrain.yaml"; sourceTree = SOURCE_ROOT; };
-		41397A6A6016411A9F0CCC94 /* ucdn.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucdn.c; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn/ucdn.c"; sourceTree = SOURCE_ROOT; };
 		4264137CF715400995067136 /* importer.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = importer.cpp; path = core/src/scene/importer.cpp; sourceTree = SOURCE_ROOT; };
-		42B3A35E2DBC438BA06958E7 /* umutex.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = umutex.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/umutex.cpp"; sourceTree = SOURCE_ROOT; };
+		42B3A35E2DBC438BA06958E7 /* umutex.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = umutex.cpp; path = "external/harfbuzz-icu-freetype/icu/common/umutex.cpp"; sourceTree = SOURCE_ROOT; };
 		42B75E3B8F1B4B22A98FF0D3 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		42C87CDADD9243FDA3DBC106 /* json.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = json.cpp; path = core/src/util/json.cpp; sourceTree = SOURCE_ROOT; };
 		435E064411DF498B8ECB55B5 /* textBatch.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = textBatch.cpp; path = external/alfons/src/alfons/textBatch.cpp; sourceTree = SOURCE_ROOT; };
-		435F5B6F7AF64F12A555869E /* ftincrem.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftincrem.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftincrem.h"; sourceTree = SOURCE_ROOT; };
-		43A2CDF4C89B48518CBB3F2A /* servlk.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servlk.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/servlk.cpp"; sourceTree = SOURCE_ROOT; };
+		43A2CDF4C89B48518CBB3F2A /* servlk.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servlk.cpp; path = "external/harfbuzz-icu-freetype/icu/common/servlk.cpp"; sourceTree = SOURCE_ROOT; };
 		43E78C33CB5942AC8D7AE25E /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = external/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		43F6E0C2085F4F77A13B0238 /* renderState.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = renderState.h; path = core/src/gl/renderState.h; sourceTree = SOURCE_ROOT; };
 		443ACC30B8364B0B885CEAE9 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		44877F60CDDC4670B7F4F6C3 /* fontContext.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fontContext.h; path = core/src/text/fontContext.h; sourceTree = SOURCE_ROOT; };
-		44B98922B1FD450B94D4E9AF /* ftgasp.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftgasp.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftgasp.h"; sourceTree = SOURCE_ROOT; };
-		44F22D4A200D440EA2A9CBAB /* ucln_cmn.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucln_cmn.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucln_cmn.c"; sourceTree = SOURCE_ROOT; };
-		4517E3D1558647D287320EBA /* uenum.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uenum.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uenum.c"; sourceTree = SOURCE_ROOT; };
+		44F22D4A200D440EA2A9CBAB /* ucln_cmn.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucln_cmn.c; path = "external/harfbuzz-icu-freetype/icu/common/ucln_cmn.c"; sourceTree = SOURCE_ROOT; };
+		4517E3D1558647D287320EBA /* uenum.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uenum.c; path = "external/harfbuzz-icu-freetype/icu/common/uenum.c"; sourceTree = SOURCE_ROOT; };
 		45583B673B9B4BEB93135488 /* scanscalar.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = scanscalar.cpp; path = "external/yaml-cpp/src/scanscalar.cpp"; sourceTree = SOURCE_ROOT; };
-		45D1CB074EFA4464A5605488 /* locmap.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = locmap.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/locmap.c"; sourceTree = SOURCE_ROOT; };
+		45D1CB074EFA4464A5605488 /* locmap.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = locmap.c; path = "external/harfbuzz-icu-freetype/icu/common/locmap.c"; sourceTree = SOURCE_ROOT; };
 		45DB033DD00C45FE8769CBBE /* styleMixer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = styleMixer.h; path = core/src/scene/styleMixer.h; sourceTree = SOURCE_ROOT; };
 		45DBD82A9722480D89FB1B9B /* platform_ios.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = platform_ios.h; path = ios/src/platform_ios.h; sourceTree = SOURCE_ROOT; };
-		45E4312EB9464D38B1E6FEB3 /* ftcache.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftcache.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/cache/ftcache.c"; sourceTree = SOURCE_ROOT; };
-		45EC751E26C543EB9810EC5A /* util_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = util_props.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/util_props.cpp"; sourceTree = SOURCE_ROOT; };
+		45E4312EB9464D38B1E6FEB3 /* ftcache.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftcache.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/cache/ftcache.c"; sourceTree = SOURCE_ROOT; };
+		45EC751E26C543EB9810EC5A /* util_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = util_props.cpp; path = "external/harfbuzz-icu-freetype/icu/common/util_props.cpp"; sourceTree = SOURCE_ROOT; };
 		466A9664A4994E92B647218C /* geojsonvt.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geojsonvt.cpp; path = "external/geojson-vt-cpp/src/geojsonvt.cpp"; sourceTree = SOURCE_ROOT; };
-		475BD0CC160C4D4A987F57FE /* rbbisetb.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbisetb.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/rbbisetb.cpp"; sourceTree = SOURCE_ROOT; };
+		475BD0CC160C4D4A987F57FE /* rbbisetb.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbisetb.cpp; path = "external/harfbuzz-icu-freetype/icu/common/rbbisetb.cpp"; sourceTree = SOURCE_ROOT; };
 		47AAF4C8750241278DCB9F89 /* null.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = null.h; path = "external/yaml-cpp/include/yaml-cpp/null.h"; sourceTree = SOURCE_ROOT; };
-		48608001BFBA4BB9AC9C9244 /* listformatter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = listformatter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/listformatter.cpp"; sourceTree = SOURCE_ROOT; };
-		486B377F0EE54264AF508D13 /* ftoutln.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftoutln.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftoutln.h"; sourceTree = SOURCE_ROOT; };
+		48608001BFBA4BB9AC9C9244 /* listformatter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = listformatter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/listformatter.cpp"; sourceTree = SOURCE_ROOT; };
 		48BE55CA144E4F329743B3E7 /* filters.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = filters.h; path = core/src/scene/filters.h; sourceTree = SOURCE_ROOT; };
 		497E8E99D3414BA28DB6826F /* ptr_stack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ptr_stack.h; path = "external/yaml-cpp/src/ptr_stack.h"; sourceTree = SOURCE_ROOT; };
-		4A18FC2AE02B41C9AAD17045 /* locbased.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locbased.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/locbased.cpp"; sourceTree = SOURCE_ROOT; };
+		4A18FC2AE02B41C9AAD17045 /* locbased.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locbased.cpp; path = "external/harfbuzz-icu-freetype/icu/common/locbased.cpp"; sourceTree = SOURCE_ROOT; };
 		4A81197754CE46A58E822E53 /* node_data.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = node_data.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/node_data.h"; sourceTree = SOURCE_ROOT; };
-		4AE005A9E2EE40DBBD6EA17F /* ftbitmap.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbitmap.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftbitmap.c"; sourceTree = SOURCE_ROOT; };
+		4AE005A9E2EE40DBBD6EA17F /* ftbitmap.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbitmap.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftbitmap.c"; sourceTree = SOURCE_ROOT; };
 		4B69055BCA0A45908E9CCAE5 /* tileHash.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tileHash.h; path = core/src/tile/tileHash.h; sourceTree = SOURCE_ROOT; };
 		4B8AAD38C81D4C68B4705E1D /* libcss-color-parser-cpp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libcss-color-parser-cpp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C214B88965C4E49BDAB8F5F /* tile.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = tile.cpp; path = core/src/tile/tile.cpp; sourceTree = SOURCE_ROOT; };
-		4C7DBE025A374E638B2E45AD /* fttype1.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = fttype1.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/fttype1.c"; sourceTree = SOURCE_ROOT; };
-		4D44A8364E794AB182FD209A /* ftwinfnt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftwinfnt.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftwinfnt.c"; sourceTree = SOURCE_ROOT; };
-		4DA2FDBE3A4D49CF92B30855 /* uobject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uobject.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uobject.cpp"; sourceTree = SOURCE_ROOT; };
-		4DE2787CC43F4D2CA16474AA /* ftlcdfil.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftlcdfil.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftlcdfil.c"; sourceTree = SOURCE_ROOT; };
-		4E08029CBC11452888927671 /* ftwinfnt.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftwinfnt.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftwinfnt.h"; sourceTree = SOURCE_ROOT; };
-		4EF6F430D50D418E977982D0 /* tttags.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tttags.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/tttags.h"; sourceTree = SOURCE_ROOT; };
-		4F40EBE058D04355BB59B621 /* autofit.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = autofit.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/autofit/autofit.c"; sourceTree = SOURCE_ROOT; };
+		4C7DBE025A374E638B2E45AD /* fttype1.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = fttype1.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/fttype1.c"; sourceTree = SOURCE_ROOT; };
+		4D44A8364E794AB182FD209A /* ftwinfnt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftwinfnt.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftwinfnt.c"; sourceTree = SOURCE_ROOT; };
+		4DA2FDBE3A4D49CF92B30855 /* uobject.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uobject.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uobject.cpp"; sourceTree = SOURCE_ROOT; };
+		4DE2787CC43F4D2CA16474AA /* ftlcdfil.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftlcdfil.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftlcdfil.c"; sourceTree = SOURCE_ROOT; };
+		4F40EBE058D04355BB59B621 /* autofit.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = autofit.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/autofit/autofit.c"; sourceTree = SOURCE_ROOT; };
 		4F83822F2DA949D6B8F19F98 /* styleParam.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = styleParam.h; path = core/src/scene/styleParam.h; sourceTree = SOURCE_ROOT; };
 		4FD58AAE4B054D4DB33E035F /* rasters.glsl */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = rasters.glsl; path = core/shaders/rasters.glsl; sourceTree = SOURCE_ROOT; };
-		5000C0D735814AA89AFFE00D /* uprops.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uprops.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uprops.cpp"; sourceTree = SOURCE_ROOT; };
+		5000C0D735814AA89AFFE00D /* uprops.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uprops.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uprops.cpp"; sourceTree = SOURCE_ROOT; };
 		500ECFC7928A413C80B43790 /* simplekey.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = simplekey.cpp; path = "external/yaml-cpp/src/simplekey.cpp"; sourceTree = SOURCE_ROOT; };
-		50F1CDCCFDBE43BFABF3AE80 /* ftmm.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftmm.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftmm.c"; sourceTree = SOURCE_ROOT; };
+		50F1CDCCFDBE43BFABF3AE80 /* ftmm.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftmm.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftmm.c"; sourceTree = SOURCE_ROOT; };
 		518574C160234637B59D2774 /* primitives.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = primitives.h; path = core/src/gl/primitives.h; sourceTree = SOURCE_ROOT; };
 		5289F5BE738948E197B30471 /* emitfromevents.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = emitfromevents.cpp; path = "external/yaml-cpp/src/emitfromevents.cpp"; sourceTree = SOURCE_ROOT; };
-		533FB87FAED549ED8F949BAE /* ftmemory.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftmemory.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftmemory.h"; sourceTree = SOURCE_ROOT; };
-		535242EF7F594815BE27AF49 /* ftbzip2.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftbzip2.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftbzip2.h"; sourceTree = SOURCE_ROOT; };
-		539108EDD3F248F09C5C1F9A /* ftgxval.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftgxval.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftgxval.h"; sourceTree = SOURCE_ROOT; };
 		54102A3C1DB749C1B4881A9B /* ptr_vector.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ptr_vector.h; path = "external/yaml-cpp/src/ptr_vector.h"; sourceTree = SOURCE_ROOT; };
 		54A6AD453C6E4A25A5ED11A2 /* point.vs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = point.vs; path = core/shaders/point.vs; sourceTree = SOURCE_ROOT; };
 		5535420D7E2640A1B74259FC /* mesh.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = mesh.cpp; path = core/src/gl/mesh.cpp; sourceTree = SOURCE_ROOT; };
 		555F4B3AE4534117B4877AFF /* scanner.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = scanner.h; path = "external/yaml-cpp/src/scanner.h"; sourceTree = SOURCE_ROOT; };
-		55A9228CB2BC4704824B0B6B /* icudataver.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = icudataver.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/icudataver.c"; sourceTree = SOURCE_ROOT; };
-		55AEA1083A4847A59AB97478 /* ucat.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucat.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucat.c"; sourceTree = SOURCE_ROOT; };
-		562CD690A6C846B581ECFE16 /* hb-ot-shape-complex-hebrew.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-hebrew.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-hebrew.cc"; sourceTree = SOURCE_ROOT; };
-		57C63E8227AD435A956134A0 /* ftsystem.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftsystem.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftsystem.c"; sourceTree = SOURCE_ROOT; };
+		55A9228CB2BC4704824B0B6B /* icudataver.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = icudataver.c; path = "external/harfbuzz-icu-freetype/icu/common/icudataver.c"; sourceTree = SOURCE_ROOT; };
+		55AEA1083A4847A59AB97478 /* ucat.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucat.c; path = "external/harfbuzz-icu-freetype/icu/common/ucat.c"; sourceTree = SOURCE_ROOT; };
+		57C63E8227AD435A956134A0 /* ftsystem.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftsystem.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftsystem.c"; sourceTree = SOURCE_ROOT; };
 		581BC2F498A24AB78BBAB720 /* singledocparser.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = singledocparser.cpp; path = "external/yaml-cpp/src/singledocparser.cpp"; sourceTree = SOURCE_ROOT; };
 		59256EC81CE94328BD2A4E9A /* mapzen-logo.png */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = image; name = "mapzen-logo.png"; path = "scenes/img/mapzen-logo.png"; sourceTree = SOURCE_ROOT; };
-		593914966EE14D458815EB38 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = external/alfons/src/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		5A0FA25ACA074A79AC327599 /* fontFace.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = fontFace.cpp; path = external/alfons/src/alfons/fontFace.cpp; sourceTree = SOURCE_ROOT; };
-		5A29C2B31ECA49C19A3E027B /* punycode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = punycode.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/punycode.cpp"; sourceTree = SOURCE_ROOT; };
-		5A6D819A5133420A91A589EF /* messagepattern.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = messagepattern.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/messagepattern.cpp"; sourceTree = SOURCE_ROOT; };
+		5A29C2B31ECA49C19A3E027B /* punycode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = punycode.cpp; path = "external/harfbuzz-icu-freetype/icu/common/punycode.cpp"; sourceTree = SOURCE_ROOT; };
+		5A6D819A5133420A91A589EF /* messagepattern.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = messagepattern.cpp; path = "external/harfbuzz-icu-freetype/icu/common/messagepattern.cpp"; sourceTree = SOURCE_ROOT; };
 		5A8AF91DFAE3473ABDE6E850 /* error.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = error.cpp; path = core/src/gl/error.cpp; sourceTree = SOURCE_ROOT; };
-		5BC0F7EFAADA403BAF6B4E1A /* hb-ucdn.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ucdn.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn.cc"; sourceTree = SOURCE_ROOT; };
-		5BCD4B4F4F0248E997DDBE67 /* ulist.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ulist.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ulist.c"; sourceTree = SOURCE_ROOT; };
-		5C1575417DF044D5BEC8632C /* uvectr64.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uvectr64.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uvectr64.cpp"; sourceTree = SOURCE_ROOT; };
-		5C5B486B2F12419DB567066F /* ucharstrieiterator.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucharstrieiterator.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucharstrieiterator.cpp"; sourceTree = SOURCE_ROOT; };
-		5C5EEA2FC8AD46F7884B432B /* ftfstype.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftfstype.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftfstype.c"; sourceTree = SOURCE_ROOT; };
-		5C6ADF486F78482682FE3945 /* ftcache.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftcache.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftcache.h"; sourceTree = SOURCE_ROOT; };
+		5BCD4B4F4F0248E997DDBE67 /* ulist.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ulist.c; path = "external/harfbuzz-icu-freetype/icu/common/ulist.c"; sourceTree = SOURCE_ROOT; };
+		5C1575417DF044D5BEC8632C /* uvectr64.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uvectr64.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uvectr64.cpp"; sourceTree = SOURCE_ROOT; };
+		5C5B486B2F12419DB567066F /* ucharstrieiterator.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucharstrieiterator.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucharstrieiterator.cpp"; sourceTree = SOURCE_ROOT; };
+		5C5EEA2FC8AD46F7884B432B /* ftfstype.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftfstype.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftfstype.c"; sourceTree = SOURCE_ROOT; };
 		5CFF753AD9D84909BF9FB25E /* regex_yaml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = regex_yaml.cpp; path = "external/yaml-cpp/src/regex_yaml.cpp"; sourceTree = SOURCE_ROOT; };
 		5D084E2A0AD845D3B87EE4BE /* node_iterator.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = node_iterator.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/node_iterator.h"; sourceTree = SOURCE_ROOT; };
 		5D227251CFC0413FA5234B5E /* geoJsonSource.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = geoJsonSource.h; path = core/src/data/geoJsonSource.h; sourceTree = SOURCE_ROOT; };
 		5D2DD8F0EF754D289CC0F905 /* emitfromevents.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = emitfromevents.h; path = "external/yaml-cpp/include/yaml-cpp/emitfromevents.h"; sourceTree = SOURCE_ROOT; };
-		5D4F75AC14234AE7A47EF109 /* rbbinode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbinode.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/rbbinode.cpp"; sourceTree = SOURCE_ROOT; };
+		5D4F75AC14234AE7A47EF109 /* rbbinode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbinode.cpp; path = "external/harfbuzz-icu-freetype/icu/common/rbbinode.cpp"; sourceTree = SOURCE_ROOT; };
 		5DD9A2D707964EE09C548B00 /* directionalLight.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = directionalLight.cpp; path = core/src/scene/directionalLight.cpp; sourceTree = SOURCE_ROOT; };
-		5DDB357BC72A4913960E448A /* patternprops.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = patternprops.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/patternprops.cpp"; sourceTree = SOURCE_ROOT; };
+		5DDB357BC72A4913960E448A /* patternprops.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = patternprops.cpp; path = "external/harfbuzz-icu-freetype/icu/common/patternprops.cpp"; sourceTree = SOURCE_ROOT; };
 		5E017BA06CCE4046B5AD32F8 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		5E3946CE8E0640C0A40E16E8 /* ucnv_lmb.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_lmb.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_lmb.c"; sourceTree = SOURCE_ROOT; };
-		5F5998818FF8417D8002DE22 /* uinvchar.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uinvchar.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uinvchar.c"; sourceTree = SOURCE_ROOT; };
-		5FFCC94F6418484E936251F2 /* ftobjs.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftobjs.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftobjs.h"; sourceTree = SOURCE_ROOT; };
+		5E3946CE8E0640C0A40E16E8 /* ucnv_lmb.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_lmb.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_lmb.c"; sourceTree = SOURCE_ROOT; };
+		5F5998818FF8417D8002DE22 /* uinvchar.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uinvchar.c; path = "external/harfbuzz-icu-freetype/icu/common/uinvchar.c"; sourceTree = SOURCE_ROOT; };
 		613839FFC8534636AB98A7AE /* geom.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geom.cpp; path = core/src/util/geom.cpp; sourceTree = SOURCE_ROOT; };
-		6138EC3342B14341B0496B2E /* ftbitmap.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftbitmap.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftbitmap.h"; sourceTree = SOURCE_ROOT; };
-		61F4E61ABDA14CD89ED0C4BA /* normalizer2.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = normalizer2.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/normalizer2.cpp"; sourceTree = SOURCE_ROOT; };
+		61F4E61ABDA14CD89ED0C4BA /* normalizer2.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = normalizer2.cpp; path = "external/harfbuzz-icu-freetype/icu/common/normalizer2.cpp"; sourceTree = SOURCE_ROOT; };
 		62C8E94A497F423E9D7C9C11 /* polylineStyle.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = polylineStyle.cpp; path = core/src/style/polylineStyle.cpp; sourceTree = SOURCE_ROOT; };
-		62ED4FD31A3E42D1B7215ACB /* caniter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = caniter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/caniter.cpp"; sourceTree = SOURCE_ROOT; };
+		62ED4FD31A3E42D1B7215ACB /* caniter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = caniter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/caniter.cpp"; sourceTree = SOURCE_ROOT; };
 		631E6730F51149D5B8DC5322 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = sourcecode.text.plist; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = build/ios/CMakeFiles/tangram.dir/Info.plist; sourceTree = SOURCE_ROOT; };
 		6331189144E343619FA5996F /* drawRule.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = drawRule.h; path = core/src/scene/drawRule.h; sourceTree = SOURCE_ROOT; };
 		63935B579EA1493BBE836B82 /* primitives.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = primitives.cpp; path = core/src/gl/primitives.cpp; sourceTree = SOURCE_ROOT; };
 		63FBA60F34C64742A0B89D52 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		644ED745E5F84F4D99665C57 /* hb-ot-tag.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-tag.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-tag.cc"; sourceTree = SOURCE_ROOT; };
 		6473FEEFFE604761ABA1C505 /* dataLayer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = dataLayer.h; path = core/src/scene/dataLayer.h; sourceTree = SOURCE_ROOT; };
-		64FD649560ED4D419CC1473D /* ustrcase.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustrcase.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustrcase.cpp"; sourceTree = SOURCE_ROOT; };
+		64FD649560ED4D419CC1473D /* ustrcase.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustrcase.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ustrcase.cpp"; sourceTree = SOURCE_ROOT; };
 		6606D1827F36410FBDCC5B43 /* binary.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = binary.cpp; path = "external/yaml-cpp/src/binary.cpp"; sourceTree = SOURCE_ROOT; };
-		6607E78C239A4A8FA58C3675 /* ucnv_io.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnv_io.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_io.cpp"; sourceTree = SOURCE_ROOT; };
+		6607E78C239A4A8FA58C3675 /* ucnv_io.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnv_io.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_io.cpp"; sourceTree = SOURCE_ROOT; };
 		662C79FC4DAA40218FF5C02E /* dynamicQuadMesh.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = dynamicQuadMesh.h; path = core/src/gl/dynamicQuadMesh.h; sourceTree = SOURCE_ROOT; };
-		66393AC62849411D9868B7D9 /* ftinit.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftinit.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftinit.c"; sourceTree = SOURCE_ROOT; };
+		66393AC62849411D9868B7D9 /* ftinit.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftinit.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftinit.c"; sourceTree = SOURCE_ROOT; };
 		665589EB286E4E839E853D36 /* debug.vs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = debug.vs; path = core/shaders/debug.vs; sourceTree = SOURCE_ROOT; };
 		66848441A71048509800C90E /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		668D0363F9B84A6CA84E1C0E /* NotoNaskh-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = "NotoNaskh-Regular.ttf"; path = "scenes/fonts/NotoNaskh-Regular.ttf"; sourceTree = SOURCE_ROOT; };
-		66A2048424DA4B598F888D7E /* fterrors.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fterrors.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/fterrors.h"; sourceTree = SOURCE_ROOT; };
 		6725CFD2D7D6445EA2ECC4DA /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		686BCC96C74C4FD79F01D4FA /* hb-ot-shape-normalize.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-normalize.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-normalize.cc"; sourceTree = SOURCE_ROOT; };
 		68B2F548D9754595BCB0A2F2 /* material.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = material.cpp; path = core/src/style/material.cpp; sourceTree = SOURCE_ROOT; };
-		68C69A72776D4E2AADDCAAD8 /* uset_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uset_props.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uset_props.cpp"; sourceTree = SOURCE_ROOT; };
-		6905E982D72D4409993842AB /* uscript_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uscript_props.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uscript_props.cpp"; sourceTree = SOURCE_ROOT; };
+		68C69A72776D4E2AADDCAAD8 /* uset_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uset_props.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uset_props.cpp"; sourceTree = SOURCE_ROOT; };
+		6905E982D72D4409993842AB /* uscript_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uscript_props.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uscript_props.cpp"; sourceTree = SOURCE_ROOT; };
 		6916238462434231A4802CD2 /* iterator.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = iterator.h; path = "external/yaml-cpp/include/yaml-cpp/node/iterator.h"; sourceTree = SOURCE_ROOT; };
 		6925D02CDA674724B4FF2F34 /* nodeevents.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = nodeevents.cpp; path = "external/yaml-cpp/src/nodeevents.cpp"; sourceTree = SOURCE_ROOT; };
-		693A4ABB57EA4DD88EC78F7F /* sfnt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = sfnt.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/sfnt/sfnt.c"; sourceTree = SOURCE_ROOT; };
-		6949653E52D84329BC42BFC6 /* hb-font.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-font.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-font.cc"; sourceTree = SOURCE_ROOT; };
+		693A4ABB57EA4DD88EC78F7F /* sfnt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = sfnt.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/sfnt/sfnt.c"; sourceTree = SOURCE_ROOT; };
 		69C4C29B6E354D1CAAB35466 /* null.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = null.cpp; path = "external/yaml-cpp/src/null.cpp"; sourceTree = SOURCE_ROOT; };
 		69CD0046B2B443E18754D834 /* tileBuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = tileBuilder.cpp; path = core/src/tile/tileBuilder.cpp; sourceTree = SOURCE_ROOT; };
-		6A0225090A204FBE8C17FCBF /* rbbiscan.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbiscan.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/rbbiscan.cpp"; sourceTree = SOURCE_ROOT; };
+		6A0225090A204FBE8C17FCBF /* rbbiscan.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbiscan.cpp; path = "external/harfbuzz-icu-freetype/icu/common/rbbiscan.cpp"; sourceTree = SOURCE_ROOT; };
 		6A6CAF3713C24A4FAA8ACBD0 /* emitter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = emitter.cpp; path = "external/yaml-cpp/src/emitter.cpp"; sourceTree = SOURCE_ROOT; };
 		6B01BEEFB3E342F99CDDEAC9 /* polygon.vs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = polygon.vs; path = core/shaders/polygon.vs; sourceTree = SOURCE_ROOT; };
 		6B78F5F29D234A0789C747A9 /* impl.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = impl.h; path = "external/yaml-cpp/include/yaml-cpp/node/impl.h"; sourceTree = SOURCE_ROOT; };
 		6B8A9025454B42B1868E9C0C /* hardware.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = hardware.h; path = core/src/gl/hardware.h; sourceTree = SOURCE_ROOT; };
 		6BE4008A71694906BF477F43 /* ambientLight.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ambientLight.h; path = core/src/scene/ambientLight.h; sourceTree = SOURCE_ROOT; };
-		6C62AC49834C4FED88006D87 /* ftgxval.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftgxval.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftgxval.c"; sourceTree = SOURCE_ROOT; };
+		6C62AC49834C4FED88006D87 /* ftgxval.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftgxval.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftgxval.c"; sourceTree = SOURCE_ROOT; };
 		6C7E41FD1CCA4E41A4CCD098 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		6D1FE92D0FD14B13B57FB1C5 /* lights.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = lights.h; path = core/src/scene/lights.h; sourceTree = SOURCE_ROOT; };
 		6D3F0D6F01EA4923A36AC547 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/yaml-cpp/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
-		6D575978B0914E81907406C1 /* ttnameid.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ttnameid.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ttnameid.h"; sourceTree = SOURCE_ROOT; };
 		6D9083EE13624F9CADE1622A /* geojsonvt_tile.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geojsonvt_tile.cpp; path = "external/geojson-vt-cpp/src/geojsonvt_tile.cpp"; sourceTree = SOURCE_ROOT; };
-		6DAB67174F8B41B5A0E0C710 /* raster.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = raster.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/raster/raster.c"; sourceTree = SOURCE_ROOT; };
-		6DB4C5A8978A4DE4AAF43386 /* rbbistbl.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbistbl.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/rbbistbl.cpp"; sourceTree = SOURCE_ROOT; };
-		6E09F660736C4CE68EB076BF /* hb-ft.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ft.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ft.cc"; sourceTree = SOURCE_ROOT; };
+		6DAB67174F8B41B5A0E0C710 /* raster.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = raster.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/raster/raster.c"; sourceTree = SOURCE_ROOT; };
+		6DB4C5A8978A4DE4AAF43386 /* rbbistbl.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbistbl.cpp; path = "external/harfbuzz-icu-freetype/icu/common/rbbistbl.cpp"; sourceTree = SOURCE_ROOT; };
 		6E41DCA187384D9193F57C7E /* spriteLabel.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = spriteLabel.h; path = core/src/labels/spriteLabel.h; sourceTree = SOURCE_ROOT; };
 		6EC018DFABB84F7988F783FF /* textureCube.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = textureCube.h; path = core/src/gl/textureCube.h; sourceTree = SOURCE_ROOT; };
 		6EFA9A522A7F494F8FA97494 /* fontContext.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = fontContext.cpp; path = core/src/text/fontContext.cpp; sourceTree = SOURCE_ROOT; };
 		6F21644849AB419A9275F7A4 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		6F4B43236B0D48189F8B7018 /* locavailable.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locavailable.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/locavailable.cpp"; sourceTree = SOURCE_ROOT; };
+		6F4B43236B0D48189F8B7018 /* locavailable.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locavailable.cpp; path = "external/harfbuzz-icu-freetype/icu/common/locavailable.cpp"; sourceTree = SOURCE_ROOT; };
 		6F50414EBC2746F29A98672C /* collectionstack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = collectionstack.h; path = "external/yaml-cpp/src/collectionstack.h"; sourceTree = SOURCE_ROOT; };
-		6F5DF6CCD14143FFBE0FC434 /* bytestriebuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bytestriebuilder.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/bytestriebuilder.cpp"; sourceTree = SOURCE_ROOT; };
+		6F5DF6CCD14143FFBE0FC434 /* bytestriebuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bytestriebuilder.cpp; path = "external/harfbuzz-icu-freetype/icu/common/bytestriebuilder.cpp"; sourceTree = SOURCE_ROOT; };
 		6F9AB8A66AE94C04B690D998 /* parse.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = parse.h; path = "external/yaml-cpp/include/yaml-cpp/node/parse.h"; sourceTree = SOURCE_ROOT; };
 		6FF9F0E1A2024356A5D6673F /* langHelper.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = langHelper.cpp; path = external/alfons/src/alfons/langHelper.cpp; sourceTree = SOURCE_ROOT; };
 		7000A79E2D56438ABDC3A1E1 /* DroidSansFallback.ttf */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = DroidSansFallback.ttf; path = scenes/fonts/DroidSansFallback.ttf; sourceTree = SOURCE_ROOT; };
 		700FFA393A2C4B01886FDCFA /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = external/alfons/src/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		706F4BBA1EF844F3B823523D /* unistr_case.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_case.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unistr_case.cpp"; sourceTree = SOURCE_ROOT; };
+		706F4BBA1EF844F3B823523D /* unistr_case.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_case.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unistr_case.cpp"; sourceTree = SOURCE_ROOT; };
 		709B36A8D466433A90122AFB /* directionalLight.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = directionalLight.h; path = core/src/scene/directionalLight.h; sourceTree = SOURCE_ROOT; };
-		70D4B5F34EC24B3F88A0CF63 /* brkiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = brkiter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/brkiter.cpp"; sourceTree = SOURCE_ROOT; };
+		70D4B5F34EC24B3F88A0CF63 /* brkiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = brkiter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/brkiter.cpp"; sourceTree = SOURCE_ROOT; };
 		722A8028108F45EAA450A5A2 /* exp.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = exp.h; path = "external/yaml-cpp/src/exp.h"; sourceTree = SOURCE_ROOT; };
 		72AFE7E66F444EBEBE103034 /* extrude.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = extrude.cpp; path = core/src/util/extrude.cpp; sourceTree = SOURCE_ROOT; };
 		72CC9730D0F9437D9B8CE91E /* textureCube.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = textureCube.cpp; path = core/src/gl/textureCube.cpp; sourceTree = SOURCE_ROOT; };
-		72DABCE405E94F879F04EF01 /* hb-ot-shape-complex-indic.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-indic.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-indic.cc"; sourceTree = SOURCE_ROOT; };
-		731EED971DA240CC97EE8E59 /* ucharstriebuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucharstriebuilder.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucharstriebuilder.cpp"; sourceTree = SOURCE_ROOT; };
+		731EED971DA240CC97EE8E59 /* ucharstriebuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucharstriebuilder.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucharstriebuilder.cpp"; sourceTree = SOURCE_ROOT; };
 		735CEB241CBD4D2787FB0781 /* rasterStyle.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rasterStyle.cpp; path = core/src/style/rasterStyle.cpp; sourceTree = SOURCE_ROOT; };
 		737A10AC172841CBA052C01E /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/yaml-cpp/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
 		738D9E459E804C10A8741CEC /* importer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = importer.h; path = core/src/scene/importer.h; sourceTree = SOURCE_ROOT; };
@@ -1735,75 +1691,61 @@
 		73F8900DD4DD4B21B8D31767 /* vao.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = vao.cpp; path = core/src/gl/vao.cpp; sourceTree = SOURCE_ROOT; };
 		7482EAF1435745518E91142C /* import.yaml */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = import.yaml; path = scenes/import.yaml; sourceTree = SOURCE_ROOT; };
 		74A424F6865B457C9F1F6278 /* label.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = label.h; path = core/src/labels/label.h; sourceTree = SOURCE_ROOT; };
-		74A9D30932B54E009E59CFE0 /* servlkf.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servlkf.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/servlkf.cpp"; sourceTree = SOURCE_ROOT; };
-		74BC0F384B4F49EEA2C93AE4 /* ftserv.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftserv.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftserv.h"; sourceTree = SOURCE_ROOT; };
+		74A9D30932B54E009E59CFE0 /* servlkf.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servlkf.cpp; path = "external/harfbuzz-icu-freetype/icu/common/servlkf.cpp"; sourceTree = SOURCE_ROOT; };
 		75B594DE2DEE410ABC9B4488 /* filters.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = filters.cpp; path = core/src/scene/filters.cpp; sourceTree = SOURCE_ROOT; };
-		75DCA99F75F94C92AD416E0C /* ftgzip.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftgzip.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftgzip.h"; sourceTree = SOURCE_ROOT; };
 		761A811A431E4662A77CA3E7 /* debug.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = debug.fs; path = core/shaders/debug.fs; sourceTree = SOURCE_ROOT; };
-		7644BF2125BF4FF9824AEC52 /* ftoption.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftoption.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftoption.h"; sourceTree = SOURCE_ROOT; };
-		768FCBD848404284B0CFEFC2 /* fterrdef.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fterrdef.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/fterrdef.h"; sourceTree = SOURCE_ROOT; };
-		76A85B97F292445EBE56E5F6 /* propname.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = propname.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/propname.cpp"; sourceTree = SOURCE_ROOT; };
-		771E109CFF8E452591731523 /* psaux.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = psaux.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/psaux/psaux.c"; sourceTree = SOURCE_ROOT; };
-		77278044AD334A2BAE6F0552 /* ustrenum.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustrenum.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustrenum.cpp"; sourceTree = SOURCE_ROOT; };
-		77ADAAB3809B4893B732953E /* ftstroke.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftstroke.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftstroke.h"; sourceTree = SOURCE_ROOT; };
+		76A85B97F292445EBE56E5F6 /* propname.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = propname.cpp; path = "external/harfbuzz-icu-freetype/icu/common/propname.cpp"; sourceTree = SOURCE_ROOT; };
+		771E109CFF8E452591731523 /* psaux.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = psaux.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/psaux/psaux.c"; sourceTree = SOURCE_ROOT; };
+		77278044AD334A2BAE6F0552 /* ustrenum.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustrenum.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ustrenum.cpp"; sourceTree = SOURCE_ROOT; };
 		788DAE8D6AEE472EBD49DD27 /* geoJson.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geoJson.cpp; path = core/src/util/geoJson.cpp; sourceTree = SOURCE_ROOT; };
-		7915CAC428B34887B6C78108 /* unames.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unames.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unames.cpp"; sourceTree = SOURCE_ROOT; };
+		7915CAC428B34887B6C78108 /* unames.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unames.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unames.cpp"; sourceTree = SOURCE_ROOT; };
 		79B68032A81A4212A65F701C /* vertexLayout.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = vertexLayout.h; path = core/src/gl/vertexLayout.h; sourceTree = SOURCE_ROOT; };
-		79EE8C2A34794EAB8924D52D /* ftpfr.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftpfr.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftpfr.c"; sourceTree = SOURCE_ROOT; };
-		7A35E5B416314D47B83456A6 /* ubrk.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ubrk.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ubrk.cpp"; sourceTree = SOURCE_ROOT; };
+		79EE8C2A34794EAB8924D52D /* ftpfr.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftpfr.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftpfr.c"; sourceTree = SOURCE_ROOT; };
+		7A35E5B416314D47B83456A6 /* ubrk.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ubrk.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ubrk.cpp"; sourceTree = SOURCE_ROOT; };
 		7AA6E6BC2BF64C58BC1570EE /* pbfParser.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = pbfParser.h; path = core/src/util/pbfParser.h; sourceTree = SOURCE_ROOT; };
-		7AEBC5C36E4B491C9A4B6905 /* uidna.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uidna.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uidna.cpp"; sourceTree = SOURCE_ROOT; };
+		7AEBC5C36E4B491C9A4B6905 /* uidna.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uidna.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uidna.cpp"; sourceTree = SOURCE_ROOT; };
 		7B71CE7485F34DC0B9ADAC1E /* emitterstate.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = emitterstate.h; path = "external/yaml-cpp/src/emitterstate.h"; sourceTree = SOURCE_ROOT; };
 		7B90411A8ACE480B8F974811 /* styleContext.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = styleContext.h; path = core/src/scene/styleContext.h; sourceTree = SOURCE_ROOT; };
 		7C2D3F41F339435EAFA6BD4C /* font.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = font.cpp; path = external/alfons/src/alfons/font.cpp; sourceTree = SOURCE_ROOT; };
-		7CC43DCF305B40BE87C2F6ED /* locid.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locid.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/locid.cpp"; sourceTree = SOURCE_ROOT; };
+		7CC43DCF305B40BE87C2F6ED /* locid.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locid.cpp; path = "external/harfbuzz-icu-freetype/icu/common/locid.cpp"; sourceTree = SOURCE_ROOT; };
 		7CE57667392D4463BC053505 /* pointStyleBuilder.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = pointStyleBuilder.h; path = core/src/style/pointStyleBuilder.h; sourceTree = SOURCE_ROOT; };
-		7D1EDCFB573241F0BDB70CDA /* ftpic.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftpic.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftpic.h"; sourceTree = SOURCE_ROOT; };
-		7D75D93C5C0E4625A7F2D132 /* config.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = config.h; path = "external/alfons/deps/harfbuzz-icu-freetype/config.h"; sourceTree = SOURCE_ROOT; };
 		7D873DC3AA7B40FF82909987 /* libcore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libcore.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DAE507977D34508AA769413 /* nodebuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = nodebuilder.cpp; path = "external/yaml-cpp/src/nodebuilder.cpp"; sourceTree = SOURCE_ROOT; };
-		7DCB220339F34CF5B25008B0 /* smooth.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = smooth.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/smooth/smooth.c"; sourceTree = SOURCE_ROOT; };
+		7DCB220339F34CF5B25008B0 /* smooth.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = smooth.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/smooth/smooth.c"; sourceTree = SOURCE_ROOT; };
 		7DCEAB50CF0D4CF78DC82D69 /* anchordict.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = anchordict.h; path = "external/yaml-cpp/include/yaml-cpp/contrib/anchordict.h"; sourceTree = SOURCE_ROOT; };
 		7DD976B411CF487F9282A1CD /* emitterutils.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = emitterutils.h; path = "external/yaml-cpp/src/emitterutils.h"; sourceTree = SOURCE_ROOT; };
-		7DF0E7730D374746A4C4F56D /* parsepos.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = parsepos.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/parsepos.cpp"; sourceTree = SOURCE_ROOT; };
+		7DF0E7730D374746A4C4F56D /* parsepos.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = parsepos.cpp; path = "external/harfbuzz-icu-freetype/icu/common/parsepos.cpp"; sourceTree = SOURCE_ROOT; };
 		7DF2F8E21AC1411D834BAD2B /* streamcharsource.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = streamcharsource.h; path = "external/yaml-cpp/src/streamcharsource.h"; sourceTree = SOURCE_ROOT; };
 		7DF7E61E550E4CED95D5F9ED /* setting.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = setting.h; path = "external/yaml-cpp/src/setting.h"; sourceTree = SOURCE_ROOT; };
 		7E0641464D8342A197476C2D /* tag.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = tag.cpp; path = "external/yaml-cpp/src/tag.cpp"; sourceTree = SOURCE_ROOT; };
 		7E7AFFC52A434C7B9E6E8D1A /* debugPrimitive.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = debugPrimitive.fs; path = core/shaders/debugPrimitive.fs; sourceTree = SOURCE_ROOT; };
-		7E91CBF178784E1A86B0F948 /* ustr_cnv.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ustr_cnv.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustr_cnv.c"; sourceTree = SOURCE_ROOT; };
+		7E91CBF178784E1A86B0F948 /* ustr_cnv.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ustr_cnv.c; path = "external/harfbuzz-icu-freetype/icu/common/ustr_cnv.c"; sourceTree = SOURCE_ROOT; };
 		7EAE6388AC6643B5B77E048E /* skybox.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = skybox.cpp; path = core/src/scene/skybox.cpp; sourceTree = SOURCE_ROOT; };
-		7EE073A7850145FD88AEB2C5 /* ftmodule.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftmodule.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftmodule.h"; sourceTree = SOURCE_ROOT; };
 		7F14FB4E4275450780FA9128 /* frameInfo.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = frameInfo.h; path = core/src/debug/frameInfo.h; sourceTree = SOURCE_ROOT; };
-		7FE738C6284C4F2DA573FED8 /* ustack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustack.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustack.cpp"; sourceTree = SOURCE_ROOT; };
-		8085F88BCDEB4F7CBC02EB46 /* ustrfmt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ustrfmt.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustrfmt.c"; sourceTree = SOURCE_ROOT; };
+		7FE738C6284C4F2DA573FED8 /* ustack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustack.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ustack.cpp"; sourceTree = SOURCE_ROOT; };
+		8085F88BCDEB4F7CBC02EB46 /* ustrfmt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ustrfmt.c; path = "external/harfbuzz-icu-freetype/icu/common/ustrfmt.c"; sourceTree = SOURCE_ROOT; };
 		80AE66120C404A2B9131101D /* shaderProgram.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = shaderProgram.h; path = core/src/gl/shaderProgram.h; sourceTree = SOURCE_ROOT; };
-		80F40CBDA8F34358A34F9419 /* hb-ot-map.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-map.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-map.cc"; sourceTree = SOURCE_ROOT; };
 		8136AD9150CE4301A99B5F2D /* tangram.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tangram.h; path = core/src/tangram.h; sourceTree = SOURCE_ROOT; };
 		8206994BB689434896596EE9 /* labelProperty.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = labelProperty.cpp; path = core/src/labels/labelProperty.cpp; sourceTree = SOURCE_ROOT; };
-		824D6B3D70B547C5A25B2F37 /* ustrcase_locale.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustrcase_locale.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustrcase_locale.cpp"; sourceTree = SOURCE_ROOT; };
-		824E57702F9F43798AE4FC9A /* normalizer2impl.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = normalizer2impl.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/normalizer2impl.cpp"; sourceTree = SOURCE_ROOT; };
-		82631D0D19684BDF92EB36B9 /* ucnvbocu.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnvbocu.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnvbocu.cpp"; sourceTree = SOURCE_ROOT; };
+		824D6B3D70B547C5A25B2F37 /* ustrcase_locale.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustrcase_locale.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ustrcase_locale.cpp"; sourceTree = SOURCE_ROOT; };
+		824E57702F9F43798AE4FC9A /* normalizer2impl.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = normalizer2impl.cpp; path = "external/harfbuzz-icu-freetype/icu/common/normalizer2impl.cpp"; sourceTree = SOURCE_ROOT; };
+		82631D0D19684BDF92EB36B9 /* ucnvbocu.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnvbocu.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucnvbocu.cpp"; sourceTree = SOURCE_ROOT; };
 		836584DFED184F0584A104A5 /* node.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = node.h; path = "external/yaml-cpp/include/yaml-cpp/node/node.h"; sourceTree = SOURCE_ROOT; };
-		83CC810132814F04B27C35D6 /* hb-ot-shape-complex-use-table.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-use-table.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-use-table.cc"; sourceTree = SOURCE_ROOT; };
-		842905D2D96540FC968FC289 /* ftmodapi.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftmodapi.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftmodapi.h"; sourceTree = SOURCE_ROOT; };
 		84BE5597ABB64216AA9323D6 /* singledocparser.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = singledocparser.h; path = "external/yaml-cpp/src/singledocparser.h"; sourceTree = SOURCE_ROOT; };
 		8514A6A9553D44BE86584314 /* error.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = error.h; path = core/src/gl/error.h; sourceTree = SOURCE_ROOT; };
-		8580335BFCCA4994BFE929E4 /* ftconfig.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftconfig.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftconfig.h"; sourceTree = SOURCE_ROOT; };
 		860773F593ED40BBBC1613B5 /* quadMatrix.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = quadMatrix.cpp; path = external/alfons/src/alfons/quadMatrix.cpp; sourceTree = SOURCE_ROOT; };
 		862A94978C0C444D8AB70316 /* geojsonvt_simplify.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geojsonvt_simplify.cpp; path = "external/geojson-vt-cpp/src/geojsonvt_simplify.cpp"; sourceTree = SOURCE_ROOT; };
 		86740E1A1B9B44568C277218 /* extrude.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = extrude.h; path = core/src/util/extrude.h; sourceTree = SOURCE_ROOT; };
 		86D06153196F491CB2FDF6FE /* properties.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = properties.h; path = core/src/data/properties.h; sourceTree = SOURCE_ROOT; };
 		8766957E389C4EC8BDE60B8F /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		876D4FD59AFF4A2286849D26 /* hb-ot-shape-complex-use.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-use.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-use.cc"; sourceTree = SOURCE_ROOT; };
-		877336945001499882ED5C21 /* stringtriebuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = stringtriebuilder.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/stringtriebuilder.cpp"; sourceTree = SOURCE_ROOT; };
+		877336945001499882ED5C21 /* stringtriebuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = stringtriebuilder.cpp; path = "external/harfbuzz-icu-freetype/icu/common/stringtriebuilder.cpp"; sourceTree = SOURCE_ROOT; };
 		8779D61B29794A6BACFF5108 /* exp.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = exp.cpp; path = "external/yaml-cpp/src/exp.cpp"; sourceTree = SOURCE_ROOT; };
 		8881BE1FD14D426C9647F07C /* bool_type.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = bool_type.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/bool_type.h"; sourceTree = SOURCE_ROOT; };
 		8944C81893D3437196C2DC41 /* emitterstyle.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = emitterstyle.h; path = "external/yaml-cpp/include/yaml-cpp/emitterstyle.h"; sourceTree = SOURCE_ROOT; };
 		895C90AF35524D1AA3D52CE1 /* topoJson.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = topoJson.h; path = core/src/util/topoJson.h; sourceTree = SOURCE_ROOT; };
-		899C8D0BD75E4F7BA8FF2B90 /* hb-ot-layout.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-layout.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-layout.cc"; sourceTree = SOURCE_ROOT; };
-		8A7D13E34C9646848DF0BA6E /* schriter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = schriter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/schriter.cpp"; sourceTree = SOURCE_ROOT; };
+		8A7D13E34C9646848DF0BA6E /* schriter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = schriter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/schriter.cpp"; sourceTree = SOURCE_ROOT; };
 		8B188A4B2A574D908B38E36E /* pointStyle.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = pointStyle.h; path = core/src/style/pointStyle.h; sourceTree = SOURCE_ROOT; };
-		8B290E826E3E4F4896DFD97C /* chariter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = chariter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/chariter.cpp"; sourceTree = SOURCE_ROOT; };
+		8B290E826E3E4F4896DFD97C /* chariter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = chariter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/chariter.cpp"; sourceTree = SOURCE_ROOT; };
 		8B688FDCD6BD4A9FA471C42D /* mapProjection.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = mapProjection.h; path = core/src/util/mapProjection.h; sourceTree = SOURCE_ROOT; };
 		8BA40D864F32462381F35296 /* emitter.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = emitter.h; path = "external/yaml-cpp/include/yaml-cpp/emitter.h"; sourceTree = SOURCE_ROOT; };
 		8CCAC1B4EAE04A45809CF91D /* stops.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = stops.h; path = core/src/scene/stops.h; sourceTree = SOURCE_ROOT; };
@@ -1811,88 +1753,75 @@
 		8CF4246515C2484EB800E1A1 /* propertyItem.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = propertyItem.h; path = core/src/data/propertyItem.h; sourceTree = SOURCE_ROOT; };
 		8CF928D77C4848249CBF43DE /* shaderProgram.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = shaderProgram.cpp; path = core/src/gl/shaderProgram.cpp; sourceTree = SOURCE_ROOT; };
 		8D276F06645D478DB2014580 /* Main_iPad.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main_iPad.storyboard; path = ios/resources/Main_iPad.storyboard; sourceTree = SOURCE_ROOT; };
-		8D34C0351CEB43B8817F6DC3 /* locresdata.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locresdata.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/locresdata.cpp"; sourceTree = SOURCE_ROOT; };
-		8D897D55C19D482CAF4C4314 /* ftmoderr.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftmoderr.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftmoderr.h"; sourceTree = SOURCE_ROOT; };
-		8DA56675286A4E1B9E2BE242 /* loclikely.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = loclikely.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/loclikely.cpp"; sourceTree = SOURCE_ROOT; };
+		8D34C0351CEB43B8817F6DC3 /* locresdata.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locresdata.cpp; path = "external/harfbuzz-icu-freetype/icu/common/locresdata.cpp"; sourceTree = SOURCE_ROOT; };
+		8DA56675286A4E1B9E2BE242 /* loclikely.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = loclikely.cpp; path = "external/harfbuzz-icu-freetype/icu/common/loclikely.cpp"; sourceTree = SOURCE_ROOT; };
 		8DAA8B5D3CB045EB827CA073 /* grid.jpg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = image; name = grid.jpg; path = scenes/img/grid.jpg; sourceTree = SOURCE_ROOT; };
-		8E5100F0D6394567AAFE0EDB /* ucnv_u7.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_u7.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_u7.c"; sourceTree = SOURCE_ROOT; };
+		8E5100F0D6394567AAFE0EDB /* ucnv_u7.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_u7.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_u7.c"; sourceTree = SOURCE_ROOT; };
 		8F1BC4AC9C244DF499CC063D /* tileWorker.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tileWorker.h; path = core/src/tile/tileWorker.h; sourceTree = SOURCE_ROOT; };
-		8F56C8E4FCE44395A96AC1DE /* utf_impl.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = utf_impl.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/utf_impl.c"; sourceTree = SOURCE_ROOT; };
-		8F9E6FED24A0436CA6900665 /* ftgasp.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftgasp.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftgasp.c"; sourceTree = SOURCE_ROOT; };
-		8FC082F7FBE04C34B69EF60A /* internal.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = internal.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/internal.h"; sourceTree = SOURCE_ROOT; };
+		8F56C8E4FCE44395A96AC1DE /* utf_impl.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = utf_impl.c; path = "external/harfbuzz-icu-freetype/icu/common/utf_impl.c"; sourceTree = SOURCE_ROOT; };
+		8F9E6FED24A0436CA6900665 /* ftgasp.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftgasp.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftgasp.c"; sourceTree = SOURCE_ROOT; };
 		8FE448F514A644ED91B34871 /* scrptrun.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = scrptrun.cpp; path = external/alfons/src/alfons/scrptrun.cpp; sourceTree = SOURCE_ROOT; };
-		9006850B4F4246CA823BB6EC /* ftmac.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftmac.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftmac.h"; sourceTree = SOURCE_ROOT; };
-		9062234BC5F348B7981B52AE /* uvector.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uvector.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uvector.cpp"; sourceTree = SOURCE_ROOT; };
+		9062234BC5F348B7981B52AE /* uvector.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uvector.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uvector.cpp"; sourceTree = SOURCE_ROOT; };
 		906CF68A5131468F8D4B6104 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = external/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		90C3E1C2FBB7441B9D459218 /* ambientLight.glsl */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = ambientLight.glsl; path = core/shaders/ambientLight.glsl; sourceTree = SOURCE_ROOT; };
 		916A778142A244D78F55FE3F /* lineSampler.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = lineSampler.cpp; path = external/alfons/src/alfons/path/lineSampler.cpp; sourceTree = SOURCE_ROOT; };
-		91EA08E248204C68B0C526A0 /* pfr.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = pfr.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/pfr/pfr.c"; sourceTree = SOURCE_ROOT; };
-		928E759186DB46149875E3DA /* udata.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = udata.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/udata.cpp"; sourceTree = SOURCE_ROOT; };
-		92D153F82CFF4F4FB851DC4A /* ftdriver.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftdriver.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftdriver.h"; sourceTree = SOURCE_ROOT; };
+		91EA08E248204C68B0C526A0 /* pfr.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = pfr.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/pfr/pfr.c"; sourceTree = SOURCE_ROOT; };
+		928E759186DB46149875E3DA /* udata.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = udata.cpp; path = "external/harfbuzz-icu-freetype/icu/common/udata.cpp"; sourceTree = SOURCE_ROOT; };
 		92D77849CD524983B42CD2EB /* scene.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = scene.h; path = core/src/scene/scene.h; sourceTree = SOURCE_ROOT; };
 		93026C0C36354A8B982EFA72 /* ostream_wrapper.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ostream_wrapper.h; path = "external/yaml-cpp/include/yaml-cpp/ostream_wrapper.h"; sourceTree = SOURCE_ROOT; };
-		9308428BB35E4BFD95439EF8 /* ucasemap.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucasemap.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucasemap.cpp"; sourceTree = SOURCE_ROOT; };
+		9308428BB35E4BFD95439EF8 /* ucasemap.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucasemap.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucasemap.cpp"; sourceTree = SOURCE_ROOT; };
 		931911F85C274E39A490EB61 /* textStyle.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = textStyle.cpp; path = core/src/style/textStyle.cpp; sourceTree = SOURCE_ROOT; };
-		9323D9BDA8744039BA985786 /* truetype.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = truetype.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/truetype/truetype.c"; sourceTree = SOURCE_ROOT; };
-		934966E99587479C8C3C46C4 /* lineWrap.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = lineWrap.cpp; path = external/alfons/src/alfons/lineWrap.cpp; sourceTree = SOURCE_ROOT; };
+		9323D9BDA8744039BA985786 /* truetype.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = truetype.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/truetype/truetype.c"; sourceTree = SOURCE_ROOT; };
 		93CF5BBD73F141C8BF661BFA /* spotLight.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = spotLight.cpp; path = core/src/scene/spotLight.cpp; sourceTree = SOURCE_ROOT; };
 		93E191DEED814057AB101C4F /* tileWorker.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = tileWorker.cpp; path = core/src/tile/tileWorker.cpp; sourceTree = SOURCE_ROOT; };
-		9439A77FC5ED4437BC471CD3 /* ushape.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ushape.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ushape.cpp"; sourceTree = SOURCE_ROOT; };
+		9439A77FC5ED4437BC471CD3 /* ushape.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ushape.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ushape.cpp"; sourceTree = SOURCE_ROOT; };
 		948B79370581424BAAC00539 /* linebreakdef.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = linebreakdef.c; path = external/alfons/src/linebreak/linebreakdef.c; sourceTree = SOURCE_ROOT; };
-		95B453D89F4C4C13ACB50C13 /* utrace.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = utrace.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/utrace.c"; sourceTree = SOURCE_ROOT; };
-		9641D70C933942DB9F9A43BA /* ftgzip.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftgzip.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/gzip/ftgzip.c"; sourceTree = SOURCE_ROOT; };
+		95B453D89F4C4C13ACB50C13 /* utrace.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = utrace.c; path = "external/harfbuzz-icu-freetype/icu/common/utrace.c"; sourceTree = SOURCE_ROOT; };
+		9641D70C933942DB9F9A43BA /* ftgzip.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftgzip.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/gzip/ftgzip.c"; sourceTree = SOURCE_ROOT; };
 		96467DE755734AE8890A5A2F /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		966830C8FFFA429AB86CD934 /* cubemap.vs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = cubemap.vs; path = core/shaders/cubemap.vs; sourceTree = SOURCE_ROOT; };
-		970A171864A94B209FA02FEE /* ftautoh.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftautoh.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftautoh.h"; sourceTree = SOURCE_ROOT; };
-		970DE29C2B1A4AEC96CAD2CB /* psnames.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = psnames.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/psnames/psnames.c"; sourceTree = SOURCE_ROOT; };
+		970DE29C2B1A4AEC96CAD2CB /* psnames.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = psnames.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/psnames/psnames.c"; sourceTree = SOURCE_ROOT; };
 		9745069B75EE48D79F08D9F9 /* liblinebreak.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = liblinebreak.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C1DD25FB9B44CD83F98604 /* stream.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = stream.h; path = "external/yaml-cpp/src/stream.h"; sourceTree = SOURCE_ROOT; };
-		981ACF92DFD8423EA9D32310 /* ucnv_set.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_set.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_set.c"; sourceTree = SOURCE_ROOT; };
+		981ACF92DFD8423EA9D32310 /* ucnv_set.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_set.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_set.c"; sourceTree = SOURCE_ROOT; };
 		98350B49F52F41428DCC6204 /* convert.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = convert.h; path = "external/yaml-cpp/include/yaml-cpp/node/convert.h"; sourceTree = SOURCE_ROOT; };
 		98C2BDB99C1A459E8D71D1C4 /* material.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = material.h; path = core/src/style/material.h; sourceTree = SOURCE_ROOT; };
 		98CA906932E0419989718831 /* style.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = style.h; path = core/src/style/style.h; sourceTree = SOURCE_ROOT; };
 		9950827798B64F789AC8CB33 /* properties.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = properties.cpp; path = core/src/data/properties.cpp; sourceTree = SOURCE_ROOT; };
 		9A0E245128EC4F3DB575D58A /* tileManager.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tileManager.h; path = core/src/tile/tileManager.h; sourceTree = SOURCE_ROOT; };
 		9A1BFB704DE34AC79D176120 /* emit.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = emit.h; path = "external/yaml-cpp/include/yaml-cpp/node/emit.h"; sourceTree = SOURCE_ROOT; };
-		9A59608F50904420B5393801 /* ucnvlat1.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvlat1.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnvlat1.c"; sourceTree = SOURCE_ROOT; };
+		9A59608F50904420B5393801 /* ucnvlat1.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvlat1.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnvlat1.c"; sourceTree = SOURCE_ROOT; };
 		9B2615264A6A43A69699B39C /* eventhandler.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = eventhandler.h; path = "external/yaml-cpp/include/yaml-cpp/eventhandler.h"; sourceTree = SOURCE_ROOT; };
 		9C5C54FBE92C4AC3B1DFF7E8 /* pointStyleBuilder.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = pointStyleBuilder.cpp; path = core/src/style/pointStyleBuilder.cpp; sourceTree = SOURCE_ROOT; };
-		9D34F19EA0A34D9EB54AFD33 /* unistr.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unistr.cpp"; sourceTree = SOURCE_ROOT; };
+		9D34F19EA0A34D9EB54AFD33 /* unistr.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unistr.cpp"; sourceTree = SOURCE_ROOT; };
 		9D5093E9813D4A16AD6BADF9 /* regeximpl.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = regeximpl.h; path = "external/yaml-cpp/src/regeximpl.h"; sourceTree = SOURCE_ROOT; };
-		9D5140D6265E42CDBFE42BF1 /* ustr_wcs.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustr_wcs.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustr_wcs.cpp"; sourceTree = SOURCE_ROOT; };
+		9D5140D6265E42CDBFE42BF1 /* ustr_wcs.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustr_wcs.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ustr_wcs.cpp"; sourceTree = SOURCE_ROOT; };
 		9DAF9A34F72A4B4DBE12BF1E /* node_ref.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = node_ref.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/node_ref.h"; sourceTree = SOURCE_ROOT; };
-		9E358A80543F488197A93F1F /* hb-common.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-common.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-common.cc"; sourceTree = SOURCE_ROOT; };
 		9E635932FA784915BA699A5E /* token.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = token.h; path = "external/yaml-cpp/src/token.h"; sourceTree = SOURCE_ROOT; };
-		9E7A68AE52EE4636B2792CFA /* ftvalid.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftvalid.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftvalid.h"; sourceTree = SOURCE_ROOT; };
-		9EB1B87FE85442988DEB996A /* uset.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uset.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uset.cpp"; sourceTree = SOURCE_ROOT; };
+		9EB1B87FE85442988DEB996A /* uset.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uset.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uset.cpp"; sourceTree = SOURCE_ROOT; };
 		9F7D005C9BDE403E8BD8DD40 /* styleMixer.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = styleMixer.cpp; path = core/src/scene/styleMixer.cpp; sourceTree = SOURCE_ROOT; };
 		9FDC9F5C088B419F82CF907A /* libicucommon.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libicucommon.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		9FF69F09F9B846C3BAC096C4 /* unisetspan.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unisetspan.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unisetspan.cpp"; sourceTree = SOURCE_ROOT; };
+		9FF69F09F9B846C3BAC096C4 /* unisetspan.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unisetspan.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unisetspan.cpp"; sourceTree = SOURCE_ROOT; };
 		A012E679A238411B8692BBEF /* noncopyable.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = noncopyable.h; path = "external/yaml-cpp/include/yaml-cpp/noncopyable.h"; sourceTree = SOURCE_ROOT; };
 		A03739DD89C7479C87083A03 /* alfons.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = alfons.cpp; path = external/alfons/src/alfons/alfons.cpp; sourceTree = SOURCE_ROOT; };
-		A0A90AA1033544E9B5789B0A /* ubidiwrt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ubidiwrt.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ubidiwrt.c"; sourceTree = SOURCE_ROOT; };
-		A167CD84C937483C80AC0EBE /* serv.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = serv.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/serv.cpp"; sourceTree = SOURCE_ROOT; };
+		A0A90AA1033544E9B5789B0A /* ubidiwrt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ubidiwrt.c; path = "external/harfbuzz-icu-freetype/icu/common/ubidiwrt.c"; sourceTree = SOURCE_ROOT; };
+		A167CD84C937483C80AC0EBE /* serv.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = serv.cpp; path = "external/harfbuzz-icu-freetype/icu/common/serv.cpp"; sourceTree = SOURCE_ROOT; };
 		A1EF8C8BA5B54AC3BB0BD995 /* uniform.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = uniform.h; path = core/src/gl/uniform.h; sourceTree = SOURCE_ROOT; };
-		A2F01B0632FA43FBADDDA13B /* ucnv_u16.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_u16.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_u16.c"; sourceTree = SOURCE_ROOT; };
-		A300BA04863A448786767B5C /* hb-ot-shape-complex-arabic.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-arabic.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-arabic.cc"; sourceTree = SOURCE_ROOT; };
+		A2F01B0632FA43FBADDDA13B /* ucnv_u16.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_u16.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_u16.c"; sourceTree = SOURCE_ROOT; };
 		A3781A5CC46B4B97BC62C25A /* node_data.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = node_data.cpp; path = "external/yaml-cpp/src/node_data.cpp"; sourceTree = SOURCE_ROOT; };
-		A3BEBA78AF574CE0B61D1A0D /* tttypes.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tttypes.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/tttypes.h"; sourceTree = SOURCE_ROOT; };
 		A42BADF6F1E945E6B959817F /* indentation.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = indentation.h; path = "external/yaml-cpp/src/indentation.h"; sourceTree = SOURCE_ROOT; };
-		A4F108EC23A8434A8C5CB026 /* unistr_case_locale.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_case_locale.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unistr_case_locale.cpp"; sourceTree = SOURCE_ROOT; };
-		A4F12328C7C641DB95E3046D /* umath.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = umath.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/umath.c"; sourceTree = SOURCE_ROOT; };
+		A4F108EC23A8434A8C5CB026 /* unistr_case_locale.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_case_locale.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unistr_case_locale.cpp"; sourceTree = SOURCE_ROOT; };
+		A4F12328C7C641DB95E3046D /* umath.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = umath.c; path = "external/harfbuzz-icu-freetype/icu/common/umath.c"; sourceTree = SOURCE_ROOT; };
 		A56ADA05AB2040CCA73658D0 /* builders.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = builders.cpp; path = core/src/util/builders.cpp; sourceTree = SOURCE_ROOT; };
 		A59930103F7848F89278D200 /* arrow-3.png */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = image; name = "arrow-3.png"; path = "scenes/img/arrow-3.png"; sourceTree = SOURCE_ROOT; };
 		A5D2C74FEEE74E4989D63342 /* dataLayer.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dataLayer.cpp; path = core/src/scene/dataLayer.cpp; sourceTree = SOURCE_ROOT; };
-		A6CF05A8CDD74553BFFBDDC4 /* appendable.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = appendable.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/appendable.cpp"; sourceTree = SOURCE_ROOT; };
+		A6CF05A8CDD74553BFFBDDC4 /* appendable.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = appendable.cpp; path = "external/harfbuzz-icu-freetype/icu/common/appendable.cpp"; sourceTree = SOURCE_ROOT; };
 		A6DAD79368E84079B029FEAF /* texture.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = texture.cpp; path = core/src/gl/texture.cpp; sourceTree = SOURCE_ROOT; };
 		A6DD98ABF35747D182F0B192 /* rasterize.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = rasterize.h; path = core/src/util/rasterize.h; sourceTree = SOURCE_ROOT; };
 		A7DD94B3F9234BF790A81FF1 /* style.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = style.cpp; path = core/src/style/style.cpp; sourceTree = SOURCE_ROOT; };
-		A80E6451636B4FB894E03883 /* ftsizes.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftsizes.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftsizes.h"; sourceTree = SOURCE_ROOT; };
-		A85FD3396A87458F8576E8BD /* hb-shape.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-shape.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-shape.cc"; sourceTree = SOURCE_ROOT; };
-		A8A999D350A641ABB3BC0C55 /* ucnvisci.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvisci.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnvisci.c"; sourceTree = SOURCE_ROOT; };
+		A8A999D350A641ABB3BC0C55 /* ucnvisci.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvisci.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnvisci.c"; sourceTree = SOURCE_ROOT; };
 		A94A132B239B4CE2AC51D221 /* scanner.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = scanner.cpp; path = "external/yaml-cpp/src/scanner.cpp"; sourceTree = SOURCE_ROOT; };
-		A9B315937D244B2A9F114041 /* ftcalc.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftcalc.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftcalc.h"; sourceTree = SOURCE_ROOT; };
-		A9E6597AC3EA4425A0006AB7 /* ruleiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ruleiter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ruleiter.cpp"; sourceTree = SOURCE_ROOT; };
+		A9E6597AC3EA4425A0006AB7 /* ruleiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ruleiter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ruleiter.cpp"; sourceTree = SOURCE_ROOT; };
 		AA5D047E1144452BA64E92C8 /* scene.yaml */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = scene.yaml; path = scenes/scene.yaml; sourceTree = SOURCE_ROOT; };
 		AA7CF1E74BE04DEBB54B2D77 /* inputHandler.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = inputHandler.cpp; path = core/src/util/inputHandler.cpp; sourceTree = SOURCE_ROOT; };
 		AA95D883EE3540D89CB281D8 /* spriteAtlas.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = spriteAtlas.h; path = core/src/scene/spriteAtlas.h; sourceTree = SOURCE_ROOT; };
@@ -1901,129 +1830,107 @@
 		AB1FD8945C2F445396C4061C /* tileBuilder.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tileBuilder.h; path = core/src/tile/tileBuilder.h; sourceTree = SOURCE_ROOT; };
 		ABC94BD85CD74F32B95E819F /* geom.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = geom.h; path = core/src/util/geom.h; sourceTree = SOURCE_ROOT; };
 		AC990CED614D445ABE08A8D5 /* clientGeoJsonSource.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = clientGeoJsonSource.cpp; path = core/src/data/clientGeoJsonSource.cpp; sourceTree = SOURCE_ROOT; };
-		ACF2D570512A4C08BC511459 /* uiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uiter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uiter.cpp"; sourceTree = SOURCE_ROOT; };
+		ACF2D570512A4C08BC511459 /* uiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uiter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uiter.cpp"; sourceTree = SOURCE_ROOT; };
 		AD132164FF964FEAB3FD3984 /* dashArray.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dashArray.cpp; path = core/src/util/dashArray.cpp; sourceTree = SOURCE_ROOT; };
 		AD87A211F8D745A0960C4E26 /* label.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = label.cpp; path = core/src/labels/label.cpp; sourceTree = SOURCE_ROOT; };
 		AD8FBFC77A074B5DA615625E /* regex_yaml.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = regex_yaml.h; path = "external/yaml-cpp/src/regex_yaml.h"; sourceTree = SOURCE_ROOT; };
 		ADB8F015FD8B473D84824EEA /* textLabel.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = textLabel.cpp; path = core/src/labels/textLabel.cpp; sourceTree = SOURCE_ROOT; };
-		ADFA48762B824B9A8B1588DD /* uinit.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uinit.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uinit.cpp"; sourceTree = SOURCE_ROOT; };
+		ADFA48762B824B9A8B1588DD /* uinit.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uinit.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uinit.cpp"; sourceTree = SOURCE_ROOT; };
 		AECD304EE8524424A16F22A8 /* dataSource.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = dataSource.h; path = core/src/data/dataSource.h; sourceTree = SOURCE_ROOT; };
-		AEDD3930A6D34D3185C584DF /* uresbund.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uresbund.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uresbund.cpp"; sourceTree = SOURCE_ROOT; };
-		AF1CC7205183453482DD4D8C /* rbbi.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbi.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/rbbi.cpp"; sourceTree = SOURCE_ROOT; };
-		AF25A489B1DB4864AFB80635 /* hb-ot-shape-fallback.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-fallback.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-fallback.cc"; sourceTree = SOURCE_ROOT; };
-		AF349BB08B8D4CD2B3804795 /* fttypes.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fttypes.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/fttypes.h"; sourceTree = SOURCE_ROOT; };
+		AEDD3930A6D34D3185C584DF /* uresbund.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uresbund.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uresbund.cpp"; sourceTree = SOURCE_ROOT; };
+		AF1CC7205183453482DD4D8C /* rbbi.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbi.cpp; path = "external/harfbuzz-icu-freetype/icu/common/rbbi.cpp"; sourceTree = SOURCE_ROOT; };
 		AF4A953732C84E3EA49708CF /* geoJson.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = geoJson.h; path = core/src/util/geoJson.h; sourceTree = SOURCE_ROOT; };
 		AF6017075F214CDC906894C5 /* parser.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = parser.cpp; path = "external/yaml-cpp/src/parser.cpp"; sourceTree = SOURCE_ROOT; };
 		B004296DE2D44B8B807BE471 /* hardware.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = hardware.cpp; path = core/src/gl/hardware.cpp; sourceTree = SOURCE_ROOT; };
-		B00AA657D2CB49168258FA5D /* ucnvscsu.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvscsu.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnvscsu.c"; sourceTree = SOURCE_ROOT; };
-		B07E4CBD073F4339BF398AD5 /* dictionarydata.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dictionarydata.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/dictionarydata.cpp"; sourceTree = SOURCE_ROOT; };
+		B00AA657D2CB49168258FA5D /* ucnvscsu.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvscsu.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnvscsu.c"; sourceTree = SOURCE_ROOT; };
+		B07E4CBD073F4339BF398AD5 /* dictionarydata.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dictionarydata.cpp; path = "external/harfbuzz-icu-freetype/icu/common/dictionarydata.cpp"; sourceTree = SOURCE_ROOT; };
 		B0A92BAD2ED24D8EB01AEC0B /* pointLight.glsl */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = pointLight.glsl; path = core/shaders/pointLight.glsl; sourceTree = SOURCE_ROOT; };
-		B0D6DA605D8F4F9CA978B5C4 /* bytestrie.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bytestrie.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/bytestrie.cpp"; sourceTree = SOURCE_ROOT; };
+		B0D6DA605D8F4F9CA978B5C4 /* bytestrie.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bytestrie.cpp; path = "external/harfbuzz-icu-freetype/icu/common/bytestrie.cpp"; sourceTree = SOURCE_ROOT; };
 		B150B48300F543E1ABAA42AB /* sceneLoader.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = sceneLoader.cpp; path = core/src/scene/sceneLoader.cpp; sourceTree = SOURCE_ROOT; };
 		B21AF636F223474A88BE0A4A /* polyline.vs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = polyline.vs; path = core/shaders/polyline.vs; sourceTree = SOURCE_ROOT; };
-		B29164703DEF4128B962221E /* hb-shaper.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-shaper.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-shaper.cc"; sourceTree = SOURCE_ROOT; };
 		B311B9A5AB354218BD93E95C /* util.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = util.h; path = core/src/util/util.h; sourceTree = SOURCE_ROOT; };
 		B318BD28F3584366BBE62C0F /* dataSource.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dataSource.cpp; path = core/src/data/dataSource.cpp; sourceTree = SOURCE_ROOT; };
 		B33FA34A99974A608203311B /* libduktape.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libduktape.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4A6350E54A6473C981FABCD /* topologicalSort.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = topologicalSort.h; path = core/src/util/topologicalSort.h; sourceTree = SOURCE_ROOT; };
 		B4D05233B53447F5BD2F0C5A /* stringsource.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = stringsource.h; path = "external/yaml-cpp/src/stringsource.h"; sourceTree = SOURCE_ROOT; };
-		B52D89676F3842268693ACE2 /* fttrigon.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fttrigon.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/fttrigon.h"; sourceTree = SOURCE_ROOT; };
-		B5827BFED8C54B9B814E52E6 /* locutil.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locutil.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/locutil.cpp"; sourceTree = SOURCE_ROOT; };
-		B5C865C350EF4EE5A2CA2968 /* unifilt.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unifilt.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unifilt.cpp"; sourceTree = SOURCE_ROOT; };
-		B6D4D3C23F1E46398935E454 /* ftrender.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftrender.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftrender.h"; sourceTree = SOURCE_ROOT; };
-		B702D2E499E54901ABED616E /* uchriter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uchriter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uchriter.cpp"; sourceTree = SOURCE_ROOT; };
+		B5827BFED8C54B9B814E52E6 /* locutil.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = locutil.cpp; path = "external/harfbuzz-icu-freetype/icu/common/locutil.cpp"; sourceTree = SOURCE_ROOT; };
+		B5C865C350EF4EE5A2CA2968 /* unifilt.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unifilt.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unifilt.cpp"; sourceTree = SOURCE_ROOT; };
+		B702D2E499E54901ABED616E /* uchriter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uchriter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uchriter.cpp"; sourceTree = SOURCE_ROOT; };
 		B72E9EABC0974052867F4E0A /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		B78237D6BCC2458095AEDE94 /* ucnvdisp.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvdisp.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnvdisp.c"; sourceTree = SOURCE_ROOT; };
+		B78237D6BCC2458095AEDE94 /* ucnvdisp.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvdisp.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnvdisp.c"; sourceTree = SOURCE_ROOT; };
 		B7A1A4B0F23145FA96716552 /* tileCache.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tileCache.h; path = core/src/tile/tileCache.h; sourceTree = SOURCE_ROOT; };
-		B7A27565DEDB4C72A8C9CE31 /* hb-ot-shape-complex-hangul.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-hangul.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-hangul.cc"; sourceTree = SOURCE_ROOT; };
-		B84F458CD5D9499FB8FE8A25 /* ftttdrv.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftttdrv.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftttdrv.h"; sourceTree = SOURCE_ROOT; };
 		B85FE04BC1F34C468C8BDEFD /* pointLight.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = pointLight.cpp; path = core/src/scene/pointLight.cpp; sourceTree = SOURCE_ROOT; };
 		B953BC9B3F65444FB99A862B /* tangram.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = tangram.cpp; path = core/src/tangram.cpp; sourceTree = SOURCE_ROOT; };
 		B99A46007D764FD5A32DA46C /* sceneLayer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = sceneLayer.h; path = core/src/scene/sceneLayer.h; sourceTree = SOURCE_ROOT; };
-		BA04C8801190431DB4CB250A /* unistr_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_props.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unistr_props.cpp"; sourceTree = SOURCE_ROOT; };
-		BACAAEFD426C4E3CAEEEC729 /* hb-shape-plan.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-shape-plan.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-shape-plan.cc"; sourceTree = SOURCE_ROOT; };
-		BB0FAB9F0AB44792898CF141 /* utext.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = utext.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/utext.cpp"; sourceTree = SOURCE_ROOT; };
+		BA04C8801190431DB4CB250A /* unistr_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unistr_props.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unistr_props.cpp"; sourceTree = SOURCE_ROOT; };
+		BB0FAB9F0AB44792898CF141 /* utext.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = utext.cpp; path = "external/harfbuzz-icu-freetype/icu/common/utext.cpp"; sourceTree = SOURCE_ROOT; };
 		BB6828AC82AB41A9844153CD /* view.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = view.h; path = core/src/view/view.h; sourceTree = SOURCE_ROOT; };
 		BBA9BBDF50D0411DAF29F275 /* normals.jpg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = image; name = normals.jpg; path = scenes/img/normals.jpg; sourceTree = SOURCE_ROOT; };
-		BC321E5836D34A029CAE59AC /* putil.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = putil.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/putil.cpp"; sourceTree = SOURCE_ROOT; };
+		BC321E5836D34A029CAE59AC /* putil.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = putil.cpp; path = "external/harfbuzz-icu-freetype/icu/common/putil.cpp"; sourceTree = SOURCE_ROOT; };
 		BC4F78BEC5654CDCB906283C /* DroidSansJapanese.ttf */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = DroidSansJapanese.ttf; path = scenes/fonts/DroidSansJapanese.ttf; sourceTree = SOURCE_ROOT; };
 		BC5A94CEC8AF41EFA1946584 /* dashArray.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = dashArray.h; path = core/src/util/dashArray.h; sourceTree = SOURCE_ROOT; };
 		BCBC363C0A734020BAD6517B /* tileTask.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = tileTask.cpp; path = core/src/tile/tileTask.cpp; sourceTree = SOURCE_ROOT; };
-		BD3D5257BEBF42FDADA0A811 /* ucnv_cnv.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_cnv.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_cnv.c"; sourceTree = SOURCE_ROOT; };
+		BD3D5257BEBF42FDADA0A811 /* ucnv_cnv.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_cnv.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_cnv.c"; sourceTree = SOURCE_ROOT; };
 		BD780A93F33745EDAE6E45A3 /* iterator_fwd.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = iterator_fwd.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/iterator_fwd.h"; sourceTree = SOURCE_ROOT; };
-		BE49F19E1FB34A9EA2F24696 /* ustrtrns.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustrtrns.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustrtrns.cpp"; sourceTree = SOURCE_ROOT; };
+		BE49F19E1FB34A9EA2F24696 /* ustrtrns.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustrtrns.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ustrtrns.cpp"; sourceTree = SOURCE_ROOT; };
 		BE80AF0E1C6F404A8CF00D04 /* test.yaml */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = test.yaml; path = scenes/import/test.yaml; sourceTree = SOURCE_ROOT; };
 		BEE59BBCB84C4B649002F8CE /* renderState.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = renderState.cpp; path = core/src/gl/renderState.cpp; sourceTree = SOURCE_ROOT; };
 		BF0DAF17A76844C39FEA45EB /* directionalLight.glsl */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = directionalLight.glsl; path = core/shaders/directionalLight.glsl; sourceTree = SOURCE_ROOT; };
-		BFBEB047CFDB4C5BB0101B5A /* icuplug.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = icuplug.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/icuplug.c"; sourceTree = SOURCE_ROOT; };
+		BFBEB047CFDB4C5BB0101B5A /* icuplug.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = icuplug.c; path = "external/harfbuzz-icu-freetype/icu/common/icuplug.c"; sourceTree = SOURCE_ROOT; };
 		BFF14A00AC17437F802908BB /* texture.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = texture.h; path = core/src/gl/texture.h; sourceTree = SOURCE_ROOT; };
 		C157A9CA3D68479492C35EDA /* hash.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = hash.h; path = core/src/util/hash.h; sourceTree = SOURCE_ROOT; };
 		C177DA3DA1F24333BC0515B9 /* emitterdef.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = emitterdef.h; path = "external/yaml-cpp/include/yaml-cpp/emitterdef.h"; sourceTree = SOURCE_ROOT; };
-		C2E3B7447B66442B9414E3DC /* ucnv_bld.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnv_bld.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_bld.cpp"; sourceTree = SOURCE_ROOT; };
-		C2F891A6E32B4B4AA007A06C /* uhash_us.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uhash_us.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uhash_us.cpp"; sourceTree = SOURCE_ROOT; };
+		C2E3B7447B66442B9414E3DC /* ucnv_bld.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnv_bld.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_bld.cpp"; sourceTree = SOURCE_ROOT; };
+		C2F891A6E32B4B4AA007A06C /* uhash_us.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uhash_us.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uhash_us.cpp"; sourceTree = SOURCE_ROOT; };
 		C3129C0118304FA69C34D04A /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		C3A20923B5E045588089E0C5 /* debugStyle.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = debugStyle.cpp; path = core/src/style/debugStyle.cpp; sourceTree = SOURCE_ROOT; };
-		C3A742FB2B5941019B177A48 /* propsvec.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = propsvec.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/propsvec.c"; sourceTree = SOURCE_ROOT; };
+		C3A742FB2B5941019B177A48 /* propsvec.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = propsvec.c; path = "external/harfbuzz-icu-freetype/icu/common/propsvec.c"; sourceTree = SOURCE_ROOT; };
 		C3E57C445FA34A04ACCB1829 /* raster-simple.yaml */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = "raster-simple.yaml"; path = "scenes/raster-simple.yaml"; sourceTree = SOURCE_ROOT; };
-		C4BE61150055463B8B4B9638 /* hb-ot-shape-complex-tibetan.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-tibetan.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-tibetan.cc"; sourceTree = SOURCE_ROOT; };
 		C504B1A2746E4E49A7BBD140 /* debugTextStyle.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = debugTextStyle.cpp; path = core/src/style/debugTextStyle.cpp; sourceTree = SOURCE_ROOT; };
-		C50FBC0483A6416B95571164 /* hb-warning.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-warning.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-warning.cc"; sourceTree = SOURCE_ROOT; };
-		C59BAA2B501541869AA298FC /* ftotval.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftotval.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftotval.h"; sourceTree = SOURCE_ROOT; };
 		C5C53779B05641EC9D23568B /* textDisplay.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = textDisplay.cpp; path = core/src/debug/textDisplay.cpp; sourceTree = SOURCE_ROOT; };
 		C5C85CF36B4E4994BE68FF5D /* directives.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = directives.h; path = "external/yaml-cpp/src/directives.h"; sourceTree = SOURCE_ROOT; };
-		C5EBE669C2B04E238230EB8C /* tttables.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tttables.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/tttables.h"; sourceTree = SOURCE_ROOT; };
 		C5FF39F6C4D34A1DBEA917EF /* rasterSource.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rasterSource.cpp; path = core/src/data/rasterSource.cpp; sourceTree = SOURCE_ROOT; };
 		C60067BCF402496F8E89AB56 /* mesh.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = mesh.h; path = core/src/gl/mesh.h; sourceTree = SOURCE_ROOT; };
-		C697173F37014149BFE44AE9 /* psaux.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = psaux.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/psaux.h"; sourceTree = SOURCE_ROOT; };
-		C7548DAFD88443B2A96906C4 /* utrie2.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = utrie2.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/utrie2.cpp"; sourceTree = SOURCE_ROOT; };
+		C7548DAFD88443B2A96906C4 /* utrie2.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = utrie2.cpp; path = "external/harfbuzz-icu-freetype/icu/common/utrie2.cpp"; sourceTree = SOURCE_ROOT; };
 		C76CFE709A44440F94DAE3B2 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		C7C3EE23DA8E43A4B86FF9A2 /* ftlcdfil.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftlcdfil.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftlcdfil.h"; sourceTree = SOURCE_ROOT; };
-		C8B4627E31904B50BBB5E613 /* hb-ot-shape-complex-myanmar.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-myanmar.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-myanmar.cc"; sourceTree = SOURCE_ROOT; };
 		C9A980C2CA6842E5B8845603 /* tileID.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tileID.h; path = core/src/tile/tileID.h; sourceTree = SOURCE_ROOT; };
 		CA305754F1DC456A80437A2E /* raster-double.yaml */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = "raster-double.yaml"; path = "scenes/raster-double.yaml"; sourceTree = SOURCE_ROOT; };
 		CB25D3A3952C4A27B30DF73B /* sceneLoader.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = sceneLoader.h; path = core/src/scene/sceneLoader.h; sourceTree = SOURCE_ROOT; };
-		CB69C50348824DEDA0A6731D /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/alfons/deps/harfbuzz-icu-freetype/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
+		CB69C50348824DEDA0A6731D /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/harfbuzz-icu-freetype/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
 		CB79FA13854B4A378009CBB2 /* spotLight.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = spotLight.h; path = core/src/scene/spotLight.h; sourceTree = SOURCE_ROOT; };
-		CBD27DF9A82149E7BA1D32BB /* ftbdf.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftbdf.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftbdf.h"; sourceTree = SOURCE_ROOT; };
 		CD9DE72F07FC4AAB9E06F393 /* drawRule.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = drawRule.cpp; path = core/src/scene/drawRule.cpp; sourceTree = SOURCE_ROOT; };
-		CDADEF40B917470F9A442890 /* ucnv_err.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_err.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_err.c"; sourceTree = SOURCE_ROOT; };
+		CDADEF40B917470F9A442890 /* ucnv_err.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_err.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_err.c"; sourceTree = SOURCE_ROOT; };
 		CE19C334A4EA4D90923F4D34 /* textStyle.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = textStyle.h; path = core/src/style/textStyle.h; sourceTree = SOURCE_ROOT; };
-		CE9F0EF933BD42C790E94C1E /* ucnv2022.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnv2022.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv2022.cpp"; sourceTree = SOURCE_ROOT; };
+		CE9F0EF933BD42C790E94C1E /* ucnv2022.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnv2022.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucnv2022.cpp"; sourceTree = SOURCE_ROOT; };
 		CEAEC6E988DA49C88C8FE261 /* memory.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = memory.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/memory.h"; sourceTree = SOURCE_ROOT; };
 		CEF45C59B685432D832DC072 /* tag.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tag.h; path = "external/yaml-cpp/src/tag.h"; sourceTree = SOURCE_ROOT; };
 		CEFE0FD19E9C4CF7841AAAE9 /* node.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = node.cpp; path = "external/yaml-cpp/src/node.cpp"; sourceTree = SOURCE_ROOT; };
 		CF1A280A93124905874AFB03 /* topoJsonSource.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = topoJsonSource.cpp; path = core/src/data/topoJsonSource.cpp; sourceTree = SOURCE_ROOT; };
-		CF3FB6499885482DBD5EDBF3 /* pcf.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = pcf.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/pcf/pcf.c"; sourceTree = SOURCE_ROOT; };
-		CF8DAE04F3934E6384311CC2 /* hb-ot-font.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-font.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-font.cc"; sourceTree = SOURCE_ROOT; };
+		CF3FB6499885482DBD5EDBF3 /* pcf.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = pcf.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/pcf/pcf.c"; sourceTree = SOURCE_ROOT; };
 		CFB1AC1C185147EEBA64D995 /* drawRuleWarnings.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = drawRuleWarnings.h; path = core/src/scene/drawRuleWarnings.h; sourceTree = SOURCE_ROOT; };
-		CFC1C2CAEFE9469FAE96227A /* ustr_titlecase_brkiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustr_titlecase_brkiter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ustr_titlecase_brkiter.cpp"; sourceTree = SOURCE_ROOT; };
-		D03B53B1F0E3499EBC82F65A /* unifunct.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unifunct.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unifunct.cpp"; sourceTree = SOURCE_ROOT; };
+		CFC1C2CAEFE9469FAE96227A /* ustr_titlecase_brkiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ustr_titlecase_brkiter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ustr_titlecase_brkiter.cpp"; sourceTree = SOURCE_ROOT; };
+		D03B53B1F0E3499EBC82F65A /* unifunct.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unifunct.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unifunct.cpp"; sourceTree = SOURCE_ROOT; };
 		D093862540414DA69EDBE318 /* yamlHelper.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = yamlHelper.cpp; path = core/src/util/yamlHelper.cpp; sourceTree = SOURCE_ROOT; };
-		D0B88738F30942C698B8A844 /* bytestream.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bytestream.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/bytestream.cpp"; sourceTree = SOURCE_ROOT; };
+		D0B88738F30942C698B8A844 /* bytestream.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bytestream.cpp; path = "external/harfbuzz-icu-freetype/icu/common/bytestream.cpp"; sourceTree = SOURCE_ROOT; };
 		D0C1726F1FB34CA99AEA37C0 /* polylineStyle.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = polylineStyle.h; path = core/src/style/polylineStyle.h; sourceTree = SOURCE_ROOT; };
 		D115ACF7366C474EBFBC2483 /* pointLight.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = pointLight.h; path = core/src/scene/pointLight.h; sourceTree = SOURCE_ROOT; };
-		D18D22924FA242029A921609 /* resbund.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = resbund.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/resbund.cpp"; sourceTree = SOURCE_ROOT; };
-		D1CB611363504B3292990EE4 /* uvectr32.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uvectr32.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uvectr32.cpp"; sourceTree = SOURCE_ROOT; };
-		D22696AB3B244019961F5546 /* ftstream.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftstream.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/ftstream.h"; sourceTree = SOURCE_ROOT; };
-		D28B7ACB1CCF4BB3BE28FA17 /* ucnv_cb.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_cb.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv_cb.c"; sourceTree = SOURCE_ROOT; };
+		D18D22924FA242029A921609 /* resbund.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = resbund.cpp; path = "external/harfbuzz-icu-freetype/icu/common/resbund.cpp"; sourceTree = SOURCE_ROOT; };
+		D1CB611363504B3292990EE4 /* uvectr32.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uvectr32.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uvectr32.cpp"; sourceTree = SOURCE_ROOT; };
+		D28B7ACB1CCF4BB3BE28FA17 /* ucnv_cb.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv_cb.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv_cb.c"; sourceTree = SOURCE_ROOT; };
 		D2ECA29DC82243C58552285E /* tangram.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = tangram.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D31C592103CA42909F98E439 /* fontManager.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = fontManager.cpp; path = external/alfons/src/alfons/fontManager.cpp; sourceTree = SOURCE_ROOT; };
 		D37C7246824F4E2491FDC40A /* tileTask.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tileTask.h; path = core/src/tile/tileTask.h; sourceTree = SOURCE_ROOT; };
-		D3FFA51387AF4AE2B1E804D6 /* t1types.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = t1types.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/t1types.h"; sourceTree = SOURCE_ROOT; };
 		D43823DF777446EF8350827E /* light.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = light.cpp; path = core/src/scene/light.cpp; sourceTree = SOURCE_ROOT; };
 		D48060EFA1CC45CB9FD02DCA /* cross.png */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = image; name = cross.png; path = scenes/img/cross.png; sourceTree = SOURCE_ROOT; };
-		D50385D9D2CE450395A740F8 /* pshints.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = pshints.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/pshints.h"; sourceTree = SOURCE_ROOT; };
-		D554D63C2EED4DE487BA1BE7 /* uniset.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uniset.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uniset.cpp"; sourceTree = SOURCE_ROOT; };
-		D7B2E93618A8491A9E0E279E /* ftcid.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftcid.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftcid.c"; sourceTree = SOURCE_ROOT; };
+		D554D63C2EED4DE487BA1BE7 /* uniset.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uniset.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uniset.cpp"; sourceTree = SOURCE_ROOT; };
+		D7B2E93618A8491A9E0E279E /* ftcid.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftcid.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftcid.c"; sourceTree = SOURCE_ROOT; };
 		D82885D110964D4B913FEECF /* mvtSource.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = mvtSource.h; path = core/src/data/mvtSource.h; sourceTree = SOURCE_ROOT; };
-		D88EAA2A88384EB5985B036D /* hb-buffer.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-buffer.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-buffer.cc"; sourceTree = SOURCE_ROOT; };
-		D8B6016F6E0C4C3EB9418B04 /* uhash.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uhash.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uhash.c"; sourceTree = SOURCE_ROOT; };
+		D8B6016F6E0C4C3EB9418B04 /* uhash.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uhash.c; path = "external/harfbuzz-icu-freetype/icu/common/uhash.c"; sourceTree = SOURCE_ROOT; };
 		D91915C759F844B18E38CB18 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		D93CAF8C95F048AE830FB18D /* ftstroke.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftstroke.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftstroke.c"; sourceTree = SOURCE_ROOT; };
-		D977F6B0C0D74C8CA3E27A71 /* ftbase.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbase.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftbase.c"; sourceTree = SOURCE_ROOT; };
-		D978D6BB4D6E4A4CB7B81E5F /* utrie.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = utrie.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/utrie.cpp"; sourceTree = SOURCE_ROOT; };
+		D93CAF8C95F048AE830FB18D /* ftstroke.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftstroke.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftstroke.c"; sourceTree = SOURCE_ROOT; };
+		D977F6B0C0D74C8CA3E27A71 /* ftbase.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbase.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftbase.c"; sourceTree = SOURCE_ROOT; };
+		D978D6BB4D6E4A4CB7B81E5F /* utrie.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = utrie.cpp; path = "external/harfbuzz-icu-freetype/icu/common/utrie.cpp"; sourceTree = SOURCE_ROOT; };
 		D99A1422F1384DA5ACD64CC5 /* stream.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = stream.cpp; path = "external/yaml-cpp/src/stream.cpp"; sourceTree = SOURCE_ROOT; };
-		D9EA2433E83343E3800D6A30 /* ftpfr.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftpfr.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftpfr.h"; sourceTree = SOURCE_ROOT; };
 		D9F26FF465A54427A05F2765 /* debugTextStyle.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = debugTextStyle.h; path = core/src/style/debugTextStyle.h; sourceTree = SOURCE_ROOT; };
 		DA62633156A9465EB19C0D59 /* viewConstraint.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = viewConstraint.cpp; path = core/src/view/viewConstraint.cpp; sourceTree = SOURCE_ROOT; };
 		DAFEC74411BD434BA5EBFAC6 /* emit.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = emit.cpp; path = "external/yaml-cpp/src/emit.cpp"; sourceTree = SOURCE_ROOT; };
@@ -2031,46 +1938,128 @@
 		DB1174E61D66105E00CD70DB /* disposer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = disposer.h; path = core/src/gl/disposer.h; sourceTree = "<group>"; };
 		DB3C11771D4BBE1F00534CA9 /* TGMapViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TGMapViewController.h; path = ios/src/TGMapViewController.h; sourceTree = "<group>"; };
 		DB3C11791D4BBE2600534CA9 /* TGMapViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = TGMapViewController.mm; path = ios/src/TGMapViewController.mm; sourceTree = "<group>"; };
+		DB44A80D1D996EFD00719BFB /* hb-blob.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-blob.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-blob.cc"; sourceTree = "<group>"; };
+		DB44A80F1D996EFD00719BFB /* hb-buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-buffer.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-buffer.cc"; sourceTree = "<group>"; };
+		DB44A8101D996EFD00719BFB /* hb-common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-common.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-common.cc"; sourceTree = "<group>"; };
+		DB44A8131D996EFD00719BFB /* hb-face.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-face.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-face.cc"; sourceTree = "<group>"; };
+		DB44A8151D996EFD00719BFB /* hb-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-font.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-font.cc"; sourceTree = "<group>"; };
+		DB44A8161D996EFD00719BFB /* hb-ft.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ft.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ft.cc"; sourceTree = "<group>"; };
+		DB44A81B1D996EFD00719BFB /* hb-ot-font.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-font.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-font.cc"; sourceTree = "<group>"; };
+		DB44A81C1D996EFD00719BFB /* hb-ot-layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-layout.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-layout.cc"; sourceTree = "<group>"; };
+		DB44A81D1D996EFD00719BFB /* hb-ot-map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-map.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-map.cc"; sourceTree = "<group>"; };
+		DB44A81E1D996EFD00719BFB /* hb-ot-shape-complex-arabic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-arabic.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-arabic.cc"; sourceTree = "<group>"; };
+		DB44A81F1D996EFD00719BFB /* hb-ot-shape-complex-default.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-default.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-default.cc"; sourceTree = "<group>"; };
+		DB44A8201D996EFD00719BFB /* hb-ot-shape-complex-hangul.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-hangul.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-hangul.cc"; sourceTree = "<group>"; };
+		DB44A8211D996EFD00719BFB /* hb-ot-shape-complex-hebrew.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-hebrew.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-hebrew.cc"; sourceTree = "<group>"; };
+		DB44A8221D996EFD00719BFB /* hb-ot-shape-complex-indic-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic-table.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-indic-table.cc"; sourceTree = "<group>"; };
+		DB44A8231D996EFD00719BFB /* hb-ot-shape-complex-indic.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-indic.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-indic.cc"; sourceTree = "<group>"; };
+		DB44A8241D996EFD00719BFB /* hb-ot-shape-complex-myanmar.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-myanmar.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-myanmar.cc"; sourceTree = "<group>"; };
+		DB44A8251D996EFD00719BFB /* hb-ot-shape-complex-thai.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-thai.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-thai.cc"; sourceTree = "<group>"; };
+		DB44A8261D996EFD00719BFB /* hb-ot-shape-complex-tibetan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-tibetan.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-tibetan.cc"; sourceTree = "<group>"; };
+		DB44A8271D996EFD00719BFB /* hb-ot-shape-complex-use-table.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-use-table.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-use-table.cc"; sourceTree = "<group>"; };
+		DB44A8281D996EFD00719BFB /* hb-ot-shape-complex-use.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-complex-use.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-use.cc"; sourceTree = "<group>"; };
+		DB44A8291D996EFD00719BFB /* hb-ot-shape-fallback.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-fallback.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-fallback.cc"; sourceTree = "<group>"; };
+		DB44A82A1D996EFD00719BFB /* hb-ot-shape-normalize.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape-normalize.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-normalize.cc"; sourceTree = "<group>"; };
+		DB44A82B1D996EFD00719BFB /* hb-ot-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-shape.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape.cc"; sourceTree = "<group>"; };
+		DB44A82C1D996EFD00719BFB /* hb-ot-tag.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ot-tag.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-tag.cc"; sourceTree = "<group>"; };
+		DB44A82D1D996EFD00719BFB /* hb-set.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-set.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-set.cc"; sourceTree = "<group>"; };
+		DB44A82E1D996EFD00719BFB /* hb-shape-plan.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape-plan.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-shape-plan.cc"; sourceTree = "<group>"; };
+		DB44A82F1D996EFD00719BFB /* hb-shape.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shape.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-shape.cc"; sourceTree = "<group>"; };
+		DB44A8301D996EFD00719BFB /* hb-shaper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-shaper.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-shaper.cc"; sourceTree = "<group>"; };
+		DB44A8311D996EFD00719BFB /* hb-ucdn.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-ucdn.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn.cc"; sourceTree = "<group>"; };
+		DB44A8321D996EFD00719BFB /* hb-unicode.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-unicode.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-unicode.cc"; sourceTree = "<group>"; };
+		DB44A8341D996EFD00719BFB /* hb-warning.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "hb-warning.cc"; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-warning.cc"; sourceTree = "<group>"; };
+		DB44A8681D996F2000719BFB /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = CMakeLists.txt; path = "external/harfbuzz-icu-freetype/CMakeLists.txt"; sourceTree = "<group>"; };
+		DB44A8691D9970C400719BFB /* freetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = freetype.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/freetype.h"; sourceTree = "<group>"; };
+		DB44A86A1D9970C400719BFB /* ftadvanc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftadvanc.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftadvanc.h"; sourceTree = "<group>"; };
+		DB44A86B1D9970C400719BFB /* ftautoh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftautoh.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftautoh.h"; sourceTree = "<group>"; };
+		DB44A86C1D9970C400719BFB /* ftbbox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftbbox.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftbbox.h"; sourceTree = "<group>"; };
+		DB44A86D1D9970C400719BFB /* ftbdf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftbdf.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftbdf.h"; sourceTree = "<group>"; };
+		DB44A86E1D9970C400719BFB /* ftbitmap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftbitmap.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftbitmap.h"; sourceTree = "<group>"; };
+		DB44A86F1D9970C400719BFB /* ftbzip2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftbzip2.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftbzip2.h"; sourceTree = "<group>"; };
+		DB44A8701D9970C400719BFB /* ftcache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftcache.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftcache.h"; sourceTree = "<group>"; };
+		DB44A8711D9970C400719BFB /* ftcffdrv.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftcffdrv.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftcffdrv.h"; sourceTree = "<group>"; };
+		DB44A8721D9970C400719BFB /* ftchapters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftchapters.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftchapters.h"; sourceTree = "<group>"; };
+		DB44A8731D9970C400719BFB /* ftcid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftcid.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftcid.h"; sourceTree = "<group>"; };
+		DB44A8741D9970C400719BFB /* fterrdef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fterrdef.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/fterrdef.h"; sourceTree = "<group>"; };
+		DB44A8751D9970C400719BFB /* fterrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fterrors.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/fterrors.h"; sourceTree = "<group>"; };
+		DB44A8761D9970C400719BFB /* ftfntfmt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftfntfmt.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftfntfmt.h"; sourceTree = "<group>"; };
+		DB44A8771D9970C400719BFB /* ftgasp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftgasp.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftgasp.h"; sourceTree = "<group>"; };
+		DB44A8781D9970C400719BFB /* ftglyph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftglyph.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftglyph.h"; sourceTree = "<group>"; };
+		DB44A8791D9970C400719BFB /* ftgxval.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftgxval.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftgxval.h"; sourceTree = "<group>"; };
+		DB44A87A1D9970C400719BFB /* ftgzip.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftgzip.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftgzip.h"; sourceTree = "<group>"; };
+		DB44A87B1D9970C400719BFB /* ftimage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftimage.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftimage.h"; sourceTree = "<group>"; };
+		DB44A87C1D9970C400719BFB /* ftincrem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftincrem.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftincrem.h"; sourceTree = "<group>"; };
+		DB44A87D1D9970C400719BFB /* ftlcdfil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftlcdfil.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftlcdfil.h"; sourceTree = "<group>"; };
+		DB44A87E1D9970C400719BFB /* ftlist.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftlist.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftlist.h"; sourceTree = "<group>"; };
+		DB44A87F1D9970C400719BFB /* ftlzw.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftlzw.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftlzw.h"; sourceTree = "<group>"; };
+		DB44A8801D9970C400719BFB /* ftmac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftmac.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftmac.h"; sourceTree = "<group>"; };
+		DB44A8811D9970C400719BFB /* ftmm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftmm.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftmm.h"; sourceTree = "<group>"; };
+		DB44A8821D9970C400719BFB /* ftmodapi.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftmodapi.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftmodapi.h"; sourceTree = "<group>"; };
+		DB44A8831D9970C400719BFB /* ftmoderr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftmoderr.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftmoderr.h"; sourceTree = "<group>"; };
+		DB44A8841D9970C400719BFB /* ftotval.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftotval.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftotval.h"; sourceTree = "<group>"; };
+		DB44A8851D9970C400719BFB /* ftoutln.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftoutln.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftoutln.h"; sourceTree = "<group>"; };
+		DB44A8861D9970C400719BFB /* ftpfr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftpfr.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftpfr.h"; sourceTree = "<group>"; };
+		DB44A8871D9970C400719BFB /* ftrender.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftrender.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftrender.h"; sourceTree = "<group>"; };
+		DB44A8881D9970C400719BFB /* ftsizes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftsizes.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftsizes.h"; sourceTree = "<group>"; };
+		DB44A8891D9970C400719BFB /* ftsnames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftsnames.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftsnames.h"; sourceTree = "<group>"; };
+		DB44A88A1D9970C400719BFB /* ftstroke.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftstroke.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftstroke.h"; sourceTree = "<group>"; };
+		DB44A88B1D9970C400719BFB /* ftsynth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftsynth.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftsynth.h"; sourceTree = "<group>"; };
+		DB44A88C1D9970C400719BFB /* ftsystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftsystem.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftsystem.h"; sourceTree = "<group>"; };
+		DB44A88D1D9970C400719BFB /* fttrigon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fttrigon.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/fttrigon.h"; sourceTree = "<group>"; };
+		DB44A88E1D9970C400719BFB /* ftttdrv.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftttdrv.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftttdrv.h"; sourceTree = "<group>"; };
+		DB44A88F1D9970C400719BFB /* fttypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fttypes.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/fttypes.h"; sourceTree = "<group>"; };
+		DB44A8901D9970C400719BFB /* ftwinfnt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftwinfnt.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftwinfnt.h"; sourceTree = "<group>"; };
+		DB44A8911D9970C400719BFB /* t1tables.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = t1tables.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/t1tables.h"; sourceTree = "<group>"; };
+		DB44A8921D9970C400719BFB /* ttnameid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ttnameid.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ttnameid.h"; sourceTree = "<group>"; };
+		DB44A8931D9970C400719BFB /* tttables.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = tttables.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/tttables.h"; sourceTree = "<group>"; };
+		DB44A8941D9970C400719BFB /* tttags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = tttags.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/tttags.h"; sourceTree = "<group>"; };
+		DB44A8951D9970C400719BFB /* ttunpat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ttunpat.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ttunpat.h"; sourceTree = "<group>"; };
+		DB44A8961D9970D100719BFB /* ftconfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftconfig.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftconfig.h"; sourceTree = "<group>"; };
+		DB44A8971D9970D100719BFB /* ftheader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftheader.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftheader.h"; sourceTree = "<group>"; };
+		DB44A8981D9970D100719BFB /* ftmodule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftmodule.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftmodule.h"; sourceTree = "<group>"; };
+		DB44A8991D9970D100719BFB /* ftoption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftoption.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftoption.h"; sourceTree = "<group>"; };
+		DB44A89A1D9970D100719BFB /* ftstdlib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ftstdlib.h; path = "external/harfbuzz-icu-freetype/freetype-2.6/include/freetype/config/ftstdlib.h"; sourceTree = "<group>"; };
+		DB44A89B1D99770000719BFB /* ucdn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ucdn.c; path = "external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn/ucdn.c"; sourceTree = "<group>"; };
+		DB44A89D1D997DD700719BFB /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = config.h; path = "external/harfbuzz-icu-freetype/config.h"; sourceTree = "<group>"; };
+		DB44A8A11D99818E00719BFB /* marker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = marker.cpp; sourceTree = "<group>"; };
+		DB44A8A21D99818E00719BFB /* marker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = marker.h; sourceTree = "<group>"; };
+		DB44A8A31D99818E00719BFB /* markerManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markerManager.cpp; sourceTree = "<group>"; };
+		DB44A8A41D99818E00719BFB /* markerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markerManager.h; sourceTree = "<group>"; };
+		DB44A8A91D9982C600719BFB /* platform_gl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = platform_gl.cpp; path = core/common/platform_gl.cpp; sourceTree = "<group>"; };
 		DB7E43971D4B8A5400A6F40D /* labelCollider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = labelCollider.h; path = core/src/labels/labelCollider.h; sourceTree = "<group>"; };
 		DB7E43981D4B8A5400A6F40D /* labelCollider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = labelCollider.cpp; path = core/src/labels/labelCollider.cpp; sourceTree = "<group>"; };
 		DB7E439A1D4B8A7200A6F40D /* jobQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = jobQueue.cpp; path = core/src/util/jobQueue.cpp; sourceTree = "<group>"; };
 		DB7E439B1D4B8A7200A6F40D /* jobQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = jobQueue.h; path = core/src/util/jobQueue.h; sourceTree = "<group>"; };
 		DB97698706544B96A6F3951D /* sceneLayer.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = sceneLayer.cpp; path = core/src/scene/sceneLayer.cpp; sourceTree = SOURCE_ROOT; };
-		DBBE42258D674F5DA25B28C5 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
+		DBBE42258D674F5DA25B28C5 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/harfbuzz-icu-freetype/freetype-2.6/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
 		DBD8895F1D2FC0EF00D05B1F /* tangram_framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = tangram_framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBD889611D2FC0EF00D05B1F /* tangram_framework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = tangram_framework.h; sourceTree = "<group>"; };
 		DBD889631D2FC0EF00D05B1F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DBE41D624D0A45C5955F7DDA /* ftadvanc.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftadvanc.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftadvanc.h"; sourceTree = SOURCE_ROOT; };
-		DC4A65A098B245138F8730E1 /* ucharstrie.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucharstrie.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucharstrie.cpp"; sourceTree = SOURCE_ROOT; };
-		DC831E3E071640D4BDD020E7 /* ftsynth.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftsynth.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftsynth.h"; sourceTree = SOURCE_ROOT; };
+		DC4A65A098B245138F8730E1 /* ucharstrie.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucharstrie.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucharstrie.cpp"; sourceTree = SOURCE_ROOT; };
 		DCD34909F8CD4F1BB4519332 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		DD7478AF4850404BA9E5B8AD /* scantag.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = scantag.h; path = "external/yaml-cpp/src/scantag.h"; sourceTree = SOURCE_ROOT; };
 		DD80160F9DE64783B9BE8928 /* color.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = color.h; path = core/src/util/color.h; sourceTree = SOURCE_ROOT; };
 		DE3B5DF4B35249FCAA79FF1A /* tileData.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = tileData.h; path = core/src/data/tileData.h; sourceTree = SOURCE_ROOT; };
-		DE55431AA08E4D84816A609E /* sfnt.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = sfnt.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/sfnt.h"; sourceTree = SOURCE_ROOT; };
-		DE8CBF1370B247AB9BAF4373 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = "external/alfons/deps/harfbuzz-icu-freetype/CMakeLists.txt"; sourceTree = SOURCE_ROOT; };
 		DF4D6FD16EB541108E39676F /* tangram-Info.plist */ = {isa = PBXFileReference; explicitFileType = sourcecode.text.plist; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "tangram-Info.plist"; path = "ios/resources/tangram-Info.plist"; sourceTree = SOURCE_ROOT; };
-		DF64007CC9794D63B710D086 /* ftmm.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftmm.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftmm.h"; sourceTree = SOURCE_ROOT; };
 		DF64F4981E9B4B2C904DF290 /* geojsonvt_convert.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geojsonvt_convert.cpp; path = "external/geojson-vt-cpp/src/geojsonvt_convert.cpp"; sourceTree = SOURCE_ROOT; };
-		DF9AA05BB1684BA9A34F6D3F /* ucnvmbcs.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvmbcs.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnvmbcs.c"; sourceTree = SOURCE_ROOT; };
+		DF9AA05BB1684BA9A34F6D3F /* ucnvmbcs.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnvmbcs.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnvmbcs.c"; sourceTree = SOURCE_ROOT; };
 		DFE2D30C68654306B2E56B5C /* convert.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = convert.cpp; path = "external/yaml-cpp/src/convert.cpp"; sourceTree = SOURCE_ROOT; };
-		E0335A7002A94682BE065E07 /* cwchar.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = cwchar.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/cwchar.c"; sourceTree = SOURCE_ROOT; };
+		E0335A7002A94682BE065E07 /* cwchar.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = cwchar.c; path = "external/harfbuzz-icu-freetype/icu/common/cwchar.c"; sourceTree = SOURCE_ROOT; };
 		E071676F48384E64A63072F6 /* base64.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = base64.h; path = core/src/util/base64.h; sourceTree = SOURCE_ROOT; };
-		E08983525AE24CBEA77AEB36 /* hb-face.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-face.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-face.cc"; sourceTree = SOURCE_ROOT; };
 		E0C13F12E59943A8BD33B257 /* debugStyle.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = debugStyle.h; path = core/src/style/debugStyle.h; sourceTree = SOURCE_ROOT; };
-		E0E275C4FCA2489E86AEF353 /* hb-ot-shape.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape.cc"; sourceTree = SOURCE_ROOT; };
-		E11ED99DDBD14C88ADE05709 /* rbbirb.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbirb.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/rbbirb.cpp"; sourceTree = SOURCE_ROOT; };
+		E11ED99DDBD14C88ADE05709 /* rbbirb.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbirb.cpp; path = "external/harfbuzz-icu-freetype/icu/common/rbbirb.cpp"; sourceTree = SOURCE_ROOT; };
 		E156A298AB74465FAAB4BA64 /* geojsonvt_wrap.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = geojsonvt_wrap.cpp; path = "external/geojson-vt-cpp/src/geojsonvt_wrap.cpp"; sourceTree = SOURCE_ROOT; };
 		E2063FAED8F24A5ABD1B9804 /* emitterutils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = emitterutils.cpp; path = "external/yaml-cpp/src/emitterutils.cpp"; sourceTree = SOURCE_ROOT; };
-		E32703E6994B4379819CC00B /* servnotf.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servnotf.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/servnotf.cpp"; sourceTree = SOURCE_ROOT; };
+		E32703E6994B4379819CC00B /* servnotf.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = servnotf.cpp; path = "external/harfbuzz-icu-freetype/icu/common/servnotf.cpp"; sourceTree = SOURCE_ROOT; };
 		E35EE8FDABAA4257A83D9FE9 /* spriteLabel.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = spriteLabel.cpp; path = core/src/labels/spriteLabel.cpp; sourceTree = SOURCE_ROOT; };
-		E445A15182C245F79D86E010 /* ftdebug.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftdebug.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftdebug.c"; sourceTree = SOURCE_ROOT; };
+		E445A15182C245F79D86E010 /* ftdebug.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftdebug.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftdebug.c"; sourceTree = SOURCE_ROOT; };
 		E45F2ECEA9C24737AF3D1F9F /* textShaper.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = textShaper.cpp; path = external/alfons/src/alfons/textShaper.cpp; sourceTree = SOURCE_ROOT; };
-		E48A719B6DC34279BC14C27E /* uchar.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uchar.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uchar.c"; sourceTree = SOURCE_ROOT; };
+		E48A719B6DC34279BC14C27E /* uchar.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uchar.c; path = "external/harfbuzz-icu-freetype/icu/common/uchar.c"; sourceTree = SOURCE_ROOT; };
 		E4C71C7891ED4675B26A1B1E /* iterator.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = iterator.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/iterator.h"; sourceTree = SOURCE_ROOT; };
-		E4D884C7B2024DEF985667CD /* ftbdf.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbdf.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftbdf.c"; sourceTree = SOURCE_ROOT; };
+		E4D884C7B2024DEF985667CD /* ftbdf.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftbdf.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftbdf.c"; sourceTree = SOURCE_ROOT; };
 		E55273FAF9A94E91A7DC0AC7 /* csscolorparser.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = csscolorparser.cpp; path = "external/css-color-parser-cpp/csscolorparser.cpp"; sourceTree = SOURCE_ROOT; };
-		E5D22799B9D2428CA0F9875D /* unorm_it.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = unorm_it.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unorm_it.c"; sourceTree = SOURCE_ROOT; };
+		E5D22799B9D2428CA0F9875D /* unorm_it.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = unorm_it.c; path = "external/harfbuzz-icu-freetype/icu/common/unorm_it.c"; sourceTree = SOURCE_ROOT; };
 		E5F580663BA048F79A613B80 /* emitterstate.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = emitterstate.cpp; path = "external/yaml-cpp/src/emitterstate.cpp"; sourceTree = SOURCE_ROOT; };
 		E6BBF0DA8EC943B4B0D54E2F /* impl.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = impl.h; path = "external/yaml-cpp/include/yaml-cpp/node/detail/impl.h"; sourceTree = SOURCE_ROOT; };
 		E726B1E618724A8EAE97E0BF /* inputHandler.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = inputHandler.h; path = core/src/util/inputHandler.h; sourceTree = SOURCE_ROOT; };
@@ -2082,57 +2071,53 @@
 		EB4437A0D285482D9E3DC284 /* pbfParser.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = pbfParser.cpp; path = core/src/util/pbfParser.cpp; sourceTree = SOURCE_ROOT; };
 		EB7788F432D84ECABD3EF615 /* material.glsl */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = material.glsl; path = core/shaders/material.glsl; sourceTree = SOURCE_ROOT; };
 		EBA2C334947B46A5BE4AECC5 /* light.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = light.h; path = core/src/scene/light.h; sourceTree = SOURCE_ROOT; };
-		ED447DCCFBEA460591A65423 /* dictbe.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dictbe.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/dictbe.cpp"; sourceTree = SOURCE_ROOT; };
+		ED447DCCFBEA460591A65423 /* dictbe.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dictbe.cpp; path = "external/harfbuzz-icu-freetype/icu/common/dictbe.cpp"; sourceTree = SOURCE_ROOT; };
 		ED9BADDB3B52483C9A564F12 /* labelProperty.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = labelProperty.h; path = core/src/labels/labelProperty.h; sourceTree = SOURCE_ROOT; };
 		EF041F4644DE4A7E871A0256 /* mapProjection.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = mapProjection.cpp; path = core/src/util/mapProjection.cpp; sourceTree = SOURCE_ROOT; };
-		EF117E971CC84998991E721E /* ubidiln.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ubidiln.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ubidiln.c"; sourceTree = SOURCE_ROOT; };
-		EF41347D818540FB919CED53 /* dtintrv.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dtintrv.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/dtintrv.cpp"; sourceTree = SOURCE_ROOT; };
-		EF6212D90607497796F2A401 /* bdf.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = bdf.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/bdf/bdf.c"; sourceTree = SOURCE_ROOT; };
+		EF117E971CC84998991E721E /* ubidiln.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ubidiln.c; path = "external/harfbuzz-icu-freetype/icu/common/ubidiln.c"; sourceTree = SOURCE_ROOT; };
+		EF41347D818540FB919CED53 /* dtintrv.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = dtintrv.cpp; path = "external/harfbuzz-icu-freetype/icu/common/dtintrv.cpp"; sourceTree = SOURCE_ROOT; };
+		EF6212D90607497796F2A401 /* bdf.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = bdf.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/bdf/bdf.c"; sourceTree = SOURCE_ROOT; };
 		EF8C3CA3EA4C435FB8FA0D08 /* sem.jpg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = image; name = sem.jpg; path = scenes/img/sem.jpg; sourceTree = SOURCE_ROOT; };
 		F0BC1A37422F42E0B39F2D0D /* debugPrimitive.vs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = debugPrimitive.vs; path = core/shaders/debugPrimitive.vs; sourceTree = SOURCE_ROOT; };
 		F0E61E9697CA4487AE463FC8 /* clientGeoJsonSource.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = clientGeoJsonSource.h; path = core/src/data/clientGeoJsonSource.h; sourceTree = SOURCE_ROOT; };
-		F0FD715275634CD2AC796E2A /* ucasemap_titlecase_brkiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucasemap_titlecase_brkiter.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucasemap_titlecase_brkiter.cpp"; sourceTree = SOURCE_ROOT; };
-		F11B988C8EBB4ADDBA03C5C6 /* normlzr.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = normlzr.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/normlzr.cpp"; sourceTree = SOURCE_ROOT; };
-		F2A3101ACE12434E833A281E /* charstr.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = charstr.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/charstr.cpp"; sourceTree = SOURCE_ROOT; };
+		F0FD715275634CD2AC796E2A /* ucasemap_titlecase_brkiter.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucasemap_titlecase_brkiter.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucasemap_titlecase_brkiter.cpp"; sourceTree = SOURCE_ROOT; };
+		F11B988C8EBB4ADDBA03C5C6 /* normlzr.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = normlzr.cpp; path = "external/harfbuzz-icu-freetype/icu/common/normlzr.cpp"; sourceTree = SOURCE_ROOT; };
+		F2A3101ACE12434E833A281E /* charstr.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = charstr.cpp; path = "external/harfbuzz-icu-freetype/icu/common/charstr.cpp"; sourceTree = SOURCE_ROOT; };
 		F2A536EB751342AABB298001 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LaunchScreen.xib; path = ios/resources/LaunchScreen.xib; sourceTree = SOURCE_ROOT; };
 		F2BD3714F99F463A8104EEA4 /* dll.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = dll.h; path = "external/yaml-cpp/include/yaml-cpp/dll.h"; sourceTree = SOURCE_ROOT; };
-		F32B5C4A88FD4E6C8261DBE1 /* uloc.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uloc.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uloc.cpp"; sourceTree = SOURCE_ROOT; };
-		F3F8DF3A93B7408284DC25A3 /* hb-ot-shape-complex-thai.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-ot-shape-complex-thai.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ot-shape-complex-thai.cc"; sourceTree = SOURCE_ROOT; };
-		F4936D962CD44160ABA7FEEB /* uniset_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uniset_props.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uniset_props.cpp"; sourceTree = SOURCE_ROOT; };
+		F32B5C4A88FD4E6C8261DBE1 /* uloc.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uloc.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uloc.cpp"; sourceTree = SOURCE_ROOT; };
+		F4936D962CD44160ABA7FEEB /* uniset_props.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uniset_props.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uniset_props.cpp"; sourceTree = SOURCE_ROOT; };
 		F4B4743A65AE4697A030E0BD /* pointStyle.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = pointStyle.cpp; path = core/src/style/pointStyle.cpp; sourceTree = SOURCE_ROOT; };
 		F51EE24BEB864601A1F7ED10 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		F5225540B3284C9C87B9F52E /* textStyleBuilder.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = textStyleBuilder.h; path = core/src/style/textStyleBuilder.h; sourceTree = SOURCE_ROOT; };
 		F59E6DDA3CD3410292FA8516 /* linebreakdata.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = linebreakdata.c; path = external/alfons/src/linebreak/linebreakdata.c; sourceTree = SOURCE_ROOT; };
 		F5BC28CAECE14005A9FBDA20 /* rasterStyle.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = rasterStyle.h; path = core/src/style/rasterStyle.h; sourceTree = SOURCE_ROOT; };
-		F6015093C7884BA28C91507E /* usprep.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = usprep.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/usprep.cpp"; sourceTree = SOURCE_ROOT; };
+		F6015093C7884BA28C91507E /* usprep.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = usprep.cpp; path = "external/harfbuzz-icu-freetype/icu/common/usprep.cpp"; sourceTree = SOURCE_ROOT; };
 		F72EA0FF51534E57813CCF3C /* polyline.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = polyline.fs; path = core/shaders/polyline.fs; sourceTree = SOURCE_ROOT; };
 		F7501AD4AE844FFD9579BB6E /* frameInfo.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = frameInfo.cpp; path = core/src/debug/frameInfo.cpp; sourceTree = SOURCE_ROOT; };
 		F7943AFE85484D4DA3700F55 /* splinePath.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = splinePath.cpp; path = external/alfons/src/alfons/path/splinePath.cpp; sourceTree = SOURCE_ROOT; };
-		F8A6511865A143AE8F21F2FF /* ftpatent.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftpatent.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftpatent.c"; sourceTree = SOURCE_ROOT; };
+		F8A6511865A143AE8F21F2FF /* ftpatent.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftpatent.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftpatent.c"; sourceTree = SOURCE_ROOT; };
 		F9109D360F7346EB8DB8DA03 /* type.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = type.h; path = "external/yaml-cpp/include/yaml-cpp/node/type.h"; sourceTree = SOURCE_ROOT; };
 		F922089B0F1C4B83996076E0 /* scene.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = scene.cpp; path = core/src/scene/scene.cpp; sourceTree = SOURCE_ROOT; };
 		F9372F8C51C04128A9B13CFB /* variant.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = variant.h; path = core/src/util/variant.h; sourceTree = SOURCE_ROOT; };
-		F9D1D325F10E4C188AA2F9FC /* uniset_closure.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uniset_closure.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uniset_closure.cpp"; sourceTree = SOURCE_ROOT; };
-		F9D7720642C74E168E43BF34 /* ucol_swp.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucol_swp.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucol_swp.cpp"; sourceTree = SOURCE_ROOT; };
-		F9F42FEDFA93438CB15EADE1 /* ucnvsel.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnvsel.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnvsel.cpp"; sourceTree = SOURCE_ROOT; };
-		FA19F27C73F14AD288625A41 /* unorm.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unorm.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/unorm.cpp"; sourceTree = SOURCE_ROOT; };
+		F9D1D325F10E4C188AA2F9FC /* uniset_closure.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uniset_closure.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uniset_closure.cpp"; sourceTree = SOURCE_ROOT; };
+		F9D7720642C74E168E43BF34 /* ucol_swp.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucol_swp.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucol_swp.cpp"; sourceTree = SOURCE_ROOT; };
+		F9F42FEDFA93438CB15EADE1 /* ucnvsel.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = ucnvsel.cpp; path = "external/harfbuzz-icu-freetype/icu/common/ucnvsel.cpp"; sourceTree = SOURCE_ROOT; };
+		FA19F27C73F14AD288625A41 /* unorm.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = unorm.cpp; path = "external/harfbuzz-icu-freetype/icu/common/unorm.cpp"; sourceTree = SOURCE_ROOT; };
 		FA3E0E6C9E3D4DD684F4CACD /* firasans-medium.ttf */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = "firasans-medium.ttf"; path = "scenes/fonts/firasans-medium.ttf"; sourceTree = SOURCE_ROOT; };
-		FA4A99F528B74DB7AA98BD7D /* hb-set.cc */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = "hb-set.cc"; path = "external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-set.cc"; sourceTree = SOURCE_ROOT; };
-		FB2E4B3F2F6A40A5B8A851E6 /* fthash.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = fthash.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/internal/fthash.h"; sourceTree = SOURCE_ROOT; };
-		FB3260C1B8B849EA8742E5FD /* bmpset.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bmpset.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/bmpset.cpp"; sourceTree = SOURCE_ROOT; };
-		FBE83FA8BC994F449BF31FFD /* ucnv.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/ucnv.c"; sourceTree = SOURCE_ROOT; };
+		FB3260C1B8B849EA8742E5FD /* bmpset.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = bmpset.cpp; path = "external/harfbuzz-icu-freetype/icu/common/bmpset.cpp"; sourceTree = SOURCE_ROOT; };
+		FBE83FA8BC994F449BF31FFD /* ucnv.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ucnv.c; path = "external/harfbuzz-icu-freetype/icu/common/ucnv.c"; sourceTree = SOURCE_ROOT; };
 		FC0B8D96B19B47DEA2FAE93A /* cubemap.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = cubemap.fs; path = core/shaders/cubemap.fs; sourceTree = SOURCE_ROOT; };
 		FCBC63D9F944485A885847BD /* text.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = text.fs; path = core/shaders/text.fs; sourceTree = SOURCE_ROOT; };
-		FD46B3D658784501963FE106 /* winfnt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = winfnt.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/winfonts/winfnt.c"; sourceTree = SOURCE_ROOT; };
+		FD46B3D658784501963FE106 /* winfnt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = winfnt.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/winfonts/winfnt.c"; sourceTree = SOURCE_ROOT; };
 		FD6EC7D2D7A94B70BA5214A5 /* vao.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = vao.h; path = core/src/gl/vao.h; sourceTree = SOURCE_ROOT; };
-		FD76E600884F452DA58BF03C /* ftfntfmt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftfntfmt.c; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/src/base/ftfntfmt.c"; sourceTree = SOURCE_ROOT; };
-		FD81881DE5D640F9823C6BCD /* rbbidata.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbidata.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/rbbidata.cpp"; sourceTree = SOURCE_ROOT; };
+		FD76E600884F452DA58BF03C /* ftfntfmt.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = ftfntfmt.c; path = "external/harfbuzz-icu-freetype/freetype-2.6/src/base/ftfntfmt.c"; sourceTree = SOURCE_ROOT; };
+		FD81881DE5D640F9823C6BCD /* rbbidata.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = rbbidata.cpp; path = "external/harfbuzz-icu-freetype/icu/common/rbbidata.cpp"; sourceTree = SOURCE_ROOT; };
 		FD9516596B1040E592D04106 /* polygonStyle.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = polygonStyle.h; path = core/src/style/polygonStyle.h; sourceTree = SOURCE_ROOT; };
-		FE32163E5D2240F58D53EF81 /* ftcffdrv.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = ftcffdrv.h; path = "external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include/freetype/ftcffdrv.h"; sourceTree = SOURCE_ROOT; };
-		FE62FEBCEBCF419FB8C92D94 /* udatamem.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = udatamem.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/udatamem.c"; sourceTree = SOURCE_ROOT; };
+		FE62FEBCEBCF419FB8C92D94 /* udatamem.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = udatamem.c; path = "external/harfbuzz-icu-freetype/icu/common/udatamem.c"; sourceTree = SOURCE_ROOT; };
 		FED00CAC627A49DF80F86641 /* cubemap.png */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = image; name = cubemap.png; path = scenes/img/cubemap.png; sourceTree = SOURCE_ROOT; };
-		FEDDB95F164D4A168C66F3F0 /* umapfile.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = umapfile.c; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/umapfile.c"; sourceTree = SOURCE_ROOT; };
-		FF5CE7B23EF74A29AA4EE5EA /* uts46.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uts46.cpp; path = "external/alfons/deps/harfbuzz-icu-freetype/icu/common/uts46.cpp"; sourceTree = SOURCE_ROOT; };
+		FEDDB95F164D4A168C66F3F0 /* umapfile.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = umapfile.c; path = "external/harfbuzz-icu-freetype/icu/common/umapfile.c"; sourceTree = SOURCE_ROOT; };
+		FF5CE7B23EF74A29AA4EE5EA /* uts46.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = uts46.cpp; path = "external/harfbuzz-icu-freetype/icu/common/uts46.cpp"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2315,15 +2300,6 @@
 				F0BC1A37422F42E0B39F2D0D /* debugPrimitive.vs */,
 			);
 			name = debugPrimitive_vs;
-			sourceTree = "<group>";
-		};
-		26C78AF3BF404836B33D4342 /* alfons_wrap */ = {
-			isa = PBXGroup;
-			children = (
-				4F9137661C794C1BA505F031 /* Source Files */,
-				593914966EE14D458815EB38 /* CMakeLists.txt */,
-			);
-			name = alfons_wrap;
 			sourceTree = "<group>";
 		};
 		2997CCD340604AB495EFDF21 /* cubemap_fs */ = {
@@ -2537,14 +2513,6 @@
 			children = (
 			);
 			name = "CMake Rules";
-			sourceTree = "<group>";
-		};
-		4F9137661C794C1BA505F031 /* Source Files */ = {
-			isa = PBXGroup;
-			children = (
-				934966E99587479C8C3C46C4 /* lineWrap.cpp */,
-			);
-			name = "Source Files";
 			sourceTree = "<group>";
 		};
 		5499517E33CA475F96554BE2 /* duktape */ = {
@@ -2765,38 +2733,38 @@
 		8EA0A4E3B22C491D87D9A2F1 /* Source Files */ = {
 			isa = PBXGroup;
 			children = (
-				3D7EE01226884E699C85D35E /* hb-blob.cc */,
-				D88EAA2A88384EB5985B036D /* hb-buffer.cc */,
-				9E358A80543F488197A93F1F /* hb-common.cc */,
-				E08983525AE24CBEA77AEB36 /* hb-face.cc */,
-				6949653E52D84329BC42BFC6 /* hb-font.cc */,
-				6E09F660736C4CE68EB076BF /* hb-ft.cc */,
-				CF8DAE04F3934E6384311CC2 /* hb-ot-font.cc */,
-				899C8D0BD75E4F7BA8FF2B90 /* hb-ot-layout.cc */,
-				80F40CBDA8F34358A34F9419 /* hb-ot-map.cc */,
-				A300BA04863A448786767B5C /* hb-ot-shape-complex-arabic.cc */,
-				0FF14C75A77449ECABDBEBC4 /* hb-ot-shape-complex-default.cc */,
-				B7A27565DEDB4C72A8C9CE31 /* hb-ot-shape-complex-hangul.cc */,
-				562CD690A6C846B581ECFE16 /* hb-ot-shape-complex-hebrew.cc */,
-				023E9B0FDFC74C8BAB1CBDF8 /* hb-ot-shape-complex-indic-table.cc */,
-				72DABCE405E94F879F04EF01 /* hb-ot-shape-complex-indic.cc */,
-				C8B4627E31904B50BBB5E613 /* hb-ot-shape-complex-myanmar.cc */,
-				F3F8DF3A93B7408284DC25A3 /* hb-ot-shape-complex-thai.cc */,
-				C4BE61150055463B8B4B9638 /* hb-ot-shape-complex-tibetan.cc */,
-				83CC810132814F04B27C35D6 /* hb-ot-shape-complex-use-table.cc */,
-				876D4FD59AFF4A2286849D26 /* hb-ot-shape-complex-use.cc */,
-				AF25A489B1DB4864AFB80635 /* hb-ot-shape-fallback.cc */,
-				686BCC96C74C4FD79F01D4FA /* hb-ot-shape-normalize.cc */,
-				E0E275C4FCA2489E86AEF353 /* hb-ot-shape.cc */,
-				644ED745E5F84F4D99665C57 /* hb-ot-tag.cc */,
-				FA4A99F528B74DB7AA98BD7D /* hb-set.cc */,
-				BACAAEFD426C4E3CAEEEC729 /* hb-shape-plan.cc */,
-				A85FD3396A87458F8576E8BD /* hb-shape.cc */,
-				B29164703DEF4128B962221E /* hb-shaper.cc */,
-				5BC0F7EFAADA403BAF6B4E1A /* hb-ucdn.cc */,
-				41397A6A6016411A9F0CCC94 /* ucdn.c */,
-				1B10C7CB7E454D708D806F4C /* hb-unicode.cc */,
-				C50FBC0483A6416B95571164 /* hb-warning.cc */,
+				DB44A80D1D996EFD00719BFB /* hb-blob.cc */,
+				DB44A80F1D996EFD00719BFB /* hb-buffer.cc */,
+				DB44A8101D996EFD00719BFB /* hb-common.cc */,
+				DB44A8131D996EFD00719BFB /* hb-face.cc */,
+				DB44A8151D996EFD00719BFB /* hb-font.cc */,
+				DB44A8161D996EFD00719BFB /* hb-ft.cc */,
+				DB44A81B1D996EFD00719BFB /* hb-ot-font.cc */,
+				DB44A81C1D996EFD00719BFB /* hb-ot-layout.cc */,
+				DB44A81D1D996EFD00719BFB /* hb-ot-map.cc */,
+				DB44A81E1D996EFD00719BFB /* hb-ot-shape-complex-arabic.cc */,
+				DB44A81F1D996EFD00719BFB /* hb-ot-shape-complex-default.cc */,
+				DB44A8201D996EFD00719BFB /* hb-ot-shape-complex-hangul.cc */,
+				DB44A8211D996EFD00719BFB /* hb-ot-shape-complex-hebrew.cc */,
+				DB44A8221D996EFD00719BFB /* hb-ot-shape-complex-indic-table.cc */,
+				DB44A8231D996EFD00719BFB /* hb-ot-shape-complex-indic.cc */,
+				DB44A8241D996EFD00719BFB /* hb-ot-shape-complex-myanmar.cc */,
+				DB44A8251D996EFD00719BFB /* hb-ot-shape-complex-thai.cc */,
+				DB44A8261D996EFD00719BFB /* hb-ot-shape-complex-tibetan.cc */,
+				DB44A8271D996EFD00719BFB /* hb-ot-shape-complex-use-table.cc */,
+				DB44A8281D996EFD00719BFB /* hb-ot-shape-complex-use.cc */,
+				DB44A8291D996EFD00719BFB /* hb-ot-shape-fallback.cc */,
+				DB44A82A1D996EFD00719BFB /* hb-ot-shape-normalize.cc */,
+				DB44A82B1D996EFD00719BFB /* hb-ot-shape.cc */,
+				DB44A82C1D996EFD00719BFB /* hb-ot-tag.cc */,
+				DB44A82D1D996EFD00719BFB /* hb-set.cc */,
+				DB44A82E1D996EFD00719BFB /* hb-shape-plan.cc */,
+				DB44A82F1D996EFD00719BFB /* hb-shape.cc */,
+				DB44A8301D996EFD00719BFB /* hb-shaper.cc */,
+				DB44A8311D996EFD00719BFB /* hb-ucdn.cc */,
+				DB44A8321D996EFD00719BFB /* hb-unicode.cc */,
+				DB44A8341D996EFD00719BFB /* hb-warning.cc */,
+				DB44A89B1D99770000719BFB /* ucdn.c */,
 			);
 			name = "Source Files";
 			sourceTree = "<group>";
@@ -2804,6 +2772,7 @@
 		908C858C292248D094EDE3E7 /* Source Files */ = {
 			isa = PBXGroup;
 			children = (
+				DB44A8A91D9982C600719BFB /* platform_gl.cpp */,
 				0BA5DC042F9640FFA77BDF79 /* AppDelegate.m */,
 				DB3C11791D4BBE2600534CA9 /* TGMapViewController.mm */,
 				3C88EC1FF3F945DAAE931700 /* main.m */,
@@ -2918,77 +2887,56 @@
 		9B3E8257AC204059BF096CD6 /* Header Files */ = {
 			isa = PBXGroup;
 			children = (
-				8580335BFCCA4994BFE929E4 /* ftconfig.h */,
-				188C57F8138D4CF89FA40EC9 /* ftheader.h */,
-				7EE073A7850145FD88AEB2C5 /* ftmodule.h */,
-				7644BF2125BF4FF9824AEC52 /* ftoption.h */,
-				0B9B8FE1F8EE4F5F9C7F36D0 /* ftstdlib.h */,
-				19D13E69EFC94C23B219D313 /* freetype.h */,
-				DBE41D624D0A45C5955F7DDA /* ftadvanc.h */,
-				970A171864A94B209FA02FEE /* ftautoh.h */,
-				36EB54BF5BCD4EF09D34FC5B /* ftbbox.h */,
-				CBD27DF9A82149E7BA1D32BB /* ftbdf.h */,
-				6138EC3342B14341B0496B2E /* ftbitmap.h */,
-				535242EF7F594815BE27AF49 /* ftbzip2.h */,
-				5C6ADF486F78482682FE3945 /* ftcache.h */,
-				FE32163E5D2240F58D53EF81 /* ftcffdrv.h */,
-				3798346A289F4EEB854D0AD8 /* ftchapters.h */,
-				261A75845FB54795BC903F9B /* ftcid.h */,
-				768FCBD848404284B0CFEFC2 /* fterrdef.h */,
-				66A2048424DA4B598F888D7E /* fterrors.h */,
-				273D169246FA498C904D290E /* ftfntfmt.h */,
-				44B98922B1FD450B94D4E9AF /* ftgasp.h */,
-				1EA20290CE3C41D8933195E5 /* ftglyph.h */,
-				539108EDD3F248F09C5C1F9A /* ftgxval.h */,
-				75DCA99F75F94C92AD416E0C /* ftgzip.h */,
-				1ABBA628FC7545178CE83E8B /* ftimage.h */,
-				435F5B6F7AF64F12A555869E /* ftincrem.h */,
-				C7C3EE23DA8E43A4B86FF9A2 /* ftlcdfil.h */,
-				176486E188AB464AA5A993B7 /* ftlist.h */,
-				3879E6A3DC52440CB88FFD4D /* ftlzw.h */,
-				9006850B4F4246CA823BB6EC /* ftmac.h */,
-				DF64007CC9794D63B710D086 /* ftmm.h */,
-				842905D2D96540FC968FC289 /* ftmodapi.h */,
-				8D897D55C19D482CAF4C4314 /* ftmoderr.h */,
-				C59BAA2B501541869AA298FC /* ftotval.h */,
-				486B377F0EE54264AF508D13 /* ftoutln.h */,
-				D9EA2433E83343E3800D6A30 /* ftpfr.h */,
-				B6D4D3C23F1E46398935E454 /* ftrender.h */,
-				A80E6451636B4FB894E03883 /* ftsizes.h */,
-				1A19607F600D40069B6889D1 /* ftsnames.h */,
-				77ADAAB3809B4893B732953E /* ftstroke.h */,
-				DC831E3E071640D4BDD020E7 /* ftsynth.h */,
-				273EB10A30B844DCBAF4E743 /* ftsystem.h */,
-				B52D89676F3842268693ACE2 /* fttrigon.h */,
-				B84F458CD5D9499FB8FE8A25 /* ftttdrv.h */,
-				AF349BB08B8D4CD2B3804795 /* fttypes.h */,
-				4E08029CBC11452888927671 /* ftwinfnt.h */,
-				1FB0F1DD8CF2472CBAFB3692 /* autohint.h */,
-				A9B315937D244B2A9F114041 /* ftcalc.h */,
-				253B46759EF94D14981B11B9 /* ftdebug.h */,
-				92D153F82CFF4F4FB851DC4A /* ftdriver.h */,
-				17A3016425C14777B3C14089 /* ftgloadr.h */,
-				FB2E4B3F2F6A40A5B8A851E6 /* fthash.h */,
-				533FB87FAED549ED8F949BAE /* ftmemory.h */,
-				5FFCC94F6418484E936251F2 /* ftobjs.h */,
-				7D1EDCFB573241F0BDB70CDA /* ftpic.h */,
-				20E0296423684E389250384A /* ftrfork.h */,
-				74BC0F384B4F49EEA2C93AE4 /* ftserv.h */,
-				D22696AB3B244019961F5546 /* ftstream.h */,
-				251DE69AF832448F9A3820C2 /* fttrace.h */,
-				9E7A68AE52EE4636B2792CFA /* ftvalid.h */,
-				8FC082F7FBE04C34B69EF60A /* internal.h */,
-				C697173F37014149BFE44AE9 /* psaux.h */,
-				D50385D9D2CE450395A740F8 /* pshints.h */,
-				DE55431AA08E4D84816A609E /* sfnt.h */,
-				D3FFA51387AF4AE2B1E804D6 /* t1types.h */,
-				A3BEBA78AF574CE0B61D1A0D /* tttypes.h */,
-				176990C6063243D3A824F414 /* t1tables.h */,
-				6D575978B0914E81907406C1 /* ttnameid.h */,
-				C5EBE669C2B04E238230EB8C /* tttables.h */,
-				4EF6F430D50D418E977982D0 /* tttags.h */,
-				3A3AEC05FD6145AF9620A9BD /* ttunpat.h */,
-				2265F6BEE92940979DCB247B /* ft2build.h */,
+				DB44A8961D9970D100719BFB /* ftconfig.h */,
+				DB44A8971D9970D100719BFB /* ftheader.h */,
+				DB44A8981D9970D100719BFB /* ftmodule.h */,
+				DB44A8991D9970D100719BFB /* ftoption.h */,
+				DB44A89A1D9970D100719BFB /* ftstdlib.h */,
+				DB44A8691D9970C400719BFB /* freetype.h */,
+				DB44A86A1D9970C400719BFB /* ftadvanc.h */,
+				DB44A86B1D9970C400719BFB /* ftautoh.h */,
+				DB44A86C1D9970C400719BFB /* ftbbox.h */,
+				DB44A86D1D9970C400719BFB /* ftbdf.h */,
+				DB44A86E1D9970C400719BFB /* ftbitmap.h */,
+				DB44A86F1D9970C400719BFB /* ftbzip2.h */,
+				DB44A8701D9970C400719BFB /* ftcache.h */,
+				DB44A8711D9970C400719BFB /* ftcffdrv.h */,
+				DB44A8721D9970C400719BFB /* ftchapters.h */,
+				DB44A8731D9970C400719BFB /* ftcid.h */,
+				DB44A8741D9970C400719BFB /* fterrdef.h */,
+				DB44A8751D9970C400719BFB /* fterrors.h */,
+				DB44A8761D9970C400719BFB /* ftfntfmt.h */,
+				DB44A8771D9970C400719BFB /* ftgasp.h */,
+				DB44A8781D9970C400719BFB /* ftglyph.h */,
+				DB44A8791D9970C400719BFB /* ftgxval.h */,
+				DB44A87A1D9970C400719BFB /* ftgzip.h */,
+				DB44A87B1D9970C400719BFB /* ftimage.h */,
+				DB44A87C1D9970C400719BFB /* ftincrem.h */,
+				DB44A87D1D9970C400719BFB /* ftlcdfil.h */,
+				DB44A87E1D9970C400719BFB /* ftlist.h */,
+				DB44A87F1D9970C400719BFB /* ftlzw.h */,
+				DB44A8801D9970C400719BFB /* ftmac.h */,
+				DB44A8811D9970C400719BFB /* ftmm.h */,
+				DB44A8821D9970C400719BFB /* ftmodapi.h */,
+				DB44A8831D9970C400719BFB /* ftmoderr.h */,
+				DB44A8841D9970C400719BFB /* ftotval.h */,
+				DB44A8851D9970C400719BFB /* ftoutln.h */,
+				DB44A8861D9970C400719BFB /* ftpfr.h */,
+				DB44A8871D9970C400719BFB /* ftrender.h */,
+				DB44A8881D9970C400719BFB /* ftsizes.h */,
+				DB44A8891D9970C400719BFB /* ftsnames.h */,
+				DB44A88A1D9970C400719BFB /* ftstroke.h */,
+				DB44A88B1D9970C400719BFB /* ftsynth.h */,
+				DB44A88C1D9970C400719BFB /* ftsystem.h */,
+				DB44A88D1D9970C400719BFB /* fttrigon.h */,
+				DB44A88E1D9970C400719BFB /* ftttdrv.h */,
+				DB44A88F1D9970C400719BFB /* fttypes.h */,
+				DB44A8901D9970C400719BFB /* ftwinfnt.h */,
+				DB44A8911D9970C400719BFB /* t1tables.h */,
+				DB44A8921D9970C400719BFB /* ttnameid.h */,
+				DB44A8931D9970C400719BFB /* tttables.h */,
+				DB44A8941D9970C400719BFB /* tttags.h */,
+				DB44A8951D9970C400719BFB /* ttunpat.h */,
 			);
 			name = "Header Files";
 			sourceTree = "<group>";
@@ -3040,6 +2988,7 @@
 				799D09C5BD654C8E8E6098D7 /* debug */,
 				9204DA1ECD874847B527196C /* gl */,
 				426BCEEC37E84F46860EAC66 /* labels */,
+				DB44A8A01D99818E00719BFB /* marker */,
 				57B0B52F68EC4A649B94ABAD /* scene */,
 				C618A7CF5B674F23B2DF573A /* style */,
 				A76DBDF53759409E8312095E /* text */,
@@ -3085,7 +3034,7 @@
 		BF11566A877B44FF93B4692D /* Header Files */ = {
 			isa = PBXGroup;
 			children = (
-				7D75D93C5C0E4625A7F2D132 /* config.h */,
+				DB44A89D1D997DD700719BFB /* config.h */,
 			);
 			name = "Header Files";
 			sourceTree = "<group>";
@@ -3303,6 +3252,18 @@
 			name = data;
 			sourceTree = "<group>";
 		};
+		DB44A8A01D99818E00719BFB /* marker */ = {
+			isa = PBXGroup;
+			children = (
+				DB44A8A11D99818E00719BFB /* marker.cpp */,
+				DB44A8A21D99818E00719BFB /* marker.h */,
+				DB44A8A31D99818E00719BFB /* markerManager.cpp */,
+				DB44A8A41D99818E00719BFB /* markerManager.h */,
+			);
+			name = marker;
+			path = core/src/marker;
+			sourceTree = "<group>";
+		};
 		DBD889601D2FC0EF00D05B1F /* tangram_framework */ = {
 			isa = PBXGroup;
 			children = (
@@ -3329,7 +3290,6 @@
 				5C4907C67A60456991D52184 /* freetype */,
 				D62A042566D64E05A18EA02F /* dist */,
 				E3A3AAE43DAF474299B3FD61 /* alfons */,
-				26C78AF3BF404836B33D4342 /* alfons_wrap */,
 				BE9C266E58814F938312B2C2 /* linebreak */,
 				5A23A448198848308610AC8F /* rasters_glsl */,
 				60CD810B5B95464491EF5116 /* sdf_fs */,
@@ -3367,9 +3327,9 @@
 		E30043A777544678ADA1E63D /* harfbuzz */ = {
 			isa = PBXGroup;
 			children = (
+				DB44A8681D996F2000719BFB /* CMakeLists.txt */,
 				8EA0A4E3B22C491D87D9A2F1 /* Source Files */,
 				BF11566A877B44FF93B4692D /* Header Files */,
-				DE8CBF1370B247AB9BAF4373 /* CMakeLists.txt */,
 			);
 			name = harfbuzz;
 			sourceTree = "<group>";
@@ -4228,7 +4188,7 @@
 			name = "CMake Rules";
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "make -C $SRCROO)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6 -f $SRCROOT/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/CMakeScripts/dist_cmakeRulesBuildPhase.make$CONFIGURATION all";
+			shellScript = "make -C $SRCROO)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6 -f $SRCROOT/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/CMakeScripts/dist_cmakeRulesBuildPhase.make$CONFIGURATION all";
 			showEnvVarsInLog = 0;
 		};
 		DC2F2D0291874B96A5DFAB03 /* CMake Rules */ = {
@@ -4304,38 +4264,38 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C198AA6DF50F48FA9B139172 /* hb-blob.cc in Sources */,
-				53951EBC618F4ABFA6652DB3 /* hb-buffer.cc in Sources */,
-				89B9A524A49147E3A2037D7F /* hb-common.cc in Sources */,
-				951DEA3CB3F743E694E9BD12 /* hb-face.cc in Sources */,
-				16DFF4AB21E24FDB992F9284 /* hb-font.cc in Sources */,
-				0E4D388D8FDD425AB842DB88 /* hb-ft.cc in Sources */,
-				C6275F1B1AC54EE7942AA512 /* hb-ot-font.cc in Sources */,
-				59DDE5EF15D74D8CB519F842 /* hb-ot-layout.cc in Sources */,
-				83A2DE91DD894885A2D0E8CF /* hb-ot-map.cc in Sources */,
-				52AE6341CD824BE3909E7C39 /* hb-ot-shape-complex-arabic.cc in Sources */,
-				62BD16CF79154060888C9540 /* hb-ot-shape-complex-default.cc in Sources */,
-				562AFC2E1E004CECA5384C8F /* hb-ot-shape-complex-hangul.cc in Sources */,
-				AD1407F8CA8B48E2A3850098 /* hb-ot-shape-complex-hebrew.cc in Sources */,
-				D7B973A8B4FB43BEA3C056C5 /* hb-ot-shape-complex-indic-table.cc in Sources */,
-				98D8D465AAA949CE8064B107 /* hb-ot-shape-complex-indic.cc in Sources */,
-				157EE348F99D456380D30F16 /* hb-ot-shape-complex-myanmar.cc in Sources */,
-				3F5343F1EBA94323A1BDE204 /* hb-ot-shape-complex-thai.cc in Sources */,
-				5DC33CD9744640ECAF592700 /* hb-ot-shape-complex-tibetan.cc in Sources */,
-				7858581B008449679A86728B /* hb-ot-shape-complex-use-table.cc in Sources */,
-				E793B7E0B95F438D8D0CAE30 /* hb-ot-shape-complex-use.cc in Sources */,
-				9189CD96735F468CA3F9B6DB /* hb-ot-shape-fallback.cc in Sources */,
-				A0F3E7B0FBD14AC5A41D5F02 /* hb-ot-shape-normalize.cc in Sources */,
-				DBE8AA5457204CB7B92F2857 /* hb-ot-shape.cc in Sources */,
-				DE7E3658F5B84014B3D907E9 /* hb-ot-tag.cc in Sources */,
-				3A4DE9FB7A5346F6B7F160FD /* hb-set.cc in Sources */,
-				129F817BECA2442B847240A1 /* hb-shape-plan.cc in Sources */,
-				DA329467AD5E41B1A5AEA2B0 /* hb-shape.cc in Sources */,
-				3948B5C298DB404AAFD5E820 /* hb-shaper.cc in Sources */,
-				6BA4AA3D89B04041B64BD0EB /* hb-ucdn.cc in Sources */,
-				5D066900C1B34A5B819381F9 /* ucdn.c in Sources */,
-				3CB448B4A45947FB8A2F103D /* hb-unicode.cc in Sources */,
-				B39F082FF8BA478C985B9F0A /* hb-warning.cc in Sources */,
+				DB44A84A1D996EFD00719BFB /* hb-ot-map.cc in Sources */,
+				DB44A89C1D99770000719BFB /* ucdn.c in Sources */,
+				DB44A8551D996EFD00719BFB /* hb-ot-shape-complex-use.cc in Sources */,
+				DB44A8511D996EFD00719BFB /* hb-ot-shape-complex-myanmar.cc in Sources */,
+				DB44A8591D996EFD00719BFB /* hb-ot-tag.cc in Sources */,
+				DB44A8401D996EFD00719BFB /* hb-face.cc in Sources */,
+				DB44A8431D996EFD00719BFB /* hb-ft.cc in Sources */,
+				DB44A8521D996EFD00719BFB /* hb-ot-shape-complex-thai.cc in Sources */,
+				DB44A8581D996EFD00719BFB /* hb-ot-shape.cc in Sources */,
+				DB44A83D1D996EFD00719BFB /* hb-common.cc in Sources */,
+				DB44A84C1D996EFD00719BFB /* hb-ot-shape-complex-default.cc in Sources */,
+				DB44A85F1D996EFD00719BFB /* hb-unicode.cc in Sources */,
+				DB44A8501D996EFD00719BFB /* hb-ot-shape-complex-indic.cc in Sources */,
+				DB44A8561D996EFD00719BFB /* hb-ot-shape-fallback.cc in Sources */,
+				DB44A8611D996EFD00719BFB /* hb-warning.cc in Sources */,
+				DB44A84F1D996EFD00719BFB /* hb-ot-shape-complex-indic-table.cc in Sources */,
+				DB44A8421D996EFD00719BFB /* hb-font.cc in Sources */,
+				DB44A8481D996EFD00719BFB /* hb-ot-font.cc in Sources */,
+				DB44A84D1D996EFD00719BFB /* hb-ot-shape-complex-hangul.cc in Sources */,
+				DB44A8531D996EFD00719BFB /* hb-ot-shape-complex-tibetan.cc in Sources */,
+				DB44A8491D996EFD00719BFB /* hb-ot-layout.cc in Sources */,
+				DB44A85C1D996EFD00719BFB /* hb-shape.cc in Sources */,
+				DB44A8541D996EFD00719BFB /* hb-ot-shape-complex-use-table.cc in Sources */,
+				DB44A84B1D996EFD00719BFB /* hb-ot-shape-complex-arabic.cc in Sources */,
+				DB44A85A1D996EFD00719BFB /* hb-set.cc in Sources */,
+				DB44A8571D996EFD00719BFB /* hb-ot-shape-normalize.cc in Sources */,
+				DB44A85B1D996EFD00719BFB /* hb-shape-plan.cc in Sources */,
+				DB44A85D1D996EFD00719BFB /* hb-shaper.cc in Sources */,
+				DB44A83A1D996EFD00719BFB /* hb-blob.cc in Sources */,
+				DB44A83C1D996EFD00719BFB /* hb-buffer.cc in Sources */,
+				DB44A84E1D996EFD00719BFB /* hb-ot-shape-complex-hebrew.cc in Sources */,
+				DB44A85E1D996EFD00719BFB /* hb-ucdn.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4386,6 +4346,7 @@
 				DB7E43991D4B8A5400A6F40D /* labelCollider.cpp in Sources */,
 				9AFCD4D6ADE4400E85E1355B /* spriteAtlas.cpp in Sources */,
 				010218B0DA5A49A4B7D39DE9 /* stops.cpp in Sources */,
+				DB44A8A71D99818E00719BFB /* markerManager.cpp in Sources */,
 				AB325FE2C11F44DD994541FA /* styleContext.cpp in Sources */,
 				373C5CD876804F5FAB7B56C6 /* styleMixer.cpp in Sources */,
 				4BC2E58E15244CA281EFB1FC /* styleParam.cpp in Sources */,
@@ -4405,6 +4366,7 @@
 				E28EFC378A93498F8357272F /* textUtil.cpp in Sources */,
 				A0940ECEC24941B2B2222B24 /* tile.cpp in Sources */,
 				67F9E23E41054A53860777A7 /* tileBuilder.cpp in Sources */,
+				DB44A8A51D99818E00719BFB /* marker.cpp in Sources */,
 				4DC5517701714CCA890E1912 /* tileManager.cpp in Sources */,
 				7BB0A157D50646468F180EB9 /* tileTask.cpp in Sources */,
 				B55F3F28EBAA433387E6B687 /* tileWorker.cpp in Sources */,
@@ -4713,7 +4675,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B88F25DCA8804803ADB0FAEB /* lineWrap.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4721,6 +4682,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB44A8AB1D9982C600719BFB /* platform_gl.cpp in Sources */,
 				DB3C117A1D4BBE2600534CA9 /* TGMapViewController.mm in Sources */,
 				DBD8896A1D2FC15700D05B1F /* platform_ios.mm in Sources */,
 			);
@@ -4751,6 +4713,7 @@
 				1E20C6E86AB94DEEA51DCC65 /* AppDelegate.m in Sources */,
 				9673CE5410E4499181745C24 /* main.m in Sources */,
 				156612B0394B47209CF10D33 /* platform_ios.mm in Sources */,
+				DB44A8AA1D9982C600719BFB /* platform_gl.cpp in Sources */,
 				DB3C117C1D4BC14800534CA9 /* TGMapViewController.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5287,9 +5250,9 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -5300,25 +5263,25 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = icucommon;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -5357,13 +5320,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -5372,13 +5335,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -5515,13 +5478,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-DGEOJSONVT_CUSTOM_TAGS",
 					"-Wno-unknown-pragmas",
 				);
@@ -5594,11 +5557,11 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -5609,25 +5572,25 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = harfbuzz;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -5660,8 +5623,8 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -5672,13 +5635,13 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = freetype;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -5721,29 +5684,27 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
-					"
-",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -5822,13 +5783,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-DGEOJSONVT_CUSTOM_TAGS",
 					"-Wno-unknown-pragmas",
 				);
@@ -5962,13 +5923,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -5977,13 +5938,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -6043,15 +6004,15 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
 				);
 				INSTALL_PATH = "";
 				OTHER_LDFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = dist;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -6206,13 +6167,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -6266,8 +6227,9 @@
 					armv7s,
 					arm64,
 				);
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk;
+				SDKROOT = iphoneos10.0;
 				SYMROOT = "$(SRCROOT)/build/ios/build";
+				VALID_ARCHS = "arm64 armv7s armv7";
 			};
 			name = Debug;
 		};
@@ -6564,29 +6526,27 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
-					"
-",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -6691,7 +6651,7 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -6769,29 +6729,27 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
-					"
-",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -6995,13 +6953,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/build/ios/CMakeFiles/tangram.dir/Info.plist";
 				INSTALL_PATH = "";
@@ -7013,20 +6971,20 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
+					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk\n",
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-std=c++1y\n",
 					"-stdlib=libc++\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_LDFLAGS = (
@@ -7135,7 +7093,7 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-fstrict-aliasing",
 					"-fomit-frame-pointer",
 					"'-std=c99'",
@@ -7144,6 +7102,7 @@
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = duktape;
+				SDKROOT = iphoneos;
 				SECTORDER_FLAGS = "";
 				SYMROOT = "$(SRCROOT)/build/ios/external";
 				USE_HEADERMAP = NO;
@@ -7197,13 +7156,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -7212,13 +7171,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_LIBTOOLFLAGS = " ";
@@ -7409,11 +7368,11 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -7424,25 +7383,25 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = harfbuzz;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -7478,11 +7437,11 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -7493,25 +7452,25 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = harfbuzz;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -7559,8 +7518,9 @@
 					armv7s,
 					arm64,
 				);
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk;
+				SDKROOT = iphoneos10.0;
 				SYMROOT = "$(SRCROOT)/build/ios/build";
+				VALID_ARCHS = "arm64 armv7s armv7";
 			};
 			name = MinSizeRel;
 		};
@@ -7592,13 +7552,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -7607,13 +7567,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -7719,13 +7679,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -7756,15 +7716,15 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
 				);
 				INSTALL_PATH = "";
 				OTHER_LDFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = dist;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -7803,13 +7763,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -7818,13 +7778,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -7871,7 +7831,7 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-fstrict-aliasing",
 					"-fomit-frame-pointer",
 					"'-std=c99'",
@@ -7880,6 +7840,7 @@
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = duktape;
+				SDKROOT = iphoneos;
 				SECTORDER_FLAGS = "";
 				SYMROOT = "$(SRCROOT)/build/ios/external";
 				USE_HEADERMAP = NO;
@@ -7920,13 +7881,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -7935,13 +7896,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -8027,15 +7988,15 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
 				);
 				INSTALL_PATH = "";
 				OTHER_LDFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = dist;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -8083,8 +8044,9 @@
 					armv7s,
 					arm64,
 				);
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk;
+				SDKROOT = iphoneos10.0;
 				SYMROOT = "$(SRCROOT)/build/ios/build";
+				VALID_ARCHS = "arm64 armv7s armv7";
 			};
 			name = Release;
 		};
@@ -8158,13 +8120,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -8173,13 +8135,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_LIBTOOLFLAGS = " ";
@@ -8254,13 +8216,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -8269,13 +8231,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -8409,7 +8371,7 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-fstrict-aliasing",
 					"-fomit-frame-pointer",
 					"'-std=c99'",
@@ -8418,6 +8380,7 @@
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = duktape;
+				SDKROOT = iphoneos;
 				SECTORDER_FLAGS = "";
 				SYMROOT = "$(SRCROOT)/build/ios/external";
 				USE_HEADERMAP = NO;
@@ -8470,8 +8433,9 @@
 					armv7s,
 					arm64,
 				);
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk;
+				SDKROOT = iphoneos10.0;
 				SYMROOT = "$(SRCROOT)/build/ios/build";
+				VALID_ARCHS = "arm64 armv7s armv7";
 			};
 			name = RelWithDebInfo;
 		};
@@ -8575,13 +8539,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/build/ios/CMakeFiles/tangram.dir/Info.plist";
 				INSTALL_PATH = "";
@@ -8593,20 +8557,20 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
+					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk\n",
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-std=c++1y\n",
 					"-stdlib=libc++\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_LDFLAGS = (
@@ -8716,13 +8680,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -8825,11 +8789,11 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -8840,26 +8804,26 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-g",
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = harfbuzz;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -8956,13 +8920,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -8971,13 +8935,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -9053,7 +9017,7 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -9098,13 +9062,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -9113,13 +9077,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -9166,7 +9130,7 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-fstrict-aliasing",
 					"-fomit-frame-pointer",
 					"'-std=c99'",
@@ -9175,6 +9139,7 @@
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = duktape;
+				SDKROOT = iphoneos;
 				SECTORDER_FLAGS = "";
 				SYMROOT = "$(SRCROOT)/build/ios/external";
 				USE_HEADERMAP = NO;
@@ -9201,15 +9166,15 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
 				);
 				INSTALL_PATH = "";
 				OTHER_LDFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = dist;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -9244,9 +9209,9 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -9257,26 +9222,26 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-g",
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = icucommon;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -9491,7 +9456,7 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -9598,29 +9563,27 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
-					"
-",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -9659,8 +9622,8 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -9671,13 +9634,13 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = freetyped;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -10023,8 +9986,8 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -10035,13 +9998,13 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = freetype;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -10221,7 +10184,7 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -10329,8 +10292,11 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
+					"'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'",
+					PLATFORM_IOS,
+					"'U_STATIC_IMPLEMENTATION=1'",
+					PIC,
+					U_COMMON_IMPLEMENTATION,
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -10356,20 +10322,20 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INFOPLIST_FILE = build/ios/tangram_framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-Wl,-search_paths_first",
 					"-Wl,-headerpad_max_install_names",
@@ -10440,6 +10406,13 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'",
+					PLATFORM_IOS,
+					"'U_STATIC_IMPLEMENTATION=1'",
+					PIC,
+					U_COMMON_IMPLEMENTATION,
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -10464,13 +10437,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INFOPLIST_FILE = build/ios/tangram_framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -10548,6 +10521,13 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'",
+					PLATFORM_IOS,
+					"'U_STATIC_IMPLEMENTATION=1'",
+					PIC,
+					U_COMMON_IMPLEMENTATION,
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -10572,13 +10552,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INFOPLIST_FILE = build/ios/tangram_framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -10656,6 +10636,13 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'",
+					PLATFORM_IOS,
+					"'U_STATIC_IMPLEMENTATION=1'",
+					PIC,
+					U_COMMON_IMPLEMENTATION,
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -10680,13 +10667,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INFOPLIST_FILE = build/ios/tangram_framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -10776,13 +10763,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/build/ios/CMakeFiles/tangram.dir/Info.plist";
 				INSTALL_PATH = "";
@@ -10794,20 +10781,20 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
+					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk\n",
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-std=c++1y\n",
 					"-stdlib=libc++\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_LDFLAGS = (
@@ -11061,13 +11048,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-DGEOJSONVT_CUSTOM_TAGS",
 					"-Wno-unknown-pragmas",
 				);
@@ -11128,13 +11115,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/build/ios/CMakeFiles/tangram.dir/Info.plist";
 				INSTALL_PATH = "";
@@ -11146,20 +11133,20 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
+					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk\n",
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-std=c++1y\n",
 					"-stdlib=libc++\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 					"-g",
 				);
@@ -11275,13 +11262,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-DGEOJSONVT_CUSTOM_TAGS",
 					"-Wno-unknown-pragmas",
 				);
@@ -11382,9 +11369,9 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -11395,25 +11382,25 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = icucommon;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -11510,13 +11497,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
@@ -11661,13 +11648,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -11676,13 +11663,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_LIBTOOLFLAGS = " ";
@@ -11724,9 +11711,9 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -11737,25 +11724,25 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = icucommon;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -11846,8 +11833,8 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -11858,13 +11845,13 @@
 					"-fobjc-abi-version=2\n",
 					"-fobjc-arc\n",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 				);
 				OTHER_LIBTOOLFLAGS = " ";
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = freetype;
 				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6";
+				SYMROOT = "$(SRCROOT)/build/ios/external/harfbuzz-icu-freetype/freetype-2.6";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -11974,13 +11961,13 @@
 					"$(SRCROOT)/external/../core/include/glm",
 					"$(SRCROOT)/external/alfons/src/logger",
 					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/alfons/deps/harfbuzz-icu-freetype/icu/common/unicode",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
+					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
 				);
 				INSTALL_PATH = "";
 				LIBRARY_STYLE = STATIC;
@@ -11989,13 +11976,13 @@
 					"-fvisibility=hidden",
 					"-fvisibility-inlines-hidden",
 					"-isysroot",
-					"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk\n",
-					"-fobjc-abi-version=2\n",
-					"-fobjc-arc\n",
-					"-std=c++1y\n",
-					"-stdlib=libc++\n",
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
+					"-fobjc-abi-version=2",
+					"-fobjc-arc",
+					"-std=c++1y",
+					"-stdlib=libc++",
 					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk,
+					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
 					"-Wno-unknown-pragmas",
 				);
 				OTHER_LIBTOOLFLAGS = " ";

--- a/ios/xcodeproj/tangram.xcodeproj/project.pbxproj
+++ b/ios/xcodeproj/tangram.xcodeproj/project.pbxproj
@@ -78,7 +78,6 @@
 				CED331D90DB64A848B493013 /* PBXTargetDependency */,
 				EE62E588204C41ED9793339F /* PBXTargetDependency */,
 				BDAAF571ED854F9CBD0EBAF7 /* PBXTargetDependency */,
-				CEF74CACC71A4A6DA2EFECFD /* PBXTargetDependency */,
 				853E7C3926E345E7A2C9EBA2 /* PBXTargetDependency */,
 				17CC0BFFC2314293BFC66FB2 /* PBXTargetDependency */,
 				48823124E1114E75B39E9F34 /* PBXTargetDependency */,
@@ -642,7 +641,7 @@
 		DB1174E71D66105E00CD70DB /* disposer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DB1174E51D66105E00CD70DB /* disposer.cpp */; };
 		DB1174E81D66105E00CD70DB /* disposer.h in Headers */ = {isa = PBXBuildFile; fileRef = DB1174E61D66105E00CD70DB /* disposer.h */; };
 		DB3C117A1D4BBE2600534CA9 /* TGMapViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = DB3C11791D4BBE2600534CA9 /* TGMapViewController.mm */; };
-		DB3C117B1D4BC11900534CA9 /* TGMapViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = DB3C11771D4BBE1F00534CA9 /* TGMapViewController.h */; };
+		DB3C117B1D4BC11900534CA9 /* TGMapViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = DB3C11771D4BBE1F00534CA9 /* TGMapViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB3C117C1D4BC14800534CA9 /* TGMapViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = DB3C11791D4BBE2600534CA9 /* TGMapViewController.mm */; };
 		DB44A83A1D996EFD00719BFB /* hb-blob.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A80D1D996EFD00719BFB /* hb-blob.cc */; };
 		DB44A83C1D996EFD00719BFB /* hb-buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB44A80F1D996EFD00719BFB /* hb-buffer.cc */; };
@@ -746,20 +745,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		003B8EFBBABA462E89B2A517 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ABBDAA98293E4207AFE4A442;
-			remoteInfo = ZERO_CHECK;
-		};
-		0149B31C0C6D48B083B72335 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9461B6A3A0404FD68D5325F0;
-			remoteInfo = icucommon;
-		};
 		018232C15D2B455080D3F611 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
@@ -1054,26 +1039,12 @@
 			remoteGlobalIDString = 110B8E59AA0848829E605DFA;
 			remoteInfo = alfons;
 		};
-		A72ECD065B474D7890E9A6CA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 08BF3320EF0A434A9C866774;
-			remoteInfo = alfons_wrap;
-		};
 		AB681FFCC9224D0A94C7F984 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7A6FBED9A04B4ADD8EF4453F;
 			remoteInfo = freetype;
-		};
-		ADAB1861307B4F9C8A96F707 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 110B8E59AA0848829E605DFA;
-			remoteInfo = alfons;
 		};
 		ADC33682A51A41A390606646 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1088,13 +1059,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 472AF0CE33A142AEA03A2848;
 			remoteInfo = "geojson-vt-cpp";
-		};
-		B33FB28A22E74AA3B6972601 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B02B005F0C7848408139DAB3;
-			remoteInfo = linebreak;
 		};
 		B34AAF8612644D1B87B32677 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1144,13 +1108,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = A6D26DEAB769466088BD77C1;
 			remoteInfo = polyline_fs;
-		};
-		C2FE4FCDF55E4846BC42A2D8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7A6FBED9A04B4ADD8EF4453F;
-			remoteInfo = freetype;
 		};
 		CA89B600146742F3ACA8E6A4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1250,13 +1207,6 @@
 			remoteGlobalIDString = 110B8E59AA0848829E605DFA;
 			remoteInfo = alfons;
 		};
-		DBD8897E1D2FC1D800D05B1F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 08BF3320EF0A434A9C866774;
-			remoteInfo = alfons_wrap;
-		};
 		DBD889801D2FC1D800D05B1F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
@@ -1319,13 +1269,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 472AF0CE33A142AEA03A2848;
 			remoteInfo = "geojson-vt-cpp";
-		};
-		F8B246990AB4419CA08BD487 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D8FA5D60A96745C3ACF1BC9D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 595AA110554A4ABDAF673DC7;
-			remoteInfo = harfbuzz;
 		};
 		FB83B60042804568ACB96A33 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1537,7 +1480,6 @@
 		33EBD0B4ABEE4F4BB1BBE9E9 /* libfreetyped.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libfreetyped.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3418AADB97104A90BD0A4063 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = core/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		3441011F320A4DF189D42404 /* uscript.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 4; name = uscript.c; path = "external/harfbuzz-icu-freetype/icu/common/uscript.c"; sourceTree = SOURCE_ROOT; };
-		34A120DD463049C0B4DC441B /* libalfons_wrap.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libalfons_wrap.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		35353C9387E14DD880274974 /* gl.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = gl.h; path = core/src/gl.h; sourceTree = SOURCE_ROOT; };
 		3663EF19BAA44F6890BB0B72 /* point.fs */ = {isa = PBXFileReference; explicitFileType = sourcecode; fileEncoding = 4; name = point.fs; path = core/shaders/point.fs; sourceTree = SOURCE_ROOT; };
 		3847B717150243DCA53207A3 /* Main_iPhone.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main_iPhone.storyboard; path = ios/resources/Main_iPhone.storyboard; sourceTree = SOURCE_ROOT; };
@@ -2163,7 +2105,6 @@
 				9FDC9F5C088B419F82CF907A /* libicucommon.a */,
 				33EBD0B4ABEE4F4BB1BBE9E9 /* libfreetyped.a */,
 				3ED77B7A24B34274B96428CA /* libalfons.a */,
-				34A120DD463049C0B4DC441B /* libalfons_wrap.a */,
 				9745069B75EE48D79F08D9F9 /* liblinebreak.a */,
 				7D873DC3AA7B40FF82909987 /* libcore.a */,
 				DBD8895F1D2FC0EF00D05B1F /* tangram_framework.framework */,
@@ -3595,27 +3536,6 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		08BF3320EF0A434A9C866774 /* alfons_wrap */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7571B68DFFBF4D24B5D23036 /* Build configuration list for PBXNativeTarget "alfons_wrap" */;
-			buildPhases = (
-				AA8A2531432F4170910BB39C /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				6C419F82FFB246F4B98A4053 /* PBXTargetDependency */,
-				4C0470919CE34FF3940EF549 /* PBXTargetDependency */,
-				0FB9FBF3A12B452681F9C437 /* PBXTargetDependency */,
-				EC447777DB274152A6897A94 /* PBXTargetDependency */,
-				2E32CF61F2B94EB78EA95E1E /* PBXTargetDependency */,
-				215E999513FB4461B54FDBD1 /* PBXTargetDependency */,
-			);
-			name = alfons_wrap;
-			productName = alfons_wrap;
-			productReference = 34A120DD463049C0B4DC441B /* libalfons_wrap.a */;
-			productType = "com.apple.product-type.library.static";
-		};
 		110B8E59AA0848829E605DFA /* alfons */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAECFB8D7EE143CF90B7FE11 /* Build configuration list for PBXNativeTarget "alfons" */;
@@ -3815,7 +3735,6 @@
 				DBD889791D2FC1D800D05B1F /* PBXTargetDependency */,
 				DBD8897B1D2FC1D800D05B1F /* PBXTargetDependency */,
 				DBD8897D1D2FC1D800D05B1F /* PBXTargetDependency */,
-				DBD8897F1D2FC1D800D05B1F /* PBXTargetDependency */,
 				DBD889811D2FC1D800D05B1F /* PBXTargetDependency */,
 				DBD889831D2FC1D800D05B1F /* PBXTargetDependency */,
 			);
@@ -3878,8 +3797,123 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				TargetAttributes = {
+					0C41B21D792C404FA5AB8D16 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					110B8E59AA0848829E605DFA = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					18FB8B8913DF474BAA35E61E = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					1C8E349C5B7048418B7E281A = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					40435E8D2545403FB68684AA = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					441599D8D0ED4F569C59E2AE = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					472AF0CE33A142AEA03A2848 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					4DC6D601129740A9ACCD2C3C = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					595AA110554A4ABDAF673DC7 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					5EF6728773D243A3A16C9956 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					69101BFA86C84CD493024E1D = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					716AE3BC09F9419FAB12383F = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					73C84822E36F4727A37CDAA0 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					7A6FBED9A04B4ADD8EF4453F = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					81F80F338AE54ED9A3F4C797 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					841DD1AB59E144F2859418B3 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					883E973B8158479CA6AB0D88 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					88FA58613CEF4970AA33621A = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					90A7FAD802A149F68399E789 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					9461B6A3A0404FD68D5325F0 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					9FD5C8ACE1E346D09BB4BFCA = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					A35E090E9A014CCC969277E8 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					A6D26DEAB769466088BD77C1 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					AAE76773E75C4377A4A57CF7 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					ABBDAA98293E4207AFE4A442 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					B02B005F0C7848408139DAB3 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					C0ABFE8C14DE4954BBA7D780 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					C41177EED60244C4A7751854 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					CD9C0C3F609C484BA511D513 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					D29D62E77F814DE485890F79 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					D455D32BEC034DB2A6F5D154 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					D5631D125C874E9EABE24458 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					D6D26B3C75474708962A06E3 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					D7B000CD12144ADFBEA3BDAC = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
 					DBD8895E1D2FC0EF00D05B1F = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					DCBCA070F1D840C683B77231 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					E5E2F77E95B440E6BE091D88 = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					F029143B4C6A4E84B73279FF = {
+						DevelopmentTeam = LTQC954SPQ;
+					};
+					FC942AADA8744F68B2A3B230 = {
+						DevelopmentTeam = LTQC954SPQ;
 					};
 				};
 			};
@@ -3909,7 +3943,6 @@
 				0C41B21D792C404FA5AB8D16 /* dist */,
 				7A6FBED9A04B4ADD8EF4453F /* freetype */,
 				110B8E59AA0848829E605DFA /* alfons */,
-				08BF3320EF0A434A9C866774 /* alfons_wrap */,
 				B02B005F0C7848408139DAB3 /* linebreak */,
 				88FA58613CEF4970AA33621A /* ambientLight_glsl */,
 				FC942AADA8744F68B2A3B230 /* core */,
@@ -4671,13 +4704,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AA8A2531432F4170910BB39C /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DBD8895A1D2FC0EF00D05B1F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -4745,11 +4771,6 @@
 			target = 40435E8D2545403FB68684AA /* yaml-cpp */;
 			targetProxy = 699CB79D0EC84C3BA0791C34 /* PBXContainerItemProxy */;
 		};
-		0FB9FBF3A12B452681F9C437 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 7A6FBED9A04B4ADD8EF4453F /* freetype */;
-			targetProxy = C2FE4FCDF55E4846BC42A2D8 /* PBXContainerItemProxy */;
-		};
 		12C8F56EAB4F450B918A627F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = ABBDAA98293E4207AFE4A442 /* ZERO_CHECK */;
@@ -4770,11 +4791,6 @@
 			target = D29D62E77F814DE485890F79 /* duktape */;
 			targetProxy = FBF6A5C913A14781B97D0B54 /* PBXContainerItemProxy */;
 		};
-		215E999513FB4461B54FDBD1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = ABBDAA98293E4207AFE4A442 /* ZERO_CHECK */;
-			targetProxy = 003B8EFBBABA462E89B2A517 /* PBXContainerItemProxy */;
-		};
 		296CCBDCE9674DB59C348DCE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D7B000CD12144ADFBEA3BDAC /* tangram */;
@@ -4789,11 +4805,6 @@
 			isa = PBXTargetDependency;
 			target = 595AA110554A4ABDAF673DC7 /* harfbuzz */;
 			targetProxy = 6F210A228EDE4F42B51819E3 /* PBXContainerItemProxy */;
-		};
-		2E32CF61F2B94EB78EA95E1E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = B02B005F0C7848408139DAB3 /* linebreak */;
-			targetProxy = B33FB28A22E74AA3B6972601 /* PBXContainerItemProxy */;
 		};
 		31FC793E8D9842F48D07009C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4814,11 +4825,6 @@
 			isa = PBXTargetDependency;
 			target = ABBDAA98293E4207AFE4A442 /* ZERO_CHECK */;
 			targetProxy = BEB020179C9B4816838DB20A /* PBXContainerItemProxy */;
-		};
-		4C0470919CE34FF3940EF549 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 9461B6A3A0404FD68D5325F0 /* icucommon */;
-			targetProxy = 0149B31C0C6D48B083B72335 /* PBXContainerItemProxy */;
 		};
 		4C8F41744023471D9771D918 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4864,11 +4870,6 @@
 			isa = PBXTargetDependency;
 			target = 9461B6A3A0404FD68D5325F0 /* icucommon */;
 			targetProxy = 7143E71063904DF6A3237421 /* PBXContainerItemProxy */;
-		};
-		6C419F82FFB246F4B98A4053 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 595AA110554A4ABDAF673DC7 /* harfbuzz */;
-			targetProxy = F8B246990AB4419CA08BD487 /* PBXContainerItemProxy */;
 		};
 		6DE58F7DDFB240488EE414A8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5045,11 +5046,6 @@
 			target = 9461B6A3A0404FD68D5325F0 /* icucommon */;
 			targetProxy = 3139A3E7CEBC4A49BB70054F /* PBXContainerItemProxy */;
 		};
-		CEF74CACC71A4A6DA2EFECFD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 08BF3320EF0A434A9C866774 /* alfons_wrap */;
-			targetProxy = A72ECD065B474D7890E9A6CA /* PBXContainerItemProxy */;
-		};
 		D26FC95B3C0E4D5691850296 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9FD5C8ACE1E346D09BB4BFCA /* material_glsl */;
@@ -5110,11 +5106,6 @@
 			target = 110B8E59AA0848829E605DFA /* alfons */;
 			targetProxy = DBD8897C1D2FC1D800D05B1F /* PBXContainerItemProxy */;
 		};
-		DBD8897F1D2FC1D800D05B1F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 08BF3320EF0A434A9C866774 /* alfons_wrap */;
-			targetProxy = DBD8897E1D2FC1D800D05B1F /* PBXContainerItemProxy */;
-		};
 		DBD889811D2FC1D800D05B1F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B02B005F0C7848408139DAB3 /* linebreak */;
@@ -5134,11 +5125,6 @@
 			isa = PBXTargetDependency;
 			target = 88FA58613CEF4970AA33621A /* ambientLight_glsl */;
 			targetProxy = 1444E9C6AA6441258AC4531A /* PBXContainerItemProxy */;
-		};
-		EC447777DB274152A6897A94 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 110B8E59AA0848829E605DFA /* alfons */;
-			targetProxy = ADAB1861307B4F9C8A96F707 /* PBXContainerItemProxy */;
 		};
 		EDA46961B6824507A5379EC1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5291,72 +5277,6 @@
 				);
 			};
 			name = MinSizeRel;
-		};
-		067E622306BA497389DBA3A7 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = (
-					armv7,
-					armv7s,
-					arm64,
-				);
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/build/ios/lib/Release";
-				EXECUTABLE_PREFIX = lib;
-				EXECUTABLE_SUFFIX = .a;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'",
-					PLATFORM_IOS,
-					"'U_STATIC_IMPLEMENTATION=1'",
-					PIC,
-					U_COMMON_IMPLEMENTATION,
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/src",
-					"$(SRCROOT)/external/../core/include/glm",
-					"$(SRCROOT)/external/alfons/src/logger",
-					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
-				);
-				INSTALL_PATH = "";
-				LIBRARY_STYLE = STATIC;
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = (
-					"-fvisibility=hidden",
-					"-fvisibility-inlines-hidden",
-					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
-					"-fobjc-abi-version=2",
-					"-fobjc-arc",
-					"-std=c++1y",
-					"-stdlib=libc++",
-					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
-				);
-				OTHER_LIBTOOLFLAGS = " ";
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = alfons_wrap;
-				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/src";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = (
-					"-Wmost",
-					"-Wno-four-char-constants",
-					"-Wno-unknown-pragmas",
-					"$(inherited)",
-				);
-			};
-			name = Release;
 		};
 		09207954F7BF4578B0F8C41D /* MinSizeRel */ = {
 			isa = XCBuildConfiguration;
@@ -7853,72 +7773,6 @@
 			};
 			name = Debug;
 		};
-		7B352980ED104AE9A76C1F18 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = (
-					armv7,
-					armv7s,
-					arm64,
-				);
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/build/ios/lib/Debug";
-				EXECUTABLE_PREFIX = lib;
-				EXECUTABLE_SUFFIX = .a;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'",
-					PLATFORM_IOS,
-					"'U_STATIC_IMPLEMENTATION=1'",
-					PIC,
-					U_COMMON_IMPLEMENTATION,
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/src",
-					"$(SRCROOT)/external/../core/include/glm",
-					"$(SRCROOT)/external/alfons/src/logger",
-					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
-				);
-				INSTALL_PATH = "";
-				LIBRARY_STYLE = STATIC;
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = (
-					"-fvisibility=hidden",
-					"-fvisibility-inlines-hidden",
-					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
-					"-fobjc-abi-version=2",
-					"-fobjc-arc",
-					"-std=c++1y",
-					"-stdlib=libc++",
-					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
-				);
-				OTHER_LIBTOOLFLAGS = " ";
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = alfons_wrap;
-				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/src";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = (
-					"-Wmost",
-					"-Wno-four-char-constants",
-					"-Wno-unknown-pragmas",
-					"$(inherited)",
-				);
-			};
-			name = Debug;
-		};
 		7B7E6DA5C7CD462FA3F3AF67 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -8178,72 +8032,6 @@
 				PRODUCT_NAME = polygon_fs;
 				SECTORDER_FLAGS = "";
 				SYMROOT = "$(SRCROOT)/build/ios/core";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = (
-					"-Wmost",
-					"-Wno-four-char-constants",
-					"-Wno-unknown-pragmas",
-					"$(inherited)",
-				);
-			};
-			name = MinSizeRel;
-		};
-		867B764734BE47129BFE3FB6 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = (
-					armv7,
-					armv7s,
-					arm64,
-				);
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/build/ios/lib/MinSizeRel";
-				EXECUTABLE_PREFIX = lib;
-				EXECUTABLE_SUFFIX = .a;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'",
-					PLATFORM_IOS,
-					"'U_STATIC_IMPLEMENTATION=1'",
-					PIC,
-					U_COMMON_IMPLEMENTATION,
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/src",
-					"$(SRCROOT)/external/../core/include/glm",
-					"$(SRCROOT)/external/alfons/src/logger",
-					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
-				);
-				INSTALL_PATH = "";
-				LIBRARY_STYLE = STATIC;
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = (
-					"-fvisibility=hidden",
-					"-fvisibility-inlines-hidden",
-					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
-					"-fobjc-abi-version=2",
-					"-fobjc-arc",
-					"-std=c++1y",
-					"-stdlib=libc++",
-					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
-				);
-				OTHER_LIBTOOLFLAGS = " ";
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = alfons_wrap;
-				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/src";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -9033,72 +8821,6 @@
 				);
 			};
 			name = Release;
-		};
-		9BD768F5B2384ABFB9719F0C /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = (
-					armv7,
-					armv7s,
-					arm64,
-				);
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/build/ios/lib/RelWithDebInfo";
-				EXECUTABLE_PREFIX = lib;
-				EXECUTABLE_SUFFIX = .a;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'",
-					PLATFORM_IOS,
-					"'U_STATIC_IMPLEMENTATION=1'",
-					PIC,
-					U_COMMON_IMPLEMENTATION,
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/external/alfons/src",
-					"$(SRCROOT)/external/../core/include/glm",
-					"$(SRCROOT)/external/alfons/src/logger",
-					"$(SRCROOT)/external/alfons/src/linebreak",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz-generated",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/freetype-2.6/include",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/harfbuzz/src/hb-ucdn",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/stubdata",
-					"$(SRCROOT)/external/harfbuzz-icu-freetype/icu/common/unicode",
-				);
-				INSTALL_PATH = "";
-				LIBRARY_STYLE = STATIC;
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = (
-					"-fvisibility=hidden",
-					"-fvisibility-inlines-hidden",
-					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
-					"-fobjc-abi-version=2",
-					"-fobjc-arc",
-					"-std=c++1y",
-					"-stdlib=libc++",
-					"-isysroot",
-					/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk,
-				);
-				OTHER_LIBTOOLFLAGS = " ";
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = alfons_wrap;
-				SECTORDER_FLAGS = "";
-				SYMROOT = "$(SRCROOT)/build/ios/external/alfons/src";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = (
-					"-Wmost",
-					"-Wno-four-char-constants",
-					"-Wno-unknown-pragmas",
-					"$(inherited)",
-				);
-			};
-			name = RelWithDebInfo;
 		};
 		A11C04E2E1C74BDD92CFA47E /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -12237,17 +11959,6 @@
 				0CF76743A52D480786EC0BC3 /* Release */,
 				DE8EFEA12E184B3DA938B586 /* MinSizeRel */,
 				3CDA802FB0534F2395398D61 /* RelWithDebInfo */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		7571B68DFFBF4D24B5D23036 /* Build configuration list for PBXNativeTarget "alfons_wrap" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				7B352980ED104AE9A76C1F18 /* Debug */,
-				067E622306BA497389DBA3A7 /* Release */,
-				867B764734BE47129BFE3FB6 /* MinSizeRel */,
-				9BD768F5B2384ABFB9719F0C /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;


### PR DESCRIPTION
Most of the changes here lie within the xcode project file, and involve removing additional hard links to the iOS 9 SDK, so now the project file references `iPhoneOS.sdk` rather than `iPhoneOS9.3.sdk`. It also updates the project to be compliant with changes that occurred in the main codebase, specifically pulling the harfbuzz requirement out of alfons and up into the main dependencies, and the removal of the alfons-wrap library.

Previously, changes were made that exposed the internal instance of the Tangram `Map` object that TGMapViewController uses. The issue here is that by exposing that, it requires the framework implementation to then expose nearly the entire tangram-es public interface, since the Map object depends upon almost the entirety of the core interface to function. 

However, the underlying tangram-es core project uses relative paths to header files that the Xcode framework doesn't replicate. Merely adding the headers to be exposed via the framework's public headers isn't good enough because the include statements fail. The easy fix (included here) is to just remove the public `Map` reference and make it private for now. However, we should really address the relative path issues in the core framework, maybe as part of the ongoing build improvements. 