### PR TITLE
Okhttp 3.5

### DIFF
--- a/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -102,10 +102,12 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
     }
 
     HttpHandler getHttpHandler() {
-        HttpHandler handler = new HttpHandler();
         File cacheDir = getExternalCacheDir();
+        HttpHandler handler;
         if (cacheDir != null && cacheDir.exists()) {
-            handler.setCache(new File(cacheDir, "tile_cache"), 30 * 1024 * 1024);
+            handler = new HttpHandler(new File(cacheDir, "tile_cache"), 30 * 1024 * 1024);
+        } else {
+            handler = new HttpHandler();
         }
 
         return handler;

--- a/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -103,14 +103,10 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
     HttpHandler getHttpHandler() {
         File cacheDir = getExternalCacheDir();
-        HttpHandler handler;
         if (cacheDir != null && cacheDir.exists()) {
-            handler = new HttpHandler(new File(cacheDir, "tile_cache"), 30 * 1024 * 1024);
-        } else {
-            handler = new HttpHandler();
+            return new HttpHandler(new File(cacheDir, "tile_cache"), 30 * 1024 * 1024);
         }
-
-        return handler;
+        return new HttpHandler();
     }
 
     @Override

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -56,7 +56,7 @@ android {
 }
 
 dependencies {
-  compile 'com.squareup.okhttp:okhttp:3.5.0'
+  compile 'com.squareup.okhttp3:okhttp:3.5.0'
   compile 'xmlpull:xmlpull:1.1.3.1'
   compile 'com.android.support:support-annotations:25.0.0'
 }

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -56,7 +56,7 @@ android {
 }
 
 dependencies {
-  compile 'com.squareup.okhttp:okhttp:2.5.0'
+  compile 'com.squareup.okhttp:okhttp:3.5.0'
   compile 'xmlpull:xmlpull:1.1.3.1'
   compile 'com.android.support:support-annotations:25.0.0'
 }

--- a/android/tangram/src/main/java/com/mapzen/tangram/HttpHandler.java
+++ b/android/tangram/src/main/java/com/mapzen/tangram/HttpHandler.java
@@ -1,9 +1,9 @@
 package com.mapzen.tangram;
 
-import com.squareup.okhttp.Cache;
-import com.squareup.okhttp.Callback;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
+import com.squareup.okhttp3.Cache;
+import com.squareup.okhttp3.Callback;
+import com.squareup.okhttp3.OkHttpClient;
+import com.squareup.okhttp3.Request;
 
 import java.io.File;
 import java.io.IOException;

--- a/android/tangram/src/main/java/com/mapzen/tangram/HttpHandler.java
+++ b/android/tangram/src/main/java/com/mapzen/tangram/HttpHandler.java
@@ -1,9 +1,10 @@
 package com.mapzen.tangram;
 
-import com.squareup.okhttp3.Cache;
-import com.squareup.okhttp3.Callback;
-import com.squareup.okhttp3.OkHttpClient;
-import com.squareup.okhttp3.Request;
+import okhttp3.Cache;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,16 +17,32 @@ import java.util.concurrent.TimeUnit;
 public class HttpHandler {
 
     private OkHttpClient okClient;
-    protected Request.Builder okRequestBuilder;
 
     /**
      * Construct an {@code HttpHandler} with default options.
      */
     public HttpHandler() {
-        okRequestBuilder = new Request.Builder();
-        okClient = new OkHttpClient();
-        okClient.setConnectTimeout(10, TimeUnit.SECONDS);
-        okClient.setReadTimeout(30, TimeUnit.SECONDS);
+        okClient = new OkHttpClient.Builder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
+    }
+
+    /**
+     * Construct an {@code HttpHandler} with cache.
+     * Cache map data in a directory with a specified size limit
+     * @param directory Directory in which map data will be cached
+     * @param maxSize Maximum size of data to cache, in bytes
+     */
+    public HttpHandler(File directory, long maxSize) {
+        Cache okTileCache = new Cache(directory, maxSize);
+        okClient = new OkHttpClient.Builder()
+                .cache(okTileCache)
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
     }
 
     /**
@@ -35,7 +52,10 @@ public class HttpHandler {
      * @return true if request was successfully started
      */
     public boolean onRequest(String url, Callback cb) {
-        Request request = okRequestBuilder.tag(url).url(url).build();
+        Request request = new Request.Builder()
+                .tag(url)
+                .url(url)
+                .build();
         okClient.newCall(request).enqueue(cb);
         return true;
     }
@@ -45,20 +65,22 @@ public class HttpHandler {
      * @param url URL of the request to be cancelled
      */
     public void onCancel(String url) {
-        okClient.cancel(url);
-    }
 
-    /**
-     * Cache map data in a directory with a specified size limit
-     * @param directory Directory in which map data will be cached
-     * @param maxSize Maximum size of data to cache, in bytes
-     * @return true if cache was successfully created
-     */
-    public boolean setCache(File directory, long maxSize) {
-        Cache okTileCache = new Cache(directory, maxSize);
-        okClient.setCache(okTileCache);
+        // check and cancel running call
+        for (Call runningCall : okClient.dispatcher().runningCalls()) {
+            if (runningCall.request().tag().equals(url)) {
+                runningCall.cancel();
+                return;
+            }
+        }
 
-        return true;
+        // check and cancel queued call
+        for (Call queuedCall : okClient.dispatcher().queuedCalls()) {
+            if (queuedCall.request().tag().equals(url)) {
+                queuedCall.cancel();
+                return;
+            }
+        }
     }
 
 }

--- a/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -8,9 +8,10 @@ import android.opengl.GLSurfaceView.Renderer;
 import android.util.DisplayMetrics;
 
 import com.mapzen.tangram.TouchInput.Gestures;
-import com.squareup.okhttp3.Callback;
-import com.squareup.okhttp3.Request;
-import com.squareup.okhttp3.Response;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Request;
+import okhttp3.Response;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1038,14 +1039,15 @@ public class MapController implements Renderer {
         if (httpHandler == null) {
             return false;
         }
+
         httpHandler.onRequest(url, new Callback() {
             @Override
-            public void onFailure(Request request, IOException e) {
+            public void onFailure(Call call, IOException e) {
                 nativeOnUrlFailure(callbackPtr);
             }
 
             @Override
-            public void onResponse(Response response) throws IOException {
+            public void onResponse(Call call, Response response) throws IOException {
                 if (!response.isSuccessful()) {
                     nativeOnUrlFailure(callbackPtr);
                     throw new IOException("Unexpected response code: " + response);

--- a/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -10,7 +10,6 @@ import android.util.DisplayMetrics;
 import com.mapzen.tangram.TouchInput.Gestures;
 import okhttp3.Call;
 import okhttp3.Callback;
-import okhttp3.Request;
 import okhttp3.Response;
 
 import java.io.IOException;
@@ -22,8 +21,6 @@ import java.util.Map;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
-
-import okio.BufferedSource;
 
 /**
  * {@code MapController} is the main class for interacting with a Tangram map.
@@ -1052,8 +1049,7 @@ public class MapController implements Renderer {
                     nativeOnUrlFailure(callbackPtr);
                     throw new IOException("Unexpected response code: " + response);
                 }
-                BufferedSource source = response.body().source();
-                byte[] bytes = source.readByteArray();
+                byte[] bytes = response.body().bytes();
                 nativeOnUrlSuccess(bytes, callbackPtr);
             }
         });

--- a/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -8,9 +8,9 @@ import android.opengl.GLSurfaceView.Renderer;
 import android.util.DisplayMetrics;
 
 import com.mapzen.tangram.TouchInput.Gestures;
-import com.squareup.okhttp.Callback;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
+import com.squareup.okhttp3.Callback;
+import com.squareup.okhttp3.Request;
+import com.squareup.okhttp3.Response;
 
 import java.io.IOException;
 import java.util.ArrayList;


### PR DESCRIPTION
We were 1 full version behind with OKHTTP. We have been using Okhttp2.5, while they have released some major upgrades to their library. This PR moves us to latest and greatest from OKHttp.

Note: This is an API breaking change.
`HttpHandler` does not have a `setCache` method. A new parameterized constructor is added to `HttpHandler` to set the cache. This is because of the API change(s) in OkHttp3.0 and beyond.