### PR TITLE
Fix polygon centroid calculation

### DIFF
--- a/core/src/util/geom.cpp
+++ b/core/src/util/geom.cpp
@@ -102,24 +102,27 @@ glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosit
 }
 
 glm::vec2 centroid(const std::vector<std::vector<glm::vec3>>& _polygon) {
+
+    if (_polygon.empty()) {
+        return glm::vec2();
+    }
+
+    // We will consider only the outer ring of the polygon when calculating
+    // the centroid - holes will be ignored. It would be possible to transform
+    // a polygon with holes into a polygon that covers the same set of points
+    // without any holes, but that seems overly complex for our needs.
+    const auto& ring = _polygon.front();
     glm::vec2 centroid;
-    int n = 0;
+    float area = 0.f;
 
-    for (auto& l : _polygon) {
-        for (auto& p : l) {
-            centroid.x += p.x;
-            centroid.y += p.y;
-            n++;
-        }
+    for (auto curr = ring.begin(), prev = ring.end() - 1; curr != ring.end(); prev = curr, ++curr) {
+        float a = (prev->x * curr->y - curr->x * prev->y);
+        centroid.x += (prev->x + curr->x) * a;
+        centroid.y += (prev->y + curr->y) * a;
+        area += a;
     }
 
-    if (n == 0) {
-        return centroid;
-    }
-
-    centroid /= n;
-
-    return centroid;
+    return centroid / (3.f * area);
 }
 
 // square distance from a point <_p> to a segment <_p1,_p2>

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -106,7 +106,7 @@ glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosit
 
 glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosition, const glm::vec2& _screenSize, bool& _clipped);
 
-/* Computes the geometric center of the two dimentionnal region defined by the polygon */
+/* Computes the geometric center of the two dimensional region defined by the polygon */
 glm::vec2 centroid(const std::vector<std::vector<glm::vec3>>& _polygon);
 
 inline glm::vec2 rotateBy(const glm::vec2& _in, const glm::vec2& _normal) {


### PR DESCRIPTION
The previous implementation was not correctly calculating the centroid of polygons, which we use for some label placement.

Tested by adding draw rules to the `water` layer in the default test scene:
```yaml
            lines:
                order: 9
                color: 'red'
                width: '2px'
                tile_edges: true
            points:
                order: 10
                color: 'green'
                centroid: true
                collide: false
```

The equivalent function in tangram-js: https://github.com/tangrams/tangram/blob/master/src/geo.js#L181-L198

Resolves #1140 