### PR TITLE
Android flipbitmap

### DIFF
--- a/android/demo/src/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/com/mapzen/tangram/android/MainActivity.java
@@ -14,6 +14,7 @@ import com.mapzen.tangram.MapController.FeaturePickListener;
 import com.mapzen.tangram.MapController.LabelPickListener;
 import com.mapzen.tangram.MapController.ViewCompleteListener;
 import com.mapzen.tangram.MapData;
+import com.mapzen.tangram.Marker;
 import com.mapzen.tangram.MapView;
 import com.mapzen.tangram.MapView.OnMapReadyCallback;
 import com.mapzen.tangram.TouchInput.DoubleTapResponder;
@@ -34,6 +35,10 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     MapView view;
     LngLat lastTappedPoint;
     MapData markers;
+
+    String pointStyle = "{ style: 'points', color: 'white', size: [50px, 50px], order: 2000, collide: false }";
+    ArrayList<Marker> pointMarkers = new ArrayList<Marker>();
+
     boolean showTileInfo = false;
 
     @Override
@@ -125,9 +130,10 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
             line.add(tappedPoint);
             markers.addPolyline(line, props);
 
-            props = new HashMap<>();
-            props.put("type", "point");
-            markers.addPoint(tappedPoint, props);
+            Marker p = map.addMarker();
+            p.setStyling(pointStyle);
+            p.setPoint(tappedPoint);
+            pointMarkers.add(p);
         }
 
         lastTappedPoint = tappedPoint;
@@ -154,6 +160,8 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
     @Override
     public void onLongPress(float x, float y) {
+        map.removeAllMarkers();
+        pointMarkers.clear();
         markers.clear();
         showTileInfo = !showTileInfo;
         map.setDebugFlag(MapController.DebugFlag.TILE_INFOS, showTileInfo);

--- a/android/tangram/src/com/mapzen/tangram/Marker.java
+++ b/android/tangram/src/com/mapzen/tangram/Marker.java
@@ -176,12 +176,16 @@ public class Marker {
         bitmap.getPixels(argb, 0, width, 0, 0, width, height);
 
         int[] abgr = new int[width * height];
+        int row, col;
         for (int i = 0; i < argb.length; i++) {
+            row = i % width;
+            col = i / width;
             int pix = argb[i];
             int pb = (pix >> 16) & 0xff;
             int pr = (pix << 16) & 0x00ff0000;
             int pix1 = (pix & 0xff00ff00) | pr | pb;
-            abgr[i] = pix1;
+            int flippedIndex = (height - 1 - row) * width + col;
+            abgr[flippedIndex] = pix1;
         }
 
         return map.setMarkerBitmap(markerId, width, height, abgr);


### PR DESCRIPTION
- flip bitmaps for point markers
- use point marker interface instead of MapData in the demo app for Point. (Still uses MapData interface for polyline as the demo is a generic example to show all).