### PR TITLE
Url: remove duplicate slashes from path

### DIFF
--- a/core/src/util/url.cpp
+++ b/core/src/util/url.cpp
@@ -455,7 +455,11 @@ size_t Url::removeDotSegmentsFromRange(std::string& str, size_t start, size_t co
     size_t out = pos; // 'output' position.
 
     while (pos < end) {
-        if (pos + 2 < end &&
+        if (pos + 1 < end &&
+                   str[pos] == '/' &&
+                   str[pos + 1] == '/') {
+            pos += 1;
+        } else if (pos + 2 < end &&
                    str[pos] == '.' &&
                    str[pos + 1] == '.' &&
                    str[pos + 2] == '/') {

--- a/tests/unit/urlTests.cpp
+++ b/tests/unit/urlTests.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Remove dot segments from a path", "[Url]") {
     CHECK(Url::removeDotSegmentsFromString("..") == "");
     CHECK(Url::removeDotSegmentsFromString("a/b/../../..") == "");
     CHECK(Url::removeDotSegmentsFromString("a/b/../c/../d/./e/..") == "a/d");
-    CHECK(Url::removeDotSegmentsFromString("a//b//c") == "a//b//c");
+    CHECK(Url::removeDotSegmentsFromString("a//b//c") == "a/b/c");
     CHECK(Url::removeDotSegmentsFromString("a./b../..c/.d") == "a./b../..c/.d");
 
 }
@@ -202,3 +202,10 @@ TEST_CASE("Resolve an abnormal relative URL against an absolute base URL", "[Url
 // in our implementation because the interpretation of the parameters string in RFC 3986 is
 // in conflict with RFC 1808, which many URL utilities adhere to (e.g. NSURL). In RFC 1808
 // the 'path' component stops at a ';', but in RFC 3986 it goes up to a '?'.
+
+TEST_CASE("Resolve relative URL against an non-normalized absolute base URL", "[Url]") {
+
+    Url base("http://a/b//c/");
+
+    CHECK(Url("../../g").resolved(base).string() == "http://a/g");
+}


### PR DESCRIPTION
Another option would be to change removeLastSegmentFromRange
to drop duplicate slashes