### PR TITLE
Fix stops for size style param

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1439,6 +1439,10 @@ void SceneLoader::parseStyleParams(Node params, const std::shared_ptr<Scene>& sc
                         scene->stops().push_back(Stops::Colors(value));
                         out.push_back(StyleParam{ styleKey, &(scene->stops().back()) });
 
+                    } else if (StyleParam::isSize(styleKey)) {
+                        scene->stops().push_back(Stops::Sizes(value, StyleParam::unitsForStyleParam(styleKey)));
+                        out.push_back(StyleParam{ styleKey, &(scene->stops().back()) });
+
                     } else if (StyleParam::isWidth(styleKey)) {
                         scene->stops().push_back(Stops::Widths(value, *scene->mapProjection(),
                                                               StyleParam::unitsForStyleParam(styleKey)));

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -58,7 +58,7 @@ auto Stops::FontSize(const YAML::Node& _node) -> Stops {
         float key = frameNode[0].as<float>();
 
         if (lastKey > key) {
-            LOGW("Invalid stop order: key %f > %f\n", lastKey, key);
+            LOGW("Invalid stop order: key %f > %f", lastKey, key);
             continue;
         }
 
@@ -88,7 +88,7 @@ auto Stops::Sizes(const YAML::Node& _node, const std::vector<Unit>& _units) -> S
         float key = frameNode[0].as<float>();
 
         if (lastKey > key) {
-            LOGW("Invalid stop order: key %f > %f\n", lastKey, key);
+            LOGW("Invalid stop order: key %f > %f", lastKey, key);
             continue;
         }
         lastKey = key;
@@ -101,8 +101,7 @@ auto Stops::Sizes(const YAML::Node& _node, const std::vector<Unit>& _units) -> S
             if (StyleParam::parseValueUnitPair(frameNode[1].Scalar(), start, sizeValue)) {
                 for (auto& unit : _units) {
                     if (sizeValue.unit != unit) {
-                        LOGW("Size StyleParam can only take in pixel values.");
-                        return {};
+                        LOGW("Size StyleParam can only take in pixel values in: %s", Dump(_node).c_str());
                     }
                 }
 
@@ -119,8 +118,7 @@ auto Stops::Sizes(const YAML::Node& _node, const std::vector<Unit>& _units) -> S
                 if (StyleParam::parseValueUnitPair(sequenceNode.Scalar(), 0, sizeValue)) {
                     for (auto& unit : _units) {
                         if (sizeValue.unit != unit) {
-                            LOGW("Size StyleParam can only take in pixel values.");
-                            return {};
+                            LOGW("Size StyleParam can only take in pixel values in: %s", Dump(_node).c_str());
                         }
                     }
                     sizeValues.push_back(sizeValue);
@@ -147,7 +145,7 @@ auto Stops::Offsets(const YAML::Node& _node, const std::vector<Unit>& _units) ->
         float key = frameNode[0].as<float>();
 
         if (lastKey > key) {
-            LOGW("Invalid stop order: key %f > %f\n", lastKey, key);
+            LOGW("Invalid stop order: key %f > %f", lastKey, key);
             continue;
         }
         lastKey = key;
@@ -166,7 +164,7 @@ auto Stops::Offsets(const YAML::Node& _node, const std::vector<Unit>& _units) ->
                     }
                     lastUnit = width.unit;
                 } else {
-                    LOGW("could not parse node %s\n", Dump(sequenceNode).c_str());
+                    LOGW("could not parse node %s", Dump(sequenceNode).c_str());
                 }
             }
             if (widths.size() == 2) {

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -81,13 +81,6 @@ auto Stops::Sizes(const YAML::Node& _node, const std::vector<Unit>& _units) -> S
         return stops;
     }
 
-    for (auto& unit : _units) {
-        if (unit != Unit::pixel) {
-            LOGW("Size StyleParam can only take in pixel values.");
-            return stops;
-        }
-    }
-
     float lastKey = 0;
 
     for (const auto& frameNode : _node) {
@@ -106,6 +99,13 @@ auto Stops::Sizes(const YAML::Node& _node, const std::vector<Unit>& _units) -> S
             size_t start = 0;
 
             if (StyleParam::parseValueUnitPair(frameNode[1].Scalar(), start, sizeValue)) {
+                for (auto& unit : _units) {
+                    if (sizeValue.unit != unit) {
+                        LOGW("Size StyleParam can only take in pixel values.");
+                        return {};
+                    }
+                }
+
                 stops.frames.emplace_back(key, sizeValue.value);
             } else {
                 LOGW("could not parse node %s\n", Dump(frameNode[1]).c_str());
@@ -117,6 +117,12 @@ auto Stops::Sizes(const YAML::Node& _node, const std::vector<Unit>& _units) -> S
                 StyleParam::ValueUnitPair sizeValue;
                 sizeValue.unit = Unit::pixel; // default to pixel
                 if (StyleParam::parseValueUnitPair(sequenceNode.Scalar(), 0, sizeValue)) {
+                    for (auto& unit : _units) {
+                        if (sizeValue.unit != unit) {
+                            LOGW("Size StyleParam can only take in pixel values.");
+                            return {};
+                        }
+                    }
                     sizeValues.push_back(sizeValue);
                 } else {
                     LOGW("could not parse node %s\n", Dump(sequenceNode).c_str());

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -30,6 +30,7 @@ struct Stops {
     static Stops Colors(const YAML::Node& _node);
     static Stops Widths(const YAML::Node& _node, const MapProjection& _projection, const std::vector<Unit>& _units);
     static Stops FontSize(const YAML::Node& _node);
+    static Stops Sizes(const YAML::Node& _node, const std::vector<Unit>& _units);
     static Stops Offsets(const YAML::Node& _node, const std::vector<Unit>& _units);
     static Stops Numbers(const YAML::Node& node);
 
@@ -41,6 +42,7 @@ struct Stops {
     auto evalWidth(float _key) const -> float;
     auto evalColor(float _key) const -> uint32_t;
     auto evalVec2(float _key) const -> glm::vec2;
+    auto evalSize(float _key) const -> StyleParam::Value;
     auto nearestHigherFrame(float _key) const -> std::vector<Frame>::const_iterator;
 
     static void eval(const Stops& _stops, StyleParamKey _key, float _zoom, StyleParam::Value& _result);

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -39,9 +39,10 @@ struct Stops {
     Stops() {}
 
     auto evalFloat(float _key) const -> float;
-    auto evalWidth(float _key) const -> float;
+    auto evalExpFloat(float _key) const -> float;
     auto evalColor(float _key) const -> uint32_t;
     auto evalVec2(float _key) const -> glm::vec2;
+    auto evalExpVec2(float _key) const -> glm::vec2;
     auto evalSize(float _key) const -> StyleParam::Value;
     auto nearestHigherFrame(float _key) const -> std::vector<Frame>::const_iterator;
 

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -619,6 +619,15 @@ bool StyleParam::isColor(StyleParamKey _key) {
     }
 }
 
+bool StyleParam::isSize(StyleParamKey _key) {
+    switch (_key) {
+        case StyleParamKey::size:
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool StyleParam::isWidth(StyleParamKey _key) {
     switch (_key) {
         case StyleParamKey::width:
@@ -634,7 +643,6 @@ bool StyleParam::isOffsets(StyleParamKey _key) {
     switch (_key) {
         case StyleParamKey::offset:
         case StyleParamKey::text_offset:
-        case StyleParamKey::size:
             return true;
         default:
             return false;

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -180,6 +180,7 @@ struct StyleParam {
     static Value parseString(StyleParamKey key, const std::string& _value);
 
     static bool isColor(StyleParamKey _key);
+    static bool isSize(StyleParamKey _key);
     static bool isWidth(StyleParamKey _key);
     static bool isOffsets(StyleParamKey _key);
     static bool isFontSize(StyleParamKey _key);

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -141,11 +141,11 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
     if (sizeParam.stops) {
         if (sizeParam.value.is<float>()) {
             float lowerSize = sizeParam.value.get<float>();
-            float higherSize = sizeParam.stops->evalFloat(m_zoom + 1);
+            float higherSize = sizeParam.stops->evalExpFloat(m_zoom + 1);
             p.extrudeScale = (higherSize - lowerSize) * 0.5f - 1.f;
             p.size = glm::vec2(lowerSize);
         } else if (sizeParam.value.is<glm::vec2>()) {
-            p.size = sizeParam.stops->evalVec2(m_zoom + 1);
+            p.size = sizeParam.stops->evalExpVec2(m_zoom + 1);
         } else {
             p.size = glm::vec2(NAN, NAN);
         }

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -138,11 +138,17 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
     _rule.get(StyleParamKey::angle, p.labelOptions.angle);
 
     auto sizeParam = _rule.findParameter(StyleParamKey::size);
-    if (sizeParam.stops && sizeParam.value.is<float>()) {
-        float lowerSize = sizeParam.value.get<float>();
-        float higherSize = sizeParam.stops->evalWidth(m_zoom + 1);
-        p.extrudeScale = (higherSize - lowerSize) * 0.5f - 1.f;
-        p.size = glm::vec2(lowerSize);
+    if (sizeParam.stops) {
+        if (sizeParam.value.is<float>()) {
+            float lowerSize = sizeParam.value.get<float>();
+            float higherSize = sizeParam.stops->evalFloat(m_zoom + 1);
+            p.extrudeScale = (higherSize - lowerSize) * 0.5f - 1.f;
+            p.size = glm::vec2(lowerSize);
+        } else if (sizeParam.value.is<glm::vec2>()) {
+            p.size = sizeParam.stops->evalVec2(m_zoom + 1);
+        } else {
+            p.size = glm::vec2(NAN, NAN);
+        }
     } else if (_rule.get(StyleParamKey::size, size)) {
         if (size.x == 0.f || std::isnan(size.y)) {
             p.size = glm::vec2(size.x);

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -361,7 +361,7 @@ bool PolylineStyleBuilder<V>::evalWidth(const StyleParam& _styleParam, float& wi
         width = _styleParam.value.get<float>();
         width *= pixelWidthScale;
 
-        slope = _styleParam.stops->evalWidth(m_zoom + 1);
+        slope = _styleParam.stops->evalExpFloat(m_zoom + 1);
         slope *= pixelWidthScale;
         return true;
     }

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -160,3 +160,31 @@ TEST_CASE("Regression test - Dont crash on evaluating empty stops", "[Stops][YAM
 
 }
 
+TEST_CASE("2 dimension stops for icon sizes with mixed units", "[Stops][YAML]") {
+    YAML::Node node = YAML::Load(R"END(
+        [[6, [18.0 px, 14px]], [13, [20 m, 15px]], [16, [24, 18]]]
+    )END");
+
+    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+
+    REQUIRE(stops.frames.size() == 3);
+
+    REQUIRE(stops.evalSize(0).get<glm::vec2>() == glm::vec2(18, 14));
+    REQUIRE(stops.evalSize(13).get<glm::vec2>() == glm::vec2(20, 15));
+    REQUIRE(stops.evalSize(18).get<glm::vec2>() == glm::vec2(24, 18));
+}
+
+
+TEST_CASE("1 dimension stops for icon sizes", "[Stops][YAML]") {
+    YAML::Node node = YAML::Load(R"END(
+        [[6, 18], [13, 20]]
+    )END");
+
+    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+
+    REQUIRE(stops.frames.size() == 2);
+
+    REQUIRE(stops.evalSize(0).get<float>() == 18);
+    REQUIRE(stops.evalSize(18).get<float>() == 20);
+}
+

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -68,18 +68,18 @@ TEST_CASE("Stops evaluate width values correctly at and between key frames", "[S
 
     });
 
-    REQUIRE(stops.evalWidth(-3) == 0.f);
-    REQUIRE(stops.evalWidth(0) == 0.f);
-    REQUIRE(std::abs(stops.evalWidth(0.3) - 2.31144f) < 0.00001);
-    REQUIRE(stops.evalWidth(1) == 10.f);
-    REQUIRE(stops.evalWidth(3) == 18.f);
-    REQUIRE(stops.evalWidth(5) == 50.f);
-    REQUIRE(std::abs(stops.evalWidth(6) - 33.33333f) < 0.00001);
-    REQUIRE(stops.evalWidth(7) == 0.f);
-    REQUIRE(stops.evalWidth(8) == 3.f);
-    REQUIRE(stops.evalWidth(8.4) == 3.f); // flat interpolation
-    REQUIRE(stops.evalWidth(9.3) == 3.f); // flat interpolation
-    REQUIRE(stops.evalWidth(10) == 3.f);
+    REQUIRE(stops.evalExpFloat(-3) == 0.f);
+    REQUIRE(stops.evalExpFloat(0) == 0.f);
+    REQUIRE(std::abs(stops.evalExpFloat(0.3) - 2.31144f) < 0.00001);
+    REQUIRE(stops.evalExpFloat(1) == 10.f);
+    REQUIRE(stops.evalExpFloat(3) == 18.f);
+    REQUIRE(stops.evalExpFloat(5) == 50.f);
+    REQUIRE(std::abs(stops.evalExpFloat(6) - 33.33333f) < 0.00001);
+    REQUIRE(stops.evalExpFloat(7) == 0.f);
+    REQUIRE(stops.evalExpFloat(8) == 3.f);
+    REQUIRE(stops.evalExpFloat(8.4) == 3.f); // flat interpolation
+    REQUIRE(stops.evalExpFloat(9.3) == 3.f); // flat interpolation
+    REQUIRE(stops.evalExpFloat(10) == 3.f);
 
 }
 


### PR DESCRIPTION
Size parameter is special and can be a 1d or a 2d. Unlike width or offsets.
This creates a different handling for size style param for stops.

Note: `stops` definitely need some refactoring love. Can definitely be made much concise. FUTURE PR!