### PR TITLE
Remove xcpretty dependency and update ios feature selection code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ OSX_XCODE_PROJ = tangram.xcodeproj
 IOS_XCODE_PROJ = tangram.xcodeproj
 IOS_FRAMEWORK_XCODE_PROJ = tangram.xcodeproj
 
-XCPRETTY = eval `command -v xcpretty || echo 'xargs echo'`
+# XCPRETTY = eval `command -v xcpretty || echo 'xargs echo'`
 
 # Default build type is Release
 CONFIG = Release
@@ -310,7 +310,7 @@ ios: ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ}
 		ONLY_ACTIVE_ARCH=NO \
 		-sdk iphonesimulator \
 		-project ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ} \
-		-configuration ${CONFIG} | ${XCPRETTY}
+		-configuration ${CONFIG} # | ${XCPRETTY}
 
 ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ}: cmake-ios
 
@@ -331,11 +331,11 @@ cmake-ios-framework-sim:
 
 ios-framework: cmake-ios-framework
 	xcodebuild -target ${IOS_FRAMEWORK_TARGET} -project ${IOS_FRAMEWORK_BUILD_DIR}/${IOS_FRAMEWORK_XCODE_PROJ} \
-		-configuration ${CONFIG} | ${XCPRETTY}
+		-configuration ${CONFIG} # | ${XCPRETTY}
 
 ios-framework-sim: cmake-ios-framework-sim
 	xcodebuild -target ${IOS_FRAMEWORK_TARGET} -project ${IOS_FRAMEWORK_SIM_BUILD_DIR}/${IOS_FRAMEWORK_XCODE_PROJ} \
-		-configuration ${CONFIG} | ${XCPRETTY}
+		-configuration ${CONFIG} # | ${XCPRETTY}
 
 ios-framework-universal: ios-framework ios-framework-sim
 	@mkdir -p ${IOS_FRAMEWORK_UNIVERSAL_BUILD_DIR}/${CONFIG}

--- a/ios/demo/src/MapViewController.h
+++ b/ios/demo/src/MapViewController.h
@@ -11,7 +11,7 @@
 @interface MapViewControllerDelegate : NSObject <TGMapViewDelegate>
 
 - (void)mapView:(TGMapViewController *)mapView didLoadSceneAsync:(NSString *)scene;
-- (void)mapView:(TGMapViewController*)mapView didSelectFeatures:(NSDictionary *)features atScreenPosition:(CGPoint)position;
+- (void)mapView:(TGMapViewController*)mapView didSelectFeature:(NSDictionary *)feature atScreenPosition:(CGPoint)position;
 
 @end
 

--- a/ios/demo/src/MapViewController.m
+++ b/ios/demo/src/MapViewController.m
@@ -28,11 +28,11 @@
     [mapView setPosition:newYork];
 }
 
-- (void)mapView:(TGMapViewController *)mapView didSelectFeatures:(NSDictionary *)features atScreenPosition:(CGPoint)position
+- (void)mapView:(TGMapViewController *)mapView didSelectFeature:(NSDictionary *)feature atScreenPosition:(CGPoint)position
 {
 
     // Not feature selected
-    if (features.count == 0) {
+    if (feature.count == 0) {
 
         // Convert the 2d screen position to the lat lon
         TGGeoPoint latlon = [mapView screenPositionToLngLat:position];
@@ -44,12 +44,12 @@
 
     NSLog(@"Picked features:");
 
-    for (id key in features) {
-        NSLog(@"\t%@ -- %@", key, [features objectForKey:key]);
+    for (id key in feature) {
+        NSLog(@"\t%@ -- %@", key, [feature objectForKey:key]);
 
         if ([key isEqualToString:@"name"]) {
              UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Selection callback"
-                                                             message:[features objectForKey:key]
+                                                             message:[feature objectForKey:key]
                                                             delegate:nil
                                                    cancelButtonTitle:@"OK"
                                                    otherButtonTitles:nil];

--- a/ios/src/TGMapViewController.h
+++ b/ios/src/TGMapViewController.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol TGMapViewDelegate <NSObject>
 @optional
 - (void)mapView:(TGMapViewController*)mapView didLoadSceneAsync:(NSString*)scene;
-- (void)mapView:(TGMapViewController*)mapView didSelectFeatures:(NSDictionary*)features atScreenPosition:(CGPoint)position;
+- (void)mapView:(TGMapViewController*)mapView didSelectFeature:(NSDictionary*)feature atScreenPosition:(CGPoint)position;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
We didn't catch that the build [was failing](https://travis-ci.org/tangrams/tangram-es/jobs/178332272#L1190) on https://github.com/tangrams/tangram-es/pull/1076. The return status was always returning 0 (success) when using xcpretty, so travis would keep going even though the build failed..

Xcpretty was useful to reduce logs of xcode (travis has a maximum output size of 4mb, and this was easily reached when building for all architectures on iOS), hopefully for now we would be under this limit since we don't publish the framework from travis so it's safe to remove it for now.

Fix https://github.com/tangrams/tangram-es/issues/1042