### PR TITLE
Catch BadSubscript exceptions

### DIFF
--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -284,7 +284,11 @@ void Importer::importScenesRecursive(Node& root, const Url& scenePath, std::vect
 
     mergeMapFields(root, sceneNode);
 
-    resolveSceneUrls(root, scenePath);
+    try {
+        resolveSceneUrls(root, scenePath);
+    } catch (YAML::BadSubscript e) {
+        LOGE("%s", e.what());
+    }
 }
 
 void Importer::mergeMapFields(Node& target, const Node& import) {


### PR DESCRIPTION
Prevent crashes on exception when trying to access missing YAML keys.