### PR TITLE
Add robust URL handling and use it for scene imports

### DIFF
--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -254,6 +254,9 @@ void Importer::importScenesRecursive(Node& root, const Url& scenePath, std::vect
 
     auto imports = getResolvedImportUrls(sceneNode, scenePath);
 
+    // Don't want to merge imports, so remove them here.
+    sceneNode.remove("import");
+
     for (const auto& url : imports) {
 
         importScenesRecursive(root, url, sceneStack);
@@ -272,9 +275,6 @@ void Importer::mergeMapFields(Node& target, const Node& import) {
     for (const auto& entry : import) {
 
         const auto &key = entry.first.Scalar();
-
-        // do not merge ignore property
-        if (key == "import") { continue; }
 
         if (!target[key]) {
             target[key] = entry.second;

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -80,6 +80,11 @@ void Importer::processScene(const Url& scenePath, const std::string &sceneString
 
     LOGD("Process: '%s'", scenePath.string().c_str());
 
+    // Don't load imports twice
+    if (m_scenes.find(scenePath) != m_scenes.end()) {
+        return;
+    }
+
     try {
         auto sceneNode = YAML::Load(sceneString);
 

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -227,7 +227,11 @@ void Importer::importScenes(Node& root, const Url& scenePath, std::vector<Url>& 
     auto imports = getScenesToImport(sceneNode);
 
     for (const auto& importScene : imports) {
-        importScenes(root, importScene, sceneStack, globalTextures);
+        std::unordered_set<std::string> textures;
+
+        importScenes(root, importScene, sceneStack, textures);
+
+        for (auto& t : textures) { globalTextures.insert(t); }
     }
 
     // Resolve inline texture URLs after m_globalTextures are determined.

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -33,18 +33,19 @@ protected:
     std::vector<Url> getScenesToImport(const Node& scene);
 
     // loads all the imported scenes and the master scene and returns a unified YAML root node.
-    void importScenes(Node& root, const Url& scenePath, std::vector<Url>& sceneStack);
+    void importScenes(Node& root, const Url& scenePath, std::vector<Url>& sceneStack,
+                      std::unordered_set<std::string>& globalTextures);
 
     void mergeMapFields(Node& target, const Node& import);
 
-    void setResolvedTextureUrl(Node& textureNode, const Url& base);
+    void setResolvedTextureUrl(const std::unordered_set<std::string>& globalTextures,
+                               Node& textureNode, const Url& base);
 
     void resolveSceneUrls(Node& root, const Url& base);
 
 private:
     // import scene to respective root nodes
     std::unordered_map<Url, Node> m_scenes;
-    std::unordered_set<std::string> m_globalTextures;
 
     std::vector<Url> m_sceneQueue;
     static std::atomic_uint progressCounter;

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -10,11 +9,8 @@
 #include <atomic>
 #include <condition_variable>
 
-#include "util/fastmap.h"
-
-namespace YAML {
-    class Node;
-}
+#include "util/url.h"
+#include "yaml-cpp/yaml.h"
 
 namespace Tangram {
 
@@ -24,39 +20,33 @@ public:
 
     using Node = YAML::Node;
 
-    // Loads the main scene with deep merging dependentent imported scenes.
-    Node applySceneImports(const std::string& scenePath, const std::string& resourceRoot = "");
+    // Loads the main scene with deep merging dependent imported scenes.
+    Node applySceneImports(const Url& scenePath, const Url& resourceRoot = Url());
 
 // protected for testing purposes, else could be private
 protected:
-    virtual std::string getSceneString(const std::string& scenePath);
-    void processScene(const std::string& scenePath, const std::string& sceneString);
+    virtual std::string getSceneString(const Url& scenePath);
+    void processScene(const Url& scenePath, const std::string& sceneString);
 
     // Get the sequence of scene names that are designated to be imported into the
     // input scene node by its 'import' fields.
-    std::vector<std::string> getScenesToImport(const Node& scene);
+    std::vector<Url> getScenesToImport(const Node& scene);
 
     // loads all the imported scenes and the master scene and returns a unified YAML root node.
-    void importScenes(Node& root, const std::string& sceneName, std::vector<std::string>& sceneStack);
+    void importScenes(Node& root, const Url& scenePath, std::vector<Url>& sceneStack);
 
-    //void mergeMapFieldsTaskingLast(const std::string& key, Node target, const std::vector<Node>& imports);
     void mergeMapFields(Node& target, const Node& import);
 
-    void normalizeSceneTextures(Node& root, const std::string& parentPath);
-    void setNormalizedTexture(Node& texture, const std::vector<std::string>& names,
-            const std::string& parentPath);
-    void normalizeSceneImports(Node& root, const std::string& parentPath);
-    void normalizeSceneDataSources(Node& root, const std::string& parentPath);
-    void normalizeFonts(Node& root, const std::string& parentPath);
-    std::string normalizePath(const std::string& path, const std::string& parentPath);
+    void setResolvedTextureUrl(Node& textureNode, const Url& base);
+
+    void resolveSceneUrls(Node& root, const Url& base);
 
 private:
     // import scene to respective root nodes
-    std::map<std::string, Node> m_scenes;
+    std::unordered_map<Url, Node> m_scenes;
     std::unordered_set<std::string> m_globalTextures;
-    std::unordered_map<std::string, std::string> m_textureNames;
 
-    std::vector<std::string> m_sceneQueue;
+    std::vector<Url> m_sceneQueue;
     static std::atomic_uint progressCounter;
     std::mutex sceneMutex;
     std::condition_variable m_condition;

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -26,20 +26,17 @@ public:
 // protected for testing purposes, else could be private
 protected:
     virtual std::string getSceneString(const Url& scenePath);
+
     void processScene(const Url& scenePath, const std::string& sceneString);
 
     // Get the sequence of scene names that are designated to be imported into the
     // input scene node by its 'import' fields.
-    std::vector<Url> getScenesToImport(const Node& scene);
+    std::vector<Url> getResolvedImportUrls(const Node& scene, const Url& base);
 
     // loads all the imported scenes and the master scene and returns a unified YAML root node.
-    void importScenes(Node& root, const Url& scenePath, std::vector<Url>& sceneStack,
-                      std::unordered_set<std::string>& globalTextures);
+    void importScenesRecursive(Node& root, const Url& scenePath, std::vector<Url>& sceneStack);
 
     void mergeMapFields(Node& target, const Node& import);
-
-    void setResolvedTextureUrl(const std::unordered_set<std::string>& globalTextures,
-                               Node& textureNode, const Url& base);
 
     void resolveSceneUrls(Node& root, const Url& base);
 

--- a/core/src/util/url.cpp
+++ b/core/src/util/url.cpp
@@ -1,0 +1,487 @@
+#include "url.h"
+#include <cstdlib>
+#include <cassert>
+
+namespace Tangram {
+
+Url::Url() {}
+
+Url::Url(const std::string& source) :
+    buffer(source) {
+    parse();
+}
+
+Url::Url(std::string&& source) :
+    buffer(source) {
+    parse();
+}
+
+Url::Url(const char* source) :
+    buffer(source) {
+    parse();
+}
+
+Url::Url(const Url& other) :
+    buffer(other.buffer),
+    parts(other.parts),
+    flags(other.flags) {
+}
+
+Url::Url(Url&& other) :
+    buffer(std::move(other.buffer)),
+    parts(other.parts),
+    flags(other.flags) {
+}
+
+Url& Url::operator=(const Url& other) {
+    buffer = other.buffer;
+    parts = other.parts;
+    flags = other.flags;
+    return *this;
+}
+
+Url& Url::operator=(Url&& other) {
+    buffer = std::move(other.buffer);
+    parts = other.parts;
+    flags = other.flags;
+    return *this;
+}
+
+bool Url::operator==(const Url& rhs) const {
+    return buffer == rhs.buffer;
+}
+
+bool Url::isEmpty() const {
+    return buffer.empty();
+}
+
+bool Url::isAbsolute() const {
+    return (flags & IS_ABSOLUTE);
+}
+
+bool Url::isStandardized() const {
+    return (flags & IS_STANDARDIZED);
+}
+
+bool Url::hasHttpScheme() const {
+    return (flags & HAS_HTTP_SCHEME);
+}
+
+bool Url::hasFileScheme() const {
+    return (flags & HAS_FILE_SCHEME);
+}
+
+bool Url::hasDataScheme() const {
+    return (flags & HAS_DATA_SCHEME);
+}
+
+bool Url::hasBase64Data() const {
+    return (flags & HAS_BASE64_DATA);
+}
+
+bool Url::hasScheme() const {
+    return parts.scheme.count != 0;
+}
+
+bool Url::hasNetLocation() const {
+    return parts.location.count != 0;
+}
+
+bool Url::hasPath() const {
+    return parts.path.count != 0;
+}
+
+bool Url::hasParameters() const {
+    return parts.parameters.count != 0;
+}
+
+bool Url::hasQuery() const {
+    return parts.query.count != 0;
+}
+
+bool Url::hasFragment() const {
+    return parts.fragment.count != 0;
+}
+
+bool Url::hasMediaType() const {
+    return parts.media.count != 0;
+}
+
+bool Url::hasData() const {
+    return parts.data.count != 0;
+}
+
+std::string Url::scheme() const {
+    return std::string(buffer, parts.scheme.start, parts.scheme.count);
+}
+
+std::string Url::netLocation() const {
+    return std::string(buffer, parts.location.start, parts.location.count);
+}
+
+std::string Url::path() const {
+    return std::string(buffer, parts.path.start, parts.path.count);
+}
+
+std::string Url::parameters() const {
+    return std::string(buffer, parts.parameters.start, parts.parameters.count);
+}
+
+std::string Url::query() const {
+    return std::string(buffer, parts.query.start, parts.query.count);
+}
+
+std::string Url::fragment() const {
+    return std::string(buffer, parts.fragment.start, parts.fragment.count);
+}
+
+std::string Url::mediaType() const {
+    return std::string(buffer, parts.media.start, parts.media.count);
+}
+
+std::string Url::data() const {
+    return std::string(buffer, parts.data.start, parts.data.count);
+}
+
+const std::string& Url::string() const {
+    return buffer;
+}
+
+Url Url::standardized() const {
+
+    // If this URL is already standardized, return a copy.
+    if (isStandardized()) {
+        return *this;
+    }
+
+    // If this is a data URI, return a copy.
+    if (hasDataScheme()) {
+        return *this;
+    }
+
+    // Create the target URL by copying this URL.
+    Url t(*this);
+
+    // Remove any dot segments from the path.
+    size_t count = removeDotSegmentsFromRange(t.buffer, t.parts.path.start, t.parts.path.count);
+
+    if (count != t.parts.path.count) {
+
+        // The new path should always be the same size or shorter.
+        assert(count < t.parts.path.count);
+        size_t offset = t.parts.path.count - count;
+
+        // Adjust the size of the 'path' part.
+        t.parts.path.count = count;
+
+        // Remove any extra parts of the old path from the string.
+        t.buffer.erase(t.parts.path.start + t.parts.path.count, offset);
+
+        // Adjust the locations of the URL parts after 'path'.
+        t.parts.parameters.start -= offset;
+        t.parts.query.start -= offset;
+        t.parts.fragment.start -= offset;
+    }
+
+    // Set the standardized flag.
+    t.flags |= IS_STANDARDIZED;
+
+    return t;
+}
+
+Url Url::resolved(const Url& base) const {
+    return resolve(base, *this);
+}
+
+Url Url::resolve(const Url& b, const Url& r) {
+    // https://tools.ietf.org/html/rfc1808#section-4
+    // https://tools.ietf.org/html/rfc3986#section-5.2
+
+    // If the base URL is empty or the relative URL is already absolute, return the relative URL.
+    // This includes the case where the relative URL is a data URI.
+    if (r.isAbsolute() || b.isEmpty()) {
+        return r.standardized();
+    }
+
+    // If the relative URL is empty, return the base URL.
+    if (r.isEmpty()) {
+        return b;
+    }
+
+    // Start composing the new target URL.
+    Url t;
+
+    // Take the scheme from the base URL.
+    if (b.hasScheme()) {
+        t.parts.scheme = b.parts.scheme;
+        t.buffer.append(b.buffer, b.parts.scheme.start, b.parts.scheme.count);
+        t.buffer.append("://");
+    }
+
+    // Resolve the netLocation.
+    t.parts.location.start = t.buffer.size();
+    if (r.hasNetLocation()) {
+        // If the relative URL has a netLocation, use it for the new URL.
+        t.buffer.append(r.buffer, r.parts.location.start, r.parts.location.count);
+    } else {
+        // Use the netLocation of the base in the new URL.
+        t.buffer.append(b.buffer, b.parts.location.start, b.parts.location.count);
+    }
+    t.parts.location.count = t.buffer.size() - t.parts.location.start;
+
+    // Resolve the path.
+    t.parts.path.start = t.buffer.size();
+    if (r.hasNetLocation()) {
+        // If the relative URL has a netLocation, use its path as well.
+        t.buffer.append(r.buffer, r.parts.path.start, r.parts.path.count);
+    } else if (r.hasPath()) {
+        // If the relative URL's path starts with '/', it is absolute.
+        if (r.buffer[r.parts.path.start] == '/') {
+            t.buffer.append(r.buffer, r.parts.path.start, r.parts.path.count);
+        } else {
+            // Merge the relative path with the base path.
+            if (b.hasNetLocation() && !b.hasPath()) {
+                t.buffer.append("/");
+                t.buffer.append(r.buffer, r.parts.path.start, r.parts.path.count);
+            } else {
+                // Add the base URL's path.
+                t.buffer.append(b.buffer, b.parts.path.start, b.parts.path.count);
+                // Remove the last segment of the base URL's path.
+                size_t end = removeLastSegmentFromRange(t.buffer, t.parts.path.start, t.buffer.size());
+                t.buffer.resize(end);
+                // Add the relative URL's path.
+                if (r.buffer[r.parts.path.start] != '/') {
+                    t.buffer += '/';
+                }
+                t.buffer.append(r.buffer, r.parts.path.start, r.parts.path.count);
+            }
+        }
+    } else {
+        // If the relative URL has no netLocation or path, use the base URL's path.
+        t.buffer.append(b.buffer, b.parts.path.start, b.parts.path.count);
+    }
+    t.parts.path.count = t.buffer.size() - t.parts.path.start;
+
+    // Remove dot segments from the resolved path.
+    t.parts.path.count = removeDotSegmentsFromRange(t.buffer, t.parts.path.start, t.parts.path.count);
+    t.buffer.resize(t.parts.path.start + t.parts.path.count);
+
+    // Resolve the parameters.
+    t.parts.parameters.start = t.buffer.size();
+    if (r.hasParameters()) {
+        // If the relative URL has parameters, use it in the new URL.
+        t.buffer += ';';
+        t.parts.parameters.start += 1;
+        t.parts.parameters.count = r.parts.parameters.count;
+        t.buffer.append(r.buffer, r.parts.parameters.start, r.parts.parameters.count);
+    } else if (b.hasParameters() && !(r.hasNetLocation() || r.hasPath())) {
+        // Use the base URL parameters.
+        t.buffer += ';';
+        t.parts.parameters.start += 1;
+        t.parts.parameters.count = b.parts.parameters.count;
+        t.buffer.append(b.buffer, b.parts.parameters.start, b.parts.parameters.count);
+    }
+    t.parts.parameters.count = t.buffer.size() - t.parts.parameters.start;
+
+    // Resolve the query.
+    t.parts.query.start = t.buffer.size();
+    if (r.hasQuery()) {
+        // If this URL has a query, use it in the new URL.
+        t.buffer += '?';
+        t.parts.query.start += 1;
+        t.buffer.append(r.buffer, r.parts.query.start, r.parts.query.count);
+    } else if (b.hasQuery() && !(r.hasNetLocation() || r.hasPath() || r.hasParameters())) {
+        // Use the base URL query.
+        t.buffer += '?';
+        t.parts.query.start += 1;
+        t.buffer.append(b.buffer, b.parts.query.start, b.parts.query.count);
+    }
+    t.parts.query.count = t.buffer.size() - t.parts.query.start;
+
+    // Use the fragment from the relative URL.
+    t.parts.fragment.start = t.buffer.size();
+    if (r.hasFragment()) {
+        t.buffer += '#';
+        t.parts.fragment.start += 1;
+        t.buffer.append(r.buffer, r.parts.fragment.start, r.parts.fragment.count);
+    }
+    t.parts.fragment.count = t.buffer.size() - t.parts.fragment.start;
+
+    // Flags can be copied from the base URL.
+    t.flags = b.flags;
+
+    // The path had dot segments removed, so we can set the standardized flag.
+    t.flags |= IS_STANDARDIZED;
+
+    return t;
+}
+
+std::string Url::removeDotSegmentsFromString(std::string path) {
+    auto count = removeDotSegmentsFromRange(path, 0, path.size());
+    path.resize(count);
+    return path;
+}
+
+void Url::parse() {
+
+    // The parsing process roughly follows https://tools.ietf.org/html/rfc1808#section-2.4
+
+    size_t start = 0;
+    size_t end = buffer.size();
+
+    // Parse the fragment.
+    {
+        // If there's a '#' in the string, the substring after it to the end is the fragment.
+        auto pound = std::min(buffer.find('#', start), end);
+        parts.fragment.start = std::min(pound + 1, end);
+        parts.fragment.count = end - parts.fragment.start;
+
+        // Remove the '#' and fragment from parsing.
+        end = pound;
+    }
+
+    // Parse the scheme.
+    {
+        size_t i = start;
+        auto c = buffer[i];
+
+        // A scheme is permitted to contain only alphanumeric characters, '+', '.', and '-'.
+        while (i < end && (isalnum(c) || c == '+' || c == '.' || c == '-')) {
+            c = buffer[++i];
+        }
+
+        // If a scheme is present, it must be followed by a ':'.
+        if (c == ':') {
+            parts.scheme.start = start;
+            parts.scheme.count = i - start;
+
+            // Remove the scheme and ':' from parsing.
+            start = i + 1;
+
+            // Set the absolute URL flag.
+            flags |= IS_ABSOLUTE;
+        }
+    }
+
+    // If scheme is 'data', parse as data URI.
+    if (buffer.compare(parts.scheme.start, parts.scheme.count, "data") == 0) {
+
+        // Set the data scheme flag.
+        flags |= HAS_DATA_SCHEME;
+
+        // A data scheme will be followed by a media type, then either a comma or a base 64 indicator string.
+        auto base64Indicator = std::min(buffer.find(";base64", start), end);
+        auto comma = std::min(buffer.find(',', start), end);
+
+        // If the base 64 indicator string is found before the comma, set the matching flag.
+        if (base64Indicator < comma) {
+            flags |= HAS_BASE64_DATA;
+        }
+
+        // The media type goes from the colon after the scheme up to either the comma or the base 64 string.
+        parts.media.start = start;
+        parts.media.count = std::min(base64Indicator, comma) - start;
+
+        // The data section is separated by a comma and goes to the end of the URI.
+        start = std::min(comma + 1, end);
+        parts.data.start = start;
+        parts.data.count = end - start;
+
+        // We're done!
+        return;
+    }
+
+    // Check whether the scheme is 'http', 'https', or 'file' and set appropriate flags.
+    if (buffer.compare(parts.scheme.start, parts.scheme.count, "http") == 0 ||
+        buffer.compare(parts.scheme.start, parts.scheme.count, "https") == 0) {
+        flags |= HAS_HTTP_SCHEME;
+    } else if (buffer.compare(parts.scheme.start, parts.scheme.count, "file") == 0) {
+        flags |= HAS_FILE_SCHEME;
+    }
+
+    // If '//' is next in the string, then the substring up to the following '/' is the network location.
+    if (buffer.compare(start, 2, "//") == 0) {
+        start += 2;
+        auto slash = std::min(buffer.find('/', start), end);
+        parts.location.start = start;
+        parts.location.count = slash - start;
+
+        // Remove the network location from parsing.
+        start = slash;
+    }
+
+    // Parse the query.
+    {
+        // If there's a '?' in the remaining string, the substring after it to the end is the query string.
+        auto qmark = std::min(buffer.find('?', start), end);
+        parts.query.start = std::min(qmark + 1, end);
+        parts.query.count = end - parts.query.start;
+
+        // Remove the '?' and query from parsing.
+        end = qmark;
+    }
+
+    // Parse the parameters.
+    {
+        // If there's a ';' in the remaining string, the substring after it to the end is the parameters string.
+        auto semicolon = std::min(buffer.find(';', start), end);
+        parts.parameters.start = std::min(semicolon + 1, end);
+        parts.parameters.count = end - parts.parameters.start;
+
+        // Remove the ';' and parameters from parsing.
+        end = semicolon;
+    }
+
+    // Parse the path. After the preceding steps, the remaining string is the URL path.
+    parts.path.start = start;
+    parts.path.count = end - start;
+
+}
+
+size_t Url::removeLastSegmentFromRange(std::string& string, size_t start, size_t end) {
+    if (start >= end) { return start; }
+    size_t pos = end - 1;
+    while (pos > start && string[pos] != '/') { pos--; }
+    return pos;
+}
+
+size_t Url::removeDotSegmentsFromRange(std::string& str, size_t start, size_t count) {
+
+    // Implements https://tools.ietf.org/html/rfc3986#section-5.2.4
+    // with in-place manipulation instead of making a new buffer.
+
+    size_t end = start + count;
+    size_t pos = start; // 'input' position.
+    size_t out = pos; // 'output' position.
+
+    while (pos < end) {
+        if (str[pos] == '.' && str[pos + 1] == '.' && str[pos + 2] == '/') {
+            pos += 3;
+        } else if (str[pos] == '.' && str[pos + 1] == '/') {
+            pos += 2;
+        } else if (str[pos] == '/' && str[pos + 1] == '.' && str[pos + 2] == '/') {
+            pos += 2;
+        } else if (str[pos] == '/' && str[pos + 1] == '.' && pos + 2 == end) {
+            pos += 1;
+            str[pos] = '/';
+        } else if (str[pos] == '/' && str[pos + 1] == '.' && str[pos + 2] == '.' && str[pos + 3] == '/') {
+            pos += 3;
+            out = removeLastSegmentFromRange(str, start, out);
+        } else if (str[pos] == '/' && str[pos + 1] == '.' && str[pos + 2] == '.' && pos + 3 == end) {
+            pos += 3;
+            out = removeLastSegmentFromRange(str, start, out);
+        } else if (str[pos] == '.' && pos + 1 == end) {
+            pos += 1;
+        } else if (str[pos] == '.' && str[pos + 1] == '.' && pos + 2 == end) {
+            pos += 2;
+        } else {
+            do {
+                str[out++] = str[pos++];
+            } while (pos < end && str[pos] != '/');
+        }
+    }
+
+    return out - start;
+}
+
+} // namespace Tangram

--- a/core/src/util/url.cpp
+++ b/core/src/util/url.cpp
@@ -455,24 +455,44 @@ size_t Url::removeDotSegmentsFromRange(std::string& str, size_t start, size_t co
     size_t out = pos; // 'output' position.
 
     while (pos < end) {
-        if (str[pos] == '.' && str[pos + 1] == '.' && str[pos + 2] == '/') {
+        if (pos + 2 < end &&
+                   str[pos] == '.' &&
+                   str[pos + 1] == '.' &&
+                   str[pos + 2] == '/') {
             pos += 3;
-        } else if (str[pos] == '.' && str[pos + 1] == '/') {
+        } else if (pos + 1 < end &&
+                   str[pos] == '.' &&
+                   str[pos + 1] == '/') {
             pos += 2;
-        } else if (str[pos] == '/' && str[pos + 1] == '.' && str[pos + 2] == '/') {
+        } else if (pos + 2 < end &&
+                   str[pos] == '/' &&
+                   str[pos + 1] == '.' &&
+                   str[pos + 2] == '/') {
             pos += 2;
-        } else if (str[pos] == '/' && str[pos + 1] == '.' && pos + 2 == end) {
+        } else if (pos + 2 == end &&
+                   str[pos] == '/' &&
+                   str[pos + 1] == '.') {
             pos += 1;
             str[pos] = '/';
-        } else if (str[pos] == '/' && str[pos + 1] == '.' && str[pos + 2] == '.' && str[pos + 3] == '/') {
+        } else if (pos + 3 < end &&
+                   str[pos] == '/' &&
+                   str[pos + 1] == '.' &&
+                   str[pos + 2] == '.' &&
+                   str[pos + 3] == '/') {
             pos += 3;
             out = removeLastSegmentFromRange(str, start, out);
-        } else if (str[pos] == '/' && str[pos + 1] == '.' && str[pos + 2] == '.' && pos + 3 == end) {
+        } else if (pos + 3 == end &&
+                   str[pos] == '/' &&
+                   str[pos + 1] == '.' &&
+                   str[pos + 2] == '.') {
             pos += 3;
             out = removeLastSegmentFromRange(str, start, out);
-        } else if (str[pos] == '.' && pos + 1 == end) {
+        } else if (pos + 1 == end &&
+                   str[pos] == '.') {
             pos += 1;
-        } else if (str[pos] == '.' && str[pos + 1] == '.' && pos + 2 == end) {
+        } else if (pos + 2 == end &&
+                   str[pos] == '.' &&
+                   str[pos + 1] == '.') {
             pos += 2;
         } else {
             do {

--- a/core/src/util/url.h
+++ b/core/src/util/url.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <string>
+
+namespace Tangram {
+
+// This class is based on the URL concept specified by IETF RFC 1808
+// (https://tools.ietf.org/html/rfc1808) and the URI concept specified by
+// IETF RFC 3986 (https://tools.ietf.org/html/rfc3986) In particular this
+// class is intended to handle URLs using the 'http' and 'file' schemes,
+// with special case handling of some data URIs.
+//
+// URLs are decomposed as:
+//
+// foo://user:pword@host.com:80/over/there;type=a?name=ferret#nose
+// \_/   \____________________/\_________/ \____/ \_________/ \__/
+//  |              |               |         |         |       |
+// scheme      netLocation        path   parameters  query  fragment
+//
+// Data URIs are decomposed as:
+//
+// data:image/png;base64,iVBORw0KGgoAAAANSUhE... (abbreviated)
+// \__/ \_______/ \____/ \__________________ _ _
+//  |       |       |         |
+// scheme mediaType isBase64 data
+//
+// Ideas were borrowed from:
+// https://github.com/cpp-netlib/uri/blob/master/include/network/uri/uri.hpp
+// https://github.com/opensource-apple/CF/blob/master/CFURL.h
+//
+
+class Url {
+
+public:
+
+    // Create an empty URL.
+    Url();
+
+    // Create an absolute or relative URL from a string.
+    Url(const std::string& source);
+    Url(std::string&& source);
+    Url(const char* source);
+
+    // Create a URL by copy.
+    Url(const Url& other);
+
+    // Create a URL by move.
+    Url(Url&& other);
+
+    // Replace the contents of this URL.
+    Url& operator=(const Url& other);
+    Url& operator=(Url&& other);
+
+    // Compare this URL and another using their string representations.
+    bool operator==(const Url& other) const;
+
+    // Query the state of this URL.
+    bool isEmpty() const;
+    bool isAbsolute() const;
+    bool isStandardized() const;
+    bool hasHttpScheme() const;
+    bool hasFileScheme() const;
+    bool hasDataScheme() const;
+    bool hasBase64Data() const;
+
+    // Query the presence of URL components.
+    bool hasScheme() const;
+    bool hasNetLocation() const;
+    bool hasPath() const;
+    bool hasParameters() const;
+    bool hasQuery() const;
+    bool hasFragment() const;
+
+    // Query the presence of data URI components.
+    bool hasMediaType() const;
+    bool hasData() const;
+
+    // Get copies of URL components.
+    std::string scheme() const;
+    std::string netLocation() const;
+    std::string path() const;
+    std::string parameters() const;
+    std::string query() const;
+    std::string fragment() const;
+
+    // Get copies of data URI components.
+    std::string mediaType() const;
+    std::string data() const;
+
+    // Get the entire URL as a string.
+    const std::string& string() const;
+
+    // Get an equivalent URL with dot segments removed from the path. If this is
+    // a data URI then the same URI is returned.
+    Url standardized() const;
+
+    // Get an absolute URL by applying this URL relative to the given base.
+    // e.g. "example.com/a/b/c.txt" == ("b/c.txt").resolved("example.com/a/")
+    Url resolved(const Url& base) const;
+
+    // Get an absolute URL by applying a relative URL to a base URL.
+    // e.g. "example.com/a/b/c.txt" == resolve("example.com/a/", "b/c.txt")
+    static Url resolve(const Url& base, const Url& relative);
+
+    // Remove any '.' or '..' segments from a string containing a heirarchical path
+    // and return a modified copy of the string.
+    static std::string removeDotSegmentsFromString(std::string path);
+
+private:
+
+    // buffer contains the actual text of the URL.
+    std::string buffer;
+
+    // parts describes URL components by their location within the buffer.
+    struct Parts {
+        struct Range {
+            size_t start = 0, count = 0;
+        } scheme, location, path, parameters, query, fragment, media, data;
+    } parts;
+
+    // flags contains Boolean information about the URL state.
+    int flags = 0;
+
+    // flags uses these bitmasks.
+    enum {
+        IS_ABSOLUTE =     1 << 0,
+        IS_STANDARDIZED = 1 << 1,
+        HAS_HTTP_SCHEME = 1 << 2,
+        HAS_FILE_SCHEME = 1 << 3,
+        HAS_DATA_SCHEME = 1 << 4,
+        HAS_BASE64_DATA = 1 << 5,
+    };
+
+    // parse the URL parts and flags from the source text.
+    void parse();
+
+    // Remove the last segment and its preceding '/' (if any) from a string range
+    // containing a heirarchical path and return the index past the end of the new path.
+    static size_t removeLastSegmentFromRange(std::string& string, size_t start, size_t count);
+
+    // Remove any '.' or '..' segments from a string range containing a heirarchical
+    // path and return the size of the new path.
+    static size_t removeDotSegmentsFromRange(std::string& string, size_t start, size_t count);
+
+}; // class Url
+
+} // namespace Tangram
+
+// A hash function allows Tangram::Url to be a key type for STL containers.
+// To match the '==' operator, the hash function should only use the string value.
+namespace std {
+    template <>
+    struct hash<Tangram::Url> {
+        size_t operator()(const Tangram::Url& url) const {
+            return std::hash<std::string>{}(url.string());
+        }
+    };
+}

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -59,7 +59,7 @@ TestImporter::TestImporter() {
     m_testScenes["/root/urls.yaml"] = R"END(
         import: imports/urls.yaml
         fonts: { fontA: { url: https://host/font.woff } }
-        sources: { sourceA: { url: "https://host/tiles/{z}/{y}/{x}.mvt" } }
+        sources: { sourceA: { url: 'https://host/tiles/{z}/{y}/{x}.mvt' } }
         textures:
             tex1: { url: "path/to/texture.png" }
             tex2: { url: "../up_a_directory.png" }
@@ -70,6 +70,7 @@ TestImporter::TestImporter() {
                     uniforms:
                         u_tex1: "/at_root.png"
                         u_tex2: ["path/to/texture.png", tex2]
+                        u_tex3: tex3
                         u_bool: true
                         u_float: 0.25
     )END";
@@ -164,6 +165,7 @@ TEST_CASE("Scene URLs are resolved against their parent during import", "[import
     CHECK(uniformsA["u_tex2"][1].Scalar() == "tex2");
     CHECK(uniformsA["u_bool"].Scalar() == "true");
     CHECK(uniformsA["u_float"].Scalar() == "0.25");
+    CHECK(uniformsA["u_tex3"].Scalar() == "tex3");
 
     auto styleB = root["styles"]["styleB"];
 

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -174,7 +174,8 @@ TEST_CASE("Scene URLs are resolved against their parent during import", "[import
     auto uniformsB = styleB["shaders"]["uniforms"];
 
     CHECK(uniformsB["u_tex1"].Scalar() == "/root/imports/in_imports.png");
-    CHECK(uniformsB["u_tex2"].Scalar() == "tex2");
+    // Don't use global textures from importing scene
+    CHECK(uniformsB["u_tex2"].Scalar() == "/root/imports/tex2");
 
     // Check that data source URLs are resolved correctly.
 

--- a/tests/unit/urlTests.cpp
+++ b/tests/unit/urlTests.cpp
@@ -1,0 +1,204 @@
+#include "catch.hpp"
+
+#include "util/url.h"
+
+using namespace Tangram;
+
+TEST_CASE("Parse components of a correctly formatted URL", "[Url]") {
+
+    // Tests conformance to https://tools.ietf.org/html/rfc1808#section-2.1
+
+    Url url("https://vector.mapzen.com/osm/all/0/0/0.mvt;param=val?api_key=mapsRcool#yolo");
+
+    CHECK(!url.isEmpty());
+    CHECK(url.isAbsolute());
+    CHECK(!url.hasDataScheme());
+    CHECK(!url.hasBase64Data());
+    CHECK(!url.hasFileScheme());
+    CHECK(url.hasHttpScheme());
+    CHECK(url.hasScheme());
+    CHECK(url.scheme() == "https");
+    CHECK(url.hasNetLocation());
+    CHECK(url.netLocation() == "vector.mapzen.com");
+    CHECK(url.hasPath());
+    CHECK(url.path() == "/osm/all/0/0/0.mvt");
+    CHECK(url.hasParameters());
+    CHECK(url.parameters() == "param=val");
+    CHECK(url.hasQuery());
+    CHECK(url.query() == "api_key=mapsRcool");
+    CHECK(url.hasFragment());
+    CHECK(url.fragment() == "yolo");
+    CHECK(!url.hasMediaType());
+    CHECK(!url.hasData());
+
+}
+
+TEST_CASE("Parse components of a correctly formatted data URI", "[Url]") {
+
+    // Tests conformance to https://tools.ietf.org/html/rfc2397#section-3
+
+    Url url("data:text/html;charset=utf-8;base64,YmFzZTY0");
+
+    CHECK(!url.isEmpty());
+    CHECK(url.isAbsolute());
+    CHECK(url.hasDataScheme());
+    CHECK(url.hasBase64Data());
+    CHECK(!url.hasFileScheme());
+    CHECK(!url.hasHttpScheme());
+    CHECK(url.hasScheme());
+    CHECK(url.scheme() == "data");
+    CHECK(!url.hasNetLocation());
+    CHECK(!url.hasParameters());
+    CHECK(!url.hasQuery());
+    CHECK(!url.hasFragment());
+    CHECK(url.hasMediaType());
+    CHECK(url.mediaType() == "text/html;charset=utf-8");
+    CHECK(url.hasData());
+    CHECK(url.data() == "YmFzZTY0");
+
+}
+
+TEST_CASE("Parse an empty URL", "[Url]") {
+
+    Url url("");
+
+    CHECK(url.isEmpty());
+    CHECK(!url.isAbsolute());
+    CHECK(!url.hasDataScheme());
+    CHECK(!url.hasBase64Data());
+    CHECK(!url.hasScheme());
+    CHECK(!url.hasNetLocation());
+    CHECK(!url.hasPath());
+    CHECK(!url.hasParameters());
+    CHECK(!url.hasQuery());
+    CHECK(!url.hasFragment());
+    CHECK(!url.hasMediaType());
+    CHECK(!url.hasData());
+
+}
+
+TEST_CASE("Remove dot segments from a path", "[Url]") {
+
+    // Tests conformance to https://tools.ietf.org/html/rfc3986#section-5.2.4
+
+    CHECK(Url::removeDotSegmentsFromString("") == "");
+    CHECK(Url::removeDotSegmentsFromString("a/b/c") == "a/b/c");
+    CHECK(Url::removeDotSegmentsFromString("a/b=?.;5/c") == "a/b=?.;5/c");
+    CHECK(Url::removeDotSegmentsFromString("/a/b/c/./../../g") == "/a/g");
+    CHECK(Url::removeDotSegmentsFromString("../a/b") == "a/b");
+    CHECK(Url::removeDotSegmentsFromString("./") == "");
+    CHECK(Url::removeDotSegmentsFromString("..") == "");
+    CHECK(Url::removeDotSegmentsFromString("a/b/../../..") == "");
+    CHECK(Url::removeDotSegmentsFromString("a/b/../c/../d/./e/..") == "a/d");
+    CHECK(Url::removeDotSegmentsFromString("a//b//c") == "a//b//c");
+    CHECK(Url::removeDotSegmentsFromString("a./b../..c/.d") == "a./b../..c/.d");
+
+}
+
+TEST_CASE("Produce a 'standardized' URL", "[Url]") {
+
+    CHECK(Url("http://example.com/path/oops/not/here/../../../file.txt;p?q#f").standardized().string() == "http://example.com/path/file.txt;p?q#f");
+    CHECK(Url("http://example.com/../../no/going/back/file.txt;p?q#f").standardized().string() == "http://example.com/no/going/back/file.txt;p?q#f");
+    CHECK(Url("data:text/html;charset=utf-8,LoremIpsum").standardized().string() == "data:text/html;charset=utf-8,LoremIpsum");
+
+}
+
+TEST_CASE("Maintain URL components when 'standardized'", "[URL]") {
+
+    Url url(Url("http://mapzen.com/nothing/to/see/here/../../../../index.html;p?q#f").standardized());
+
+    CHECK(!url.isEmpty());
+    CHECK(url.isAbsolute());
+    CHECK(!url.hasDataScheme());
+    CHECK(!url.hasBase64Data());
+    CHECK(!url.hasFileScheme());
+    CHECK(url.hasHttpScheme());
+    CHECK(url.hasScheme());
+    CHECK(url.scheme() == "http");
+    CHECK(url.hasNetLocation());
+    CHECK(url.netLocation() == "mapzen.com");
+    CHECK(url.hasPath());
+    CHECK(url.path() == "/index.html");
+    CHECK(url.hasParameters());
+    CHECK(url.parameters() == "p");
+    CHECK(url.hasQuery());
+    CHECK(url.query() == "q");
+    CHECK(url.hasFragment());
+    CHECK(url.fragment() == "f");
+    CHECK(!url.hasMediaType());
+    CHECK(!url.hasData());
+
+}
+
+TEST_CASE("Resolve a URL against an absolute base URL", "[Url]") {
+
+    // https://tools.ietf.org/html/rfc3986#section-5.4.1
+
+    Url base("http://a/b/c/d;p?q");
+
+    CHECK(Url("g:h").resolved(base).string() == "g:h");
+    CHECK(Url("g").resolved(base).string() == "http://a/b/c/g");
+    CHECK(Url("./g").resolved(base).string() == "http://a/b/c/g");
+    CHECK(Url("g/").resolved(base).string() == "http://a/b/c/g/");
+    CHECK(Url("/g").resolved(base).string() == "http://a/g");
+    CHECK(Url("?y").resolved(base).string() == "http://a/b/c/d;p?y");
+    CHECK(Url("g?y").resolved(base).string() == "http://a/b/c/g?y");
+    CHECK(Url("#s").resolved(base).string() == "http://a/b/c/d;p?q#s");
+    CHECK(Url("g#s").resolved(base).string() == "http://a/b/c/g#s");
+    CHECK(Url("g?y#s").resolved(base).string() == "http://a/b/c/g?y#s");
+    CHECK(Url(";x").resolved(base).string() == "http://a/b/c/d;x"); // See [1] below.
+    CHECK(Url("g;x").resolved(base).string() == "http://a/b/c/g;x");
+    CHECK(Url("g;x?y#s").resolved(base).string() == "http://a/b/c/g;x?y#s");
+    CHECK(Url("").resolved(base).string() == "http://a/b/c/d;p?q");
+
+}
+
+TEST_CASE("Resolve a URL against a relative base URL", "[Url]") {
+
+    Url base("a/b/c/d;p?q");
+
+    CHECK(Url("g:h").resolved(base).string() == "g:h");
+    CHECK(Url("g").resolved(base).string() == "a/b/c/g");
+    CHECK(Url("./g").resolved(base).string() == "a/b/c/g");
+    CHECK(Url("g/").resolved(base).string() == "a/b/c/g/");
+    CHECK(Url("/g").resolved(base).string() == "/g");
+    CHECK(Url("?y").resolved(base).string() == "a/b/c/d;p?y");
+    CHECK(Url("g?y").resolved(base).string() == "a/b/c/g?y");
+    CHECK(Url("#s").resolved(base).string() == "a/b/c/d;p?q#s");
+    CHECK(Url("g#s").resolved(base).string() == "a/b/c/g#s");
+    CHECK(Url("g?y#s").resolved(base).string() == "a/b/c/g?y#s");
+    CHECK(Url(";x").resolved(base).string() == "a/b/c/d;x"); // See [1] below.
+    CHECK(Url("g;x").resolved(base).string() == "a/b/c/g;x");
+    CHECK(Url("g;x?y#s").resolved(base).string() == "a/b/c/g;x?y#s");
+    CHECK(Url("").resolved(base).string() == "a/b/c/d;p?q");
+
+}
+
+TEST_CASE("Resolve an abnormal relative URL against an absolute base URL", "[Url]") {
+
+    // https://tools.ietf.org/html/rfc3986#section-5.4.2
+
+    Url base("http://a/b/c/d;p?q");
+
+    CHECK(Url("../../../g").resolved(base).string() == "http://a/g");
+    CHECK(Url("../../../../g").resolved(base).string() == "http://a/g");
+    CHECK(Url("/./g").resolved(base).string() == "http://a/g");
+    CHECK(Url("/../g").resolved(base).string() == "http://a/g");
+    CHECK(Url("g.").resolved(base).string() == "http://a/b/c/g.");
+    CHECK(Url(".g").resolved(base).string() == "http://a/b/c/.g");
+    CHECK(Url("g..").resolved(base).string() == "http://a/b/c/g..");
+    CHECK(Url("..g").resolved(base).string() == "http://a/b/c/..g");
+    CHECK(Url("./../g").resolved(base).string() == "http://a/b/g");
+    CHECK(Url("./g/.").resolved(base).string() == "http://a/b/c/g/");
+    CHECK(Url("g/./h").resolved(base).string() == "http://a/b/c/g/h");
+    CHECK(Url("g/../h").resolved(base).string() == "http://a/b/c/h");
+    CHECK(Url("g;x=1/./y").resolved(base).string() == "http://a/b/c/g;x=1/./y"); // See [1] below.
+    CHECK(Url("g;x=1/../y").resolved(base).string() == "http://a/b/c/g;x=1/../y"); // See [1] below.
+
+}
+
+// [1]:
+// Some of the examples for path resolution given in RFC 3986 don't produce the same result
+// in our implementation because the interpretation of the parameters string in RFC 3986 is
+// in conflict with RFC 1808, which many URL utilities adhere to (e.g. NSURL). In RFC 1808
+// the 'path' component stops at a ';', but in RFC 3986 it goes up to a '?'.


### PR DESCRIPTION
 - Adds the `Tangram::Url` class, which represents URLs and data URIs, compliant with IETF RFCs 1808 and 3986. (I'm pretty happy with how this turned out, parsing and resolving URLs gets complicated but it's all done without allocating additional memory).
 - Adds a ton of tests for `Tangram::Url`, using examples from IETF RFC 3986.
 - Uses `Url` for resolving resource locations in `Importer`.
 - Fixes up and clarifies the tests for scene importing.