### PR TITLE
Scene 'global' refactor

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -64,25 +64,12 @@ Scene::Scene(const Scene& _other)
     m_path = _other.m_path;
     m_resourceRoot = _other.m_resourceRoot;
 
+    m_globalRefs = _other.m_globalRefs;
+
     m_mapProjection.reset(new MercatorProjection());
 }
 
 Scene::~Scene() {}
-
-bool Scene::removeGlobalRef(const std::string& key) {
-    bool found = false;
-    for (auto& globalRef : m_referencedGlobals) {
-        if (globalRef.first == key) {
-            globalRef.swap(m_referencedGlobals.back());
-            m_referencedGlobals.pop_back();
-            LOG("Found keys: %s", key.c_str());
-            found = true;
-            break;
-        }
-    }
-
-    return found;
-}
 
 const Style* Scene::findStyle(const std::string& _name) const {
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -13,6 +13,7 @@
 
 #include "glm/vec2.hpp"
 #include "yaml-cpp/yaml.h"
+#include "util/yamlHelper.h"
 
 namespace Tangram {
 
@@ -25,6 +26,7 @@ class Light;
 class MapProjection;
 class SpriteAtlas;
 struct Stops;
+
 
 /* Singleton container of <Style> information
  *
@@ -74,8 +76,7 @@ public:
     auto& background() { return m_background; }
     auto& fontContext() { return m_fontContext; }
     auto& globals() { return m_globals; }
-    auto& referencedGlobals() { return m_referencedGlobals; }
-    bool removeGlobalRef(const std::string& key);
+    auto& globalRefs() { return m_globalRefs; }
     Style* findStyle(const std::string& _name);
 
     const auto& path() const { return m_path; }
@@ -89,7 +90,7 @@ public:
     const auto& mapProjection() const { return m_mapProjection; };
     const auto& fontContext() const { return m_fontContext; }
     const auto& globals() const { return m_globals; }
-    const auto& referencedGlobals() const { return m_referencedGlobals; }
+    const auto& globalRefs() const { return m_globalRefs; }
 
     const Style* findStyle(const std::string& _name) const;
     const Light* findLight(const std::string& _name) const;
@@ -139,9 +140,13 @@ private:
     std::vector<std::unique_ptr<Light>> m_lights;
     std::unordered_map<std::string, std::shared_ptr<Texture>> m_textures;
     std::unordered_map<std::string, std::shared_ptr<SpriteAtlas>> m_spriteAtlases;
+
+    // Contains all global nodes mapped by their delimited path in the scene config.
     std::unordered_map<std::string, YAML::Node> m_globals;
-    // save the YAML Nodes for which global values have been swapped
-    std::vector<std::pair<std::string, YAML::Node>> m_referencedGlobals;
+
+    // Records the YAML Nodes for which global values have been swapped; keys are
+    // nodes that referenced globals, values are nodes of globals themselves.
+    std::vector<std::pair<YamlPath, YamlPath>> m_globalRefs;
 
     // Container of all strings used in styling rules; these need to be
     // copied and compared frequently when applying styling, so rules use

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -75,7 +75,6 @@ public:
     auto& stops() { return m_stops; }
     auto& background() { return m_background; }
     auto& fontContext() { return m_fontContext; }
-    auto& globals() { return m_globals; }
     auto& globalRefs() { return m_globalRefs; }
     Style* findStyle(const std::string& _name);
 
@@ -89,7 +88,6 @@ public:
     const auto& functions() const { return m_jsFunctions; };
     const auto& mapProjection() const { return m_mapProjection; };
     const auto& fontContext() const { return m_fontContext; }
-    const auto& globals() const { return m_globals; }
     const auto& globalRefs() const { return m_globalRefs; }
 
     const Style* findStyle(const std::string& _name) const;
@@ -140,9 +138,6 @@ private:
     std::vector<std::unique_ptr<Light>> m_lights;
     std::unordered_map<std::string, std::shared_ptr<Texture>> m_textures;
     std::unordered_map<std::string, std::shared_ptr<SpriteAtlas>> m_spriteAtlases;
-
-    // Contains all global nodes mapped by their delimited path in the scene config.
-    std::unordered_map<std::string, YAML::Node> m_globals;
 
     // Records the YAML Nodes for which global values have been swapped; keys are
     // nodes that referenced globals, values are nodes of globals themselves.

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -128,25 +128,8 @@ void createGlobalRefsRecursive(Node node, Scene& scene, YamlPath path) {
     }
 }
 
-void parseGlobalsRecursive(const Node& node, Scene& scene, YamlPath path) {
-    switch (node.Type()) {
-    case NodeType::Scalar:
-    case NodeType::Sequence:
-        scene.globals()[path.codedPath] = node;
-        break;
-    case NodeType::Map:
-        scene.globals()[path.codedPath].reset(node);
-        for (const auto& entry : node) {
-            parseGlobalsRecursive(entry.second, scene, path.add(entry.first.Scalar()));
-        }
-    default:
-        break;
-    }
-}
-
 void SceneLoader::applyGlobals(Node root, Scene& scene) {
 
-    parseGlobalsRecursive(root["global"], scene, YamlPath("global"));
     createGlobalRefsRecursive(root, scene, YamlPath());
 
     for (auto& globalRef : scene.globalRefs()) {

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -44,9 +44,7 @@ struct SceneLoader {
     static bool loadConfig(const std::string& _sceneString, Node& _root);
     static bool applyConfig(Node& config, const std::shared_ptr<Scene>& scene);
     static void applyUpdates(Scene& scene, const std::vector<SceneUpdate>& updates);
-    static void applyUpdate(Node& root, const std::vector<std::string>& keys, Node value);
-    static void applyGlobalProperties(Node& node, const std::shared_ptr<Scene>& scene, const std::string& keys = "");
-    static void applyGlobalRefUpdates(Node& node, const std::shared_ptr<Scene>& scene);
+    static void applyGlobals(Node root, Scene& scene);
 
     /*** all public for testing ***/
 
@@ -91,7 +89,6 @@ struct SceneLoader {
 
     static bool parseStyleUniforms(const Node& value, const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
 
-    static void parseGlobals(const Node& node, const std::shared_ptr<Scene>& scene, const std::string& key="");
     static void parseLightPosition(Node position, PointLight& light);
 
     static bool loadStyle(const std::string& styleName, Node config, const std::shared_ptr<Scene>& scene);

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -70,7 +70,7 @@ public:
 
     bool setFunctions(const std::vector<std::string>& _functions);
     bool addFunction(const std::string& _function);
-    void setSceneGlobals(const std::unordered_map<std::string, YAML::Node>& sceneGlobals);
+    void setSceneGlobals(const YAML::Node& sceneGlobals);
 
     void setKeyword(const std::string& _key, Value _value);
     const Value& getKeyword(const std::string& _key) const;
@@ -81,7 +81,7 @@ private:
 
     bool evalFunction(FunctionID id);
     void parseStyleResult(StyleParamKey _key, StyleParam::Value& _val) const;
-    void parseSceneGlobals(const YAML::Node& node, const std::string& key, int seqIndex, int dukObject);
+    void parseSceneGlobals(const YAML::Node& node);
 
     std::array<Value, 4> m_keywords;
     int m_keywordGeom= -1;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -221,7 +221,6 @@ void Map::applySceneUpdates() {
         if (impl->sceneUpdates.empty()) { return; }
 
         impl->nextScene = std::make_shared<Scene>(*impl->scene);
-        impl->nextScene->referencedGlobals() = impl->scene->referencedGlobals();
         impl->nextScene->useScenePosition = false;
 
         updates = impl->sceneUpdates;

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -18,7 +18,7 @@ struct TouchItem {
 };
 
 struct SceneUpdate {
-    std::string keys;
+    std::string path;
     std::string value;
 };
 

--- a/core/src/util/yamlHelper.cpp
+++ b/core/src/util/yamlHelper.cpp
@@ -23,11 +23,11 @@ YamlPath YamlPath::add(const std::string& key) {
 }
 
 YAML::Node YamlPath::get(YAML::Node node) {
-    size_t beginToken = 0, endToken = 0;
+    size_t beginToken = 0, endToken = 0, pathSize = codedPath.size();
     auto delimiter = MAP_DELIM; // First token must be a map key.
-    while (endToken < codedPath.size()) {
+    while (endToken < pathSize) {
         beginToken = endToken;
-        endToken = codedPath.size();
+        endToken = pathSize;
         endToken = std::min(endToken, codedPath.find(SEQ_DELIM, beginToken));
         endToken = std::min(endToken, codedPath.find(MAP_DELIM, beginToken));
         if (delimiter == SEQ_DELIM) {
@@ -41,6 +41,9 @@ YAML::Node YamlPath::get(YAML::Node node) {
         }
         delimiter = codedPath[endToken]; // Get next character as the delimiter.
         ++endToken; // Move past the delimiter.
+        if (endToken < pathSize && !node) {
+            return Node(); // A node in the path was missing, return null node.
+        }
     }
     return node;
 }

--- a/core/src/util/yamlHelper.cpp
+++ b/core/src/util/yamlHelper.cpp
@@ -3,7 +3,47 @@
 #include "log.h"
 #include "csscolorparser.hpp"
 
+#define MAP_DELIM '.'
+#define SEQ_DELIM '#'
+
 namespace Tangram {
+
+YamlPath::YamlPath() {}
+
+YamlPath::YamlPath(const std::string& path)
+    : codedPath(path) {}
+
+YamlPath YamlPath::add(int index) {
+    return YamlPath(codedPath + SEQ_DELIM + std::to_string(index));
+}
+
+YamlPath YamlPath::add(const std::string& key) {
+    if (codedPath.empty()) { return YamlPath(key); }
+    return YamlPath(codedPath + MAP_DELIM + key);
+}
+
+YAML::Node YamlPath::get(YAML::Node node) {
+    size_t beginToken = 0, endToken = 0;
+    auto delimiter = MAP_DELIM; // First token must be a map key.
+    while (endToken < codedPath.size()) {
+        beginToken = endToken;
+        endToken = codedPath.size();
+        endToken = std::min(endToken, codedPath.find(SEQ_DELIM, beginToken));
+        endToken = std::min(endToken, codedPath.find(MAP_DELIM, beginToken));
+        if (delimiter == SEQ_DELIM) {
+            int index = std::stoi(&codedPath[beginToken]);
+            node.reset(node[index]);
+        } else if (delimiter == MAP_DELIM) {
+            auto key = codedPath.substr(beginToken, endToken - beginToken);
+            node.reset(node[key]);
+        } else {
+            return Node(); // Path is malformed, return null node.
+        }
+        delimiter = codedPath[endToken]; // Get next character as the delimiter.
+        ++endToken; // Move past the delimiter.
+    }
+    return node;
+}
 
 glm::vec4 getColorAsVec4(const Node& node) {
     double val;

--- a/core/src/util/yamlHelper.h
+++ b/core/src/util/yamlHelper.h
@@ -11,6 +11,17 @@ using YAML::BadConversion;
 
 namespace Tangram {
 
+// A YamlPath encodes the location of a node in a yaml document in a string,
+// e.g. "lorem.ipsum#0" identifies root["lorem"]["ipsum"][0]
+struct YamlPath {
+    YamlPath();
+    YamlPath(const std::string& path);
+    YamlPath add(int index);
+    YamlPath add(const std::string& key);
+    YAML::Node get(YAML::Node root);
+    std::string codedPath;
+};
+
 template<typename T>
 inline T parseVec(const Node& node) {
     T vec;

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -326,8 +326,7 @@ TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
 
     std::vector<StyleParam> styles;
 
-    SceneLoader::parseGlobals(n0["global"], scene);
-    SceneLoader::applyGlobalProperties(n0, scene);
+    scene->config() = n0;
 
     SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
 
@@ -335,7 +334,6 @@ TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
 
     StyleContext ctx;
     ctx.initFunctions(*scene);
-    ctx.setSceneGlobals(scene->globals());
 
     for (auto& style : styles) {
         if (style.key == StyleParamKey::color) {

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Apply scene update to a top-level node") {
     // Apply scene updates, reload scene.
     SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
-    REQUIRE(root["map"].Scalar() == "new_value");
+    CHECK(root["map"].Scalar() == "new_value");
 }
 
 TEST_CASE("Apply scene update to a map entry") {
@@ -50,7 +50,9 @@ TEST_CASE("Apply scene update to a map entry") {
     // Apply scene updates, reload scene.
     SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
-    REQUIRE(root["map"]["a"].Scalar() == "new_value");
+    CHECK(root["map"]["a"].Scalar() == "new_value");
+    // Check that nearby values are unchanged.
+    CHECK(root["map"]["b"].Scalar() == "global.b");
 }
 
 TEST_CASE("Apply scene update to a nested map entry") {
@@ -62,7 +64,9 @@ TEST_CASE("Apply scene update to a nested map entry") {
     // Apply scene updates, reload scene.
     SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
-    REQUIRE(root["nest"]["map"]["a"].Scalar() == "new_value");
+    CHECK(root["nest"]["map"]["a"].Scalar() == "new_value");
+    // Check that nearby values are unchanged.
+    CHECK(root["nest"]["map"]["b"].Scalar() == "nest_map_b_value");
 }
 
 TEST_CASE("Apply scene update to a sequence node") {
@@ -74,7 +78,7 @@ TEST_CASE("Apply scene update to a sequence node") {
     // Apply scene updates, reload scene.
     SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
-    REQUIRE(root["seq"].Scalar() == "new_value");
+    CHECK(root["seq"].Scalar() == "new_value");
 }
 
 TEST_CASE("Apply scene update to a nested sequence node") {
@@ -86,7 +90,9 @@ TEST_CASE("Apply scene update to a nested sequence node") {
     // Apply scene updates, reload scene.
     SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
-    REQUIRE(root["nest"]["seq"].Scalar() == "new_value");
+    CHECK(root["nest"]["seq"].Scalar() == "new_value");
+    // Check that nearby values are unchanged.
+    CHECK(root["nest"]["map"]["a"].Scalar() == "nest_map_a_value");
 }
 
 TEST_CASE("Apply scene update to a new map entry") {
@@ -98,7 +104,9 @@ TEST_CASE("Apply scene update to a new map entry") {
     // Apply scene updates, reload scene.
     SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
-    REQUIRE(root["map"]["c"].Scalar() == "new_value");
+    CHECK(root["map"]["c"].Scalar() == "new_value");
+    // Check that nearby values are unchanged.
+    CHECK(root["map"]["b"].Scalar() == "global.b");
 }
 
 // This was previously enforced but it didn't seem clearly useful or desirable,
@@ -126,7 +134,9 @@ TEST_CASE("Apply scene update that removes a node") {
     // Apply scene updates, reload scene.
     SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
-    REQUIRE(!root["nest"]["map"]["a"]);
+    CHECK(!root["nest"]["map"]["a"]);
+    CHECK(root["nest"]["map"].IsNull());
+    CHECK(root["nest"]["seq"]);
 }
 
 TEST_CASE("Apply multiple scene updates in order of request") {
@@ -138,7 +148,9 @@ TEST_CASE("Apply multiple scene updates in order of request") {
     // Apply scene updates, reload scene.
     SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
-    REQUIRE(root["map"]["a"].Scalar() == "second_value");
+    CHECK(root["map"]["a"].Scalar() == "second_value");
+    // Check that nearby values are unchanged.
+    CHECK(root["map"]["b"].Scalar() == "global.b");
 }
 
 TEST_CASE("Apply and propogate repeated global value updates") {
@@ -148,24 +160,24 @@ TEST_CASE("Apply and propogate repeated global value updates") {
     Node& root = scene.config();
     // Apply initial globals.
     SceneLoader::applyGlobals(root, scene);
-    REQUIRE(root["seq"][1].Scalar() == "global_a_value");
-    REQUIRE(root["map"]["b"].Scalar() == "global_b_value");
+    CHECK(root["seq"][1].Scalar() == "global_a_value");
+    CHECK(root["map"]["b"].Scalar() == "global_b_value");
     // Add an update.
     std::vector<SceneUpdate> updates = {{"global.b", "new_global_b_value"}};
     // Apply the update.
     SceneLoader::applyUpdates(scene, updates);
-    REQUIRE(root["global"]["b"].Scalar() == "new_global_b_value");
+    CHECK(root["global"]["b"].Scalar() == "new_global_b_value");
     // Apply updated globals.
     SceneLoader::applyGlobals(root, scene);
-    REQUIRE(root["seq"][1].Scalar() == "global_a_value");
-    REQUIRE(root["map"]["b"].Scalar() == "new_global_b_value");
+    CHECK(root["seq"][1].Scalar() == "global_a_value");
+    CHECK(root["map"]["b"].Scalar() == "new_global_b_value");
     // Add an update.
     updates = {{"global.b", "newer_global_b_value"}};
     // Apply the update.
     SceneLoader::applyUpdates(scene, updates);
-    REQUIRE(root["global"]["b"].Scalar() == "newer_global_b_value");
+    CHECK(root["global"]["b"].Scalar() == "newer_global_b_value");
     // Apply updated globals.
     SceneLoader::applyGlobals(root, scene);
-    REQUIRE(root["seq"][1].Scalar() == "global_a_value");
-    REQUIRE(root["map"]["b"].Scalar() == "newer_global_b_value");
+    CHECK(root["seq"][1].Scalar() == "global_a_value");
+    CHECK(root["map"]["b"].Scalar() == "newer_global_b_value");
 }

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -109,9 +109,6 @@ TEST_CASE("Apply scene update to a new map entry") {
     CHECK(root["map"]["b"].Scalar() == "global.b");
 }
 
-// This was previously enforced but it didn't seem clearly useful or desirable,
-// so I've now allowed updates like this. We'll see how it goes.
-/*
 TEST_CASE("Do not apply scene update to a non-existent node") {
     // Setup.
     Scene scene;
@@ -123,7 +120,6 @@ TEST_CASE("Do not apply scene update to a non-existent node") {
     const Node& root = scene.config();
     REQUIRE(!root["none"]);
 }
-*/
 
 TEST_CASE("Apply scene update that removes a node") {
     // Setup.


### PR DESCRIPTION
 - Add YamlPath struct
 - Use YamlPath to store locations of global values and nodes that reference them
 - Remove function to delete global references, to match behavior of tangram-js
 - Simplify SceneLoader functions for applying global values
 - Allow scene updates to operate on nodes that didn't previously exist (this was
   not intentional but seems to be the most natural behavior).
 - Fix issue where global references within sequences would not be updated
 - Simplify and clarify sceneUpdateTests
