### PR TITLE
More infos for label feature selection

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 public class MainActivity extends Activity implements OnMapReadyCallback, TapResponder,
-        DoubleTapResponder, LongPressResponder, FeaturePickListener {
+        DoubleTapResponder, LongPressResponder, FeaturePickListener, LabelsPickListener {
 
     MapController map;
     MapView view;
@@ -82,6 +82,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
         map.setDoubleTapResponder(this);
         map.setLongPressResponder(this);
         map.setFeaturePickListener(this);
+        map.setLabelsPickListener(this);
 
         map.setViewCompleteListener(new ViewCompleteListener() {
                 public void onViewComplete() {
@@ -179,6 +180,24 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
                           }
                       });
 
+    }
+
+    @Override
+    public void onLabelsPick(List<TouchLabel> labels, float positionX, float positionY) {
+        if (labels.isEmpty()) {
+            Log.d("Tangram", "Empty selection of labels");
+            return;
+        }
+
+        Log.d("Tangram", "Picked label");
+        runOnUiThread(new Runnable() {
+                          @Override
+                          public void run() {
+                              Toast.makeText(getApplicationContext(),
+                                      "Selected label",
+                                      Toast.LENGTH_SHORT).show();
+                          }
+                      });
     }
 }
 

--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -18,7 +18,7 @@ import com.mapzen.tangram.MapView.OnMapReadyCallback;
 import com.mapzen.tangram.TouchInput.DoubleTapResponder;
 import com.mapzen.tangram.TouchInput.LongPressResponder;
 import com.mapzen.tangram.TouchInput.TapResponder;
-import com.squareup.okhttp.Callback;
+import com.mapzen.tangram.TouchLabel;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -157,7 +157,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     }
 
     @Override
-    public void onFeaturePick(Map<String, String> properties, float positionX, float positionY) {
+    public void onFeaturePick(Map<String, String> properties, List<TouchLabel> labels, float positionX, float positionY) {
         if (properties.isEmpty()) {
             Log.d("Tangram", "Empty selection");
             return;

--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -19,7 +19,7 @@ import com.mapzen.tangram.MapView.OnMapReadyCallback;
 import com.mapzen.tangram.TouchInput.DoubleTapResponder;
 import com.mapzen.tangram.TouchInput.LongPressResponder;
 import com.mapzen.tangram.TouchInput.TapResponder;
-import com.mapzen.tangram.TouchLabel;
+import com.mapzen.tangram.LabelPickResult;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -185,13 +185,13 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     }
 
     @Override
-    public void onLabelPick(TouchLabel label, float positionX, float positionY) {
-        if (label == null) {
+    public void onLabelPick(LabelPickResult labelPickResult, float positionX, float positionY) {
+        if (labelPickResult == null) {
             Log.d("Tangram", "Empty label selection");
             return;
         }
 
-        String name = label.getProperties().get("name");
+        String name = labelPickResult.getProperties().get("name");
         if (name.isEmpty()) {
             name = "unnamed";
         }

--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -11,6 +11,7 @@ import com.mapzen.tangram.HttpHandler;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.MapController.FeaturePickListener;
+import com.mapzen.tangram.MapController.LabelPickListener;
 import com.mapzen.tangram.MapController.ViewCompleteListener;
 import com.mapzen.tangram.MapData;
 import com.mapzen.tangram.MapView;
@@ -27,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 public class MainActivity extends Activity implements OnMapReadyCallback, TapResponder,
-        DoubleTapResponder, LongPressResponder, FeaturePickListener, LabelsPickListener {
+        DoubleTapResponder, LongPressResponder, FeaturePickListener, LabelPickListener {
 
     MapController map;
     MapView view;
@@ -45,7 +46,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
         view = (MapView)findViewById(R.id.map);
         view.onCreate(savedInstanceState);
-        view.getMapAsync(this, "scene.yaml");
+        view.getMapAsync(this, "https://raw.githubusercontent.com/tangrams/cinnabar-style/gh-pages/cinnabar-style.yaml");
     }
 
     @Override
@@ -82,7 +83,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
         map.setDoubleTapResponder(this);
         map.setLongPressResponder(this);
         map.setFeaturePickListener(this);
-        map.setLabelsPickListener(this);
+        map.setLabelPickListener(this);
 
         map.setViewCompleteListener(new ViewCompleteListener() {
                 public void onViewComplete() {
@@ -132,6 +133,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
         lastTappedPoint = tappedPoint;
 
         map.pickFeature(x, y);
+        map.pickLabels(x, y);
 
         map.setPositionEased(tappedPoint, 1000);
 
@@ -158,7 +160,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     }
 
     @Override
-    public void onFeaturePick(Map<String, String> properties, List<TouchLabel> labels, float positionX, float positionY) {
+    public void onFeaturePick(Map<String, String> properties, float positionX, float positionY) {
         if (properties.isEmpty()) {
             Log.d("Tangram", "Empty selection");
             return;
@@ -183,18 +185,24 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     }
 
     @Override
-    public void onLabelsPick(List<TouchLabel> labels, float positionX, float positionY) {
-        if (labels.isEmpty()) {
-            Log.d("Tangram", "Empty selection of labels");
+    public void onLabelPick(TouchLabel label, float positionX, float positionY) {
+        if (label == null) {
+            Log.d("Tangram", "Empty label selection");
             return;
         }
 
-        Log.d("Tangram", "Picked label");
+        String name = label.getProperties().get("name");
+        if (name.isEmpty()) {
+            name = "unnamed";
+        }
+
+        Log.d("Tangram", "Picked label: " + name);
+        final String message = name;
         runOnUiThread(new Runnable() {
                           @Override
                           public void run() {
                               Toast.makeText(getApplicationContext(),
-                                      "Selected label",
+                                      "Selected label: " + message,
                                       Toast.LENGTH_SHORT).show();
                           }
                       });

--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
         view = (MapView)findViewById(R.id.map);
         view.onCreate(savedInstanceState);
-        view.getMapAsync(this, "https://raw.githubusercontent.com/tangrams/cinnabar-style/gh-pages/cinnabar-style.yaml");
+        view.getMapAsync(this, "scene.yaml");
     }
 
     @Override

--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -133,7 +133,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
         lastTappedPoint = tappedPoint;
 
         map.pickFeature(x, y);
-        map.pickLabels(x, y);
+        map.pickLabel(x, y);
 
         map.setPositionEased(tappedPoint, 1000);
 

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -220,6 +220,15 @@ extern "C" {
         });
     }
 
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickLabels(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jobject listener) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto object = jniEnv->NewGlobalRef(listener);
+        map->pickLabelsAt(posX, posY, [object](const auto& labels) {
+            labelsPickCallback(object, labels);
+        });
+    }
+
     // NOTE unsigned int to jlong for precision... else we can do jint return
     JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerAdd(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);

--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -215,17 +215,17 @@ extern "C" {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto object = jniEnv->NewGlobalRef(listener);
-        map->pickFeaturesAt(posX, posY, [object](const auto& items) {
-            featurePickCallback(object, items);
+        map->pickFeatureAt(posX, posY, [object](auto pickResult) {
+            featurePickCallback(object, pickResult);
         });
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickLabels(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jobject listener) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickLabel(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jobject listener) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto object = jniEnv->NewGlobalRef(listener);
-        map->pickLabelsAt(posX, posY, [object](const auto& labels) {
-            labelsPickCallback(object, labels);
+        map->pickLabelAt(posX, posY, [object](auto pickResult) {
+            labelPickCallback(object, pickResult);
         });
     }
 

--- a/android/tangram/jni/platform_android.cpp
+++ b/android/tangram/jni/platform_android.cpp
@@ -48,9 +48,9 @@ static jmethodID getFontFilePath = 0;
 static jmethodID getFontFallbackFilePath = 0;
 static jmethodID onFeaturePickMID = 0;
 static jmethodID onLabelPickMID = 0;
-static jmethodID touchLabelInitMID = 0;
+static jmethodID labelPickResultInitMID = 0;
 
-static jclass touchLabelClass = nullptr;
+static jclass labelPickResultClass = nullptr;
 static jclass hashmapClass = nullptr;
 static jmethodID hashmapInitMID = 0;
 static jmethodID hashmapPutMID = 0;
@@ -85,13 +85,13 @@ void setupJniEnv(JNIEnv* jniEnv, jobject _tangramInstance, jobject _assetManager
     jclass featurePickListenerClass = jniEnv->FindClass("com/mapzen/tangram/MapController$FeaturePickListener");
     onFeaturePickMID = jniEnv->GetMethodID(featurePickListenerClass, "onFeaturePick", "(Ljava/util/Map;FF)V");
     jclass labelPickListenerClass = jniEnv->FindClass("com/mapzen/tangram/MapController$LabelPickListener");
-    onLabelPickMID = jniEnv->GetMethodID(labelPickListenerClass, "onLabelPick", "(Lcom/mapzen/tangram/TouchLabel;FF)V");
+    onLabelPickMID = jniEnv->GetMethodID(labelPickListenerClass, "onLabelPick", "(Lcom/mapzen/tangram/LabelPickResult;FF)V");
 
-    if (touchLabelClass) {
-        jniEnv->DeleteGlobalRef(touchLabelClass);
+    if (labelPickResultClass) {
+        jniEnv->DeleteGlobalRef(labelPickResultClass);
     }
-    touchLabelClass = (jclass)jniEnv->NewGlobalRef(jniEnv->FindClass("com/mapzen/tangram/TouchLabel"));
-    touchLabelInitMID = jniEnv->GetMethodID(touchLabelClass, "<init>", "(DDILjava/util/Map;)V");
+    labelPickResultClass = (jclass)jniEnv->NewGlobalRef(jniEnv->FindClass("com/mapzen/tangram/LabelPickResult"));
+    labelPickResultInitMID = jniEnv->GetMethodID(labelPickResultClass, "<init>", "(DDILjava/util/Map;)V");
 
     if (hashmapClass) {
         jniEnv->DeleteGlobalRef(hashmapClass);
@@ -328,7 +328,7 @@ void labelPickCallback(jobject listener, const Tangram::LabelPickResult* labelPi
 
     float position[2] = {0.0, 0.0};
 
-    jobject touchLabel = nullptr;
+    jobject labelPickResultObject = nullptr;
 
     if (labelPickResult) {
         auto properties = labelPickResult->touchItem.properties;
@@ -345,11 +345,11 @@ void labelPickCallback(jobject listener, const Tangram::LabelPickResult* labelPi
         }
 
         jdoubleArray darr = jniEnv->NewDoubleArray(2);
-        touchLabel = jniEnv->NewObject(touchLabelClass, touchLabelInitMID, labelPickResult->coordinate.longitude,
+        labelPickResultObject = jniEnv->NewObject(labelPickResultClass, labelPickResultInitMID, labelPickResult->coordinate.longitude,
             labelPickResult->coordinate.latitude, labelPickResult->type, hashmap);
     }
 
-    jniEnv->CallVoidMethod(listener, onLabelPickMID, touchLabel, position[0], position[1]);
+    jniEnv->CallVoidMethod(listener, onLabelPickMID, labelPickResultObject, position[0], position[1]);
     jniEnv->DeleteGlobalRef(listener);
 }
 

--- a/android/tangram/jni/platform_android.h
+++ b/android/tangram/jni/platform_android.h
@@ -11,14 +11,14 @@ void onUrlSuccess(JNIEnv* jniEnv, jbyteArray jFetchedBytes, jlong jCallbackPtr);
 void onUrlFailure(JNIEnv* jniEnv, jlong jCallbackPtr);
 
 namespace Tangram {
-struct TouchItem;
-struct TouchLabel;
+struct LabelPickResult;
+struct FeaturePickResult;
 }
 
-void featurePickCallback(jobject listener, const std::vector<Tangram::TouchItem>& items);
+void featurePickCallback(jobject listener, const Tangram::FeaturePickResult* featurePickResult);
 
 std::string resolveScenePath(const char* path);
 
-void labelsPickCallback(jobject listener, const std::vector<Tangram::TouchLabel>& labels);
+void labelPickCallback(jobject listener, const Tangram::LabelPickResult* labelPickResult);
 
 std::string stringFromJString(JNIEnv* jniEnv, jstring string);

--- a/android/tangram/jni/platform_android.h
+++ b/android/tangram/jni/platform_android.h
@@ -12,10 +12,13 @@ void onUrlFailure(JNIEnv* jniEnv, jlong jCallbackPtr);
 
 namespace Tangram {
 struct TouchItem;
+struct TouchLabel;
 }
 
 void featurePickCallback(jobject listener, const std::vector<Tangram::TouchItem>& items);
 
 std::string resolveScenePath(const char* path);
+
+void labelsPickCallback(jobject listener, const std::vector<Tangram::TouchLabel>& labels);
 
 std::string stringFromJString(JNIEnv* jniEnv, jstring string);

--- a/android/tangram/src/com/mapzen/tangram/LabelPickResult.java
+++ b/android/tangram/src/com/mapzen/tangram/LabelPickResult.java
@@ -5,12 +5,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * {@code TouchLabel} represents labels that can be selected on the screen
+ * {@code LabelPickResult} represents labels that can be selected on the screen
  */
-public class TouchLabel {
+public class LabelPickResult {
 
     /**
-     * Options for the type of TouchLabel
+     * Options for the type of LabelPickResult
      */
     public enum LabelType {
         ICON,
@@ -21,7 +21,7 @@ public class TouchLabel {
     private LabelType type;
     private Map<String, String> properties;
 
-    private TouchLabel(double longitude, double latitude, int type, Map<String, String> properties) {
+    private LabelPickResult(double longitude, double latitude, int type, Map<String, String> properties) {
         this.properties = properties;
         this.coordinate = new LngLat(longitude, latitude);
         this.type = LabelType.values()[type];

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.List;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
@@ -70,10 +71,11 @@ public class MapController implements Renderer {
         /**
          * Receive information about features found in a call to {@link #pickFeature(float, float)}
          * @param properties A mapping of string keys to string or number values
+         * @param labels The list of selected feature labels, empty otherwise
          * @param positionX The horizontal screen coordinate of the center of the feature
          * @param positionY The vertical screen coordinate of the center of the feature
          */
-        void onFeaturePick(Map<String, String> properties, float positionX, float positionY);
+        void onFeaturePick(Map<String, String> properties, List<TouchLabel> labels, float positionX, float positionY);
     }
 
     public interface ViewCompleteListener {

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -71,15 +71,14 @@ public class MapController implements Renderer {
         /**
          * Receive information about features found in a call to {@link #pickFeature(float, float)}
          * @param properties A mapping of string keys to string or number values
-         * @param labels The list of selected feature labels, empty otherwise
          * @param positionX The horizontal screen coordinate of the center of the feature
          * @param positionY The vertical screen coordinate of the center of the feature
          */
         void onFeaturePick(Map<String, String> properties, float positionX, float positionY);
     }
 
-    public interface LabelsPickListener {
-        void onLabelsPick(List<TouchLabel> labels, float positionX, float positionY);
+    public interface LabelPickListener {
+        void onLabelPick(TouchLabel label, float positionX, float positionY);
     }
 
     public interface ViewCompleteListener {
@@ -657,6 +656,17 @@ public class MapController implements Renderer {
         }
     }
 
+    public void setLabelPickListener(LabelPickListener listener) {
+        labelPickListener = listener;
+    }
+
+    public void pickLabels(float posX, float posY) {
+        if (labelPickListener != null) {
+            checkPointer(mapPointer);
+            nativePickLabels(mapPointer, posX, posY, labelPickListener);
+        }
+    }
+
     /**
      * Adds a {@link Marker} to the map which can be used to dynamically add points and polylines
      * to the map.
@@ -867,6 +877,7 @@ public class MapController implements Renderer {
     private synchronized native void nativeQueueSceneUpdate(long mapPtr, String componentPath, String value);
     private synchronized native void nativeApplySceneUpdates(long mapPtr);
     private synchronized native void nativePickFeature(long mapPtr, float posX, float posY, FeaturePickListener listener);
+    private synchronized native void nativePickLabels(long mapPtr, float posX, float posY, LabelPickListener listener);
     private synchronized native long nativeMarkerAdd(long mapPtr);
     private synchronized native boolean nativeMarkerRemove(long mapPtr, long markerID);
     private synchronized native boolean nativeMarkerSetStyling(long mapPtr, long markerID, String styling);
@@ -906,6 +917,7 @@ public class MapController implements Renderer {
     private DisplayMetrics displayMetrics = new DisplayMetrics();
     private HttpHandler httpHandler;
     private FeaturePickListener featurePickListener;
+    private LabelPickListener labelPickListener;
     private ViewCompleteListener viewCompleteListener;
     private FrameCaptureCallback frameCaptureCallback;
     private boolean frameCaptureAwaitCompleteView;

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -75,7 +75,11 @@ public class MapController implements Renderer {
          * @param positionX The horizontal screen coordinate of the center of the feature
          * @param positionY The vertical screen coordinate of the center of the feature
          */
-        void onFeaturePick(Map<String, String> properties, List<TouchLabel> labels, float positionX, float positionY);
+        void onFeaturePick(Map<String, String> properties, float positionX, float positionY);
+    }
+
+    public interface LabelsPickListener {
+        void onLabelsPick(List<TouchLabel> labels, float positionX, float positionY);
     }
 
     public interface ViewCompleteListener {

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -677,10 +677,10 @@ public class MapController implements Renderer {
      * @param posX The horizontal screen coordinate
      * @param posY The vertical screen coordinate
      */
-    public void pickLabels(float posX, float posY) {
+    public void pickLabel(float posX, float posY) {
         if (labelPickListener != null) {
             checkPointer(mapPointer);
-            nativePickLabels(mapPointer, posX, posY, labelPickListener);
+            nativePickLabel(mapPointer, posX, posY, labelPickListener);
         }
     }
 
@@ -894,7 +894,7 @@ public class MapController implements Renderer {
     private synchronized native void nativeQueueSceneUpdate(long mapPtr, String componentPath, String value);
     private synchronized native void nativeApplySceneUpdates(long mapPtr);
     private synchronized native void nativePickFeature(long mapPtr, float posX, float posY, FeaturePickListener listener);
-    private synchronized native void nativePickLabels(long mapPtr, float posX, float posY, LabelPickListener listener);
+    private synchronized native void nativePickLabel(long mapPtr, float posX, float posY, LabelPickListener listener);
     private synchronized native long nativeMarkerAdd(long mapPtr);
     private synchronized native boolean nativeMarkerRemove(long mapPtr, long markerID);
     private synchronized native boolean nativeMarkerSetStyling(long mapPtr, long markerID, String styling);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -71,13 +71,21 @@ public class MapController implements Renderer {
         /**
          * Receive information about features found in a call to {@link #pickFeature(float, float)}
          * @param properties A mapping of string keys to string or number values
-         * @param positionX The horizontal screen coordinate of the center of the feature
-         * @param positionY The vertical screen coordinate of the center of the feature
+         * @param positionX The horizontal screen coordinate of the tapped location
+         * @param positionY The vertical screen coordinate of the tapped location
          */
         void onFeaturePick(Map<String, String> properties, float positionX, float positionY);
     }
-
+    /**
+     * Interface for a callback to receive information about labels picked from the map
+     */
     public interface LabelPickListener {
+        /**
+         * Receive information about labels found in a call to {@link #pickLabels(float, float)}
+         * @param label The {@link TouchLabel} that has been selected
+         * @param positionX The horizontal screen coordinate of the tapped location
+         * @param positionY The vertical screen coordinate of the tapped location
+         */
         void onLabelPick(TouchLabel label, float positionX, float positionY);
     }
 
@@ -644,7 +652,7 @@ public class MapController implements Renderer {
     }
 
     /**
-     * Query the map for labeled features at the given screen coordinates; results will be returned
+     * Query the map for geometry features at the given screen coordinates; results will be returned
      * in a callback to the object set by {@link #setFeaturePickListener(FeaturePickListener)}
      * @param posX The horizontal screen coordinate
      * @param posY The vertical screen coordinate
@@ -655,11 +663,20 @@ public class MapController implements Renderer {
             nativePickFeature(mapPointer, posX, posY, featurePickListener);
         }
     }
-
+    /**
+     * Set a listener for label pick events
+     * @param listener Listener to call
+     */
     public void setLabelPickListener(LabelPickListener listener) {
         labelPickListener = listener;
     }
 
+    /**
+     * Query the map for labeled features at the given screen coordinates; results will be returned
+     * in a callback to the object set by {@link #setLabelPickListener(LabelPickListener)}
+     * @param posX The horizontal screen coordinate
+     * @param posY The vertical screen coordinate
+     */
     public void pickLabels(float posX, float posY) {
         if (labelPickListener != null) {
             checkPointer(mapPointer);

--- a/android/tangram/src/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/com/mapzen/tangram/MapController.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.List;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
@@ -82,11 +81,11 @@ public class MapController implements Renderer {
     public interface LabelPickListener {
         /**
          * Receive information about labels found in a call to {@link #pickLabels(float, float)}
-         * @param label The {@link TouchLabel} that has been selected
+         * @param label The {@link LabelPickResult} that has been selected
          * @param positionX The horizontal screen coordinate of the tapped location
          * @param positionY The vertical screen coordinate of the tapped location
          */
-        void onLabelPick(TouchLabel label, float positionX, float positionY);
+        void onLabelPick(LabelPickResult labelPickResult, float positionX, float positionY);
     }
 
     public interface ViewCompleteListener {

--- a/android/tangram/src/com/mapzen/tangram/TouchLabel.java
+++ b/android/tangram/src/com/mapzen/tangram/TouchLabel.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * {@code TouchLabel} represents labels that can be selected on the scree
+ * {@code TouchLabel} represents labels that can be selected on the screen
  */
 public class TouchLabel {
 
@@ -12,7 +12,7 @@ public class TouchLabel {
      * Options for the type of TouchLabel
      */
     public enum LabelType {
-        POINT,
+        ICON,
         TEXT,
     }
 

--- a/android/tangram/src/com/mapzen/tangram/TouchLabel.java
+++ b/android/tangram/src/com/mapzen/tangram/TouchLabel.java
@@ -1,0 +1,39 @@
+package com.mapzen.tangram;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@code TouchLabel} represents labels that can be selected on the scree
+ */
+public class TouchLabel {
+
+    /**
+     * Options for the type of TouchLabel
+     */
+    public enum LabelType {
+        POINT,
+        TEXT,
+    }
+
+    private List<LngLat> coordinates;
+    private LabelType type;
+
+    public TouchLabel(double[] coordinates, int type) {
+        this.coordinates = new ArrayList<>();
+
+        for (int i = 0; i < coordinates.length - 1; i += 2) {
+            this.coordinates.add(new LngLat(coordinates[i], coordinates[i + 1]));
+        }
+
+        this.type = LabelType.values()[type];
+    }
+
+    public LabelType getType() {
+        return this.type;
+    }
+
+    public List<LngLat> getCoordinates() {
+        return this.coordinates;
+    }
+}

--- a/android/tangram/src/com/mapzen/tangram/TouchLabel.java
+++ b/android/tangram/src/com/mapzen/tangram/TouchLabel.java
@@ -31,10 +31,16 @@ public class TouchLabel {
         return this.type;
     }
 
+    /**
+     * @return The coordinate of the feature for which this label has been created
+     */
     public LngLat getCoordinate() {
         return this.coordinate;
     }
 
+    /**
+     * @return A mapping of string keys to string or number values
+     */
     public Map<String, String> getProperties() {
         return this.properties;
     }

--- a/android/tangram/src/com/mapzen/tangram/TouchLabel.java
+++ b/android/tangram/src/com/mapzen/tangram/TouchLabel.java
@@ -2,6 +2,7 @@ package com.mapzen.tangram;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * {@code TouchLabel} represents labels that can be selected on the screen
@@ -16,16 +17,13 @@ public class TouchLabel {
         TEXT,
     }
 
-    private List<LngLat> coordinates;
+    private LngLat coordinate;
     private LabelType type;
+    private Map<String, String> properties;
 
-    public TouchLabel(double[] coordinates, int type) {
-        this.coordinates = new ArrayList<>();
-
-        for (int i = 0; i < coordinates.length - 1; i += 2) {
-            this.coordinates.add(new LngLat(coordinates[i], coordinates[i + 1]));
-        }
-
+    public TouchLabel(double[] coordinates, int type, Map<String, String> properties) {
+        this.properties = properties;
+        this.coordinate = new LngLat(coordinates[0], coordinates[1]);
         this.type = LabelType.values()[type];
     }
 
@@ -33,7 +31,11 @@ public class TouchLabel {
         return this.type;
     }
 
-    public List<LngLat> getCoordinates() {
-        return this.coordinates;
+    public LngLat getCoordinate() {
+        return this.coordinate;
+    }
+
+    public Map<String, String> getProperties() {
+        return this.properties;
     }
 }

--- a/android/tangram/src/com/mapzen/tangram/TouchLabel.java
+++ b/android/tangram/src/com/mapzen/tangram/TouchLabel.java
@@ -21,9 +21,9 @@ public class TouchLabel {
     private LabelType type;
     private Map<String, String> properties;
 
-    public TouchLabel(double[] coordinates, int type, Map<String, String> properties) {
+    private TouchLabel(double longitude, double latitude, int type, Map<String, String> properties) {
         this.properties = properties;
-        this.coordinate = new LngLat(coordinates[0], coordinates[1]);
+        this.coordinate = new LngLat(longitude, latitude);
         this.type = LabelType.values()[type];
     }
 
@@ -34,7 +34,7 @@ public class TouchLabel {
     /**
      * @return The coordinate of the feature for which this label has been created
      */
-    public LngLat getCoordinate() {
+    public LngLat getCoordinates() {
         return this.coordinate;
     }
 

--- a/android/tangram/src/com/mapzen/tangram/geometry/Point.java
+++ b/android/tangram/src/com/mapzen/tangram/geometry/Point.java
@@ -2,8 +2,6 @@ package com.mapzen.tangram.geometry;
 
 import com.mapzen.tangram.LngLat;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/core/src/gl/primitives.cpp
+++ b/core/src/gl/primitives.cpp
@@ -22,7 +22,6 @@ namespace Primitives {
 static bool s_initialized;
 static std::unique_ptr<ShaderProgram> s_shader;
 static std::unique_ptr<VertexLayout> s_layout;
-static glm::vec2 s_resolution;
 
 static UniformLocation s_uColor{"u_color"};
 static UniformLocation s_uProj{"u_proj"};

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -12,11 +12,12 @@ namespace Tangram {
 
 const float Label::activation_distance_threshold = 2;
 
-Label::Label(Label::WorldTransform _worldTransform, glm::vec2 _size, Type _type, Options _options)
+Label::Label(Label::WorldTransform _worldTransform, glm::vec2 _size, uint32_t _selectionColor, Type _type, Options _options)
     : m_state(State::none),
       m_type(_type),
       m_worldTransform(_worldTransform),
       m_dim(_size),
+      m_selectionColor(_selectionColor),
       m_options(_options) {
 
     if (!m_options.collide || m_type == Type::debug) {

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -56,21 +56,15 @@ float Label::screenDistance2(glm::vec2 _screenPosition) const {
 
 LngLat Label::coordinate(const Tile& _tile, const MapProjection& _projection) {
     LngLat coordinate;
-
-    if (m_type == Type::line) {
-        for (int i = 0; i < 2; ++i) {
-            glm::vec2 tileCoord = glm::vec2(m_worldTransform.positions[i]);
-            glm::dvec2 degrees = _tile.coordToLngLat(tileCoord, _projection);
-            coordinate.longitude += degrees.x;
-            coordinate.latitude += degrees.y;
-        }
-        coordinate.longitude /= 2.0;
-        coordinate.latitude /= 2.0;
-    } else {
-        glm::vec2 tileCoord = glm::vec2(m_worldTransform.position);
+    int coordCount = m_type == Type::line ? 2 : 1;
+    for (int i = 0; i < coordCount; ++i) {
+        glm::vec2 tileCoord = glm::vec2(m_worldTransform.positions[i]);
         glm::dvec2 degrees = _tile.coordToLngLat(tileCoord, _projection);
-        coordinate = {degrees.x, degrees.y};
+        coordinate.longitude += degrees.x;
+        coordinate.latitude += degrees.y;
     }
+    coordinate.longitude /= coordCount;
+    coordinate.latitude /= coordCount;
 
     return coordinate;
 }

--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -54,22 +54,25 @@ float Label::screenDistance2(glm::vec2 _screenPosition) const {
     return glm::length2(m_obb.getCentroid() - _screenPosition);
 }
 
-std::vector<LngLat> Label::coordinates(const Tile& _tile, const MapProjection& _projection) {
-    std::vector<LngLat> coordinates;
+LngLat Label::coordinate(const Tile& _tile, const MapProjection& _projection) {
+    LngLat coordinate;
 
     if (m_type == Type::line) {
         for (int i = 0; i < 2; ++i) {
             glm::vec2 tileCoord = glm::vec2(m_worldTransform.positions[i]);
             glm::dvec2 degrees = _tile.coordToLngLat(tileCoord, _projection);
-            coordinates.push_back({degrees.x, degrees.y});
+            coordinate.longitude += degrees.x;
+            coordinate.latitude += degrees.y;
         }
+        coordinate.longitude /= 2.0;
+        coordinate.latitude /= 2.0;
     } else {
         glm::vec2 tileCoord = glm::vec2(m_worldTransform.position);
         glm::dvec2 degrees = _tile.coordToLngLat(tileCoord, _projection);
-        coordinates.push_back({degrees.x, degrees.y});
+        coordinate = {degrees.x, degrees.y};
     }
 
-    return coordinates;
+    return coordinate;
 }
 
 float Label::worldLineLength2() const {

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -79,7 +79,6 @@ public:
     struct Options {
         glm::vec2 offset;
         float priority = std::numeric_limits<float>::max();
-        bool interactive = false;
         bool collide = true;
         Transition selectTransition;
         Transition hideTransition;
@@ -92,6 +91,7 @@ public:
         bool required = true;
         bool flat = false;
         float angle = 0.f;
+        std::shared_ptr<Properties> properties;
     };
 
     static const float activation_distance_threshold;
@@ -232,7 +232,6 @@ namespace std {
             hash_combine(seed, o.offset.x);
             hash_combine(seed, o.offset.y);
             hash_combine(seed, o.priority);
-            hash_combine(seed, o.interactive);
             hash_combine(seed, o.collide);
             hash_combine(seed, o.repeatDistance);
             hash_combine(seed, o.repeatGroup);

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -19,6 +19,8 @@
 namespace Tangram {
 
 struct ViewState;
+class Tile;
+class MapProjection;
 
 class Label {
 
@@ -157,6 +159,9 @@ public:
     bool nextAnchor();
 
     bool setAnchorIndex(int _index);
+
+    // Returns the list of lon/lat of the feature the label is associated with
+    std::vector<LngLat> coordinates(const Tile& _tile, const MapProjection& _projection);
 
     // Returns the screen distance squared from a screen coordinate
     float screenDistance2(glm::vec2 _screenPosition) const;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -10,6 +10,7 @@
 #include "util/types.h"
 #include "util/hash.h"
 #include "labels/labelProperty.h"
+#include "tangram.h"
 
 #include <string>
 #include <limits>
@@ -101,6 +102,8 @@ public:
     virtual void addVerticesToMesh() = 0;
     virtual glm::vec2 center() const;
     virtual void updateBBoxes(float _zoomFract) = 0;
+
+    virtual LabelType renderType() const = 0;
 
     // Update the screen position of the label
     virtual bool updateScreenTransform(const glm::mat4& _mvp, const ViewState& _viewState, bool _drawAllLabels) = 0;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -93,7 +93,7 @@ public:
 
     static const float activation_distance_threshold;
 
-    Label(WorldTransform _transform, glm::vec2 _size, Type _type, Options _options);
+    Label(WorldTransform _transform, glm::vec2 _size, uint32_t _selectionColor, Type _type, Options _options);
 
     virtual ~Label();
 
@@ -176,6 +176,8 @@ public:
 
     void setAlpha(float _alpha);
 
+    uint32_t selectionColor() { return m_selectionColor; }
+
 private:
 
     virtual void applyAnchor(LabelProperty::Anchor _anchor) = 0;
@@ -185,6 +187,8 @@ private:
     FadeEffect m_fade;
 
     int m_anchorIndex;
+
+    uint32_t m_selectionColor;
 
 protected:
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -161,7 +161,7 @@ public:
     bool setAnchorIndex(int _index);
 
     // Returns the list of lon/lat of the feature the label is associated with
-    std::vector<LngLat> coordinates(const Tile& _tile, const MapProjection& _projection);
+    LngLat coordinate(const Tile& _tile, const MapProjection& _projection);
 
     // Returns the screen distance squared from a screen coordinate
     float screenDistance2(glm::vec2 _screenPosition) const;

--- a/core/src/labels/labelCollider.h
+++ b/core/src/labels/labelCollider.h
@@ -21,6 +21,8 @@ public:
 
     void process(TileID _tileID, float _tileInverseScale, float _tileSize);
 
+    std::vector<Label*> labels();
+
 private:
 
     void handleRepeatGroup(size_t startPos);

--- a/core/src/labels/labelCollider.h
+++ b/core/src/labels/labelCollider.h
@@ -21,8 +21,6 @@ public:
 
     void process(TileID _tileID, float _tileInverseScale, float _tileSize);
 
-    std::vector<Label*> labels();
-
 private:
 
     void handleRepeatGroup(size_t startPos);

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -64,11 +64,9 @@ void Labels::processLabelUpdate(const ViewState& viewState,
 }
 
 
-std::vector<Label*> Labels::getLabels(const std::vector<std::unique_ptr<Style>>& _styles,
+bool Labels::getLabel(const std::vector<std::unique_ptr<Style>>& _styles,
                                       const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                      uint32_t _selectionColor) {
-
-    std::vector<Label*> labels;
+                                      uint32_t _selectionColor, Label* _label, Tile* _tile) {
 
     for (const auto& tile : _tiles) {
         for (const auto& style : _styles) {
@@ -79,13 +77,15 @@ std::vector<Label*> Labels::getLabels(const std::vector<std::unique_ptr<Style>>&
 
             for (auto& label : labelMesh->getLabels()) {
                 if (label->selectionColor() == _selectionColor) {
-                    labels.push_back(label.get());
+                    _label = label.get();
+                    _tile = tile.get();
+                    return true;
                 }
             }
         }
     }
 
-    return labels;
+    return false;
 }
 
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -66,7 +66,7 @@ void Labels::processLabelUpdate(const ViewState& viewState,
 
 bool Labels::getLabel(const std::vector<std::unique_ptr<Style>>& _styles,
                                       const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                      uint32_t _selectionColor, Label* _label, Tile* _tile) {
+                                      uint32_t _selectionColor, Label*& _label, Tile*& _tile) {
 
     for (const auto& tile : _tiles) {
         for (const auto& style : _styles) {

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -63,6 +63,32 @@ void Labels::processLabelUpdate(const ViewState& viewState,
     }
 }
 
+
+std::vector<Label*> Labels::getLabels(const std::vector<std::unique_ptr<Style>>& _styles,
+                                      const std::vector<std::shared_ptr<Tile>>& _tiles,
+                                      uint32_t _selectionColor) {
+
+    std::vector<Label*> labels;
+
+    for (const auto& tile : _tiles) {
+        for (const auto& style : _styles) {
+            const auto& mesh = tile->getMesh(*style);
+            if (!mesh) { continue; }
+            auto labelMesh = dynamic_cast<const LabelSet*>(mesh.get());
+            if (!labelMesh) { continue; }
+
+            for (auto& label : labelMesh->getLabels()) {
+                if (label->selectionColor() == _selectionColor) {
+                    labels.push_back(label.get());
+                }
+            }
+        }
+    }
+
+    return labels;
+}
+
+
 void Labels::updateLabels(const ViewState& _viewState, float _dt,
                           const std::vector<std::unique_ptr<Style>>& _styles,
                           const std::vector<std::shared_ptr<Tile>>& _tiles,

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -50,7 +50,7 @@ public:
 
     bool getLabel(const std::vector<std::unique_ptr<Style>>& _styles,
                                   const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                  uint32_t _selectionColor, Label* _label, Tile* _tile);
+                                  uint32_t _selectionColor, Label*& _label, Tile*& _tile);
 
 protected:
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -48,9 +48,9 @@ public:
 
     bool needUpdate() const { return m_needUpdate; }
 
-    std::vector<Label*> getLabels(const std::vector<std::unique_ptr<Style>>& _styles,
+    bool getLabel(const std::vector<std::unique_ptr<Style>>& _styles,
                                   const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                  uint32_t _selectionColor);
+                                  uint32_t _selectionColor, Label* _label, Tile* _tile);
 
 protected:
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -48,6 +48,10 @@ public:
 
     bool needUpdate() const { return m_needUpdate; }
 
+    std::vector<Label*> getLabels(const std::vector<std::unique_ptr<Style>>& _styles,
+                                  const std::vector<std::shared_ptr<Tile>>& _tiles,
+                                  uint32_t _selectionColor);
+
 protected:
 
     using AABB = isect2d::AABB<glm::vec2>;

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -23,7 +23,6 @@ class Marker;
 class Tile;
 class Style;
 class TileCache;
-struct TouchItem;
 
 class Labels {
 
@@ -78,8 +77,6 @@ protected:
     bool m_needUpdate;
 
     isect2d::ISect2D<glm::vec2> m_isect2d;
-
-    std::vector<TouchItem> m_touchItems;
 
     struct LabelEntry {
 

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -13,10 +13,10 @@ using namespace LabelProperty;
 const float SpriteVertex::alpha_scale = 65535.0f;
 const float SpriteVertex::texture_scale = 65535.0f;
 
-SpriteLabel::SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, Label::Options _options,
+SpriteLabel::SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, uint32_t _selectionColor, Label::Options _options,
                          SpriteLabel::VertexAttributes _attrib, Texture* _texture,
                          SpriteLabels& _labels, size_t _labelsPos)
-    : Label(_transform, _size, Label::Type::point, _options),
+    : Label(_transform, _size, _selectionColor, Label::Type::point, _options),
       m_labels(_labels),
       m_labelsPos(_labelsPos),
       m_texture(_texture),

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -13,10 +13,10 @@ using namespace LabelProperty;
 const float SpriteVertex::alpha_scale = 65535.0f;
 const float SpriteVertex::texture_scale = 65535.0f;
 
-SpriteLabel::SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, uint32_t _selectionColor, Label::Options _options,
+SpriteLabel::SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, Label::Options _options,
                          SpriteLabel::VertexAttributes _attrib, Texture* _texture,
                          SpriteLabels& _labels, size_t _labelsPos)
-    : Label(_transform, _size, _selectionColor, Label::Type::point, _options),
+    : Label(_transform, _size, _attrib.selectionColor, Label::Type::point, _options),
       m_labels(_labels),
       m_labelsPos(_labelsPos),
       m_texture(_texture),

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -34,7 +34,7 @@ public:
         float extrudeScale;
     };
 
-    SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, uint32_t _selectionColor, Label::Options _options,
+    SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, Label::Options _options,
                 SpriteLabel::VertexAttributes _attrib, Texture* _texture,
                 SpriteLabels& _labels, size_t _labelsPos);
 

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -42,6 +42,8 @@ public:
 
     void addVerticesToMesh() override;
 
+    LabelType renderType() const override { return LabelType::icon; }
+
 private:
 
     void applyAnchor(LabelProperty::Anchor _anchor) override;

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -34,7 +34,7 @@ public:
         float extrudeScale;
     };
 
-    SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, Label::Options _options,
+    SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, uint32_t _selectionColor, Label::Options _options,
                 SpriteLabel::VertexAttributes _attrib, Texture* _texture,
                 SpriteLabels& _labels, size_t _labelsPos);
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -16,11 +16,11 @@ using namespace TextLabelProperty;
 const float TextVertex::position_scale = 4.0f;
 const float TextVertex::alpha_scale = 65535.0f;
 
-TextLabel::TextLabel(Label::WorldTransform _transform, Type _type, uint32_t _selectionColor, Label::Options _options,
+TextLabel::TextLabel(Label::WorldTransform _transform, Type _type, Label::Options _options,
                      TextLabel::VertexAttributes _attrib,
                      glm::vec2 _dim,  TextLabels& _labels, TextRange _textRanges,
                      Align _preferedAlignment)
-    : Label(_transform, _dim, _selectionColor, _type, _options),
+    : Label(_transform, _dim, _attrib.selectionColor, _type, _options),
       m_textLabels(_labels),
       m_textRanges(_textRanges),
       m_fontAttrib(_attrib),

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -16,11 +16,11 @@ using namespace TextLabelProperty;
 const float TextVertex::position_scale = 4.0f;
 const float TextVertex::alpha_scale = 65535.0f;
 
-TextLabel::TextLabel(Label::WorldTransform _transform, Type _type, Label::Options _options,
+TextLabel::TextLabel(Label::WorldTransform _transform, Type _type, uint32_t _selectionColor, Label::Options _options,
                      TextLabel::VertexAttributes _attrib,
                      glm::vec2 _dim,  TextLabels& _labels, TextRange _textRanges,
                      Align _preferedAlignment)
-    : Label(_transform, _dim, _type, _options),
+    : Label(_transform, _dim, _selectionColor, _type, _options),
       m_textLabels(_labels),
       m_textRanges(_textRanges),
       m_fontAttrib(_attrib),

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -45,7 +45,7 @@ public:
         uint32_t selectionColor;
     };
 
-    TextLabel(Label::WorldTransform _transform, Type _type, uint32_t _selectionColor, Label::Options _options,
+    TextLabel(Label::WorldTransform _transform, Type _type, Label::Options _options,
               TextLabel::VertexAttributes _attrib,
               glm::vec2 _dim, TextLabels& _labels, TextRange _textRanges,
               TextLabelProperty::Align _preferedAlignment);

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -45,7 +45,7 @@ public:
         uint32_t selectionColor;
     };
 
-    TextLabel(Label::WorldTransform _transform, Type _type, Label::Options _options,
+    TextLabel(Label::WorldTransform _transform, Type _type, uint32_t _selectionColor, Label::Options _options,
               TextLabel::VertexAttributes _attrib,
               glm::vec2 _dim, TextLabels& _labels, TextRange _textRanges,
               TextLabelProperty::Align _preferedAlignment);

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -52,6 +52,8 @@ public:
 
     void updateBBoxes(float _zoomFract) override;
 
+    LabelType renderType() const override { return LabelType::text; }
+
     TextRange& textRanges() {
         return m_textRanges;
     }

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -13,6 +13,7 @@ class TileBuilder;
 class Scene;
 class SceneLayer;
 class StyleContext;
+class FeatureSelection;
 
 /*
  * A draw rule is a named collection of style parameters. When a draw rule is found to match a
@@ -76,6 +77,7 @@ struct DrawRule {
     int id;
     bool isOutlineOnly = false;
     uint32_t selectionColor = 0;
+    FeatureSelection* featureSelection = nullptr;
 
     DrawRule(const DrawRuleData& _ruleData, const std::string& _layerName, size_t _layerDepth);
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -2,6 +2,7 @@
 
 #include "textStyleBuilder.h"
 #include "labels/textLabels.h"
+#include "scene/drawRule.h"
 
 #include "tangram.h"
 #include "tile/tile.h"
@@ -61,7 +62,8 @@ std::unique_ptr<StyledMesh> DebugTextStyleBuilder::build() {
         return nullptr;
     }
 
-    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) });
+    DrawRule rule({"", 0, {}}, "", 0);
+    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) }, rule);
 
     m_textLabels->setLabels(m_labels);
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<StyledMesh> DebugTextStyleBuilder::build() {
         return nullptr;
     }
 
-    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) });
+    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) }, 0);
 
     m_textLabels->setLabels(m_labels);
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<StyledMesh> DebugTextStyleBuilder::build() {
         return nullptr;
     }
 
-    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) }, 0);
+    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) });
 
     m_textLabels->setLabels(m_labels);
 

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -20,13 +20,13 @@ public:
 
     struct Parameters {
         bool centroid = false;
+        bool interactive = false;
         std::string sprite;
         std::string spriteDefault;
         glm::vec2 size;
         uint32_t color = 0xffffffff;
         Label::Options labelOptions;
         float extrudeScale = 1.f;
-        uint32_t selectionColor = 0;
     };
 
     PointStyle(std::string _name, std::shared_ptr<FontContext> _fontContext,

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -161,11 +161,10 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
 }
 
 void PointStyleBuilder::addLabel(const Point& _point, const glm::vec4& _quad,
-                                 const PointStyle::Parameters& _params, uint32_t _selectionColor) {
+                                 const PointStyle::Parameters& _params) {
 
     m_labels.push_back(std::make_unique<SpriteLabel>(glm::vec3(glm::vec2(_point), m_zoom),
                                                      _params.size,
-                                                     _selectionColor,
                                                      _params.labelOptions,
                                                      SpriteLabel::VertexAttributes{_params.color, _params.selectionColor, _params.extrudeScale },
                                                      m_texture,
@@ -246,7 +245,7 @@ bool PointStyleBuilder::addPoint(const Point& _point, const Properties& _props,
         return false;
     }
 
-    addLabel(_point, uvsQuad, p, _rule.selectionColor);
+    addLabel(_point, uvsQuad, p);
 
     return true;
 }
@@ -262,7 +261,7 @@ bool PointStyleBuilder::addLine(const Line& _line, const Properties& _props,
     }
 
     for (size_t i = 0; i < _line.size(); ++i) {
-        addLabel(_line[i], uvsQuad, p, _rule.selectionColor);
+        addLabel(_line[i], uvsQuad, p);
     }
 
     return true;
@@ -281,13 +280,13 @@ bool PointStyleBuilder::addPolygon(const Polygon& _polygon, const Properties& _p
     if (!p.centroid) {
         for (auto line : _polygon) {
             for (auto point : line) {
-                addLabel(point, uvsQuad, p, _rule.selectionColor);
+                addLabel(point, uvsQuad, p);
             }
         }
     } else {
         glm::vec2 c = centroid(_polygon);
 
-        addLabel(Point{c,0}, uvsQuad, p, _rule.selectionColor);
+        addLabel(Point{c,0}, uvsQuad, p);
     }
 
     return true;

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -161,10 +161,11 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
 }
 
 void PointStyleBuilder::addLabel(const Point& _point, const glm::vec4& _quad,
-                                 const PointStyle::Parameters& _params) {
+                                 const PointStyle::Parameters& _params, uint32_t _selectionColor) {
 
     m_labels.push_back(std::make_unique<SpriteLabel>(glm::vec3(glm::vec2(_point), m_zoom),
                                                      _params.size,
+                                                     _selectionColor,
                                                      _params.labelOptions,
                                                      SpriteLabel::VertexAttributes{_params.color, _params.selectionColor, _params.extrudeScale },
                                                      m_texture,
@@ -245,7 +246,7 @@ bool PointStyleBuilder::addPoint(const Point& _point, const Properties& _props,
         return false;
     }
 
-    addLabel(_point, uvsQuad, p);
+    addLabel(_point, uvsQuad, p, _rule.selectionColor);
 
     return true;
 }
@@ -261,7 +262,7 @@ bool PointStyleBuilder::addLine(const Line& _line, const Properties& _props,
     }
 
     for (size_t i = 0; i < _line.size(); ++i) {
-        addLabel(_line[i], uvsQuad, p);
+        addLabel(_line[i], uvsQuad, p, _rule.selectionColor);
     }
 
     return true;
@@ -280,13 +281,13 @@ bool PointStyleBuilder::addPolygon(const Polygon& _polygon, const Properties& _p
     if (!p.centroid) {
         for (auto line : _polygon) {
             for (auto point : line) {
-                addLabel(point, uvsQuad, p);
+                addLabel(point, uvsQuad, p, _rule.selectionColor);
             }
         }
     } else {
         glm::vec2 c = centroid(_polygon);
 
-        addLabel(Point{c,0}, uvsQuad, p);
+        addLabel(Point{c,0}, uvsQuad, p, _rule.selectionColor);
     }
 
     return true;

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -43,7 +43,7 @@ struct PointStyleBuilder : public StyleBuilder {
     PointStyle::Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;
 
     void addLabel(const Point& _point, const glm::vec4& _quad,
-                  const PointStyle::Parameters& _params);
+                  const PointStyle::Parameters& _params, const DrawRule& _rule);
 
     void addLayoutItems(LabelCollider& _layout) override;
 

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -43,7 +43,7 @@ struct PointStyleBuilder : public StyleBuilder {
     PointStyle::Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;
 
     void addLabel(const Point& _point, const glm::vec4& _quad,
-                  const PointStyle::Parameters& _params);
+                  const PointStyle::Parameters& _params, uint32_t _selectionColor);
 
     void addLayoutItems(LabelCollider& _layout) override;
 

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -43,7 +43,7 @@ struct PointStyleBuilder : public StyleBuilder {
     PointStyle::Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;
 
     void addLabel(const Point& _point, const glm::vec4& _quad,
-                  const PointStyle::Parameters& _params, uint32_t _selectionColor);
+                  const PointStyle::Parameters& _params);
 
     void addLayoutItems(LabelCollider& _layout) override;
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -38,7 +38,6 @@ public:
 
         float fontScale = 1;
         float lineSpacing = 0;
-        uint32_t selectionColor = 0;
     };
 
     auto& context() const { return m_context; }
@@ -112,7 +111,6 @@ namespace std {
             // TODO
             //hash_combine(seed, p.fontId);
             hash_combine(seed, p.text);
-            hash_combine(seed, p.interactive);
             hash_combine(seed, p.fill);
             hash_combine(seed, p.strokeColor);
             hash_combine(seed, p.strokeWidth);

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -182,18 +182,18 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
     if (_feat.geometryType == GeometryType::points) {
         for (auto& point : _feat.points) {
             auto p = glm::vec2(point);
-            addLabel(params, Label::Type::point, { p, p }, _rule.selectionColor);
+            addLabel(params, Label::Type::point, { p, p });
         }
 
     } else if (_feat.geometryType == GeometryType::polygons) {
         for (auto& polygon : _feat.polygons) {
             if (_iconText) {
                 auto p = centroid(polygon);
-                addLabel(params, Label::Type::point, { p, p }, _rule.selectionColor);
+                addLabel(params, Label::Type::point, { p, p });
             } else {
                 for (auto& line : polygon) {
                     for (auto& point : line) {
-                        addLabel(params, Label::Type::point, { point }, _rule.selectionColor);
+                        addLabel(params, Label::Type::point, { point });
                     }
                 }
             }
@@ -204,11 +204,11 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
         if (_iconText) {
             for (auto& line : _feat.lines) {
                 for (auto& point : line) {
-                    addLabel(params, Label::Type::point, { point }, _rule.selectionColor);
+                    addLabel(params, Label::Type::point, { point });
                 }
             }
         } else {
-            addLineTextLabels(_feat, params, _rule.selectionColor);
+            addLineTextLabels(_feat, params);
         }
     }
 
@@ -219,7 +219,7 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
     return true;
 }
 
-void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::Parameters& _params, uint32_t _selectionColor) {
+void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::Parameters& _params) {
     float pixelScale = 1.0/m_tileSize;
     float minLength = m_attributes.width * pixelScale;
 
@@ -241,7 +241,7 @@ void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::
 
                 if (j == next) {
                     if (segmentLength > minLength) {
-                        addLabel(_params, Label::Type::line, { p1, p }, _selectionColor);
+                        addLabel(_params, Label::Type::line, { p1, p });
                     }
                 } else {
                     glm::vec2 pp = glm::vec2(line[j-1]);
@@ -265,7 +265,7 @@ void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::
                 glm::vec2 b = glm::vec2(p2 - p1) / float(run);
 
                 for (int r = 0; r < run; r++) {
-                    addLabel(_params, Label::Type::line, { a, a+b }, _selectionColor);
+                    addLabel(_params, Label::Type::line, { a, a+b });
                     a += b;
                 }
                 run *= 2;
@@ -521,9 +521,9 @@ bool TextStyleBuilder::prepareLabel(TextStyle::Parameters& _params, Label::Type 
 }
 
 void TextStyleBuilder::addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                                Label::WorldTransform _transform, uint32_t _selectionColor) {
+                                Label::WorldTransform _transform) {
 
-    m_labels.emplace_back(new TextLabel(_transform, _type, _selectionColor, _params.labelOptions,
+    m_labels.emplace_back(new TextLabel(_transform, _type, _params.labelOptions,
                                         {m_attributes.fill,
                                          m_attributes.stroke,
                                          m_attributes.fontScale,

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -182,18 +182,18 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
     if (_feat.geometryType == GeometryType::points) {
         for (auto& point : _feat.points) {
             auto p = glm::vec2(point);
-            addLabel(params, Label::Type::point, { p, p });
+            addLabel(params, Label::Type::point, { p, p }, _rule.selectionColor);
         }
 
     } else if (_feat.geometryType == GeometryType::polygons) {
         for (auto& polygon : _feat.polygons) {
             if (_iconText) {
                 auto p = centroid(polygon);
-                addLabel(params, Label::Type::point, { p, p });
+                addLabel(params, Label::Type::point, { p, p }, _rule.selectionColor);
             } else {
                 for (auto& line : polygon) {
                     for (auto& point : line) {
-                        addLabel(params, Label::Type::point, { point });
+                        addLabel(params, Label::Type::point, { point }, _rule.selectionColor);
                     }
                 }
             }
@@ -204,11 +204,11 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
         if (_iconText) {
             for (auto& line : _feat.lines) {
                 for (auto& point : line) {
-                    addLabel(params, Label::Type::point, { point });
+                    addLabel(params, Label::Type::point, { point }, _rule.selectionColor);
                 }
             }
         } else {
-            addLineTextLabels(_feat, params);
+            addLineTextLabels(_feat, params, _rule.selectionColor);
         }
     }
 
@@ -219,7 +219,7 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
     return true;
 }
 
-void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::Parameters& _params) {
+void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::Parameters& _params, uint32_t _selectionColor) {
     float pixelScale = 1.0/m_tileSize;
     float minLength = m_attributes.width * pixelScale;
 
@@ -241,7 +241,7 @@ void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::
 
                 if (j == next) {
                     if (segmentLength > minLength) {
-                        addLabel(_params, Label::Type::line, { p1, p });
+                        addLabel(_params, Label::Type::line, { p1, p }, _selectionColor);
                     }
                 } else {
                     glm::vec2 pp = glm::vec2(line[j-1]);
@@ -265,7 +265,7 @@ void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::
                 glm::vec2 b = glm::vec2(p2 - p1) / float(run);
 
                 for (int r = 0; r < run; r++) {
-                    addLabel(_params, Label::Type::line, { a, a+b });
+                    addLabel(_params, Label::Type::line, { a, a+b }, _selectionColor);
                     a += b;
                 }
                 run *= 2;
@@ -521,9 +521,9 @@ bool TextStyleBuilder::prepareLabel(TextStyle::Parameters& _params, Label::Type 
 }
 
 void TextStyleBuilder::addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                                Label::WorldTransform _transform) {
+                                Label::WorldTransform _transform, uint32_t _selectionColor) {
 
-    m_labels.emplace_back(new TextLabel(_transform, _type, _params.labelOptions,
+    m_labels.emplace_back(new TextLabel(_transform, _type, _selectionColor, _params.labelOptions,
                                         {m_attributes.fill,
                                          m_attributes.stroke,
                                          m_attributes.fontScale,

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -329,7 +329,9 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
             p.labelOptions.priority = (float)priority;
         }
         _rule.get(StyleParamKey::text_collide, p.labelOptions.collide);
-        _rule.get(StyleParamKey::text_interactive, p.interactive);
+        if (!_rule.get(StyleParamKey::text_interactive, p.interactive)) {
+            _rule.get(StyleParamKey::interactive, p.interactive);
+        }
         _rule.get(StyleParamKey::text_offset, p.labelOptions.offset);
         p.labelOptions.offset *= m_style.pixelScale();
 

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -37,9 +37,9 @@ public:
 
     // Add label to the mesh using the prepared label data
     void addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                  Label::WorldTransform _transform);
+                  Label::WorldTransform _transform, const DrawRule& _rule);
 
-    void addLineTextLabels(const Feature& _feature, const TextStyle::Parameters& _params);
+    void addLineTextLabels(const Feature& _feature, const TextStyle::Parameters& _params, const DrawRule& _rule);
 
     std::string applyTextTransform(const TextStyle::Parameters& _params, const std::string& _string);
 

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -37,9 +37,9 @@ public:
 
     // Add label to the mesh using the prepared label data
     void addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                  Label::WorldTransform _transform);
+                  Label::WorldTransform _transform, uint32_t _selectionColor);
 
-    void addLineTextLabels(const Feature& _feature, const TextStyle::Parameters& _params);
+    void addLineTextLabels(const Feature& _feature, const TextStyle::Parameters& _params, uint32_t _selectionColor);
 
     std::string applyTextTransform(const TextStyle::Parameters& _params, const std::string& _string);
 

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -37,9 +37,9 @@ public:
 
     // Add label to the mesh using the prepared label data
     void addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                  Label::WorldTransform _transform, uint32_t _selectionColor);
+                  Label::WorldTransform _transform);
 
-    void addLineTextLabels(const Feature& _feature, const TextStyle::Parameters& _params, uint32_t _selectionColor);
+    void addLineTextLabels(const Feature& _feature, const TextStyle::Parameters& _params);
 
     std::string applyTextTransform(const TextStyle::Parameters& _params, const std::string& _string);
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -472,14 +472,12 @@ void Map::render() {
 
             // Retrieve the label for this selection color
             if (impl->labels.getLabel(impl->scene->styles(), impl->tileManager.getVisibleTiles(), color, label, tile)) {
-                if (auto props = tile->getSelectionFeature(color)) {
-                    std::vector<TouchLabel> touchLabels;
-                    std::vector<LngLat> coordinates = label->coordinates(*tile, impl->view.getMapProjection());
-                    float distance = sqrt(label->screenDistance2(labelQuery.position));
+                std::vector<TouchLabel> touchLabels;
+                std::vector<LngLat> coordinates = label->coordinates(*tile, impl->view.getMapProjection());
+                float distance = sqrt(label->screenDistance2(labelQuery.position));
 
-                    labels.push_back({label->renderType(), coordinates,
-                        {props, {labelQuery.position.x, labelQuery.position.y}, distance}});
-                }
+                labels.push_back({label->renderType(), coordinates,
+                    {label->options().properties, {labelQuery.position.x, labelQuery.position.y}, distance}});
             }
 
             // TODO: sort touch labels by distance

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -434,7 +434,11 @@ void Map::render() {
             // TODO: read with a scalable thumb size
             GLuint color = impl->selectionBuffer->readAt(x, y);
 
-            for (const auto& tile : impl->tileManager.getVisibleTiles()) {
+            // Retrieve labels for this selection color
+            auto& tiles = impl->tileManager.getVisibleTiles();
+            auto labels = impl->labels.getLabels(impl->scene->styles(), tiles, color);
+
+            for (const auto& tile : tiles) {
                 if (auto props = tile->getSelectionFeature(color)) {
                     items.push_back({props, {query.position[0], query.position[1]}, 0});
                 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -445,7 +445,13 @@ void Map::render() {
                     for (auto label : labels) {
                         std::vector<LngLat> coordinates;
 
-                        if (label->type() != Label::Type::line) {
+                        if (label->type() == Label::Type::line) {
+                            for (int i = 0; i < 2; ++i) {
+                                glm::vec2 tileCoord = glm::vec2(label->worldTransform().positions[i]);
+                                glm::dvec2 degrees = tile->coordToLngLat(tileCoord, impl->view.getMapProjection());
+                                coordinates.push_back({degrees.x, degrees.y});
+                            }
+                        } else {
                             glm::vec2 tileCoord = glm::vec2(label->worldTransform().position);
                             glm::dvec2 degrees = tile->coordToLngLat(tileCoord, impl->view.getMapProjection());
                             coordinates.push_back({degrees.x, degrees.y});

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -440,7 +440,21 @@ void Map::render() {
 
             for (const auto& tile : tiles) {
                 if (auto props = tile->getSelectionFeature(color)) {
-                    items.push_back({props, {query.position[0], query.position[1]}, 0});
+                    std::vector<TouchLabel> touchLabels;
+
+                    for (auto label : labels) {
+                        std::vector<LngLat> coordinates;
+
+                        if (label->type() != Label::Type::line) {
+                            glm::vec2 tileCoord = glm::vec2(label->worldTransform().position);
+                            glm::dvec2 degrees = tile->coordToLngLat(tileCoord, impl->view.getMapProjection());
+                            coordinates.push_back({degrees.x, degrees.y});
+                        }
+
+                        touchLabels.push_back({label->renderType(), coordinates});
+                    }
+
+                    items.push_back({props, touchLabels, {query.position[0], query.position[1]}, 0});
                 }
             }
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -447,9 +447,11 @@ void Map::render() {
             // TODO: read with a scalable thumb size
             GLuint color = impl->selectionBuffer->readAt(x, y);
 
-            for (const auto& tile : impl->tileManager.getVisibleTiles()) {
-                if (auto props = tile->getSelectionFeature(color)) {
-                    items.push_back({props, {selectionQuery.position.x, selectionQuery.position.y}, 0});
+            if (color != 0) {
+                for (const auto& tile : impl->tileManager.getVisibleTiles()) {
+                    if (auto props = tile->getSelectionFeature(color)) {
+                        items.push_back({props, {selectionQuery.position.x, selectionQuery.position.y}, 0});
+                    }
                 }
             }
 
@@ -470,14 +472,16 @@ void Map::render() {
             // TODO: read with a scalable thumb size and iterate over the read colors
             GLuint color = impl->selectionBuffer->readAt(x, y);
 
-            // Retrieve the label for this selection color
-            if (impl->labels.getLabel(impl->scene->styles(), impl->tileManager.getVisibleTiles(), color, label, tile)) {
-                std::vector<TouchLabel> touchLabels;
-                std::vector<LngLat> coordinates = label->coordinates(*tile, impl->view.getMapProjection());
-                float distance = sqrt(label->screenDistance2(labelQuery.position));
+            if (color != 0) {
+                // Retrieve the label for this selection color
+                if (impl->labels.getLabel(impl->scene->styles(), impl->tileManager.getVisibleTiles(), color, label, tile)) {
+                    std::vector<TouchLabel> touchLabels;
+                    LngLat coordinate = label->coordinate(*tile, impl->view.getMapProjection());
+                    float distance = sqrt(label->screenDistance2(labelQuery.position));
 
-                labels.push_back({label->renderType(), coordinates,
-                    {label->options().properties, {labelQuery.position.x, labelQuery.position.y}, distance}});
+                    labels.push_back({label->renderType(), coordinate,
+                        {label->options().properties, {labelQuery.position.x, labelQuery.position.y}, distance}});
+                }
             }
 
             // TODO: sort touch labels by distance

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -11,8 +11,19 @@ namespace Tangram {
 
 class DataSource;
 
+enum LabelType {
+    icon,
+    text,
+};
+
+struct TouchLabel {
+    LabelType type;
+    std::vector<LngLat> coordinates;
+};
+
 struct TouchItem {
     std::shared_ptr<Properties> properties;
+    std::vector<TouchLabel> labels;
     float position[2];
     float distance;
 };

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -16,17 +16,21 @@ enum LabelType {
     text,
 };
 
-struct TouchLabel {
-    LabelType type;
-    std::vector<LngLat> coordinates;
-};
-
 struct TouchItem {
     std::shared_ptr<Properties> properties;
-    std::vector<TouchLabel> labels;
     float position[2];
     float distance;
 };
+
+using FeatureSelectionCallback = std::function<void(const std::vector<TouchItem>&)>;
+
+struct TouchLabel {
+    LabelType type;
+    std::vector<LngLat> coordinate;
+    TouchItem touchItem;
+};
+
+using LabelSelectionCallback = std::function<void(const std::vector<TouchLabel>&)>;
 
 struct SceneUpdate {
     std::string path;
@@ -243,7 +247,9 @@ public:
     // efficiency, but can cause errors if your application code makes OpenGL calls (false by default)
     void useCachedGlState(bool _use);
 
-    void pickFeaturesAt(float _x, float _y, std::function<void(const std::vector<TouchItem>&)> _onReadyCallback);
+    void pickFeaturesAt(float _x, float _y, FeatureSelectionCallback _onFeatureSelectCallback);
+
+    void pickLabelsAt(float _x, float _y, LabelSelectionCallback _onTouchLabelSelectCallback);
 
     // Run this task asynchronously to Tangram's main update loop.
     void runAsyncTask(std::function<void()> _task);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -16,21 +16,22 @@ enum LabelType {
     text,
 };
 
-struct TouchItem {
+struct FeaturePickResult {
     std::shared_ptr<Properties> properties;
     float position[2];
-    float distance;
 };
 
-using FeatureSelectionCallback = std::function<void(const std::vector<TouchItem>&)>;
+// Returns a pointer to the selected feature or null, only valid on the callback scope
+using FeaturePickCallback = std::function<void(const FeaturePickResult*)>;
 
-struct TouchLabel {
+struct LabelPickResult {
     LabelType type;
     LngLat coordinate;
-    TouchItem touchItem;
+    FeaturePickResult touchItem;
 };
 
-using LabelSelectionCallback = std::function<void(const std::vector<TouchLabel>&)>;
+// Returns a pointer to the selected label or null, only valid on the callback scope
+using LabelPickCallback = std::function<void(const LabelPickResult*)>;
 
 struct SceneUpdate {
     std::string path;
@@ -248,15 +249,15 @@ public:
     void useCachedGlState(bool _use);
 
     // Create a query to select a feature marked as 'interactive'. The query runs on the next frame.
-    // Calls _onFeatureSelectCallback once the query has completed, and returns the collection
-    // of TouchItem and their associated properties.
-    void pickFeaturesAt(float _x, float _y, FeatureSelectionCallback _onFeatureSelectCallback);
+    // Calls _onFeaturePickCallback once the query has completed, and returns the FeaturePickResult
+    // with its associated properties.
+    void pickFeatureAt(float _x, float _y, FeaturePickCallback _onFeaturePickCallback);
 
     // Create a query to select a label created for a feature marked as 'interactive'. The query runs
     // on the next frame.
-    // Calls _onTouchLabelSelectCallback once the query has completed, and returns the collection
-    // of TouchLabel and their associated properties.
-    void pickLabelsAt(float _x, float _y, LabelSelectionCallback _onTouchLabelSelectCallback);
+    // Calls _onLabelPickCallback once the query has completed, and returns the LabelPickResult
+    // with its associated properties.
+    void pickLabelAt(float _x, float _y, LabelPickCallback _onLabelPickCallback);
 
     // Run this task asynchronously to Tangram's main update loop.
     void runAsyncTask(std::function<void()> _task);

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -26,7 +26,7 @@ using FeatureSelectionCallback = std::function<void(const std::vector<TouchItem>
 
 struct TouchLabel {
     LabelType type;
-    std::vector<LngLat> coordinate;
+    LngLat coordinate;
     TouchItem touchItem;
 };
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -247,8 +247,15 @@ public:
     // efficiency, but can cause errors if your application code makes OpenGL calls (false by default)
     void useCachedGlState(bool _use);
 
+    // Create a query to select a feature marked as 'interactive'. The query runs on the next frame.
+    // Calls _onFeatureSelectCallback once the query has completed, and returns the collection
+    // of TouchItem and their associated properties.
     void pickFeaturesAt(float _x, float _y, FeatureSelectionCallback _onFeatureSelectCallback);
 
+    // Create a query to select a label created for a feature marked as 'interactive'. The query runs
+    // on the next frame.
+    // Calls _onTouchLabelSelectCallback once the query has completed, and returns the collection
+    // of TouchLabel and their associated properties.
     void pickLabelsAt(float _x, float _y, LabelSelectionCallback _onTouchLabelSelectCallback);
 
     // Run this task asynchronously to Tangram's main update loop.

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -27,6 +27,16 @@ Tile::Tile(TileID _id, const MapProjection& _projection, const DataSource* _sour
     m_modelMatrix = glm::scale(glm::mat4(1.0), glm::vec3(m_scale));
 }
 
+
+glm::dvec2 Tile::coordToLngLat(const glm::vec2& _tileCoord, const MapProjection& _projection) const {
+    double scale = 1.0 / m_inverseScale;
+
+    glm::dvec2 meters = glm::dvec2(_tileCoord) * scale + m_tileOrigin;
+    glm::dvec2 degrees = _projection.MetersToLonLat(meters);
+
+    return {degrees.x, degrees.y};
+}
+
 Tile::~Tile() {}
 
 //Note: This could set tile origin to be something different than the one if TileID's wrap is used.

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -64,6 +64,8 @@ public:
 
     const glm::mat4& mvp() const { return m_mvp; }
 
+    glm::dvec2 coordToLngLat(const glm::vec2& _tileCoord, const MapProjection& _projection) const;
+
     void initGeometry(uint32_t _size);
 
     const std::unique_ptr<StyledMesh>& getMesh(const Style& _style) const;

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -61,9 +61,10 @@ void TileBuilder::applyStyling(const Feature& _feature, const SceneLayer& _layer
         bool interactive = false;
         if (rule.get(StyleParamKey::interactive, interactive) && interactive) {
             if (selectionColor == 0) {
-                selectionColor = m_scene->featureSelection()->colorIdentifier();
+                selectionColor = m_scene->featureSelection()->nextColorIdentifier();
             }
             rule.selectionColor = selectionColor;
+            rule.featureSelection = m_scene->featureSelection().get();
         } else {
             rule.selectionColor = 0;
         }

--- a/core/src/util/featureSelection.cpp
+++ b/core/src/util/featureSelection.cpp
@@ -6,7 +6,7 @@ FeatureSelection::FeatureSelection() :
     m_entry(0) {
 }
 
-uint32_t FeatureSelection::colorIdentifier() {
+uint32_t FeatureSelection::nextColorIdentifier() {
 
     uint32_t entry = m_entry++;
 

--- a/core/src/util/featureSelection.h
+++ b/core/src/util/featureSelection.h
@@ -10,7 +10,7 @@ public:
 
     FeatureSelection();
 
-    uint32_t colorIdentifier();
+    uint32_t nextColorIdentifier();
 
 private:
 

--- a/core/src/util/util.h
+++ b/core/src/util/util.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include <sstream>
 
+namespace Tangram {
+
 inline std::vector<std::string> splitString(const std::string& s, char delim) {
     std::vector<std::string> elems;
     std::stringstream ss(s);
@@ -28,3 +30,4 @@ inline bool tryFind(M& map, const std::string& key, T& out) {
     return false;
 }
 
+}

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -91,14 +91,12 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
         logMsg("pick feature\n");
         map->clearDataSource(*data_source, true, true);
 
-        map->pickFeaturesAt(x, y, [](const auto& items) {
-            for (const auto& item : items) {
-                LOG("%s", item.properties->toJson().c_str());
-
-                std::string name = "noname";
-                item.properties->getString("name", name);
-                LOGS("%s", name.c_str());
-            }
+        map->pickFeatureAt(x, y, [](auto item) {
+            if (!item) { return; }
+            LOG("%s", item->properties->toJson().c_str());
+            std::string name = "noname";
+            item->properties->getString("name", name);
+            LOGS("%s", name.c_str());
         });
     } else if ((time - last_time_pressed) < single_tap_time) {
         // LngLat p;

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -111,12 +111,19 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
             std::string name;
             for (const auto& item : items) {
                 if (item.properties->getString("name", name)) {
-                    LOG("Selected %s", name.c_str());
+                    LOGS("Selected %s", name.c_str());
                 }
             }
         });
 
         map->pickLabelsAt(x, y, [](const auto& labels) {
+            for (auto label : labels) {
+                std::string type = label.type == LabelType::text ? "text" : "icon";
+                std::string name;
+                if (label.touchItem.properties->getString("name", name)) {
+                    LOGS("Touched label %s %s", type.c_str(), name.c_str());
+                }
+            }
         });
 
         static double last_x = 0, last_y = 0;

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -112,9 +112,11 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
             for (const auto& item : items) {
                 if (item.properties->getString("name", name)) {
                     LOG("Selected %s", name.c_str());
-                    LOGS("%s with %d labels", name.c_str(), item.labels.size());
                 }
             }
+        });
+
+        map->pickLabelsAt(x, y, [](const auto& labels) {
         });
 
         static double last_x = 0, last_y = 0;

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -112,7 +112,7 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
             for (const auto& item : items) {
                 if (item.properties->getString("name", name)) {
                     LOG("Selected %s", name.c_str());
-                    LOGS("%s", name.c_str());
+                    LOGS("%s with %d labels", name.c_str(), item.labels.size());
                 }
             }
         });

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -123,6 +123,8 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
                 if (label.touchItem.properties->getString("name", name)) {
                     LOGS("Touched label %s %s", type.c_str(), name.c_str());
                 }
+                map->markerSetPoint(marker, label.coordinate);
+                map->markerSetVisible(marker, true);
             }
         });
 

--- a/osx/src/main.cpp
+++ b/osx/src/main.cpp
@@ -107,25 +107,23 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
             visible = !visible;
         }
 
-        map->pickFeaturesAt(x, y, [](const auto& items) {
+        map->pickFeatureAt(x, y, [](const FeaturePickResult* featurePickResult) {
+            if (!featurePickResult) { return; }
             std::string name;
-            for (const auto& item : items) {
-                if (item.properties->getString("name", name)) {
-                    LOGS("Selected %s", name.c_str());
-                }
+            if (featurePickResult->properties->getString("name", name)) {
+                LOGS("Selected %s", name.c_str());
             }
         });
 
-        map->pickLabelsAt(x, y, [](const auto& labels) {
-            for (auto label : labels) {
-                std::string type = label.type == LabelType::text ? "text" : "icon";
-                std::string name;
-                if (label.touchItem.properties->getString("name", name)) {
-                    LOGS("Touched label %s %s", type.c_str(), name.c_str());
-                }
-                map->markerSetPoint(marker, label.coordinate);
-                map->markerSetVisible(marker, true);
+        map->pickLabelAt(x, y, [](const LabelPickResult* labelPickResult) {
+            if (!labelPickResult) { return; }
+            std::string type = labelPickResult->type == LabelType::text ? "text" : "icon";
+            std::string name;
+            if (labelPickResult->touchItem.properties->getString("name", name)) {
+                LOGS("Touched label %s %s", type.c_str(), name.c_str());
             }
+            map->markerSetPoint(marker, labelPickResult->coordinate);
+            map->markerSetVisible(marker, true);
         });
 
         static double last_x = 0, last_y = 0;

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -24,7 +24,6 @@ std::unique_ptr<TextLabel> makeLabel(glm::vec2 _transform, Label::Type _type, st
     options.offset = {0.0f, 0.0f};
     //options.properties = std::make_shared<Properties>();
     //options.properties->set("id", id);
-    options.interactive = true;
     options.anchors.anchor[0] = LabelProperty::Anchor::center;
     options.anchors.count = 1;
 


### PR DESCRIPTION
Add interface to get more infos when selecting POIs/Icons and text labels.

Generic feature selection makes it hard to adjust a marker on top of an icon since the interface returns back the screen position of the created feature selection query. Putting a marker at this  position makes it nearly impossible to add a marker sticking to an existing label on screen.

This PR adds the set of touched label created for that feature with their corresponding lat/lon.

Example:

Selecting any of the point or text in this POI:
<img width="207" alt="screen shot 2016-11-09 at 2 52 22 pm" src="https://cloud.githubusercontent.com/assets/7061573/20152446/40c365c6-a68c-11e6-998c-8345c4961064.png">

Returns:
<img width="582" alt="screen shot 2016-11-09 at 2 52 36 pm" src="https://cloud.githubusercontent.com/assets/7061573/20152456/4bee5e1a-a68c-11e6-893c-5d130a8e3849.png">

cc @sarahlensing @ecgreb for the Android interface.

TODO:
- [x] JNI bindings
- [x] Treat line labels