### PR TITLE
More font loading speedups

### DIFF
--- a/android/tangram/src/main/cpp/platform_android.cpp
+++ b/android/tangram/src/main/cpp/platform_android.cpp
@@ -214,12 +214,14 @@ std::vector<FontSourceHandle> systemFontFallbacksHandle() {
     return handles;
 }
 
-unsigned char* systemFont(const std::string& _name, const std::string& _weight, const std::string& _face, size_t* _size) {
+std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) {
     std::string path = fontPath(_name, _weight, _face);
 
-    if (path.empty()) { return nullptr; }
+    if (path.empty()) { return {}; }
 
-    return bytesFromFile(path.c_str(), *_size);
+    auto data = bytesFromFile(path.c_str());
+
+    return data;
 }
 
 void setContinuousRendering(bool _isContinuous) {
@@ -293,15 +295,12 @@ std::string stringFromFile(const char* _path) {
     return data;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size) {
-
-    _size = 0;
-    unsigned char* data = nullptr;
+std::vector<char> bytesFromFile(const char* _path) {
+    std::vector<char> data;
 
     auto allocator = [&](size_t size) {
-        _size = size;
-        data = (unsigned char*) malloc(sizeof(char) * size);
-        return reinterpret_cast<char*>(data);
+        data.resize(size);
+        return data.data();
     };
 
     if (strncmp(_path, aaPrefix, aaPrefixLen) == 0) {
@@ -309,6 +308,7 @@ unsigned char* bytesFromFile(const char* _path, size_t& _size) {
     } else {
         bytesFromFileSystem(_path, allocator);
     }
+
     return data;
 }
 

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -74,18 +74,16 @@ RasterSource::RasterSource(const std::string& _name, const std::string& _urlTemp
                            TextureOptions _options, bool _genMipmap)
     : DataSource(_name, _urlTemplate, _minDisplayZoom, _maxDisplayZoom, _maxZoom), m_texOptions(_options), m_genMipmap(_genMipmap) {
 
-    m_emptyTexture = std::make_shared<Texture>(nullptr, 0, m_texOptions, m_genMipmap);
+    std::vector<char> data = {};
+    m_emptyTexture = std::make_shared<Texture>(data, m_texOptions, m_genMipmap);
 }
 
 std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _rawTileData) {
-    auto udata = reinterpret_cast<const unsigned char*>(_rawTileData.data());
-    size_t dataSize = _rawTileData.size();
-
-    if (dataSize == 0) {
+    if (_rawTileData.size() == 0) {
         return m_emptyTexture;
     }
 
-    auto texture = std::make_shared<Texture>(udata, dataSize, m_texOptions, m_genMipmap);
+    auto texture = std::make_shared<Texture>(_rawTileData, m_texOptions, m_genMipmap);
 
     return texture;
 }

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -367,7 +367,9 @@ void RenderState::deleteDefaultPointTexture() {
 
 void RenderState::generateDefaultPointTexture() {
     TextureOptions options = { GL_RGBA, GL_RGBA, { GL_LINEAR, GL_LINEAR }, { GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE } };
-    m_defaultPointTexture = new Texture(default_point_texture_data, default_point_texture_size, options, true);
+    std::vector<char> defaultPoint;
+    defaultPoint.insert(defaultPoint.begin(), default_point_texture_data, default_point_texture_data + default_point_texture_size);
+    m_defaultPointTexture = new Texture(defaultPoint, options, true);
 }
 
 bool RenderState::framebuffer(GLuint handle) {

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -31,10 +31,10 @@ Texture::Texture(unsigned int _width, unsigned int _height, TextureOptions _opti
     resize(_width, _height);
 }
 
-Texture::Texture(const unsigned char* data, size_t dataSize, TextureOptions options, bool generateMipmaps)
+Texture::Texture(const std::vector<char>& _data, TextureOptions options, bool generateMipmaps)
     : Texture(0u, 0u, options, generateMipmaps) {
 
-    loadImageFromMemory(data, dataSize);
+    loadImageFromMemory(_data);
 }
 
 Texture::~Texture() {
@@ -54,12 +54,12 @@ Texture::~Texture() {
     });
 }
 
-bool Texture::loadImageFromMemory(const unsigned char* blob, unsigned int size) {
+bool Texture::loadImageFromMemory(const std::vector<char>& _data) {
     unsigned char* pixels = nullptr;
     int width, height, comp;
 
-    if (blob != nullptr && size != 0) {
-        pixels = stbi_load_from_memory(blob, size, &width, &height, &comp, STBI_rgb_alpha);
+    if (_data.size() != 0) {
+        pixels = stbi_load_from_memory(reinterpret_cast<const stbi_uc*>(_data.data()), _data.size(), &width, &height, &comp, STBI_rgb_alpha);
     }
 
     if (pixels) {

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -41,7 +41,7 @@ public:
             TextureOptions _options = DEFAULT_TEXTURE_OPTION,
             bool _generateMipmaps = false);
 
-    Texture(const unsigned char* data, size_t dataSize,
+    Texture(const std::vector<char>& _data,
             TextureOptions _options = DEFAULT_TEXTURE_OPTION,
             bool _generateMipmaps = false);
 
@@ -87,7 +87,7 @@ public:
 
     static bool isRepeatWrapping(TextureWrapping _wrapping);
 
-    bool loadImageFromMemory(const unsigned char* blob, unsigned int size);
+    bool loadImageFromMemory(const std::vector<char>& _data);
 
     static void flipImageData(unsigned char *result, int w, int h, int depth);
     static void flipImageData(GLuint *result, int w, int h);

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -11,27 +11,23 @@
 namespace Tangram {
 
 TextureCube::TextureCube(std::string _file, TextureOptions _options)
-    : Texture(0u, 0u, _options) {
+    : Texture(0, 0, _options) {
 
     m_target = GL_TEXTURE_CUBE_MAP;
     load(_file);
 }
 
 void TextureCube::load(const std::string& _file) {
-    size_t size;
-    unsigned char* data = bytesFromFile(_file.c_str(), size);
+    auto data = bytesFromFile(_file.c_str());
     unsigned char* pixels;
     int width, height, comp;
 
-    if (data == nullptr || size == 0) {
+    if (data.size() == 0) {
         LOGE("Texture not found! '%s'", _file.c_str());
-        free(data);
         return;
     }
 
-    pixels = stbi_load_from_memory(data, size, &width, &height, &comp, STBI_rgb_alpha);
-
-    size = width * height;
+    pixels = stbi_load_from_memory(reinterpret_cast<const stbi_uc*>(data.data()), data.size(), &width, &height, &comp, STBI_rgb_alpha);
 
     m_width = width / 4;
     m_height = height / 3;
@@ -63,7 +59,6 @@ void TextureCube::load(const std::string& _file) {
         }
     }
 
-    free(data);
     stbi_image_free(pixels);
 
 }

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -63,7 +63,7 @@ void cancelUrlRequest(const std::string& _url);
  */
 void setCurrentThreadPriority(int priority);
 
-unsigned char* systemFont(const std::string& _name, const std::string& _weight, const std::string& _face, size_t* _size);
+std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face);
 
 struct FontSourceHandle {
     FontSourceHandle(std::string _path) : path(_path) {}

--- a/core/src/platform.h
+++ b/core/src/platform.h
@@ -41,7 +41,7 @@ std::string stringFromFile(const char* _path);
  * containing the contents of the file. The size of the memory in bytes is written to _size.
  * If the file cannot be read, nothing is allocated and nullptr is returned.
  */
-unsigned char* bytesFromFile(const char* _path, size_t& _size);
+std::vector<char> bytesFromFile(const char* _path);
 
 /* Function type for receiving data from a successful network request */
 using UrlCallback = std::function<void(std::vector<char>&&)>;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -731,7 +731,7 @@ void loadFontDescription(const Node& node, const std::string& family, const std:
             LOGW("Local font at path %s can't be found (%s)", _ft.uri.c_str(), _ft.bundleAlias.c_str());
         } else {
             LOGN("Adding local font %s (%s)", _ft.uri.c_str(), _ft.bundleAlias.c_str());
-            scene->fontContext()->addFont(_ft, alfons::InputSource(data));
+            scene->fontContext()->addFont(_ft, alfons::InputSource(std::move(data)));
         }
     }
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -552,12 +552,10 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
     if (std::regex_search(url, match, r)) {
         scene->pendingTextures++;
         startUrlRequest(url, [=](std::vector<char>&& rawData) {
-                auto ptr = (unsigned char*)(rawData.data());
-                size_t dataSize = rawData.size();
                 std::lock_guard<std::mutex> lock(m_textureMutex);
                 auto texture = scene->getTexture(name);
                 if (texture) {
-                    if (!texture->loadImageFromMemory(ptr, dataSize)) {
+                    if (!texture->loadImageFromMemory(rawData)) {
                         LOGE("Invalid texture data '%s'", url.c_str());
                     }
 
@@ -568,7 +566,8 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
                     }
                 }
             });
-        texture = std::make_shared<Texture>(nullptr, 0, options, generateMipmaps);
+        std::vector<char> textureData = {};
+        texture = std::make_shared<Texture>(textureData, options, generateMipmaps);
     } else {
 
         if (url.substr(0, 22) == "data:image/png;base64,") {
@@ -589,24 +588,25 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, cons
             }
             texture = std::make_shared<Texture>(0, 0, options, generateMipmaps);
 
-            if (!texture->loadImageFromMemory(blob.data(), blob.size())) {
+            std::vector<char> textureData;
+            auto cdata = reinterpret_cast<char*>(blob.data());
+            textureData.insert(textureData.begin(), cdata, cdata + blob.size());
+            if (!texture->loadImageFromMemory(textureData)) {
                 LOGE("Invalid Base64 texture");
             }
 
         } else {
-            size_t size = 0;
-            unsigned char* blob = bytesFromFile(url.c_str(), size);
+            auto data = bytesFromFile(url.c_str());
 
-            if (!blob) {
+            if (data.size() == 0) {
                 LOGE("Can't load texture resource at url '%s'", url.c_str());
                 return nullptr;
             }
-            texture = std::make_shared<Texture>(0, 0, options, generateMipmaps);
 
-            if (!texture->loadImageFromMemory(blob, size)) {
+            texture = std::make_shared<Texture>(0, 0, options, generateMipmaps);
+            if (!texture->loadImageFromMemory(data)) {
                 LOGE("Invalid texture data '%s'", url.c_str());
             }
-            free(blob);
         }
     }
 
@@ -725,15 +725,13 @@ void loadFontDescription(const Node& node, const std::string& family, const std:
             scene->pendingFonts--;
         });
     } else {
-        // Load from local storage
-        size_t dataSize = 0;
+        auto data = bytesFromFile(_ft.uri.c_str());
 
-        if (unsigned char* data = bytesFromFile(_ft.uri.c_str(), dataSize)) {
-
-            LOGN("Add local font %s (%s)", _ft.uri.c_str(), _ft.bundleAlias.c_str());
-            scene->fontContext()->addFont(_ft, alfons::InputSource(reinterpret_cast<char*>(data), dataSize));
-        } else {
+        if (data.size() == 0) {
             LOGW("Local font at path %s can't be found (%s)", _ft.uri.c_str(), _ft.bundleAlias.c_str());
+        } else {
+            LOGN("Adding local font %s (%s)", _ft.uri.c_str(), _ft.bundleAlias.c_str());
+            scene->fontContext()->addFont(_ft, alfons::InputSource(data));
         }
     }
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -293,15 +293,19 @@ std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, c
         FontDescription::BundleAlias(_family, _style, _weight);
 
     data = bytesFromFile(bundleFontPath.c_str(), dataSize);
+    std::vector<char> systemFontData;
 
     // 2. System font
     if (!data) {
-        data = systemFont(_family, _weight, _style, &dataSize);
+        systemFontData = systemFont(_family, _weight, _style);
+    } else {
+        systemFontData.insert(systemFontData.begin(), reinterpret_cast<const char*>(data),
+                reinterpret_cast<const char*>(data + dataSize));
+        free(data);
     }
 
-    if (data) {
-        font->addFace(m_alfons.addFontFace(alfons::InputSource(reinterpret_cast<char*>(data), dataSize), fontSize));
-        free(data);
+    if (systemFontData.size() > 0) {
+        font->addFace(m_alfons.addFontFace(alfons::InputSource(systemFontData), fontSize));
 
         // add fallbacks from default font
         if (m_font[sizeIndex]) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -304,7 +304,7 @@ std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, c
             font->addFaces(*m_font[sizeIndex]);
         }
     } else {
-        font->addFace(m_alfons.addFontFace(alfons::InputSource(fontData), fontSize));
+        font->addFace(m_alfons.addFontFace(alfons::InputSource(std::move(fontData)), fontSize));
 
         if (m_font[sizeIndex]) {
             font->addFaces(*m_font[sizeIndex]);

--- a/ios/src/TGFontConverter.h
+++ b/ios/src/TGFontConverter.h
@@ -9,9 +9,11 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 
+#import <vector>
+
 @interface TGFontConverter : NSObject
 
-+ (unsigned char *)fontDataForCGFont:(CGFontRef)cgFont size:(size_t *)size;
++ (std::vector<char>)fontDataForCGFont:(CGFontRef)cgFont;
 
 @end
 

--- a/ios/src/TGFontConverter.mm
+++ b/ios/src/TGFontConverter.mm
@@ -65,6 +65,8 @@ static uint32_t calcTableDataRefCheckSum(CFDataRef dataRef)
 
     std::vector<size_t> tableSizes;
     tableSizes.resize(tableCount);
+    std::vector<CFDataRef> dataRefs;
+    dataRefs.resize(tableCount);
 
     BOOL containsCFFTable = NO;
 
@@ -78,11 +80,12 @@ static uint32_t calcTableDataRefCheckSum(CFDataRef dataRef)
             containsCFFTable = YES;
         }
 
-        CFDataRef tableDataRef = CGFontCopyTableForTag(cgFont, aTag);
-        if (tableDataRef != NULL) {
-            tableSize = CFDataGetLength(tableDataRef);
-            CFRelease(tableDataRef);
+        dataRefs[index] = CGFontCopyTableForTag(cgFont, aTag);
+
+        if (dataRefs[index] != NULL) {
+            tableSize = CFDataGetLength(dataRefs[index]);
         }
+
         totalSize += (tableSize + 3) & ~3;
 
         tableSizes[index] = tableSize;
@@ -134,7 +137,10 @@ static uint32_t calcTableDataRefCheckSum(CFDataRef dataRef)
     for (int index = 0; index < tableCount; ++index) {
 
         intptr_t aTag = (intptr_t)CFArrayGetValueAtIndex(tags, index);
-        CFDataRef tableDataRef = CGFontCopyTableForTag(cgFont, aTag);
+        CFDataRef tableDataRef = dataRefs[index];
+
+        if (tableDataRef == NULL) { continue; }
+
         size_t tableSize = CFDataGetLength(tableDataRef);
 
         memcpy(dataPtr, CFDataGetBytePtr(tableDataRef), tableSize);

--- a/ios/src/TGFontConverter.mm
+++ b/ios/src/TGFontConverter.mm
@@ -8,7 +8,7 @@
 
 #import "TGFontConverter.h"
 
-#include <cstdio>
+#import <cstdio>
 
 struct FontHeader {
     int32_t version;
@@ -52,10 +52,10 @@ static uint32_t calcTableDataRefCheckSum(CFDataRef dataRef)
 // https://skia.googlesource.com/skia/+/master/src/ports/SkFontHost_mac.cpp
 // https://gist.github.com/Jyczeal/1892760
 
-+ (unsigned char *)fontDataForCGFont:(CGFontRef)cgFont size:(size_t *)size
++ (std::vector<char>)fontDataForCGFont:(CGFontRef)cgFont
 {
     if (!cgFont) {
-        return nil;
+        return {};
     }
 
     CFRetain(cgFont);
@@ -63,8 +63,8 @@ static uint32_t calcTableDataRefCheckSum(CFDataRef dataRef)
     CFArrayRef tags = CGFontCopyTableTags(cgFont);
     int tableCount = CFArrayGetCount(tags);
 
-    size_t* tableSizes = (size_t*)malloc(sizeof(size_t) * tableCount);
-    memset(tableSizes, 0, sizeof(size_t) * tableCount);
+    std::vector<size_t> tableSizes;
+    tableSizes.resize(tableCount);
 
     BOOL containsCFFTable = NO;
 
@@ -88,9 +88,10 @@ static uint32_t calcTableDataRefCheckSum(CFDataRef dataRef)
         tableSizes[index] = tableSize;
     }
 
-    unsigned char* stream = (unsigned char*)malloc(totalSize);
+    std::vector<char> data;
+    data.resize(totalSize);
+    unsigned char* stream = reinterpret_cast<unsigned char*>(data.data());
 
-    memset(stream, 0, totalSize);
     char* dataStart = (char*)stream;
     char* dataPtr = dataStart;
 
@@ -150,10 +151,8 @@ static uint32_t calcTableDataRefCheckSum(CFDataRef dataRef)
     }
 
     CFRelease(cgFont);
-    free(tableSizes);
 
-    *size = totalSize;
-    return stream;
+    return data;
 }
 
 @end

--- a/linux/src/platform_linux.cpp
+++ b/linux/src/platform_linux.cpp
@@ -94,26 +94,26 @@ std::string stringFromFile(const char* _path) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size) {
+std::vector<char> bytesFromFile(const char* _path) {
+    if (!_path || strlen(_path) == 0) { return {}; }
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", _path);
-        _size = 0;
-        return nullptr;
+        LOG("Failed to read file at path: %s", _path);
+        return {};
     }
 
-    _size = resource.tellg();
+    std::vector<char> data;
+    size_t size = resource.tellg();
+    data.resize(size);
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * (_size));
-
-    resource.read(cdata, _size);
+    resource.read(data.data(), size);
     resource.close();
 
-    return reinterpret_cast<unsigned char *>(cdata);
+    return data;
 }
 
 std::vector<FontSourceHandle> systemFontFallbacksHandle() {
@@ -130,8 +130,8 @@ std::vector<FontSourceHandle> systemFontFallbacksHandle() {
 
 // System fonts are not available on linux yet, we will possibly use FontConfig in the future, for
 // references see the tizen platform implementation of system fonts
-unsigned char* systemFont(const std::string& _name, const std::string& _weight, const std::string& _face, size_t* _size) {
-    return nullptr;
+std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) {
+    return {};
 }
 
 bool startUrlRequest(const std::string& _url, UrlCallback _callback) {

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -112,8 +112,8 @@ std::vector<FontSourceHandle> systemFontFallbacksHandle() {
     return handles;
 }
 
-unsigned char* systemFont(const std::string& _name, const std::string& _weight, const std::string& _face, size_t* _size) {
-    return nullptr;
+std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) {
+    return {};
 }
 
 void NSurlInit() {

--- a/osx/src/platform_osx.mm
+++ b/osx/src/platform_osx.mm
@@ -64,40 +64,73 @@ NSString* resolvePath(const char* _path) {
     NSURL* resolvedUrl = [NSURL URLWithString:pathString
                                 relativeToURL:resourceFolderUrl];
 
-    return [resolvedUrl path];
+    NSFileManager* fileManager = [NSFileManager defaultManager];
+
+    NSString* pathInAppBundle = [resolvedUrl path];
+
+    if ([fileManager fileExistsAtPath:pathInAppBundle]) {
+        return pathInAppBundle;
+    }
+
+    LOGW("Failed to resolve path: %s", _path);
+
+    return nil;
+}
+
+bool bytesFromFileSystem(const char* _path, std::function<char*(size_t)> _allocator) {
+    std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
+
+    if(!resource.is_open()) {
+        logMsg("Failed to read file at path: %s\n", _path);
+        return false;
+    }
+
+    size_t size = resource.tellg();
+    char* cdata = _allocator(size);
+
+    resource.seekg(std::ifstream::beg);
+    resource.read(cdata, size);
+    resource.close();
+
+    return true;
 }
 
 std::string stringFromFile(const char* _path) {
-
     NSString* path = resolvePath(_path);
-    NSString* str = [NSString stringWithContentsOfFile:path
-                                          usedEncoding:NULL
-                                                 error:NULL];
 
-    if (str == nil) {
-        LOGW("Failed to read file at path: %s", [path UTF8String]);
-        return std::string();
+    if (!path) {
+        return "";
     }
 
-    return std::string([str UTF8String]);
+    std::string data;
+
+    auto allocator = [&](size_t size) {
+        data.resize(size);
+        return &data[0];
+    };
+
+    bytesFromFileSystem([path UTF8String], allocator);
+
+    return data;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size) {
-
+std::vector<char> bytesFromFile(const char* _path) {
     NSString* path = resolvePath(_path);
-    NSMutableData* data = [NSMutableData dataWithContentsOfFile:path];
 
-    if (data == nil) {
-        LOGW("Failed to read file at path: %s", [path UTF8String]);
-        _size = 0;
-        return nullptr;
+    if (path) {
+        return {};
     }
 
-    _size = data.length;
-    unsigned char* ptr = (unsigned char*)malloc(_size);
-    [data getBytes:ptr length:_size];
+    std::vector<char> data;
 
-    return ptr;
+    auto allocator = [&](size_t size) {
+        data.resize(size);
+        return data.data();
+    };
+
+    bytesFromFileSystem([path UTF8String], allocator);
+
+    return data;
 }
 
 std::vector<FontSourceHandle> systemFontFallbacksHandle() {

--- a/rpi/src/platform_rpi.cpp
+++ b/rpi/src/platform_rpi.cpp
@@ -82,26 +82,26 @@ std::string stringFromFile(const char* _path) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size) {
+std::vector<char> bytesFromFile(const char* _path) {
+    if (!_path || strlen(_path) == 0) { return {}; }
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", _path);
-        _size = 0;
-        return nullptr;
+        LOG("failed to read file at path: %s", _path);
+        return {};
     }
 
-    _size = resource.tellg();
+    std::vector<char> data;
+    size_t size = resource.tellg();
+    data.resize(size);
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * _size);
-
-    resource.read(cdata, _size);
+    resource.read(data.data(), size);
     resource.close();
 
-    return reinterpret_cast<unsigned char *>(cdata);
+    return data;
 }
 
 FontSourceHandle getFontHandle(const char* _path) {
@@ -130,8 +130,8 @@ std::vector<FontSourceHandle> systemFontFallbacksHandle() {
 
 // System fonts are not available on Raspberry Pi yet, we will possibly use FontConfig in the future,
 // for references see the tizen platform implementation of system fonts
-unsigned char* systemFont(const std::string& _name, const std::string& _weight, const std::string& _face, size_t* _size) {
-    return nullptr;
+std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) {
+    return {};
 }
 
 bool startUrlRequest(const std::string& _url, UrlCallback _callback) {

--- a/tests/src/platform_mock.cpp
+++ b/tests/src/platform_mock.cpp
@@ -15,6 +15,8 @@
 #define FONT_JA "fonts/DroidSansJapanese.ttf"
 #define FALLBACK "fonts/DroidSansFallback.ttf"
 
+#include "log.h"
+
 static bool s_isContinuousRendering = false;
 
 void logMsg(const char* fmt, ...) {
@@ -56,31 +58,30 @@ std::string stringFromFile(const char* _path) {
     return out;
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size) {
+std::vector<char> bytesFromFile(const char* _path) {
+    if (!_path || strlen(_path) == 0) { return {}; }
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", _path);
-        _size = 0;
-        return nullptr;
+        LOG("Failed to read file at path: %s", _path);
+        return {};
     }
 
-    _size = resource.tellg();
+    std::vector<char> data;
+    size_t size = resource.tellg();
+    data.resize(size);
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * _size);
-
-    resource.read(cdata, _size);
+    resource.read(data.data(), size);
     resource.close();
 
-    return reinterpret_cast<unsigned char *>(cdata);
+    return data;
 }
 
-
-unsigned char* systemFont(const std::string& _name, const std::string& _weight, const std::string& _face, size_t* _size) {
-    return nullptr;
+std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) {
+    return {};
 }
 
 std::vector<FontSourceHandle> systemFontFallbacksHandle() {

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -36,7 +36,7 @@ void initFont(std::string _font = TEST_FONT) {
     font = fontManager.addFont("default", TEST_FONT_SIZE, alfons::InputSource(_font));
 
     auto data = bytesFromFile(_font.c_str());
-    auto face = fontManager.addFontFace(alfons::InputSource(data), TEST_FONT_SIZE);
+    auto face = fontManager.addFontFace(alfons::InputSource(std::move(data)), TEST_FONT_SIZE);
     font->addFace(face);
 }
 

--- a/tests/unit/lineWrapTests.cpp
+++ b/tests/unit/lineWrapTests.cpp
@@ -35,10 +35,8 @@ std::shared_ptr<alfons::Font> font;
 void initFont(std::string _font = TEST_FONT) {
     font = fontManager.addFont("default", TEST_FONT_SIZE, alfons::InputSource(_font));
 
-    size_t dataSize = 0;
-    char* data = reinterpret_cast<char*>(bytesFromFile(_font.c_str(), dataSize));
-    auto face = fontManager.addFontFace(alfons::InputSource(data, dataSize), TEST_FONT_SIZE);
-    free(data);
+    auto data = bytesFromFile(_font.c_str());
+    auto face = fontManager.addFontFace(alfons::InputSource(data), TEST_FONT_SIZE);
     font->addFace(face);
 }
 

--- a/tizen/src/platform_tizen.cpp
+++ b/tizen/src/platform_tizen.cpp
@@ -207,36 +207,34 @@ std::string fontPath(const std::string& _name, const std::string& _weight,
     return fontFile;
 }
 
-unsigned char* systemFont(const std::string& _name, const std::string& _weight, const std::string& _face, size_t* _size) {
+std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face, size_t* _size) {
     std::string path = fontPath(_name, _weight, _face);
 
-    if (path.empty()) { return nullptr; }
+    if (path.empty()) { return {}; }
 
-    return bytesFromFile(path.c_str(), *_size);
+    return bytesFromFile(path.c_str());
 }
 
-unsigned char* bytesFromFile(const char* _path, size_t& _size) {
-
-    if (!_path || strlen(_path) == 0) { return nullptr; }
+std::vector<char> bytesFromFile(const char* _path) {
+    if (!_path || strlen(_path) == 0) { return {}; }
 
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
     if(!resource.is_open()) {
-        logMsg("Failed to read file at path: %s\n", _path);
-        _size = 0;
-        return nullptr;
+        LOG("Failed to read file at path: %s", _path);
+        return {};
     }
 
-    _size = resource.tellg();
+    std::vector<char> data;
+    size_t size = resource.tellg();
+    data.resize(size);
 
     resource.seekg(std::ifstream::beg);
 
-    char* cdata = (char*) malloc(sizeof(char) * (_size));
-
-    resource.read(cdata, _size);
+    resource.read(data.data(), size);
     resource.close();
 
-    return reinterpret_cast<unsigned char *>(cdata);
+    return data;
 }
 
 std::string stringFromFile(const char* _path) {


### PR DESCRIPTION
Reduce data reinterpretation between platform layer and alfons.
Moving from a total of 946.282ms to 425.619ms on iPhone 6s, other platforms need to be updated.