### PR TITLE
Point markers can draw in a specified order

### DIFF
--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -241,7 +241,8 @@ bool Labels::labelComparator(const LabelEntry& _a, const LabelEntry& _b) {
 }
 
 void Labels::sortLabels() {
-    std::sort(m_labels.begin(), m_labels.end(), Labels::labelComparator);
+    // Use stable sort so that relative ordering of markers is preserved.
+    std::stable_sort(m_labels.begin(), m_labels.end(), Labels::labelComparator);
 }
 
 void Labels::handleOcclusions(const ViewState& _viewState) {

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -73,8 +73,16 @@ void Marker::setVisible(bool visible) {
     m_visible = visible;
 }
 
+void Marker::setDrawOrder(int drawOrder) {
+    m_drawOrder = drawOrder;
+}
+
 int Marker::builtZoomLevel() const {
     return m_builtZoomLevel;
+}
+
+int Marker::drawOrder() const {
+    return m_drawOrder;
 }
 
 MarkerID Marker::id() const {
@@ -131,6 +139,10 @@ bool Marker::isEasing() const {
 
 bool Marker::isVisible() const {
     return m_visible;
+}
+
+bool Marker::compareByDrawOrder(const std::unique_ptr<Marker>& lhs, const std::unique_ptr<Marker>& rhs) {
+    return lhs->m_drawOrder < rhs->m_drawOrder;
 }
 
 } // namespace Tangram

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -57,6 +57,10 @@ public:
     // Set whether this marker should be visible.
     void setVisible(bool visible);
 
+    // Set the ordering of this marker relative to other markers.
+    // Markers with higher values are drawn 'above' those with lower values.
+    void setDrawOrder(int drawOrder);
+
     // Get the unique identifier for this marker. An ID of 0 indicates an invalid marker.
     MarkerID id() const;
 
@@ -65,6 +69,9 @@ public:
 
     // Get the zoom level at which the mesh for this marker was built.
     int builtZoomLevel() const;
+
+    // Get the ordering of this marker relative to other markers.
+    int drawOrder() const;
 
     // Get the length of the maximum dimension of the bounds of this marker. This is used as
     // the scale in the model matrix.
@@ -94,6 +101,8 @@ public:
 
     bool isVisible() const;
 
+    static bool compareByDrawOrder(const std::unique_ptr<Marker>& lhs, const std::unique_ptr<Marker>& rhs);
+
 protected:
 
     std::unique_ptr<Feature> m_feature;
@@ -109,6 +118,8 @@ protected:
     uint32_t m_styleId = 0;
 
     int m_builtZoomLevel = 0;
+
+    int m_drawOrder = 0;
 
     // Origin of marker geometry relative to global projection space.
     glm::dvec2 m_origin;

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -35,6 +35,9 @@ MarkerID MarkerManager::add() {
     auto id = ++m_idCounter;
     m_markers.push_back(std::make_unique<Marker>(id));
 
+    // Sort the marker list by draw order.
+    std::stable_sort(m_markers.begin(), m_markers.end(), Marker::compareByDrawOrder);
+
     // Return a handle for the marker.
     return id;
 
@@ -83,7 +86,17 @@ bool MarkerManager::setVisible(MarkerID markerID, bool visible) {
 
     marker->setVisible(visible);
     return true;
+}
 
+bool MarkerManager::setDrawOrder(MarkerID markerID, int drawOrder) {
+    Marker* marker = getMarkerOrNull(markerID);
+    if (!marker) { return false; }
+
+    marker->setDrawOrder(drawOrder);
+
+    // Sort the marker list by draw order.
+    std::stable_sort(m_markers.begin(), m_markers.end(), Marker::compareByDrawOrder);
+    return true;
 }
 
 bool MarkerManager::setPoint(MarkerID markerID, LngLat lngLat) {

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -36,6 +36,9 @@ public:
     // Set whether a marker should be visible; returns true if the marker was found and updated.
     bool setVisible(MarkerID markerID, bool visible);
 
+    // Set the ordering of this marker relative to other markers. Higher values are drawn 'above' others.
+    bool setDrawOrder(MarkerID markerID, int drawOrder);
+
     // Set a marker to a point feature at the given position; returns true if the marker was found and updated.
     bool setPoint(MarkerID markerID, LngLat lngLat);
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -668,6 +668,12 @@ bool Map::markerSetVisible(MarkerID _marker, bool _visible) {
     return success;
 }
 
+bool Map::markerSetDrawOrder(MarkerID _marker, int _drawOrder) {
+    bool success = impl->markerManager.setDrawOrder(_marker, _drawOrder);
+    requestRender();
+    return success;
+}
+
 void Map::markerRemoveAll() {
     impl->markerManager.removeAll();
     requestRender();

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -197,6 +197,10 @@ public:
     // updated, otherwise returns false.
     bool markerSetVisible(MarkerID _marker, bool _visible);
 
+    // Set the ordering of point marker object relative to other markers; higher values are drawn 'above';
+    // returns true if the marker ID was found and successfully updated, otherwise returns false.
+    bool markerSetDrawOrder(MarkerID _marker, int _drawOrder);
+
     // Remove all marker objects from the map; Any marker IDs previously returned from 'markerAdd'
     // are invalidated after this.
     void markerRemoveAll();

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -18,6 +18,7 @@ using namespace Tangram;
 void init_main_window(bool recreate);
 
 std::string sceneFile = "scene.yaml";
+std::string markerStyling = "{ style: 'points', color: 'white', size: [25px, 25px], order: 100, collide: false }";
 
 GLFWwindow* main_window = nullptr;
 Tangram::Map* map = nullptr;
@@ -43,6 +44,7 @@ double last_y_down = 0.0;
 double last_x_velocity = 0.0;
 double last_y_velocity = 0.0;
 bool scene_editing_mode = false;
+MarkerID marker = 0;
 
 std::shared_ptr<ClientGeoJsonSource> data_source;
 LngLat last_point;
@@ -96,27 +98,14 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
             }
         }
     } else if ((time - last_time_pressed) < single_tap_time) {
-        LngLat p1;
-        map->screenPositionToLngLat(x, y, &p1.longitude, &p1.latitude);
+        LngLat p;
+        map->screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
 
-        if (!(last_point == LngLat{0, 0})) {
-            LngLat p2 = last_point;
-
-            logMsg("add line %f %f - %f %f\n",
-                   p1.longitude, p1.latitude,
-                   p2.longitude, p2.latitude);
-
-            // Let's make variant public!
-            // data_source->addLine(Properties{{"type", "line" }}, {p1, p2});
-            // data_source->addPoint(Properties{{"type", "point" }}, p2);
-            Properties prop1;
-            prop1.set("type", "line");
-            data_source->addLine(prop1, {p1, p2});
-            Properties prop2;
-            prop2.set("type", "point");
-            data_source->addPoint(prop2, p2);
-        }
-        last_point = p1;
+        marker = map->markerAdd();
+        map->markerSetStyling(marker, markerStyling.c_str());
+        map->markerSetPoint(marker, p);
+        map->markerSetDrawOrder(marker, mods);
+        logMsg("Added marker with zOrder: %d\n", mods);
 
         // This updates the tiles (maybe we need a recalcTiles())
         requestRender();

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -101,11 +101,11 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
         LngLat p;
         map->screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
 
-        if (!marker) {
-            marker = map->markerAdd();
-            map->markerSetStyling(marker, markerStyling.c_str());
-        }
+        marker = map->markerAdd();
+        map->markerSetStyling(marker, markerStyling.c_str());
         map->markerSetPoint(marker, p);
+        map->markerSetDrawOrder(marker, mods);
+        logMsg("Added marker with zOrder: %d\n", mods);
 
         requestRender();
     }


### PR DESCRIPTION
Point markers can now have a `drawOrder` specified which determines their relative visual ordering among other point markers (in a painter's algorithm sense). 

This enables a tizen maps plugin feature: https://github.com/mapzen/tizen-maps-plugin-mapzen/issues/46