### PR TITLE
Prevent 'global' references from being resolved as URLs

### DIFF
--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -90,6 +90,13 @@ TestImporter::TestImporter() {
                         u_tex1: "in_imports.png"
                         u_tex2: tex2
     )END";
+
+    m_testScenes["/root/globals.yaml"] = R"END(
+        fonts: { aFont: { url: global.fontUrl } }
+        sources: { aSource: { url: global.sourceUrl } }
+        textures: { aTexture: { url: global.textureUrl } }
+        styles: { aStyle: { texture: global.textureUrl, shaders: { uniforms: { aUniform: global.textureUrl } } } }
+    )END";
 }
 
 TEST_CASE("Imported scenes are merged with the parent scene", "[import][core]") {
@@ -190,4 +197,21 @@ TEST_CASE("Scene URLs are resolved against their parent during import", "[import
 
     // We don't explicitly check that import URLs are resolved correctly because if they were not,
     // the scenes wouldn't be loaded and merged; i.e. we already test it implicitly.
+}
+
+TEST_CASE("References to globals are not treated like URLs during importing", "[import][core]") {
+
+    TestImporter importer;
+    auto root = importer.applySceneImports("globals.yaml", "/root/");
+
+    // Check that font global references are preserved.
+    CHECK(root["fonts"]["aFont"]["url"].Scalar() == "global.fontUrl");
+
+    // Check that data source global references are preserved.
+    CHECK(root["sources"]["aSource"]["url"].Scalar() == "global.sourceUrl");
+
+    // Check that texture global references are preserved.
+    CHECK(root["textures"]["aTexture"]["url"].Scalar() == "global.textureUrl");
+    CHECK(root["styles"]["aStyle"]["texture"].Scalar() == "global.textureUrl");
+    CHECK(root["styles"]["aStyle"]["shaders"]["uniforms"]["aUniform"].Scalar() == "global.textureUrl");
 }


### PR DESCRIPTION
Currently, if a `global.` reference is used in a scene node that represents a URL, that reference will be resolved as a relative URL and not replaced with the appropriate global value.

This change makes `global.` a reserved prefix that will prevent values from being treated like URLs. This means that global values will now behave as documented for values that expect URLs. 

This also implies that you cannot use `global.png` or similar file names/paths. If you _really_ need to call your file "global.png" then you can use the equivalent path `./global.png`