### PR TITLE
Fix marker functions

### DIFF
--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -11,6 +11,7 @@
 namespace Tangram {
 
 Marker::Marker(MarkerID id) : m_id(id) {
+    m_ruleSet.reset(new DrawRuleMergeSet());
 }
 
 Marker::~Marker() {
@@ -27,6 +28,10 @@ void Marker::setFeature(std::unique_ptr<Feature> feature) {
 
 void Marker::setStylingString(std::string stylingString) {
     m_stylingString = stylingString;
+}
+
+bool Marker::evaluateRuleForContext(StyleContext& ctx) {
+    return m_ruleSet->evaluateRuleForContext(*m_drawRule, ctx);
 }
 
 void Marker::setDrawRule(std::unique_ptr<DrawRuleData> drawRuleData) {

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -10,8 +10,10 @@
 
 namespace Tangram {
 
+class DrawRuleMergeSet;
 class MapProjection;
 class Scene;
+class StyleContext;
 class Texture;
 class View;
 struct DrawRule;
@@ -97,6 +99,8 @@ public:
 
     const std::string& stylingString() const;
 
+    bool evaluateRuleForContext(StyleContext& ctx);
+
     bool isEasing() const;
 
     bool isVisible() const;
@@ -109,6 +113,7 @@ protected:
     std::unique_ptr<StyledMesh> m_mesh;
     std::unique_ptr<DrawRuleData> m_drawRuleData;
     std::unique_ptr<DrawRule> m_drawRule;
+    std::unique_ptr<DrawRuleMergeSet> m_ruleSet;
     std::unique_ptr<Texture> m_texture;
 
     std::string m_stylingString;

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -334,7 +334,7 @@ bool MarkerManager::buildGeometry(Marker& marker, int zoom) {
 
     m_styleContext.setKeywordZoom(zoom);
 
-    bool valid = m_ruleSet.evaluateRuleForContext(*rule, m_styleContext);
+    bool valid = marker.evaluateRuleForContext(m_styleContext);
 
     if (!valid) { return false; }
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -72,7 +72,6 @@ private:
     bool buildStyling(Marker& marker);
     bool buildGeometry(Marker& marker, int zoom);
 
-    DrawRuleMergeSet m_ruleSet;
     StyleContext m_styleContext;
     std::shared_ptr<Scene> m_scene;
     std::vector<std::unique_ptr<Marker>> m_markers;

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -212,7 +212,7 @@ bool StyleContext::addFunction(const std::string& _function) {
         return false;
     }
 
-    int id = m_functionCount;
+    int id = m_functionCount++;
     bool ok = true;
 
     duk_push_string(m_ctx, _function.c_str());


### PR DESCRIPTION
2 main fixes here:
- Style Context need to increment JS function counter when adding new JS functions
- Since each marker has its own set of rules, the js evaluations for these must be unique to each marker. Previously these evaluations were saved in MarkerManager::m_ruleSet::m_evaluated, which was being overwritten by subsequent marker JS function evaluations.
Fixes #1094 