### PR TITLE
Fix an infinite loop in DynamicQuadMesh for very large meshes

### DIFF
--- a/core/src/gl/dynamicQuadMesh.h
+++ b/core/src/gl/dynamicQuadMesh.h
@@ -133,7 +133,7 @@ bool DynamicQuadMesh<T>::draw(RenderState& rs, ShaderProgram& shader, int textur
             if (hasNextTextureBatch) {
                 verticesTextured = nextTextureBatch->startVertex;
             } else {
-                verticesTextured = RenderState::MAX_QUAD_VERTICES;
+                verticesTextured = verticesIndexed;
             }
         }
 


### PR DESCRIPTION
When texture batches are absent, the number of vertices considered 'textured' should
equal the number of vertices 'indexed'. The previous code would cause an infinite
loop of draw calls with zero vertices when meshes without texture batches had more
than RenderState::MAX_QUAD_VERTICES vertices.

Thanks @karimnaaji! 