### PR TITLE
optimize getDouble

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1434,6 +1434,7 @@ void SceneLoader::parseStyleParams(Node params, const std::shared_ptr<Scene>& sc
                 }
 
             } else {
+                // TODO optimize for color values
                 out.push_back(StyleParam{ key, parseSequence(value) });
             }
             break;

--- a/core/src/util/yamlHelper.cpp
+++ b/core/src/util/yamlHelper.cpp
@@ -64,30 +64,44 @@ glm::vec4 getColorAsVec4(const Node& node) {
 }
 
 std::string parseSequence(const Node& node) {
+    if (node.IsSequence()) { return ""; }
+
     std::stringstream sstream;
     for (const auto& val : node) {
-        try {
-            sstream << val.as<double>() << ",";
-        } catch (const BadConversion& e) {
-            try {
-                sstream << val.as<std::string>() << ",";
-            } catch (const BadConversion& e) {
-                LOGE("Float or Unit expected for styleParam sequence value");
-            }
+        if (!val.IsScalar()) {
+            // LOG
+            return "";
+        }
+
+        double value;
+        if (getDouble(val, value)) {
+            sstream << value << ",";
+        } else {
+            sstream << val.as<std::string>() << ",";
         }
     }
     return sstream.str();
 }
 
-bool getDouble(const Node& node, double& value, const char* name) {
-    try {
-        value = node.as<double>();
-        return true;
-    } catch (const BadConversion& e) {}
+bool getDouble(const Node& node, double& value) {
 
-    if (name) {
-        LOGW("Expected a floating point value for '%s' property.:\n%s\n", name, Dump(node).c_str());
+    if (node.IsScalar()) {
+        const std::string& s = node.Scalar().c_str();
+        char* pos;;
+        value = strtod(s.c_str(), &pos);
+        if (pos == s.c_str() + s.length()) {
+            return true;
+        }
     }
+
+    return false;
+}
+
+bool getDouble(const Node& node, double& value, const char* name) {
+
+    if (getDouble(node, value)) { return true; }
+
+    LOGW("Expected a floating point value for '%s' property.:\n%s\n", name, Dump(node).c_str());
     return false;
 }
 

--- a/core/src/util/yamlHelper.cpp
+++ b/core/src/util/yamlHelper.cpp
@@ -64,21 +64,18 @@ glm::vec4 getColorAsVec4(const Node& node) {
 }
 
 std::string parseSequence(const Node& node) {
-    if (node.IsSequence()) { return ""; }
+    if (!node.IsSequence()) {
+        LOGW("Expected a plain sequence: '%'", Dump(node).c_str());
+        return "";
+    }
 
     std::stringstream sstream;
     for (const auto& val : node) {
         if (!val.IsScalar()) {
-            // LOG
+            LOGW("Expected a plain sequence: '%'", Dump(node).c_str());
             return "";
         }
-
-        double value;
-        if (getDouble(val, value)) {
-            sstream << value << ",";
-        } else {
-            sstream << val.as<std::string>() << ",";
-        }
+        sstream << val.Scalar() << ",";
     }
     return sstream.str();
 }
@@ -86,8 +83,8 @@ std::string parseSequence(const Node& node) {
 bool getDouble(const Node& node, double& value) {
 
     if (node.IsScalar()) {
-        const std::string& s = node.Scalar().c_str();
-        char* pos;;
+        const std::string& s = node.Scalar();
+        char* pos;
         value = strtod(s.c_str(), &pos);
         if (pos == s.c_str() + s.length()) {
             return true;

--- a/core/src/util/yamlHelper.h
+++ b/core/src/util/yamlHelper.h
@@ -40,7 +40,8 @@ glm::vec4 getColorAsVec4(const Node& node);
 
 std::string parseSequence(const Node& node);
 
-bool getDouble(const Node& node, double& value, const char* name = nullptr);
+bool getDouble(const Node& node, double& value);
+bool getDouble(const Node& node, double& value, const char* name);
 
 bool getBool(const Node& node, bool& value, const char* name = nullptr);
 


### PR DESCRIPTION
300ms vs 1100ms on Z3 for building layers - especially filters

- yes we may loose some infinity/nan formats but we don't handle them explicitly anyway