### PR TITLE
Handle exceptions from user provided marker styling

### DIFF
--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -287,11 +287,16 @@ bool MarkerManager::buildStyling(Marker& marker) {
 
     if (!m_scene) { return false; }
 
-    // Update the draw rule for the marker.
-    YAML::Node node = YAML::Load(marker.stylingString());
     std::vector<StyleParam> params;
-    SceneLoader::parseStyleParams(node, m_scene, "", params);
-
+    try {
+        // Update the draw rule for the marker.
+        YAML::Node node = YAML::Load(marker.stylingString());
+        SceneLoader::parseStyleParams(node, m_scene, "", params);
+    } catch (YAML::Exception e) {
+        LOG("Invalid marker styling '%s', %s",
+            marker.stylingString().c_str(), e.what());
+        return false;
+    }
     // Compile any new JS functions used for styling.
     const auto& sceneJsFnList = m_scene->functions();
     for (auto i = m_jsFnIndex; i < sceneJsFnList.size(); ++i) {
@@ -301,6 +306,7 @@ bool MarkerManager::buildStyling(Marker& marker) {
 
     marker.setDrawRule(std::make_unique<DrawRuleData>("", 0, std::move(params)));
 
+    return true;
 }
 
 bool MarkerManager::buildGeometry(Marker& marker, int zoom) {


### PR DESCRIPTION
+ missing return (please add  a clang warning for this)

untested. @blair1618 could you check this?

I think we should generally switch to YAML::Exception for SceneLoader - currently these exceptions will cause a crash without useful notice on android and tizen.