### PR TITLE
null or undefined jsfunction evaluations are legit

### DIFF
--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -460,6 +460,7 @@ void StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
     } else if (duk_is_null_or_undefined(m_ctx, -1)) {
         // Ignore setting value
         LOGD("duk evaluates JS method to null or undefined.");
+        _val = Undefined();
     } else {
         LOGW("Unhandled return type from Javascript style function for %d.", _key);
     }

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -134,7 +134,7 @@ struct StyleParam {
         }
     };
 
-    using Value = variant<none_type, bool, float, uint32_t, std::string, glm::vec2, Width, LabelProperty::Anchors>;
+    using Value = variant<Undefined, none_type, bool, float, uint32_t, std::string, glm::vec2, Width, LabelProperty::Anchors>;
 
     StyleParam() :
         key(StyleParamKey::none),

--- a/core/src/util/variant.h
+++ b/core/src/util/variant.h
@@ -17,6 +17,20 @@
 #include <string>
 
 namespace Tangram {
+// Primarily used when duk evaluated jsFunction results in a a null or undefined value
+struct Undefined {
+    template<typename T>
+    bool operator==(T const& rhs) const {
+        return false;
+    }
+    bool operator==(Undefined const& rhs) const {
+        return true;
+    }
+    bool operator<(Undefined const& rhs) const {
+        return false;
+    }
+};
+
 struct none_type {
     template<typename T>
     bool operator==(T const& rhs) const {


### PR DESCRIPTION
Style params evaluating a jsFunction as null or undefined will not be marked "inactive". These are
legal values for a js function to return!

fixes #1108 