### PR TITLE
Resolve warnings on linux builds

### DIFF
--- a/core/src/data/dataSource.cpp
+++ b/core/src/data/dataSource.cpp
@@ -91,8 +91,9 @@ struct RawCache {
 
 DataSource::DataSource(const std::string& _name, const std::string& _urlTemplate,
                        int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom) :
-    m_name(_name), m_urlTemplate(_urlTemplate),
+    m_name(_name),
     m_minDisplayZoom(_minDisplayZoom), m_maxDisplayZoom(_maxDisplayZoom), m_maxZoom(_maxZoom),
+    m_urlTemplate(_urlTemplate),
     m_cache(std::make_unique<RawCache>()){
 
     static std::atomic<int32_t> s_serial;

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -152,7 +152,8 @@ void StyleContext::setSceneGlobals(const YAML::Node& sceneGlobals) {
     if (!sceneGlobals) { return; }
 
     //[ "ctx" ]
-    auto globalObject = duk_push_object(m_ctx);
+    // globalObject
+    duk_push_object(m_ctx);
 
     parseSceneGlobals(sceneGlobals);
 


### PR DESCRIPTION
This resolves all warnings on gcc 5.4 and clang 3.8.0 (package versions on ubuntu 16.04).
On gcc 4.9.4, there's a warning, but I'm inclined to just ignore it since it goes away with later versions. For posterity it is:

```
In file included from /home/rob/dev/cpp/tangram-es/core/src/scene/filters.cpp:1:0:
/home/rob/dev/cpp/tangram-es/core/src/scene/filters.h: In function ‘void std::swap(_Tp&, _Tp&) [with _Tp = Tangram::Filter]’:
/home/rob/dev/cpp/tangram-es/core/src/scene/filters.h:30:12: warning: ‘*((void*)& __tmp +40)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     struct EqualitySet {
            ^
In file included from /usr/include/c++/4.9/bits/stl_pair.h:59:0,
                 from /usr/include/c++/4.9/bits/stl_algobase.h:64,
                 from /usr/include/c++/4.9/bits/char_traits.h:39,
                 from /usr/include/c++/4.9/string:40,
                 from /usr/include/c++/4.9/stdexcept:39,
                 from /home/rob/dev/cpp/tangram-es/core/include/variant/include/mapbox/variant.hpp:7,
                 from /home/rob/dev/cpp/tangram-es/core/src/util/variant.h:11,
                 from /home/rob/dev/cpp/tangram-es/core/src/scene/filters.h:3,
                 from /home/rob/dev/cpp/tangram-es/core/src/scene/filters.cpp:1:
/usr/include/c++/4.9/bits/move.h:175:11: note: ‘*((void*)& __tmp +40)’ was declared here
       _Tp __tmp = _GLIBCXX_MOVE(__a);
           ^
```
