### PR TITLE
[WIP] Fix Crashes during Map teardown

### DIFF
--- a/core/common/platform_gl.cpp
+++ b/core/common/platform_gl.cpp
@@ -148,6 +148,15 @@ void GL::readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
                     GLenum format, GLenum type, GLvoid* pixels) {
     GL_CHECK(glReadPixels(x, y, width, height, format, type, pixels));
 }
+void GL::getBufferParameteriv(GLenum target, GLenum value, GLint * data) {
+    GL_CHECK(glGetBufferParameteriv(target, value, data));
+}
+bool GL::isBuffer(GLuint buffer) {
+    bool result = glIsBuffer(buffer);
+    GL_CHECK();
+    return result;
+}
+
 
 // Texture
 void GL::bindTexture(GLenum target, GLuint texture ) {

--- a/core/src/gl.h
+++ b/core/src/gl.h
@@ -232,6 +232,7 @@ typedef char            GLchar;
 #define GL_ELEMENT_ARRAY_BUFFER_BINDING 0x8895
 #define GL_STATIC_DRAW                  0x88E4
 #define GL_DYNAMIC_DRAW                 0x88E8
+#define GL_BUFFER_SIZE                  0x8764
 
 // Program
 #define GL_FRAGMENT_SHADER              0x8B30
@@ -297,6 +298,8 @@ struct GL {
     static void genBuffers(GLsizei n, GLuint *buffers);
     static void bufferData(GLenum target, GLsizeiptr size, const void *data, GLenum usage);
     static void bufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const void *data);
+    static void getBufferParameteriv(GLenum target, GLenum value, GLint * data);
+    static bool isBuffer(GLuint buffer);
 
     // Texture
     static void bindTexture(GLenum target, GLuint texture );

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -11,6 +11,7 @@
 #include "defaultPointTextureData.h"
 
 #include <limits>
+#include <thread>
 
 namespace Tangram {
 
@@ -312,7 +313,14 @@ GLuint RenderState::getQuadIndexBuffer() {
 }
 
 void RenderState::deleteQuadIndexBuffer() {
+    LOG("deleting thread: %d", std::this_thread::get_id());
+    LOG("m_quadIndexBuffer: %d", m_quadIndexBuffer);
+    LOG("m_indexBuffer handle: %d, set: %d", m_indexBuffer.handle, m_indexBuffer.set);
+    GLint size = 0;
+    GL::getBufferParameteriv(GL_ELEMENT_ARRAY_BUFFER, GL_BUFFER_SIZE, &size);
+    LOG("buffer size: %d", size);
     indexBufferUnset(m_quadIndexBuffer);
+    LOG("Is Buffer: %d", GL::isBuffer(m_quadIndexBuffer));
     GL::deleteBuffers(1, &m_quadIndexBuffer);
     m_quadIndexBuffer = 0;
 }
@@ -331,10 +339,16 @@ void RenderState::generateQuadIndexBuffer() {
         indices.push_back(i + 2);
     }
 
+    LOG("generating thread: %d", std::this_thread::get_id());
+    LOG("m_quadIndexBuffer: %d", m_quadIndexBuffer);
+    LOG("m_indexBuffer handle: %d, set: %d", m_indexBuffer.handle, m_indexBuffer.set);
     GL::genBuffers(1, &m_quadIndexBuffer);
     indexBuffer(m_quadIndexBuffer);
+    LOG("generating buffer size: %d", indices.size() * sizeof(GLushort));
     GL::bufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(GLushort),
                    reinterpret_cast<GLbyte*>(indices.data()), GL_STATIC_DRAW);
+    LOG("m_quadIndexBuffer: %d", m_quadIndexBuffer);
+    LOG("m_indexBuffer handle: %d, set: %d", m_indexBuffer.handle, m_indexBuffer.set);
 
 }
 

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -87,6 +87,9 @@ bool MarkerManager::setVisible(MarkerID markerID, bool visible) {
 }
 
 bool MarkerManager::setPoint(MarkerID markerID, LngLat lngLat) {
+
+    if (!m_scene) { return false; }
+
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
 
@@ -107,6 +110,9 @@ bool MarkerManager::setPoint(MarkerID markerID, LngLat lngLat) {
 }
 
 bool MarkerManager::setPointEased(MarkerID markerID, LngLat lngLat, float duration, EaseType ease) {
+
+    if (!m_scene) { return false; }
+
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
 
@@ -122,6 +128,9 @@ bool MarkerManager::setPointEased(MarkerID markerID, LngLat lngLat, float durati
 }
 
 bool MarkerManager::setPolyline(MarkerID markerID, LngLat* coordinates, int count) {
+
+    if (!m_scene) { return false; }
+
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
     if (!coordinates || count < 2) { return false; }
@@ -165,6 +174,9 @@ bool MarkerManager::setPolyline(MarkerID markerID, LngLat* coordinates, int coun
 }
 
 bool MarkerManager::setPolygon(MarkerID markerID, LngLat* coordinates, int* counts, int rings) {
+
+    if (!m_scene) { return false; }
+
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
     if (!coordinates || !counts || rings < 1) { return false; }
@@ -248,6 +260,8 @@ const std::vector<std::unique_ptr<Marker>>& MarkerManager::markers() const {
 }
 
 void MarkerManager::buildStyling(Marker& marker) {
+
+    if (!m_scene) { return; }
 
     // Update the draw rule for the marker.
     YAML::Node node = YAML::Load(marker.stylingString());

--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -122,7 +122,7 @@ int Filter::filterCost() const {
         // Most expensive filter should be checked last
         return 1000;
     }
-    assert(false);
+    //assert(false);
     return 0;
 }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -42,6 +42,8 @@ class Map::Impl {
 
 public:
 
+    Impl() = default;
+    ~Impl();
     void setScene(std::shared_ptr<Scene>& _scene);
 
     void setEase(EaseField _f, Ease _e);
@@ -77,6 +79,10 @@ public:
     std::atomic_bool valid;
 
 };
+
+Map::Impl::~Impl() {
+    jobQueue.runJobs();
+}
 
 void Map::Impl::setEase(EaseField _f, Ease _e) {
     eases[static_cast<size_t>(_f)] = _e;

--- a/core/src/util/jobQueue.cpp
+++ b/core/src/util/jobQueue.cpp
@@ -1,13 +1,17 @@
 #include "jobQueue.h"
+#include "log.h"
 
 namespace Tangram {
 
 JobQueue::~JobQueue() {
 
+    LOG("Destructing job queue");
+
     if (!m_jobs.empty()) {
         runJobs();
     }
 
+    LOG("DONE Destructing job queue");
 }
 
 void JobQueue::add(Job job) {
@@ -23,12 +27,16 @@ void JobQueue::runJobs() {
         Job job;
         {
             std::lock_guard<std::mutex> lock(m_mutex);
+            LOG("about to run %d job", i);
             job.swap(m_jobs[i]);
         }
+        LOG("run %d job", i);
         job();
+        LOG("done running %d job", i);
     }
     m_jobs.clear();
 
+    LOG("DONE!");
 }
 
 } //namespace Tangram


### PR DESCRIPTION
Currently there are multiple places where a crash happens on destruction when a sceneUpdate is enqueued.

One such crash is fixed by:  206c052

I have noticed another after fixing this, with the following stack trace:

```
TANGRAM jobQueue.cpp:35: done running 0 job
TANGRAM jobQueue.cpp:39: DONE!
TANGRAM jobQueue.cpp:14: DONE Destructing job queue
*** Error in `/home/varun/Development/tangram-es/build/linux/bin/tangram': free(): corrupted unsorted chunks: 0x000000000159cd50 ***

Program received signal SIGABRT, Aborted.
0x00007ffff590a1c7 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:55
55	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007ffff590a1c7 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:55
#1  0x00007ffff590be2a in __GI_abort () at abort.c:89
#2  0x00007ffff594dba3 in __libc_message (do_abort=do_abort@entry=1, fmt=fmt@entry=0x7ffff5a660f8 "*** Error in `%s': %s: 0x%s ***\n") at ../sysdeps/posix/libc_fatal.c:175
#3  0x00007ffff5955bb9 in malloc_printerr (ptr=<optimized out>, str=0x7ffff5a66198 "free(): corrupted unsorted chunks", action=1) at malloc.c:4965
#4  _int_free (av=<optimized out>, p=<optimized out>, have_lock=0) at malloc.c:3834
#5  0x00007ffff59597ec in __GI___libc_free (mem=<optimized out>) at malloc.c:2950
#6  0x00007fffee191bfd in ?? () from /usr/lib/x86_64-linux-gnu/dri/i965_dri.so
#7  0x00007fffee197ecc in ?? () from /usr/lib/x86_64-linux-gnu/dri/i965_dri.so
#8  0x00000000008fab02 in Tangram::GL::deleteBuffers (n=1, buffers=0x1297328) at /home/varun/Development/tangram-es/core/common/platform_gl.cpp:136
#9  0x0000000000a7e955 in Tangram::RenderState::deleteQuadIndexBuffer (this=0x12972a0) at /home/varun/Development/tangram-es/core/src/gl/renderState.cpp:316
#10 0x0000000000a7dc5c in Tangram::RenderState::~RenderState (this=0x12972a0, __in_chrg=<optimized out>) at /home/varun/Development/tangram-es/core/src/gl/renderState.cpp:45
#11 0x000000000094a0da in Tangram::Map::Impl::~Impl (this=0x1297250, __in_chrg=<optimized out>) at /home/varun/Development/tangram-es/core/src/tangram.cpp:41
#12 0x000000000094a100 in std::default_delete<Tangram::Map::Impl>::operator() (this=0x13b26b0, __ptr=0x1297250) at /usr/include/c++/5/bits/unique_ptr.h:76
#13 0x0000000000947987 in std::unique_ptr<Tangram::Map::Impl, std::default_delete<Tangram::Map::Impl> >::~unique_ptr (this=0x13b26b0, __in_chrg=<optimized out>) at /usr/include/c++/5/bits/unique_ptr.h:236
#14 0x000000000093e3ee in Tangram::Map::~Map (this=0x13b26b0, __in_chrg=<optimized out>) at /home/varun/Development/tangram-es/core/src/tangram.cpp:99
#15 0x00000000008efe21 in main (argc=3, argv=0x7fffffffdb78) at /home/varun/Development/tangram-es/linux/src/main.cpp:406
```

These are reproducible on Linux. And is also the cause of timeouts on tizen.