### PR TITLE
fixup: Adjust visibility of symbols in iOS Framework

### DIFF
--- a/toolchains/iOS.toolchain.cmake
+++ b/toolchains/iOS.toolchain.cmake
@@ -72,7 +72,7 @@ set (CMAKE_CXX_OSX_CURRENT_VERSION_FLAG "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}")
 # Hidden visibilty is required for cxx on iOS
 set (CMAKE_C_FLAGS_INIT "")
 
-if (BUILD_IOS_FRAMEWORK)
+if (NOT BUILD_IOS_FRAMEWORK)
     set (CMAKE_CXX_FLAGS_INIT "-fvisibility=hidden -fvisibility-inlines-hidden -isysroot ${CMAKE_OSX_SYSROOT}")
 endif ()
 


### PR DESCRIPTION
Was working locally because of CMake caching