### PR TITLE
Fix tizen url worker

### DIFF
--- a/tizen/inc/urlWorker.h
+++ b/tizen/inc/urlWorker.h
@@ -35,6 +35,7 @@ private:
     void run();
 
     std::mutex m_mutex;
+    std::mutex m_mutexInitCurl;
 
     std::condition_variable m_condition;
 

--- a/tizen/src/urlWorker.cpp
+++ b/tizen/src/urlWorker.cpp
@@ -120,5 +120,8 @@ void UrlWorker::stop() {
     for (auto& worker : m_workers) {
         worker->join();
     }
+
+    m_workers.clear();
+
     curl_global_cleanup();
 }

--- a/tizen/src/urlWorker.cpp
+++ b/tizen/src/urlWorker.cpp
@@ -34,7 +34,7 @@ void UrlWorker::run() {
     CURL* curlHandle;
 
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
+        std::lock_guard<std::mutex> lock(m_mutexInitCurl);
         curlHandle = curl_easy_init();
         // set up curl to perform fetch
         curl_easy_setopt(curlHandle, CURLOPT_WRITEFUNCTION, write_data);


### PR DESCRIPTION
This partially solves the timeouts in the tizen unit tests.

There are more test failures/time outs in the `map_view` APIs, but those seemed to be linked to `readyCb` work!