### PR TITLE
Fix absolute resource resolution on on iOS and OS X

### DIFF
--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -66,8 +66,6 @@ NSString* resolvePath(const char* _path) {
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
-    if (*_path == '/') { return path; }
-
     NSString* resources = [[NSBundle mainBundle] resourcePath];
     NSString* fullBundlePath = [resources stringByAppendingPathComponent:path];
     NSFileManager* fileManager = [NSFileManager defaultManager];

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -53,8 +53,6 @@ NSString* resolvePath(const char* _path) {
 
     NSString* path = [NSString stringWithUTF8String:_path];
 
-    if (*_path == '/') { return path; }
-
     NSString* resources = [[NSBundle mainBundle] resourcePath];
     return [resources stringByAppendingPathComponent:path];
 }


### PR DESCRIPTION
Let bundle resolve absolute paths from the bundle root on iOS and OS X.

Resolve part of https://github.com/tangrams/tangram-es/issues/1113, Linux would still have issues relating to that.

Should fix https://github.com/tangrams/tangram-es/issues/1099.