### PR TITLE
optimize applyGlobals

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -48,6 +48,8 @@ const std::string DELIMITER = ":";
 // TODO: make this configurable: 16MB default in-memory DataSource cache:
 constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
+static const std::string GLOBAL_PREFIX = "global.";
+
 std::mutex SceneLoader::m_textureMutex;
 
 bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
@@ -93,25 +95,30 @@ void printFilters(const SceneLayer& layer, int indent){
     }
 };
 
-void createGlobalRefsRecursive(Node node, Scene& scene, YamlPath path) {
+void createGlobalRefs(const Node& node, Scene& scene, YamlPathBuffer& path) {
     switch(node.Type()) {
     case NodeType::Scalar: {
             const auto& value = node.Scalar();
-            if (value.compare(0, 7, "global.") == 0) {
-                scene.globalRefs().emplace_back(path, YamlPath(value));
+            if (value.length() > 7 && value.compare(0, 7, GLOBAL_PREFIX) == 0) {
+                scene.globalRefs().emplace_back(path.toYamlPath(),
+                                                YamlPath(value.substr(GLOBAL_PREFIX.length())));
             }
         }
         break;
     case NodeType::Sequence: {
-            int i = 0;
+            path.pushSequence();
             for (const auto& entry : node) {
-                createGlobalRefsRecursive(entry, scene, path.add(i++));
+                createGlobalRefs(entry, scene, path);
+                path.increment();
             }
+            path.pop();
         }
         break;
     case NodeType::Map:
         for (const auto& entry : node) {
-            createGlobalRefsRecursive(entry.second, scene, path.add(entry.first.Scalar()));
+            path.pushMap(&entry.first.Scalar());
+            createGlobalRefs(entry.second, scene, path);
+            path.pop();
         }
         break;
     default:
@@ -121,12 +128,23 @@ void createGlobalRefsRecursive(Node node, Scene& scene, YamlPath path) {
 
 void SceneLoader::applyGlobals(Node root, Scene& scene) {
 
-    createGlobalRefsRecursive(root, scene, YamlPath());
+    YamlPathBuffer path;
+    createGlobalRefs(root, scene, path);
+    const auto& globals = root["global"];
+    if (!scene.globalRefs().empty() && !globals.IsMap()) {
+        LOGW("Missing global references");
+    }
 
     for (auto& globalRef : scene.globalRefs()) {
         auto target = globalRef.first.get(root);
-        auto global = globalRef.second.get(root);
-        target = global;
+        auto global = globalRef.second.get(globals);
+        if (target && global) {
+            target = global;
+        } else {
+            LOGW("Global reference is undefined: %s <= %s",
+                 globalRef.first.codedPath.c_str(),
+                 globalRef.second.codedPath.c_str());
+        }
     }
 }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -80,8 +80,12 @@ void SceneLoader::applyUpdates(Scene& scene, const std::vector<SceneUpdate>& upd
             LOGE("Parsing scene update string failed. '%s'", e.what());
         }
         if (value) {
-            auto node = YamlPath(update.path).get(root);
-            node = value;
+            try {
+                auto node = YamlPath(update.path).get(root);
+                node = value;
+            } catch(YAML::Exception e) {
+                LOGE("Parsing scene update string failed. %s '%s'", update.path.c_str(), e.what());
+            }
         }
     }
 }

--- a/core/src/util/yamlHelper.cpp
+++ b/core/src/util/yamlHelper.cpp
@@ -8,6 +8,33 @@
 
 namespace Tangram {
 
+YamlPath YamlPathBuffer::toYamlPath() {
+    size_t length = 0;
+
+    for(auto& element : m_path) {
+        if (element.key) {
+            length += element.key->length()+1;
+        } else {
+            int c = 1;
+            while (element.index >= pow(10, c)) { c += 1; }
+            length += c + 1;
+        }
+    }
+    std::string path;
+    path.reserve(length);
+
+    for(auto& element : m_path) {
+        if (element.key) {
+            if (!path.empty()) { path += '.'; }
+            path += *element.key;
+        } else {
+            path += '#';
+            path += std::to_string(element.index);
+        }
+    }
+    return YamlPath(path);
+}
+
 YamlPath::YamlPath() {}
 
 YamlPath::YamlPath(const std::string& path)

--- a/core/src/util/yamlHelper.h
+++ b/core/src/util/yamlHelper.h
@@ -22,6 +22,23 @@ struct YamlPath {
     std::string codedPath;
 };
 
+struct YamlPathBuffer {
+
+    struct PathElement {
+        size_t index;
+        const std::string* key;
+        PathElement(size_t index, const std::string* key) : index(index), key(key) {}
+    };
+
+    std::vector<PathElement> m_path;
+
+    void pushMap(const std::string* _p) { m_path.emplace_back(0, _p);}
+    void pushSequence() { m_path.emplace_back(0, nullptr); }
+    void increment() { m_path.back().index++; }
+    void pop() { m_path.pop_back(); }
+    YamlPath toYamlPath();
+};
+
 template<typename T>
 inline T parseVec(const Node& node) {
     T vec;

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -187,3 +187,17 @@ TEST_CASE("Apply and propogate repeated global value updates") {
     CHECK(root["seq"][1].Scalar() == "global_a_value");
     CHECK(root["map"]["b"].Scalar() == "newer_global_b_value");
 }
+
+TEST_CASE("Regression: scene update requesting a sequence from a scalar") {
+
+    // Setup.
+    Scene scene;
+    REQUIRE(loadConfig(sceneString, scene.config()));
+    // Add an update.
+    std::vector<SceneUpdate> updates = {{"map.a#0", "new_value"}};
+    // Apply scene updates, reload scene.
+    SceneLoader::applyUpdates(scene, updates);
+    const Node& root = scene.config();
+
+    // causes yaml exception 'operator[] call on a scalar'
+}


### PR DESCRIPTION
- YamlPath strings were allocated for each sequence and map node. This only allocates strings for
   the global-reference nodes.
- YamlPath::get should not create nodes along the way