### PR TITLE
Relative paths resolved against relative paths remain relative.

### DIFF
--- a/core/src/util/url.cpp
+++ b/core/src/util/url.cpp
@@ -241,18 +241,14 @@ Url Url::resolve(const Url& b, const Url& r) {
         } else {
             // Merge the relative path with the base path.
             if (b.hasNetLocation() && !b.hasPath()) {
-                t.buffer.append("/");
+                t.buffer += '/';
                 t.buffer.append(r.buffer, r.parts.path.start, r.parts.path.count);
             } else {
                 // Add the base URL's path.
                 t.buffer.append(b.buffer, b.parts.path.start, b.parts.path.count);
-                // Remove the last segment of the base URL's path.
-                size_t end = removeLastSegmentFromRange(t.buffer, t.parts.path.start, t.buffer.size());
-                t.buffer.resize(end);
+                // Remove the last segment of the base URL's path, up to the last '/'.
+                while (!t.buffer.empty() && t.buffer.back() != '/') { t.buffer.pop_back(); }
                 // Add the relative URL's path.
-                if (r.buffer[r.parts.path.start] != '/') {
-                    t.buffer += '/';
-                }
                 t.buffer.append(r.buffer, r.parts.path.start, r.parts.path.count);
             }
         }

--- a/tests/unit/urlTests.cpp
+++ b/tests/unit/urlTests.cpp
@@ -174,6 +174,27 @@ TEST_CASE("Resolve a URL against a relative base URL", "[Url]") {
 
 }
 
+TEST_CASE("Resolve a relative URL against an empty base URL", "[Url]") {
+
+    Url base("");
+
+    CHECK(Url("g:h").resolved(base).string() == "g:h");
+    CHECK(Url("g").resolved(base).string() == "g");
+    CHECK(Url("./g").resolved(base).string() == "g");
+    CHECK(Url("g/").resolved(base).string() == "g/");
+    CHECK(Url("/g").resolved(base).string() == "/g");
+    CHECK(Url("?y").resolved(base).string() == "?y");
+    CHECK(Url("g?y").resolved(base).string() == "g?y");
+    CHECK(Url("#s").resolved(base).string() == "#s");
+    CHECK(Url("g#s").resolved(base).string() == "g#s");
+    CHECK(Url("g?y#s").resolved(base).string() == "g?y#s");
+    CHECK(Url(";x").resolved(base).string() == ";x");
+    CHECK(Url("g;x").resolved(base).string() == "g;x");
+    CHECK(Url("g;x?y#s").resolved(base).string() == "g;x?y#s");
+    CHECK(Url("").resolved(base).string() == "");
+
+}
+
 TEST_CASE("Resolve an abnormal relative URL against an absolute base URL", "[Url]") {
 
     // https://tools.ietf.org/html/rfc3986#section-5.4.2


### PR DESCRIPTION
This is a bit weird and should maybe be treated as an error later, but it solves an immediate bug on macOS and iOS.

Technically this doesn't violate RFC 1808 or RFC 3986 because neither covers this specific case.