### PR TITLE
Rebuild all markers when pixel density is set

### DIFF
--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -22,12 +22,7 @@ void MarkerManager::setScene(std::shared_ptr<Scene> scene) {
         m_styleBuilders[style->getName()] = style->createBuilder();
     }
 
-    // Rebuild any markers present.
-    for (auto& entry : m_markers) {
-        buildStyling(*entry);
-        buildGeometry(*entry, m_zoom);
-    }
-
+    rebuildAll();
 }
 
 MarkerID MarkerManager::add() {
@@ -273,6 +268,15 @@ bool MarkerManager::update(int zoom) {
 void MarkerManager::removeAll() {
 
     m_markers.clear();
+
+}
+
+void MarkerManager::rebuildAll() {
+
+    for (auto& entry : m_markers) {
+        buildStyling(*entry);
+        buildGeometry(*entry, m_zoom);
+    }
 
 }
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -60,6 +60,9 @@ public:
     // Remove and destroy all markers.
     void removeAll();
 
+    // Rebuild all markers.
+    void rebuildAll();
+
     const std::vector<std::unique_ptr<Marker>>& markers() const;
 
 private:

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -671,6 +671,9 @@ void Map::Impl::setPixelScale(float _pixelsPerPoint) {
     }
     // Tiles must be rebuilt to apply the new pixel scale to labels.
     tileManager.clearTileSets();
+
+    // Markers must be rebuilt to apply the new pixel scale.
+    markerManager.rebuildAll();
 }
 
 void Map::setCameraType(int _type) {


### PR DESCRIPTION
Resolves an issue that is very similar to https://github.com/mapzen/tizen-maps-plugin-mapzen/issues/72 (have not yet tested on Tizen).