### PR TITLE
Fix crashes on teardown

### DIFF
--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -122,7 +122,6 @@ int Filter::filterCost() const {
         // Most expensive filter should be checked last
         return 1000;
     }
-    assert(false);
     return 0;
 }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -62,15 +62,19 @@ public:
     Labels labels;
     std::unique_ptr<AsyncWorker> asyncWorker = std::make_unique<AsyncWorker>();
     InputHandler inputHandler{view};
-    TileWorker tileWorker{MAX_WORKERS};
-    TileManager tileManager{tileWorker};
-    MarkerManager markerManager;
 
     std::vector<SceneUpdate> sceneUpdates;
     std::array<Ease, 4> eases;
 
     std::shared_ptr<Scene> scene = std::make_shared<Scene>();
     std::shared_ptr<Scene> nextScene = nullptr;
+
+    // NB: Destruction of (managed and loading) tiles must happen
+    // before implicit destruction of 'scene' above!
+    // In particular any references of Labels and Markers to FontContext
+    TileWorker tileWorker{MAX_WORKERS};
+    TileManager tileManager{tileWorker};
+    MarkerManager markerManager;
 
     bool cacheGlState;
 


### PR DESCRIPTION
Fixes 2 instances when tangram will crash on teardown:

1. An async task starts running when the `Map`'s destructor has been invoked by another thread. This causes certain states in the `Map::Impl` to be invalid and hence cause a crash. Plus, there is no point running these async scene loading tasks if map is being destroyed. (1724989)
2. Currently due to the order in which members of `Map::Impl` are destroyed, there are deleted references of `Impl` members which are used by the `jobs` of the `Map::Impl::JobQueue`. It makes sense for these jobs (`Map::Impl`'s jobs) to be run from within its destructor, to make sure all member references are valid during the running of these jobs. (e9737d5)