### PR TITLE
evalRuleForContext should return false when no draw rules are set

### DIFF
--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -163,6 +163,7 @@ bool DrawRuleMergeSet::evaluateRuleForContext(DrawRule& rule, StyleContext& ctx)
         }
 
         bool valid = true;
+        bool drawRuleSet = false;
         for (size_t i = 0; i < StyleParamKeySize; ++i) {
 
             if (!rule.active[i]) {
@@ -170,6 +171,7 @@ bool DrawRuleMergeSet::evaluateRuleForContext(DrawRule& rule, StyleContext& ctx)
                 continue;
             }
 
+            drawRuleSet = true;
             auto*& param = rule.params[i].param;
 
             // Evaluate JS functions and Stops
@@ -195,7 +197,7 @@ bool DrawRuleMergeSet::evaluateRuleForContext(DrawRule& rule, StyleContext& ctx)
             }
         }
 
-        return valid;
+        return (drawRuleSet && valid);
 }
 
 


### PR DESCRIPTION
How I found this (Story):
During the generic attribution code (using markers), I was adding a feature with its text property set to the attribution string. But during testing when I specified no 

You add a marker with its underlying feature having a `name` property, and added some garbage rules for marker styling. I expected no text to render, but it did.