### PR TITLE
iOS framework bundle resources path resolution

### DIFF
--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -1,9 +1,9 @@
 include(${CMAKE_SOURCE_DIR}/toolchains/iOS.toolchain.cmake)
 
-add_definitions(-DPLATFORM_IOS)
-
 set(FRAMEWORK_NAME TangramMap)
 set(FRAMEWORK_VERSION "1.0")
+
+add_definitions(-DPLATFORM_IOS)
 
 set(BUILD_IOS_FRAMEWORK TRUE)
 


### PR DESCRIPTION
Update platform layer for iOS to fallback to tangram framework bundle when main executable bundle path resolution fails. This allows us dynamically resolve the absolute path of the resources put within the `.framework` file.