### PR TITLE
Use a scheme called 'asset' to denote Android asset URLs

### DIFF
--- a/android/tangram/jni/jniExports.cpp
+++ b/android/tangram/jni/jniExports.cpp
@@ -114,7 +114,7 @@ extern "C" {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         const char* cPath = jniEnv->GetStringUTFChars(path, NULL);
-        map->loadScene(cPath);
+        map->loadScene(resolveScenePath(cPath).c_str());
         jniEnv->ReleaseStringUTFChars(path, cPath);
     }
 

--- a/android/tangram/jni/platform_android.h
+++ b/android/tangram/jni/platform_android.h
@@ -16,4 +16,6 @@ struct TouchItem;
 
 void featurePickCallback(jobject listener, const std::vector<Tangram::TouchItem>& items);
 
+std::string resolveScenePath(const char* path);
+
 std::string stringFromJString(JNIEnv* jniEnv, jstring string);


### PR DESCRIPTION
Previously all asset paths were relative references, so they could never be resolved to an absolute path.

Resolves https://github.com/tangrams/tangram-es/issues/1078