### PR TITLE
store feature properties only once

### DIFF
--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -14,9 +14,9 @@ namespace Tangram {
 
 const float Label::activation_distance_threshold = 2;
 
-Label::Label(Label::WorldTransform _worldTransform, glm::vec2 _size, uint32_t _selectionColor, Type _type, Options _options)
+Label::Label(Label::WorldTransform _worldTransform, glm::vec2 _size,
+             Type _type, Options _options)
     : m_state(State::none),
-      m_selectionColor(_selectionColor),
       m_type(_type),
       m_worldTransform(_worldTransform),
       m_dim(_size),

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -91,7 +91,7 @@ public:
         bool required = true;
         bool flat = false;
         float angle = 0.f;
-        std::shared_ptr<Properties> properties;
+        uint32_t featureId = 0;
     };
 
     static const float activation_distance_threshold;

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -96,7 +96,7 @@ public:
 
     static const float activation_distance_threshold;
 
-    Label(WorldTransform _transform, glm::vec2 _size, uint32_t _selectionColor, Type _type, Options _options);
+    Label(WorldTransform _transform, glm::vec2 _size, Type _type, Options _options);
 
     virtual ~Label();
 
@@ -109,6 +109,8 @@ public:
 
     // Update the screen position of the label
     virtual bool updateScreenTransform(const glm::mat4& _mvp, const ViewState& _viewState, bool _drawAllLabels) = 0;
+
+    virtual uint32_t selectionColor() = 0;
 
     bool update(const glm::mat4& _mvp,
                 const ViewState& _viewState,
@@ -183,8 +185,6 @@ public:
     bool offViewport(const glm::vec2& _screenSize);
 
     void setAlpha(float _alpha);
-
-    uint32_t selectionColor() { return m_selectionColor; }
 
 private:
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -64,28 +64,17 @@ void Labels::processLabelUpdate(const ViewState& viewState,
 }
 
 
-bool Labels::getLabel(const std::vector<std::unique_ptr<Style>>& _styles,
-                                      const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                      uint32_t _selectionColor, Label*& _label, Tile*& _tile) {
+std::pair<Label*, Tile*> Labels::getLabel(uint32_t _selectionColor) {
 
-    for (const auto& tile : _tiles) {
-        for (const auto& style : _styles) {
-            const auto& mesh = tile->getMesh(*style);
-            if (!mesh) { continue; }
-            auto labelMesh = dynamic_cast<const LabelSet*>(mesh.get());
-            if (!labelMesh) { continue; }
+    for (auto& entry : m_labels) {
 
-            for (auto& label : labelMesh->getLabels()) {
-                if (label->selectionColor() == _selectionColor) {
-                    _label = label.get();
-                    _tile = tile.get();
-                    return true;
-                }
-            }
+        if (entry.label->visibleState() &&
+            entry.label->selectionColor() == _selectionColor) {
+
+            return { entry.label, entry.tile };
         }
     }
-
-    return false;
+    return {nullptr, nullptr};
 }
 
 
@@ -95,7 +84,6 @@ void Labels::updateLabels(const ViewState& _viewState, float _dt,
                           const std::vector<std::unique_ptr<Marker>>& _markers,
                           bool _onlyTransitions) {
 
-    // Keep labels for debugDraw
     if (!_onlyTransitions) { m_labels.clear(); }
 
     m_needUpdate = false;

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -47,9 +47,7 @@ public:
 
     bool needUpdate() const { return m_needUpdate; }
 
-    bool getLabel(const std::vector<std::unique_ptr<Style>>& _styles,
-                                  const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                  uint32_t _selectionColor, Label*& _label, Tile*& _tile);
+    std::pair<Label*, Tile*> getLabel(uint32_t _selectionColor);
 
 protected:
 

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -16,7 +16,7 @@ const float SpriteVertex::texture_scale = 65535.0f;
 SpriteLabel::SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, Label::Options _options,
                          SpriteLabel::VertexAttributes _attrib, Texture* _texture,
                          SpriteLabels& _labels, size_t _labelsPos)
-    : Label(_transform, _size, _attrib.selectionColor, Label::Type::point, _options),
+    : Label(_transform, _size, Label::Type::point, _options),
       m_labels(_labels),
       m_labelsPos(_labelsPos),
       m_texture(_texture),

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -40,9 +40,15 @@ public:
 
     void updateBBoxes(float _zoomFract) override;
 
+    LabelType renderType() const override { return LabelType::icon; }
+
+protected:
+
     void addVerticesToMesh() override;
 
-    LabelType renderType() const override { return LabelType::icon; }
+    uint32_t selectionColor() override {
+        return m_vertexAttrib.selectionColor;
+    }
 
 private:
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -20,7 +20,7 @@ TextLabel::TextLabel(Label::WorldTransform _transform, Type _type, Label::Option
                      TextLabel::VertexAttributes _attrib,
                      glm::vec2 _dim,  TextLabels& _labels, TextRange _textRanges,
                      Align _preferedAlignment)
-    : Label(_transform, _dim, _attrib.selectionColor, _type, _options),
+    : Label(_transform, _dim, _type, _options),
       m_textLabels(_labels),
       m_textRanges(_textRanges),
       m_fontAttrib(_attrib),

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -62,6 +62,10 @@ protected:
 
     void addVerticesToMesh() override;
 
+    uint32_t selectionColor() override {
+        return m_fontAttrib.selectionColor;
+    }
+
 private:
 
     void applyAnchor(LabelProperty::Anchor _anchor) override;

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -157,7 +157,7 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
     p.labelOptions.paramHash = hash(p);
 
     if (p.interactive) {
-        p.labelOptions.properties = std::make_shared<Properties>(_props);
+        p.labelOptions.featureId = _rule.selectionColor;
     }
 
     return p;
@@ -175,7 +175,8 @@ void PointStyleBuilder::addLabel(const Point& _point, const glm::vec4& _quad,
     m_labels.push_back(std::make_unique<SpriteLabel>(glm::vec3(glm::vec2(_point), m_zoom),
                                                      _params.size,
                                                      _params.labelOptions,
-                                                     SpriteLabel::VertexAttributes{_params.color, selectionColor, _params.extrudeScale },
+                                                     SpriteLabel::VertexAttributes{_params.color,
+                                                             selectionColor, _params.extrudeScale },
                                                      m_texture,
                                                      *m_spriteLabels,
                                                      m_quads.size()));

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -405,7 +405,7 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
     p.lineSpacing = 2 * m_style.pixelScale();
 
     if (p.interactive) {
-        p.labelOptions.properties = std::make_shared<Properties>(_props);
+        p.labelOptions.featureId = _rule.selectionColor;
     }
 
     return p;

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -471,9 +471,6 @@ void Map::render() {
         // Resolve label selection queries
         for (const auto& labelQuery : impl->labelSelectionQueries) {
 
-            Label* label;
-            Tile* tile;
-
             float x = labelQuery.position.x / impl->view.getWidth();
             float y = (1.f - (labelQuery.position.y / impl->view.getHeight()));
 
@@ -485,25 +482,24 @@ void Map::render() {
                 labelQuery.onLabelSelection(nullptr);
                 continue;
             }
-
-            if (impl->labels.getLabel(impl->scene->styles(),
-                                       impl->tileManager.getVisibleTiles(),
-                                       color, label, tile)) {
+            auto label = impl->labels.getLabel(color);
+            if (!label.first) {
                 labelQuery.onLabelSelection(nullptr);
                 continue;
             }
-
-            auto props = tile->getSelectionFeature(label->options().featureId);
+            auto props = label.second->getSelectionFeature(label.first->options().featureId);
             if (!props) {
                 labelQuery.onLabelSelection(nullptr);
                 continue;
             }
 
-            LngLat coordinate = label->coordinate(*tile, impl->view.getMapProjection());
+            LngLat coordinate = label.first->coordinate(*label.second,
+                                                        impl->view.getMapProjection());
+
             auto position = std::array<float, 2>{{labelQuery.position.x,
                                                   labelQuery.position.y}};
 
-            LabelPickResult queryResult(label->renderType(), coordinate,
+            LabelPickResult queryResult(label.first->renderType(), coordinate,
                                         FeaturePickResult(props, position));
 
             // TODO: sort touch labels by distance

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -439,7 +439,6 @@ void Map::render() {
 
         // Resolve feature selection queries
         for (const auto& selectionQuery : impl->featureSelectionQueries) {
-            std::unique_ptr<FeaturePickResult> queryResult;
 
             float x = selectionQuery.position.x / impl->view.getWidth();
             float y = (1.f - (selectionQuery.position.y / impl->view.getHeight()));
@@ -447,24 +446,31 @@ void Map::render() {
             // TODO: read with a scalable thumb size
             GLuint color = impl->selectionBuffer->readAt(x, y);
 
+            auto position = std::array<float, 2>{{selectionQuery.position.x,
+                                                  selectionQuery.position.y}};
+            bool found = false;
             if (color != 0) {
                 for (const auto& tile : impl->tileManager.getVisibleTiles()) {
                     if (auto props = tile->getSelectionFeature(color)) {
-                        queryResult = std::unique_ptr<FeaturePickResult>(new FeaturePickResult
-                            {props, {selectionQuery.position.x, selectionQuery.position.y}});
+
+                        FeaturePickResult queryResult(props, position);
+                        selectionQuery.onFeatureSelection(&queryResult);
+                        found = true;
                         break;
                     }
                 }
             }
-
-            selectionQuery.onFeatureSelection(queryResult.get());
+            if (!found) {
+                selectionQuery.onFeatureSelection(nullptr);
+                continue;
+            }
         }
 
         impl->featureSelectionQueries.clear();
 
         // Resolve label selection queries
         for (const auto& labelQuery : impl->labelSelectionQueries) {
-            std::unique_ptr<LabelPickResult> queryResult;
+
             Label* label;
             Tile* tile;
 
@@ -474,19 +480,35 @@ void Map::render() {
             // TODO: read with a scalable thumb size and iterate over the read colors
             GLuint color = impl->selectionBuffer->readAt(x, y);
 
-            if (color != 0) {
-                // Retrieve the label for this selection color
-                if (impl->labels.getLabel(impl->scene->styles(), impl->tileManager.getVisibleTiles(), color, label, tile)) {
-                    LngLat coordinate = label->coordinate(*tile, impl->view.getMapProjection());
-
-                    queryResult = std::unique_ptr<LabelPickResult>(new LabelPickResult {label->renderType(), coordinate,
-                        {label->options().properties, {labelQuery.position.x, labelQuery.position.y}}});
-                }
+            // Retrieve the label for this selection color
+            if (color == 0) {
+                labelQuery.onLabelSelection(nullptr);
+                continue;
             }
+
+            if (impl->labels.getLabel(impl->scene->styles(),
+                                       impl->tileManager.getVisibleTiles(),
+                                       color, label, tile)) {
+                labelQuery.onLabelSelection(nullptr);
+                continue;
+            }
+
+            auto props = tile->getSelectionFeature(label->options().featureId);
+            if (!props) {
+                labelQuery.onLabelSelection(nullptr);
+                continue;
+            }
+
+            LngLat coordinate = label->coordinate(*tile, impl->view.getMapProjection());
+            auto position = std::array<float, 2>{{labelQuery.position.x,
+                                                  labelQuery.position.y}};
+
+            LabelPickResult queryResult(label->renderType(), coordinate,
+                                        FeaturePickResult(props, position));
 
             // TODO: sort touch labels by distance
 
-            labelQuery.onLabelSelection(queryResult.get());
+            labelQuery.onLabelSelection(&queryResult);
         }
 
         impl->labelSelectionQueries.clear();

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <array>
 
 namespace Tangram {
 
@@ -17,14 +18,23 @@ enum LabelType {
 };
 
 struct FeaturePickResult {
+    FeaturePickResult(std::shared_ptr<Properties> _properties,
+                      std::array<float, 2> _position)
+        : properties(_properties), position(_position) {}
+
     std::shared_ptr<Properties> properties;
-    float position[2];
+    std::array<float, 2> position;
 };
 
 // Returns a pointer to the selected feature or null, only valid on the callback scope
 using FeaturePickCallback = std::function<void(const FeaturePickResult*)>;
 
 struct LabelPickResult {
+    LabelPickResult(LabelType _type, LngLat _coordinate,FeaturePickResult _touchItem)
+        : type(_type),
+          coordinate(_coordinate),
+          touchItem(_touchItem) {}
+
     LabelType type;
     LngLat coordinate;
     FeaturePickResult touchItem;
@@ -291,4 +301,3 @@ bool getDebugFlag(DebugFlags _flag);
 void toggleDebugFlag(DebugFlags _flag);
 
 }
-


### PR DESCRIPTION
Currently it Properties is stored three times if a feature has interactive icon and text style. This change only keeps the featureId to its tiles.m_selectionFeatures.