### PR TITLE
Run iOS builds on CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,12 @@ branches:
 
 matrix:
     include:
-        - os: osx
-          osx_image: xcode7.3
-          env: PLATFORM=osx
-          compiler: clang
         - os: linux
           env: PLATFORM=linux CXX=g++-4.9 CC=gcc-4.9
           addons:
             apt:
               sources: [ 'kubuntu-backports', 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
               packages: [ 'cmake', 'gcc-4.9', 'g++-4.9', 'xorg-dev', 'libglu1-mesa-dev' ]
-        - os: osx
-          osx_image: xcode7.3
-          env: PLATFORM=ios
-          compiler: clang
         - os: linux
           env: PLATFORM=android
           addons:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ OSX_XCODE_PROJ = tangram.xcodeproj
 IOS_XCODE_PROJ = tangram.xcodeproj
 IOS_FRAMEWORK_XCODE_PROJ = tangram.xcodeproj
 
-# XCPRETTY = eval `command -v xcpretty || echo 'xargs echo'`
+XCPRETTY = `command -v xcpretty || echo 'xargs echo'`
 
 # Default build type is Release
 CONFIG = Release
@@ -310,7 +310,7 @@ ios: ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ}
 		ONLY_ACTIVE_ARCH=NO \
 		-sdk iphonesimulator \
 		-project ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ} \
-		-configuration ${CONFIG} # | ${XCPRETTY}
+		-configuration ${CONFIG} | ${XCPRETTY}
 
 ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ}: cmake-ios
 
@@ -331,11 +331,11 @@ cmake-ios-framework-sim:
 
 ios-framework: cmake-ios-framework
 	xcodebuild -target ${IOS_FRAMEWORK_TARGET} -project ${IOS_FRAMEWORK_BUILD_DIR}/${IOS_FRAMEWORK_XCODE_PROJ} \
-		-configuration ${CONFIG} # | ${XCPRETTY}
+		-configuration ${CONFIG} | ${XCPRETTY}
 
 ios-framework-sim: cmake-ios-framework-sim
 	xcodebuild -target ${IOS_FRAMEWORK_TARGET} -project ${IOS_FRAMEWORK_SIM_BUILD_DIR}/${IOS_FRAMEWORK_XCODE_PROJ} \
-		-configuration ${CONFIG} # | ${XCPRETTY}
+		-configuration ${CONFIG} | ${XCPRETTY}
 
 ios-framework-universal: ios-framework ios-framework-sim
 	@mkdir -p ${IOS_FRAMEWORK_UNIVERSAL_BUILD_DIR}/${CONFIG}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 tangram-es
 ==========
+[![Gitter](https://badges.gitter.im/tangrams/tangram-chat.svg)](https://gitter.im/tangrams/tangram-chat?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
 
-[![Travis CI Build Status](https://travis-ci.org/tangrams/tangram-es.svg?branch=master)](https://travis-ci.org/tangrams/tangram-es/builds)
-[![Gitter](https://badges.gitter.im/pelias/pelias.svg)](https://gitter.im/tangrams/tangram-chat?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
+| Platform                                | Build status                       |
+| --------------------------------------- | ---------------------------------- |
+| Linux/Android                           | [![Travis CI BuildStatus](https://travis-ci.org/tangrams/tangram-es.svg?branch=master)](https://travis-ci.org/tangrams/tangram-es/builds) |
+| iOS | [![CircleCI](https://circleci.com/gh/tangrams/tangram-es.svg?style=shield&circle-token=741ff7f06a008b6eb491680c2d47968a7c4eaa3a)](https://circleci.com/gh/tangrams/tangram-es) |
+
 
 ![screenshot](images/screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 tangram-es
 ==========
+
+tangram-es is a C++ library for rendering 2D and 3D maps from vector data using OpenGL ES, it is a counterpart to [tangram](https://github.com/tangrams/tangram) focused on mobile and embedded devices.
+
+This repository contains both the core rendering library and sample applications that use the library on Android, iOS, Mac OS X, Ubuntu, and Raspberry Pi.
+
 [![Gitter](https://badges.gitter.im/tangrams/tangram-chat.svg)](https://gitter.im/tangrams/tangram-chat?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
 
 | Platform                                | Build status                       |
@@ -7,12 +12,7 @@ tangram-es
 | Linux/Android                           | [![Travis CI BuildStatus](https://travis-ci.org/tangrams/tangram-es.svg?branch=master)](https://travis-ci.org/tangrams/tangram-es/builds) |
 | iOS | [![CircleCI](https://circleci.com/gh/tangrams/tangram-es.svg?style=shield&circle-token=741ff7f06a008b6eb491680c2d47968a7c4eaa3a)](https://circleci.com/gh/tangrams/tangram-es) |
 
-
 ![screenshot](images/screenshot.png)
-
-tangram-es is a C++ library for rendering 2D and 3D maps from vector data using OpenGL ES, it is a counterpart to [tangram](https://github.com/tangrams/tangram) focused on mobile and embedded devices.
-
-This repository contains both the core rendering library and sample applications that use the library on Android, iOS, Mac OS X, Ubuntu, and Raspberry Pi.
 
 *tangram-es is in active development and is not yet feature-complete*
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,30 @@
-general:
-  branches:
-    only:
-      - /circle-.*/
+machine:
+  xcode:
+    version: 7.3
+  environment:
+    XCODE_PROJECT: build/tangram.xcodeproj
+    XCODE_SCHEME: phony # Dummy value, Circle won't run without a scheme.
+checkout:
+  post:
+    - git submodule sync
+    - git submodule update --init --recursive
+test:
+  pre:
+    - set -o pipefail &&
+      mkdir build &&
+      cd build &&
+      cmake ..
+      -DPLATFORM_TARGET=ios.framework
+      -DIOS_PLATFORM=SIMULATOR
+      -DCMAKE_TOOLCHAIN_FILE=toolchains/iOS.toolchain.cmake
+      -DBUILD_IOS_FRAMEWORK=TRUE
+      -G Xcode
+  override:
+    - set -o pipefail &&
+      xcodebuild
+      -project build/tangram.xcodeproj
+      -target TangramMap
+      -configuration Release |
+      xcpretty
+  post:
+    - mv build/lib/Release/TangramMap.framework ${CIRCLE_ARTIFACTS}/

--- a/circle.yml
+++ b/circle.yml
@@ -2,14 +2,15 @@ machine:
   xcode:
     version: 8.1
   environment:
+    # Dummy values, Circle won't run without a project and scheme.
     XCODE_PROJECT: build/tangram.xcodeproj
-    XCODE_SCHEME: phony # Dummy value, Circle won't run without a scheme.
+    XCODE_SCHEME: phony
 checkout:
   post:
     - git submodule sync
     - git submodule update --init --recursive
 test:
   override:
-    - make ios | xcpretty
+    - make ios
   post:
     - mv build/ios-framework-universal/Release/TangramMap.framework ${CIRCLE_ARTIFACTS}/

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 7.3
+    version: 8.1
   environment:
     XCODE_PROJECT: build/tangram.xcodeproj
     XCODE_SCHEME: phony # Dummy value, Circle won't run without a scheme.

--- a/circle.yml
+++ b/circle.yml
@@ -9,22 +9,7 @@ checkout:
     - git submodule sync
     - git submodule update --init --recursive
 test:
-  pre:
-    - set -o pipefail &&
-      mkdir build &&
-      cd build &&
-      cmake ..
-      -DPLATFORM_TARGET=ios.framework
-      -DIOS_PLATFORM=SIMULATOR
-      -DCMAKE_TOOLCHAIN_FILE=toolchains/iOS.toolchain.cmake
-      -DBUILD_IOS_FRAMEWORK=TRUE
-      -G Xcode
   override:
-    - set -o pipefail &&
-      xcodebuild
-      -project build/tangram.xcodeproj
-      -target TangramMap
-      -configuration Release |
-      xcpretty
+    - make ios | xcpretty
   post:
-    - mv build/lib/Release/TangramMap.framework ${CIRCLE_ARTIFACTS}/
+    - mv build/ios-framework-universal/Release/TangramMap.framework ${CIRCLE_ARTIFACTS}/

--- a/toolchains/iOS.toolchain.cmake
+++ b/toolchains/iOS.toolchain.cmake
@@ -115,7 +115,11 @@ endif (${IOS_PLATFORM} STREQUAL "OS")
 
 # Setup iOS developer location unless specified manually with CMAKE_IOS_DEVELOPER_ROOT
 if (NOT DEFINED CMAKE_IOS_DEVELOPER_ROOT)
-	execute_process(COMMAND xcrun --sdk iphonesimulator --show-sdk-platform-path OUTPUT_VARIABLE XCRUN_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (${IOS_PLATFORM} STREQUAL "SIMULATOR")
+        execute_process(COMMAND xcrun --sdk iphonesimulator --show-sdk-platform-path OUTPUT_VARIABLE XCRUN_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+    else()
+        execute_process(COMMAND xcrun --sdk iphoneos --show-sdk-platform-path OUTPUT_VARIABLE XCRUN_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
 	if (DEFINED XCRUN_OUTPUT)
 		set (CMAKE_IOS_DEVELOPER_ROOT "${XCRUN_OUTPUT}/Developer")
 	endif (DEFINED XCRUN_OUTPUT)

--- a/toolchains/iOS.toolchain.cmake
+++ b/toolchains/iOS.toolchain.cmake
@@ -114,15 +114,11 @@ else (${IOS_PLATFORM} STREQUAL "OS")
 endif (${IOS_PLATFORM} STREQUAL "OS")
 
 # Setup iOS developer location unless specified manually with CMAKE_IOS_DEVELOPER_ROOT
-# Note Xcode 4.3 changed the installation location, choose the most recent one available
-set (XCODE_POST_43_ROOT "/Applications/Xcode.app/Contents/Developer/Platforms/${IOS_PLATFORM_LOCATION}/Developer")
-set (XCODE_PRE_43_ROOT "/Developer/Platforms/${IOS_PLATFORM_LOCATION}/Developer")
 if (NOT DEFINED CMAKE_IOS_DEVELOPER_ROOT)
-	if (EXISTS ${XCODE_POST_43_ROOT})
-		set (CMAKE_IOS_DEVELOPER_ROOT ${XCODE_POST_43_ROOT})
-	elseif(EXISTS ${XCODE_PRE_43_ROOT})
-		set (CMAKE_IOS_DEVELOPER_ROOT ${XCODE_PRE_43_ROOT})
-	endif (EXISTS ${XCODE_POST_43_ROOT})
+	execute_process(COMMAND xcrun --sdk iphonesimulator --show-sdk-platform-path OUTPUT_VARIABLE XCRUN_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if (DEFINED XCRUN_OUTPUT)
+		set (CMAKE_IOS_DEVELOPER_ROOT "${XCRUN_OUTPUT}/Developer")
+	endif (DEFINED XCRUN_OUTPUT)
 endif (NOT DEFINED CMAKE_IOS_DEVELOPER_ROOT)
 set (CMAKE_IOS_DEVELOPER_ROOT ${CMAKE_IOS_DEVELOPER_ROOT} CACHE PATH "Location of iOS Platform")
 


### PR DESCRIPTION
Currently, CircleCI provides much lower latency for starting builds on macOS machines than Travis.

Our build process requires quite a few tweaks to the Circle build configuration, but it seems to work in principle.

This allows us to remove the iOS and macOS build jobs from our Travis configuration, ~~however I've also added a new linux configuration on Travis to build with the LLVM toolchain and ensure that we catch any compiler divergences (it may not be necessary but we can try it).~~