### PR TITLE
Attribution

### DIFF
--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -186,6 +186,8 @@ public:
 
     void setAlpha(float _alpha);
 
+    void setScreenPosition(glm::vec2 _pos) { m_screenTransform.position = _pos; }
+
 private:
 
     virtual void applyAnchor(LabelProperty::Anchor _anchor) = 0;
@@ -195,8 +197,6 @@ private:
     FadeEffect m_fade;
 
     int m_anchorIndex;
-
-    uint32_t m_selectionColor;
 
 protected:
 

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -314,14 +314,13 @@ bool MarkerManager::buildStyling(Marker& marker) {
     return true;
 }
 
-bool MarkerManager::buildGeometry(Marker& marker, int zoom) {
+bool MarkerManager::buildGeometry(Marker& marker, int zoom, StyleBuilder* styler) {
 
     auto feature = marker.feature();
     auto rule = marker.drawRule();
     if (!feature || !rule) { return false; }
 
-    StyleBuilder* styler = nullptr;
-    {
+    if (!styler) {
         auto name = rule->getStyleName();
         auto it = m_styleBuilders.find(name);
         if (it != m_styleBuilders.end()) {

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -65,12 +65,12 @@ public:
 
     const std::vector<std::unique_ptr<Marker>>& markers() const;
 
+    bool buildStyling(Marker& marker);
+    bool buildGeometry(Marker& marker, int zoom, StyleBuilder* builder = nullptr);
+
 private:
 
     Marker* getMarkerOrNull(MarkerID markerID);
-
-    bool buildStyling(Marker& marker);
-    bool buildGeometry(Marker& marker, int zoom);
 
     DrawRuleMergeSet m_ruleSet;
     StyleContext m_styleContext;

--- a/core/src/scene/attribution.cpp
+++ b/core/src/scene/attribution.cpp
@@ -1,0 +1,54 @@
+#include "data/tileData.h"
+#include "labels/labels.h"
+#include "marker/markerManager.h"
+#include "marker/marker.h"
+#include "scene/attribution.h"
+#include "scene/scene.h"
+#include "style/textStyle.h"
+
+namespace Tangram {
+
+void Attribution::setup(Scene& scene, const std::string& attributionText, const std::string& attributionStyling) {
+
+    m_style = std::make_unique<TextStyle>("attribution-overlay", scene.fontContext(), true);
+    m_style->build(scene);
+    m_builder = m_style->createBuilder();
+
+    m_marker = std::make_unique<Marker>(0);
+    auto feature = std::make_unique<Feature>();
+    feature->geometryType = GeometryType::points;
+    feature->props.set("name", attributionText);
+    auto blah = feature->props.get("name").get<std::string>();
+    feature->points.emplace_back();
+    m_marker->setFeature(std::move(feature));
+
+    m_marker->setStylingString(attributionStyling);
+}
+
+void Attribution::draw(RenderState& rs, const View& view, Scene& scene) {
+    m_style->onBeginFrame(rs);
+    m_style->onBeginDrawFrame(rs, view, scene);
+    m_style->onEndDrawFrame();
+}
+
+void Attribution::update(const View& view) {
+    if (!m_marker->mesh()) { return; }
+
+    auto* mesh = dynamic_cast<const LabelSet*>(m_marker->mesh());
+    m_style->onBeginUpdate();
+
+    for (auto& l : mesh->getLabels()) {
+        l->setScreenPosition({10, view.getHeight()});
+        l->enterState(Label::State::visible);
+        l->evalState(0);
+        l->addVerticesToMesh();
+    }
+}
+
+void Attribution::reset() {
+    m_style.reset();
+    m_builder.reset();
+    m_marker.reset();
+}
+
+}

--- a/core/src/scene/attribution.h
+++ b/core/src/scene/attribution.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <memory>
+
+namespace Tangram {
+
+class Marker;
+class RenderState;
+class StyleBuilder;
+class Scene;
+class TextStyle;
+class View;
+
+class Attribution {
+    std::unique_ptr<TextStyle> m_style = nullptr;
+    std::unique_ptr<StyleBuilder> m_builder = nullptr;
+    std::unique_ptr<Marker> m_marker = nullptr;
+
+public:
+    void reset();
+    void draw(RenderState& rs, const View& view, Scene& scene);
+    void update(const View& view);
+    void setup(Scene& scene, const std::string& attributionText, const std::string& attributionStyling);
+    Marker& marker() { return *m_marker; }
+    const std::unique_ptr<TextStyle>& style() { return m_style; }
+    StyleBuilder* builder() { return m_builder.get(); }
+    bool isSetup() { return (m_style && m_builder && m_marker); }
+};
+
+} // namespace Tangram

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -163,6 +163,7 @@ bool DrawRuleMergeSet::evaluateRuleForContext(DrawRule& rule, StyleContext& ctx)
         }
 
         bool valid = true;
+        bool drawRuleSet = false;
         for (size_t i = 0; i < StyleParamKeySize; ++i) {
 
             if (!rule.active[i]) {
@@ -170,6 +171,7 @@ bool DrawRuleMergeSet::evaluateRuleForContext(DrawRule& rule, StyleContext& ctx)
                 continue;
             }
 
+            drawRuleSet = true;
             auto*& param = rule.params[i].param;
 
             // Evaluate JS functions and Stops
@@ -195,7 +197,7 @@ bool DrawRuleMergeSet::evaluateRuleForContext(DrawRule& rule, StyleContext& ctx)
             }
         }
 
-        return valid;
+        return (drawRuleSet && valid);
 }
 
 

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<StyledMesh> DebugTextStyleBuilder::build() {
     }
 
     DrawRule rule({"", 0, {}}, "", 0);
-    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) }, rule);
+    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) }, 0);
 
     m_textLabels->setLabels(m_labels);
 

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -27,7 +27,9 @@ const static std::string key_name("name");
 
 TextStyleBuilder::TextStyleBuilder(const TextStyle& _style)
     : StyleBuilder(_style),
-      m_style(_style) {}
+      m_style(_style) {
+    m_textLabels = std::make_unique<TextLabels>(m_style);
+}
 
 void TextStyleBuilder::setup(const Tile& _tile){
     m_tileSize = _tile.getProjection()->TileSize();
@@ -179,23 +181,27 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
     size_t quadsStart = m_quads.size();
     size_t numLabels = m_labels.size();
 
+    auto selectionColor = [&]() {
+        return params.interactive ? _rule.featureSelection->nextColorIdentifier() : 0;
+    };
+
     if (!prepareLabel(params, labelType)) { return false; }
 
     if (_feat.geometryType == GeometryType::points) {
         for (auto& point : _feat.points) {
             auto p = glm::vec2(point);
-            addLabel(params, Label::Type::point, { p, p }, _rule);
+            addLabel(params, Label::Type::point, { p, p }, selectionColor());
         }
 
     } else if (_feat.geometryType == GeometryType::polygons) {
         for (auto& polygon : _feat.polygons) {
             if (_iconText) {
                 auto p = centroid(polygon);
-                addLabel(params, Label::Type::point, { p, p }, _rule);
+                addLabel(params, Label::Type::point, { p, p }, selectionColor());
             } else {
                 for (auto& line : polygon) {
                     for (auto& point : line) {
-                        addLabel(params, Label::Type::point, { point }, _rule);
+                        addLabel(params, Label::Type::point, { point }, selectionColor());
                     }
                 }
             }
@@ -206,7 +212,7 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
         if (_iconText) {
             for (auto& line : _feat.lines) {
                 for (auto& point : line) {
-                    addLabel(params, Label::Type::point, { point }, _rule);
+                    addLabel(params, Label::Type::point, { point }, selectionColor());
                 }
             }
         } else {
@@ -221,7 +227,10 @@ bool TextStyleBuilder::addFeatureCommon(const Feature& _feat, const DrawRule& _r
     return true;
 }
 
-void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::Parameters& _params, const DrawRule& _rule) {
+void TextStyleBuilder::addLineTextLabels(const Feature& _feat,
+                                         const TextStyle::Parameters& _params,
+                                         const DrawRule& _rule) {
+
     float pixelScale = 1.0/m_tileSize;
     float minLength = m_attributes.width * pixelScale;
 
@@ -243,7 +252,8 @@ void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::
 
                 if (j == next) {
                     if (segmentLength > minLength) {
-                        addLabel(_params, Label::Type::line, { p1, p }, _rule);
+                        addLabel(_params, Label::Type::line, { p1, p },
+                                 _params.interactive ? _rule.featureSelection->nextColorIdentifier() : 0);
                     }
                 } else {
                     glm::vec2 pp = glm::vec2(line[j-1]);
@@ -267,7 +277,8 @@ void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::
                 glm::vec2 b = glm::vec2(p2 - p1) / float(run);
 
                 for (int r = 0; r < run; r++) {
-                    addLabel(_params, Label::Type::line, { a, a+b }, _rule);
+                    addLabel(_params, Label::Type::line, { a, a+b },
+                             _params.interactive ? _rule.featureSelection->nextColorIdentifier() : 0);
                     a += b;
                 }
                 run *= 2;
@@ -527,13 +538,7 @@ bool TextStyleBuilder::prepareLabel(TextStyle::Parameters& _params, Label::Type 
 }
 
 void TextStyleBuilder::addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                                Label::WorldTransform _transform, const DrawRule& _rule) {
-
-    uint32_t selectionColor = 0;
-
-    if (_params.interactive) {
-        selectionColor = _rule.featureSelection->nextColorIdentifier();
-    }
+                                Label::WorldTransform _transform, uint32_t selectionColor) {
 
     m_labels.emplace_back(new TextLabel(_transform, _type, _params.labelOptions,
                                         {m_attributes.fill,

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -37,7 +37,7 @@ public:
 
     // Add label to the mesh using the prepared label data
     void addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                  Label::WorldTransform _transform, const DrawRule& _rule);
+                  Label::WorldTransform _transform, uint32_t _selectionColor);
 
     void addLineTextLabels(const Feature& _feature, const TextStyle::Parameters& _params, const DrawRule& _rule);
 

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -180,6 +180,10 @@ public:
 
     void clearDataSource(DataSource& _source, bool _data, bool _tiles);
 
+    // Adds attribution text at bottom left of the map.
+    // TODO: specify relative position with respect to map dimentions (example: bottom_left, bottom_right, etc)
+    void addMapAttribution(std::string _attributionText, std::string _attributionStyling);
+
     // Add a marker object to the map and return an ID for it; an ID of 0 indicates an invalid marker;
     // the marker will not be drawn until both styling and geometry are set using the functions below.
     MarkerID markerAdd();

--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -258,12 +258,18 @@ void window_size_callback(GLFWwindow* window, int width, int height) {
 
 }
 
+void cb(void* blah = nullptr) {
+    std::string stylingString = "{ style: 'attribution-overlay', collide: false, text_wrap: false, anchor: top-right, font: { size: 18px, fill: '#ff4444', stroke: { color: '#aaffff', width: 4px } } }";
+    std::string attribution = "© Mapzen. © OpenStreetMap";
+    map->addMapAttribution(attribution, stylingString);
+}
+
 void init_main_window(bool recreate) {
 
     // Setup tangram
     if (!map) {
         map = new Tangram::Map();
-        map->loadSceneAsync(sceneFile.c_str(), true);
+        map->loadSceneAsync(sceneFile.c_str(), true, cb);
     }
 
     if (!recreate) {
@@ -294,6 +300,7 @@ void init_main_window(bool recreate) {
     // Setup graphics
     map->setupGL();
     map->resize(width, height);
+
 
     data_source = std::make_shared<ClientGeoJsonSource>("touch", "");
     map->addDataSource(data_source);


### PR DESCRIPTION
Adds an interface for Tangram Map to add attribution, using yaml styling for the attribution text.

Breaking this work from https://github.com/tangrams/tangram-es/pull/1180

@hjanetzek some rebasing made you the main owner of all the Attribution interface.

This also has a fix on when no draw rules are specified, draw rule evaluation should return `false`.