### PR TITLE
Fix resolution of absolute file paths in iOS and macOS

### DIFF
--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -54,22 +54,31 @@ bool isContinuousRendering() {
 
 NSString* resolvePath(const char* _path) {
 
-    NSString* path = [NSString stringWithUTF8String:_path];
+    NSString* pathString = [NSString stringWithUTF8String:_path];
 
-    NSString* resources = [[NSBundle mainBundle] resourcePath];
-    NSString* fullBundlePath = [resources stringByAppendingPathComponent:path];
+    NSURL* resourceFolderUrl = [[NSBundle mainBundle] resourceURL];
+
+    NSURL* resolvedUrl = [NSURL URLWithString:pathString
+                                relativeToURL:resourceFolderUrl];
+
+    NSString* pathInAppBundle = [resolvedUrl path];
+
     NSFileManager* fileManager = [NSFileManager defaultManager];
 
-    if ([fileManager fileExistsAtPath:fullBundlePath]) {
-        return fullBundlePath;
+    if ([fileManager fileExistsAtPath:pathInAppBundle]) {
+        return pathInAppBundle;
     }
 
     if (tangramFramework) {
-        NSString* resources = [tangramFramework resourcePath];
-        fullBundlePath = [resources stringByAppendingPathComponent:path];
+        NSURL* frameworkResourcesUrl = [tangramFramework resourceURL];
 
-        if ([fileManager fileExistsAtPath:fullBundlePath]) {
-            return fullBundlePath;
+        NSURL* frameworkResolvedUrl = [NSURL URLWithString:pathString
+                                             relativeToURL:frameworkResourcesUrl];
+
+        NSString* pathInFramework = [frameworkResolvedUrl path];
+
+        if ([fileManager fileExistsAtPath:pathInFramework]) {
+            return pathInFramework;
         }
     }
 

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -57,10 +57,14 @@ bool isContinuousRendering() {
 
 NSString* resolvePath(const char* _path) {
 
-    NSString* path = [NSString stringWithUTF8String:_path];
+    NSString* pathString = [NSString stringWithUTF8String:_path];
 
-    NSString* resources = [[NSBundle mainBundle] resourcePath];
-    return [resources stringByAppendingPathComponent:path];
+    NSURL* resourceFolderUrl = [[NSBundle mainBundle] resourceURL];
+
+    NSURL* resolvedUrl = [NSURL URLWithString:pathString
+                                relativeToURL:resourceFolderUrl];
+
+    return [resolvedUrl path];
 }
 
 std::string stringFromFile(const char* _path) {


### PR DESCRIPTION
In the iOS and macOS platform code that resolves file paths, absolute file paths were not being resolved correctly. The previous implementation simply appended the relative path to the end of the bundle resource path. This is correct if the file has a relative path, but for absolute paths the bundle path should not be used. NSURL is able to perform the correct resolution process. On iOS we do not typically access files using absolute paths, but on macOS our demo application uses absolute paths when a file argument is provided with `-f`, so that feature is currently broken. 