### PR TITLE
faster stringFromFile

### DIFF
--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -75,12 +75,21 @@ bool isContinuousRendering() {
 
 std::string stringFromFile(const char* _path) {
 
-    size_t length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length);
-    if (!bytes) { return {}; }
+    std::string out;
+    if (!_path || strlen(_path) == 0) { return out; }
 
-    std::string out(reinterpret_cast<char*>(bytes), length);
-    free(bytes);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
+
+    if(!resource.is_open()) {
+        logMsg("Failed to read file at path: %s\n", _path);
+        return out;
+    }
+
+    resource.seekg(0, std::ios::end);
+    out.resize(resource.tellg());
+    resource.seekg(0, std::ios::beg);
+    resource.read(&out[0], out.size());
+    resource.close();
 
     return out;
 }

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -63,11 +63,21 @@ bool isContinuousRendering() {
 
 std::string stringFromFile(const char* _path) {
 
-    size_t length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length);
+    std::string out;
+    if (!_path || strlen(_path) == 0) { return out; }
 
-    std::string out(reinterpret_cast<char*>(bytes), length);
-    free(bytes);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
+
+    if(!resource.is_open()) {
+        logMsg("Failed to read file at path: %s\n", _path);
+        return out;
+    }
+
+    resource.seekg(0, std::ios::end);
+    out.resize(resource.tellg());
+    resource.seekg(0, std::ios::beg);
+    resource.read(&out[0], out.size());
+    resource.close();
 
     return out;
 }

--- a/tests/src/platform_mock.cpp
+++ b/tests/src/platform_mock.cpp
@@ -31,11 +31,21 @@ bool isContinuousRendering() {
 
 std::string stringFromFile(const char* _path) {
 
-    size_t length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length);
+    std::string out;
+    if (!_path || strlen(_path) == 0) { return out; }
 
-    std::string out(reinterpret_cast<char*>(bytes), length);
-    free(bytes);
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
+
+    if(!resource.is_open()) {
+        logMsg("Failed to read file at path: %s\n", _path);
+        return out;
+    }
+
+    resource.seekg(0, std::ios::end);
+    out.resize(resource.tellg());
+    resource.seekg(0, std::ios::beg);
+    resource.read(&out[0], out.size());
+    resource.close();
 
     return out;
 }

--- a/tizen/src/platform_tizen.cpp
+++ b/tizen/src/platform_tizen.cpp
@@ -96,17 +96,6 @@ bool isContinuousRendering() {
 
 }
 
-std::string stringFromFile(const char* _path) {
-
-    size_t length = 0;
-    unsigned char* bytes = bytesFromFile(_path, length);
-
-    std::string out(reinterpret_cast<char*>(bytes), length);
-    free(bytes);
-
-    return out;
-}
-
 void initPlatformFontSetup() {
 
     static bool s_platformFontsInit = false;
@@ -255,6 +244,27 @@ unsigned char* bytesFromFile(const char* _path, size_t& _size) {
     resource.close();
 
     return reinterpret_cast<unsigned char *>(cdata);
+}
+
+std::string stringFromFile(const char* _path) {
+
+    std::string out;
+    if (!_path || strlen(_path) == 0) { return out; }
+
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
+
+    if(!resource.is_open()) {
+        logMsg("Failed to read file at path: %s\n", _path);
+        return out;
+    }
+
+    resource.seekg(0, std::ios::end);
+    out.resize(resource.tellg());
+    resource.seekg(0, std::ios::beg);
+    resource.read(&out[0], out.size());
+    resource.close();
+
+    return out;
 }
 
 void setCurrentThreadPriority(int priority){


### PR DESCRIPTION
- avoid temporary buffer
- about twice as fast, tested on desktop linux and Z3
- 4ms vs 8ms on Z3 for loading bubble-wrap