### PR TITLE
Preparation for curved labels

### DIFF
--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -18,9 +18,9 @@
 
 namespace Tangram {
 
-struct LabelOBBs;
 struct ScreenTransform;
 struct ViewState;
+struct OBBBuffer;
 
 class Label {
 
@@ -112,7 +112,7 @@ public:
     const Options& options() const { return m_options; }
 
     // Adds the oriented bounding boxes of the label to _obbs, updates Range
-    virtual void obbs(ScreenTransform& _transform, LabelOBBs& _obbs) = 0;
+    virtual void obbs(ScreenTransform& _transform, OBBBuffer& _obbs) = 0;
 
     State state() const { return m_state; }
 

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -134,7 +134,7 @@ public:
     bool setAnchorIndex(int _index);
 
     // Returns the length of the segment the label is associated with
-    virtual float worldLineLength2() const { return 0; };
+    virtual float modelLineLength2() const { return 0; };
 
     void enterState(const State& _state, float _alpha = 1.0f);
 

--- a/core/src/labels/labelCollider.cpp
+++ b/core/src/labels/labelCollider.cpp
@@ -108,10 +108,10 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
     for (auto it = m_labels.begin(); it != m_labels.end(); ) {
         auto& entry = *it;
         auto* label = entry.label;
-        ScreenTransform transform { m_transforms, entry.transform, true };
+        ScreenTransform transform { m_transforms, entry.transform };
         if (label->updateScreenTransform(mvp, viewState, nullptr, transform)) {
 
-            OBBBuffer obbs { m_obbs, entry.obbs, true };
+            OBBBuffer obbs { m_obbs, entry.obbs };
 
             label->obbs(transform, obbs);
 

--- a/core/src/labels/labelCollider.cpp
+++ b/core/src/labels/labelCollider.cpp
@@ -70,7 +70,7 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
                       // Prefer the label with longer line segment as it has a chance
                       // to be shown earlier (also on the lower zoom-level)
                       // TODO compare fraction segment_length/label_width
-                      return l1->worldLineLength2() > l2->worldLineLength2();
+                      return l1->modelLineLength2() > l2->modelLineLength2();
                   }
 
                   return l1->hash() < l2->hash();
@@ -166,7 +166,7 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
                       // Prefer the label with longer line segment as it has a chance
                       // to be shown earlier (also on the lower zoom-level)
                       // TODO compare fraction segment_length/label_width
-                      return l1->worldLineLength2() > l2->worldLineLength2();
+                      return l1->modelLineLength2() > l2->modelLineLength2();
                   }
                   // just so it is consistent between two instances
                   return (l1->hash() < l2->hash());

--- a/core/src/labels/labelCollider.cpp
+++ b/core/src/labels/labelCollider.cpp
@@ -20,28 +20,28 @@ void LabelCollider::addLabels(std::vector<std::unique_ptr<Label>>& _labels) {
 
 void LabelCollider::handleRepeatGroup(size_t startPos) {
 
-    float threshold2 = pow(m_labels[startPos]->options().repeatDistance, 2);
-    size_t repeatGroup = m_labels[startPos]->options().repeatGroup;
+    float threshold2 = pow(m_labels[startPos].label->options().repeatDistance, 2);
+    size_t repeatGroup = m_labels[startPos].label->options().repeatGroup;
 
     // Get the range
     size_t endPos = startPos;
     for (;startPos > 0; startPos--) {
-        if (m_labels[startPos-1]->options().repeatGroup != repeatGroup) { break; }
+        if (m_labels[startPos-1].label->options().repeatGroup != repeatGroup) { break; }
     }
     for (;endPos < m_labels.size()-1; endPos++) {
-        if (m_labels[endPos+1]->options().repeatGroup != repeatGroup) { break; }
+        if (m_labels[endPos+1].label->options().repeatGroup != repeatGroup) { break; }
     }
 
 
     for (size_t i = startPos; i < endPos; i++) {
-        Label* l1 = m_labels[i];
+        Label* l1 = m_labels[i].label;
         if (l1->isOccluded()) { continue; }
 
         for (size_t j = i+1; j <= endPos; j++) {
-            Label* l2 = m_labels[j];
+            Label* l2 = m_labels[j].label;
             if (l2->isOccluded()) { continue; }
 
-            float d2 = distance2(l1->center(), l2->center());
+            float d2 = distance2(l1->screenCenter(), l2->screenCenter());
             if (d2 < threshold2) {
                 l2->occlude();
             }
@@ -53,7 +53,10 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
 
     // Sort labels so that all labels of one repeat group are next to each other
     std::sort(m_labels.begin(), m_labels.end(),
-              [](auto* l1, auto* l2) {
+              [](auto& e1, auto& e2) {
+                  auto* l1 = e1.label;
+                  auto* l2 = e2.label;
+
                   if (l1->options().priority != l2->options().priority) {
                       // lower numeric priority means higher priority
                       return l1->options().priority < l2->options().priority;
@@ -98,10 +101,29 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
         _tileSize, // screenTileSize
     };
 
-    for (auto* label : m_labels) {
-        label->update(mvp, viewState, true);
+    m_obbs.clear();
+    m_transforms.clear();
 
-        m_aabbs.push_back(label->aabb());
+    for (auto it = m_labels.begin(); it != m_labels.end(); ) {
+        auto& entry = *it;
+        auto* label = entry.label;
+        ScreenTransform transform { m_transforms, entry.transform, true };
+        if (label->updateScreenTransform(mvp, viewState, nullptr, transform)) {
+
+            LabelOBBs obbs { m_obbs, entry.obbs, true };
+
+            label->obbs(transform, obbs);
+
+            auto aabb = m_obbs[entry.obbs.start].getExtent();
+            for (int i = entry.obbs.start+1; i < entry.obbs.end(); i++) {
+                aabb = unionAABB(aabb, m_obbs[i].getExtent());
+            }
+
+            m_aabbs.push_back(aabb);
+            it++;
+        } else {
+            it = m_labels.erase(it);
+        }
     }
 
     m_isect2d.resize({screenSize.x / 128, screenSize.y / 128}, screenSize);
@@ -111,8 +133,10 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
     // Set the first item to be the one with higher priority
     for (auto& pair : m_isect2d.pairs) {
 
-        auto* l1 = m_labels[pair.first];
-        auto* l2 = m_labels[pair.second];
+        auto& e1 = m_labels[pair.first];
+        auto& e2 = m_labels[pair.second];
+        auto* l1 = e1.label;
+        auto* l2 = e2.label;
 
         if (l1->options().priority > l2->options().priority) {
             std::swap(pair.first, pair.second);
@@ -127,8 +151,9 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
     // Sort by priority on the first item
     std::sort(m_isect2d.pairs.begin(), m_isect2d.pairs.end(),
               [&](auto& a, auto& b) {
-                  auto* l1 = m_labels[a.first];
-                  auto* l2 = m_labels[b.first];
+
+                  auto* l1 = m_labels[a.first].label;
+                  auto* l2 = m_labels[b.first].label;
 
                   if (l1->options().priority != l2->options().priority) {
                       // lower numeric priority means higher priority
@@ -160,8 +185,10 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
     // Narrow Phase, resolve conflicts
     for (auto& pair : m_isect2d.pairs) {
 
-        auto* l1 = m_labels[pair.first];
-        auto* l2 = m_labels[pair.second];
+        auto& e1 = m_labels[pair.first];
+        auto& e2 = m_labels[pair.second];
+        auto* l1 = e1.label;
+        auto* l2 = e2.label;
 
         // Occlude labels within repeat group so that they don't occlude other labels
         if (repeatGroup != l1->options().repeatGroup) {
@@ -189,9 +216,20 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
             continue;
         }
 
-        if (!intersect(l1->obb(), l2->obb())) {
-            continue;
+        bool intersection = false;
+        for (int i = e1.obbs.start; i < e1.obbs.end(); i++) {
+            for (int j = e2.obbs.start; j < e2.obbs.end(); j++) {
+
+                if (intersect(m_obbs[i], m_obbs[j])) {
+                    intersection = true;
+
+                    // break out of outer loop
+                    i = e1.obbs.end();
+                    break;
+                }
+            }
         }
+        if (!intersection) { continue; }
 
         if (l1->options().priority != l2->options().priority) {
             // lower numeric priority means higher priority
@@ -210,7 +248,8 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
         }
     }
 
-    for (auto* label : m_labels) {
+    for (auto& entry : m_labels) {
+        auto* label = entry.label;
 
         // Manage link occlusion (unified icon labels)
         if (label->parent()) {

--- a/core/src/labels/labelCollider.cpp
+++ b/core/src/labels/labelCollider.cpp
@@ -5,6 +5,7 @@
 
 #include "glm/gtc/matrix_transform.hpp"
 #include "glm/gtx/norm.hpp"
+#include "labels/obbBuffer.h"
 
 namespace Tangram {
 
@@ -110,7 +111,7 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
         ScreenTransform transform { m_transforms, entry.transform, true };
         if (label->updateScreenTransform(mvp, viewState, nullptr, transform)) {
 
-            LabelOBBs obbs { m_obbs, entry.obbs, true };
+            OBBBuffer obbs { m_obbs, entry.obbs, true };
 
             label->obbs(transform, obbs);
 

--- a/core/src/labels/labelCollider.h
+++ b/core/src/labels/labelCollider.h
@@ -3,6 +3,9 @@
 #include "isect2d.h"
 #include "glm_vec.h" // for isect2d.h
 #include "util/mapProjection.h"
+#include "labels/label.h"
+#include "labels/screenTransform.h"
+#include "util/types.h"
 
 #include <memory>
 #include <vector>
@@ -29,12 +32,29 @@ private:
     using OBB = isect2d::OBB<glm::vec2>;
     using CollisionPairs = std::vector<isect2d::ISect2D<glm::vec2>::Pair>;
 
+    struct LabelEntry {
+
+        LabelEntry(Label* _label)
+            : label(_label),
+              priority(_label->options().priority) {}
+
+        Label* label;
+
+        float priority;
+
+        Range obbs;
+        Range transform;
+    };
+
     // Parallel vectors
-    std::vector<Label*> m_labels;
+
+    std::vector<LabelEntry> m_labels;
     std::vector<AABB> m_aabbs;
+    std::vector<OBB> m_obbs;
 
     isect2d::ISect2D<glm::vec2> m_isect2d;
 
+    ScreenTransform::Buffer m_transforms;
 };
 
 }

--- a/core/src/labels/labelProperty.h
+++ b/core/src/labels/labelProperty.h
@@ -4,6 +4,7 @@
 #include <array>
 #include "util/util.h"
 #include "glm/vec2.hpp"
+#include "aabb.h"
 
 namespace Tangram {
 
@@ -42,6 +43,61 @@ struct Anchors {
         return anchor == _other.anchor && count == _other.count;
     }
 
+    isect2d::AABB<glm::vec2> extents(glm::vec2 size) {
+
+        glm::vec2 min{0};
+        glm::vec2 max{0};
+
+        for (int i = 0; i < count; i++) {
+            switch(anchor[i]) {
+            case center:
+                min.x = std::min(min.x, -0.5f);
+                min.y = std::min(min.y, -0.5f);
+                max.x = std::max(max.x, 0.5f);
+                max.y = std::max(max.y, 0.5f);
+                break;
+            case top:
+                min.x = std::min(min.x, -0.5f);
+                min.y = -1.0f;
+                max.x = std::max(max.x, 0.5f);
+                break;
+            case bottom:
+                min.x = std::min(min.x, -0.5f);
+                max.x = std::max(max.x, 0.5f);
+                max.y = 1.0f;
+                break;
+            case left:
+                min.x = -1.0f;
+                min.y = std::min(min.y, -0.5f);
+                max.y = std::max(max.y, 0.5f);
+                break;
+            case right:
+                min.y = std::min(min.y, -0.5f);
+                max.x = 1.0f;
+                max.y = std::max(max.y, 0.5f);
+                break;
+            case top_left:
+                min.x = -1.0f;
+                min.y = -1.0f;
+                break;
+            case top_right:
+                min.y = -1.0f;
+                max.x = 1.0f;
+                break;
+            case bottom_left:
+                min.x = -1.0f;
+                max.y = 1.0f;
+                break;
+            case bottom_right:
+                max.x = 1.0f;
+                max.y = 1.0f;
+                break;
+            }
+        }
+        // TODO add AABB constructor to pass min/max
+        return isect2d::AABB<glm::vec2>(min.x * size.x, min.y * size.y,
+                                        max.x * size.x, max.y * size.y);
+    }
 };
 
 bool anchor(const std::string& _transform, Anchor& _out);

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -265,7 +265,7 @@ bool Labels::labelComparator(const LabelEntry& _a, const LabelEntry& _b) {
 
     if (l1->type() == Label::Type::line && l2->type() == Label::Type::line) {
         // Prefer the label with longer line segment as it has a chance
-        return l1->worldLineLength2() > l2->worldLineLength2();
+        return l1->modelLineLength2() > l2->modelLineLength2();
     }
 
     if (l1->hash() != l2->hash()) {

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -290,7 +290,7 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
     // Find the label to which the obb belongs
     auto findLabel = [](iterator begin, iterator end, int obb) {
         for (auto it = begin; it != end; it++) {
-            if (obb >= it->obbs.start && obb < it->obbs.end()) {
+            if (obb >= it->obbsRange.start && obb < it->obbsRange.end()) {
                 return it->label;
             }
         }
@@ -324,8 +324,8 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
             }
         }
 
-        ScreenTransform transform { m_transforms, entry.transform };
-        OBBBuffer obbs { m_obbs, entry.obbs, true };
+        ScreenTransform transform { m_transforms, entry.transformRange };
+        OBBBuffer obbs { m_obbs, entry.obbsRange, true };
 
         l->obbs(transform, obbs);
 
@@ -376,7 +376,7 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
             }
         } else {
             // Insert into ISect2D grid
-            int obbPos = entry.obbs.start;
+            int obbPos = entry.obbsRange.start;
             for (auto& obb : obbs) {
                 auto aabb = obb.getExtent();
                 aabb.m_userData = reinterpret_cast<void*>(obbPos++);
@@ -435,12 +435,12 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt,
 
     // Update label meshes
     for (auto& entry : m_labels) {
-        ScreenTransform transform { m_transforms, entry.transform };
+        ScreenTransform transform { m_transforms, entry.transformRange };
 
         m_needUpdate |= entry.label->evalState(_dt);
 
         if (entry.label->visibleState()) {
-            for (auto& obb : OBBBuffer{ m_obbs, entry.obbs }) {
+            for (auto& obb : OBBBuffer{ m_obbs, entry.obbsRange }) {
 
                 if (obb.getExtent().intersect(screenBounds)) {
                     entry.label->addVerticesToMesh(transform, _viewState.viewportSize);
@@ -501,13 +501,13 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         }
 #endif
 
-        for (auto& obb : OBBBuffer{ m_obbs, entry.obbs }) {
+        for (auto& obb : OBBBuffer{ m_obbs, entry.obbsRange }) {
             Primitives::drawPoly(rs, &(obb.getQuad())[0], 4);
         }
 
         if (label->parent() && label->parent()->visibleState() && !label->parent()->isOccluded()) {
             Primitives::setColor(rs, 0xff0000);
-            Primitives::drawLine(rs, m_obbs[entry.obbs.start].getCentroid(),
+            Primitives::drawLine(rs, m_obbs[entry.obbsRange.start].getCentroid(),
                                  label->parent()->screenCenter());
         }
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -54,7 +54,7 @@ void Labels::processLabelUpdate(const ViewState& viewState,
         }
 
         Range transformRange;
-        ScreenTransform transform { m_transforms, transformRange, true };
+        ScreenTransform transform { m_transforms, transformRange };
 
         // Use extendedBounds when labels take part in collision detection.
         auto bounds = (onlyTransitions || !label->canOcclude())
@@ -325,7 +325,7 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
         }
 
         ScreenTransform transform { m_transforms, entry.transformRange };
-        OBBBuffer obbs { m_obbs, entry.obbsRange, true };
+        OBBBuffer obbs { m_obbs, entry.obbsRange };
 
         l->obbs(transform, obbs);
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -13,6 +13,7 @@
 #include "labels/labelSet.h"
 #include "labels/textLabel.h"
 #include "marker/marker.h"
+#include "labels/obbBuffer.h"
 
 #include "glm/glm.hpp"
 #include "glm/gtc/matrix_transform.hpp"
@@ -324,7 +325,7 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
         }
 
         ScreenTransform transform { m_transforms, entry.transform };
-        LabelOBBs obbs { m_obbs, entry.obbs, true };
+        OBBBuffer obbs { m_obbs, entry.obbs, true };
 
         l->obbs(transform, obbs);
 
@@ -439,7 +440,7 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt,
         m_needUpdate |= entry.label->evalState(_dt);
 
         if (entry.label->visibleState()) {
-            for (auto& obb : LabelOBBs{ m_obbs, entry.obbs }) {
+            for (auto& obb : OBBBuffer{ m_obbs, entry.obbs }) {
 
                 if (obb.getExtent().intersect(screenBounds)) {
                     entry.label->addVerticesToMesh(transform, _viewState.viewportSize);
@@ -500,7 +501,7 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         }
 #endif
 
-        for (auto& obb : LabelOBBs{ m_obbs, entry.obbs }) {
+        for (auto& obb : OBBBuffer{ m_obbs, entry.obbs }) {
             Primitives::drawPoly(rs, &(obb.getQuad())[0], 4);
         }
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -27,10 +27,6 @@ Labels::Labels()
 
 Labels::~Labels() {}
 
-// int Labels::LODDiscardFunc(float _maxZoom, float _zoom) {
-//     return (int) MIN(floor(((log(-_zoom + (_maxZoom + 2)) / log(_maxZoom + 2) * (_maxZoom )) * 0.5)), MAX_LOD);
-// }
-
 void Labels::processLabelUpdate(const ViewState& viewState,
                                 StyledMesh* mesh, Tile* tile,
                                 const glm::mat4& mvp,
@@ -41,9 +37,30 @@ void Labels::processLabelUpdate(const ViewState& viewState,
     auto labelMesh = dynamic_cast<const LabelSet*>(mesh);
     if (!labelMesh) { return; }
 
+    // TODO appropriate buffer to filter out-of-screen labels
+    float border = 256.0f;
+    AABB extendedBounds(-border, -border,
+                        viewState.viewportSize.x + border,
+                        viewState.viewportSize.y + border);
+
+    AABB screenBounds(0, 0,
+                      viewState.viewportSize.x,
+                      viewState.viewportSize.y);
+
     for (auto& label : labelMesh->getLabels()) {
-        if (!label->update(mvp, viewState, drawAll)) {
-            // skip dead labels
+        if (!drawAll && label->state() == Label::State::dead) {
+            continue;
+        }
+
+        Range transformRange;
+        ScreenTransform transform { m_transforms, transformRange, true };
+
+        // Use extendedBounds when labels take part in collision detection.
+        auto bounds = (onlyTransitions || !label->canOcclude())
+            ? screenBounds
+            : extendedBounds;
+
+        if (!label->update(mvp, viewState, &bounds, transform)) {
             continue;
         }
 
@@ -52,20 +69,19 @@ void Labels::processLabelUpdate(const ViewState& viewState,
 
             if (label->visibleState() || !label->canOcclude()) {
                 m_needUpdate |= label->evalState(dt);
-                label->addVerticesToMesh();
+                label->addVerticesToMesh(transform, viewState.viewportSize);
             }
         } else if (label->canOcclude()) {
-            m_labels.emplace_back(label.get(), tile, isProxy);
+            m_labels.emplace_back(label.get(), tile, isProxy, transformRange);
         } else {
             m_needUpdate |= label->evalState(dt);
-            label->addVerticesToMesh();
+            label->addVerticesToMesh(transform, viewState.viewportSize);
         }
         if (label->selectionColor()) {
-            m_selectionLabels.emplace_back(label.get(), tile, isProxy);
+            m_selectionLabels.emplace_back(label.get(), tile, isProxy, transformRange);
         }
     }
 }
-
 
 std::pair<Label*, Tile*> Labels::getLabel(uint32_t _selectionColor) const {
 
@@ -79,7 +95,6 @@ std::pair<Label*, Tile*> Labels::getLabel(uint32_t _selectionColor) const {
     }
     return {nullptr, nullptr};
 }
-
 
 void Labels::updateLabels(const ViewState& _viewState, float _dt,
                           const std::vector<std::unique_ptr<Style>>& _styles,
@@ -151,7 +166,7 @@ void Labels::skipTransitions(const std::vector<const Style*>& _styles, Tile& _ti
                 if (l0->options().repeatGroup != l1->options().repeatGroup) { continue; }
                 // if (l0->hash() != l1->hash()) { continue; }
 
-                float d2 = l0->screenDistance2(l1->center());
+                float d2 = glm::distance2(l0->screenCenter(), l1->screenCenter());
 
                 // The new label lies within the circle defined by the bbox of l0
                 if (sqrt(d2) < std::max(l0->dimension().x, l0->dimension().y)) {
@@ -243,9 +258,9 @@ bool Labels::labelComparator(const LabelEntry& _a, const LabelEntry& _b) {
         return l1->visibleState();
     }
 
-    // if (l1->options().repeatGroup != l2->options().repeatGroup) {
-    //     return l1->options().repeatGroup < l2->options().repeatGroup;
-    // }
+    if (l1->options().repeatGroup != l2->options().repeatGroup) {
+        return l1->options().repeatGroup < l2->options().repeatGroup;
+    }
 
     if (l1->type() == Label::Type::line && l2->type() == Label::Type::line) {
         // Prefer the label with longer line segment as it has a chance
@@ -269,7 +284,21 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
     m_isect2d.clear();
     m_repeatGroups.clear();
 
-    for (auto& entry : m_labels){
+    using iterator = decltype(m_labels)::const_iterator;
+
+    // Find the label to which the obb belongs
+    auto findLabel = [](iterator begin, iterator end, int obb) {
+        for (auto it = begin; it != end; it++) {
+            if (obb >= it->obbs.start && obb < it->obbs.end()) {
+                return it->label;
+            }
+        }
+        assert(false);
+        return static_cast<Label*>(nullptr);
+    };
+
+    for (auto it = m_labels.begin(); it != m_labels.end(); ++it) {
+        auto& entry = *it;
         auto* l = entry.label;
 
         // Parent must have been processed earlier so at this point its
@@ -294,45 +323,48 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
             }
         }
 
+        ScreenTransform transform { m_transforms, entry.transform };
+        LabelOBBs obbs { m_obbs, entry.obbs, true };
+
+        l->obbs(transform, obbs);
+
         int anchorIndex = l->anchorIndex();
 
+        // For each anchor
         do {
             if (l->isOccluded()) {
-                // Update BBox for anchor fallback
-                l->updateBBoxes(_viewState.fractZoom);
+                // Update OBB for anchor fallback
+                obbs.clear();
+
+                l->obbs(transform, obbs);
+
                 if (anchorIndex == l->anchorIndex()) {
                     // Reached first anchor again
                     break;
                 }
             }
 
-            if (l->offViewport(_viewState.viewportSize)) { continue; }
-
             l->occlude(false);
 
-            // Skip label if it intersects with a previous label.
-            auto aabb = l->aabb();
-            aabb.m_userData = static_cast<void*>(l);
+            // Occlude label when its obbs intersect with a previous label.
+            for (auto& obb : obbs) {
+                m_isect2d.intersect(obb.getExtent(), [&](auto& a, auto& b) {
+                        size_t other = reinterpret_cast<size_t>(b.m_userData);
 
-            m_isect2d.intersect(aabb, [](auto& a, auto& b) {
-                auto* l1 = static_cast<Label*>(a.m_userData);
-                auto* l2 = static_cast<Label*>(b.m_userData);
-                // Parents do not occlude their child
-                if (l1->parent() == l2) {
-                    return true;
-                }
+                        if (!intersect(obb, m_obbs[other])) {
+                            return true;
+                        }
+                        // Ignore intersection with parent label
+                        if (l->parent() && l->parent() == findLabel(std::begin(m_labels), it, other)) {
+                            return true;
+                        }
+                        l->occlude();
+                        return false;
 
-                if (intersect(l1->obb(), l2->obb())) {
-                    l1->occlude();
-                    // Drop label
-                    return false;
-                }
-                // Continue
-                return true;
-            });
+                    }, false);
 
-
-            // Try next anchor
+                if (l->isOccluded()) { break; }
+            }
         } while (l->isOccluded() && l->nextAnchor());
 
         // At this point, the label has a parent that is visible,
@@ -341,10 +373,18 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
             if (l->parent() && !l->options().optional) {
                 l->parent()->occlude();
             }
-        }
+        } else {
+            // Insert into ISect2D grid
+            int obbPos = entry.obbs.start;
+            for (auto& obb : obbs) {
+                auto aabb = obb.getExtent();
+                aabb.m_userData = reinterpret_cast<void*>(obbPos++);
+                m_isect2d.insert(aabb);
+            }
 
-        if (l->options().repeatDistance > 0.f) {
-            m_repeatGroups[l->options().repeatGroup].push_back(l);
+            if (l->options().repeatDistance > 0.f) {
+                m_repeatGroups[l->options().repeatGroup].push_back(l);
+            }
         }
     }
 }
@@ -355,7 +395,7 @@ bool Labels::withinRepeatDistance(Label *_label) {
     auto it = m_repeatGroups.find(_label->options().repeatGroup);
     if (it != m_repeatGroups.end()) {
         for (auto* ll : it->second) {
-            float d2 = glm::distance2(_label->center(), ll->center());
+            float d2 = glm::distance2(_label->screenCenter(), ll->screenCenter());
             if (d2 < threshold2) {
                 return true;
             }
@@ -369,6 +409,9 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt,
                             const std::vector<std::shared_ptr<Tile>>& _tiles,
                             const std::vector<std::unique_ptr<Marker>>& _markers,
                             TileCache& _cache) {
+
+    m_transforms.clear();
+    m_obbs.clear();
 
     /// Collect and update labels from visible tiles
     updateLabels(_viewState, _dt, _styles, _tiles, _markers, false);
@@ -387,13 +430,23 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt,
 
     handleOcclusions(_viewState);
 
-    /// Update label meshes
+    Label::AABB screenBounds{0, 0, _viewState.viewportSize.x, _viewState.viewportSize.y};
 
+    // Update label meshes
     for (auto& entry : m_labels) {
-        Label* label = entry.label;
+        ScreenTransform transform { m_transforms, entry.transform };
 
-        m_needUpdate |= label->evalState(_dt);
-        label->addVerticesToMesh();
+        m_needUpdate |= entry.label->evalState(_dt);
+
+        if (entry.label->visibleState()) {
+            for (auto& obb : LabelOBBs{ m_obbs, entry.obbs }) {
+
+                if (obb.getExtent().intersect(screenBounds)) {
+                    entry.label->addVerticesToMesh(transform, _viewState.viewportSize);
+                    break;
+                }
+            }
+        }
     }
 }
 
@@ -408,12 +461,12 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
 
         if (label->type() == Label::Type::debug) { continue; }
 
-        glm::vec2 sp = label->center();
+        glm::vec2 sp = label->screenCenter();
 
         // draw bounding box
         switch (label->state()) {
         case Label::State::sleep:
-            Primitives::setColor(rs, 0xdddddd);
+            Primitives::setColor(rs, 0x0000ff);
             break;
         case Label::State::visible:
             Primitives::setColor(rs, 0x000000);
@@ -447,13 +500,17 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         }
 #endif
 
-        Primitives::drawPoly(rs, &(label->obb().getQuad())[0], 4);
-
-        if (label->parent()) {
-            Primitives::setColor(rs, 0xff0000);
-            Primitives::drawLine(rs, sp, label->parent()->center());
+        for (auto& obb : LabelOBBs{ m_obbs, entry.obbs }) {
+            Primitives::drawPoly(rs, &(obb.getQuad())[0], 4);
         }
 
+        if (label->parent() && label->parent()->visibleState() && !label->parent()->isOccluded()) {
+            Primitives::setColor(rs, 0xff0000);
+            Primitives::drawLine(rs, m_obbs[entry.obbs.start].getCentroid(),
+                                 label->parent()->screenCenter());
+        }
+
+#if 0
         // draw offset
         glm::vec2 rot = label->screenTransform().rotation;
         glm::vec2 offset = label->options().offset;
@@ -462,6 +519,7 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
 
         Primitives::setColor(rs, 0x000000);
         Primitives::drawLine(rs, sp, sp - glm::vec2(offset.x, -offset.y));
+#endif
 
         // draw projected anchor point
         Primitives::setColor(rs, 0x0000ff);
@@ -473,17 +531,17 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
             hash_combine(seed, label->options().repeatGroup);
             float repeatDistance = label->options().repeatDistance;
 
-            Primitives::setColor(seed);
-            Primitives::drawLine(label->center(),
-                                 glm::vec2(repeatDistance, 0.f) + label->center());
+            Primitives::setColor(rs, seed);
+            Primitives::drawLine(rs, label->screenCenter(),
+                                 glm::vec2(repeatDistance, 0.f) + label->screenCenter());
 
             float off = M_PI / 6.f;
             for (float pad = 0.f; pad < M_PI * 2.f; pad += off) {
                 glm::vec2 p0 = glm::vec2(cos(pad), sin(pad)) * repeatDistance
-                    + label->center();
+                    + label->screenCenter();
                 glm::vec2 p1 = glm::vec2(cos(pad + off), sin(pad + off)) * repeatDistance
-                    + label->center();
-                Primitives::drawLine(p0, p1);
+                    + label->screenCenter();
+                Primitives::drawLine(rs, p0, p1);
             }
         }
 #endif

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "label.h"
-#include "spriteLabel.h"
-#include "tile/tileID.h"
 #include "data/properties.h"
+#include "labels/label.h"
+#include "labels/screenTransform.h"
+#include "labels/spriteLabel.h"
+#include "tile/tileID.h"
+
 #include "isect2d.h"
 #include "glm_vec.h" // for isect2d.h
 
@@ -78,19 +80,26 @@ protected:
 
     struct LabelEntry {
 
-        LabelEntry(Label* _label, Tile* _tile, bool _proxy)
+        LabelEntry(Label* _label, Tile* _tile, bool _proxy, Range _screenTransform)
             : label(_label),
               tile(_tile),
               priority(_label->options().priority),
-              proxy(_proxy) {}
+              proxy(_proxy),
+              transform(_screenTransform) {}
 
         Label* label;
         Tile* tile;
         float priority;
         bool proxy;
+
+        Range transform;
+        Range obbs;
     };
 
     static bool labelComparator(const LabelEntry& _a, const LabelEntry& _b);
+
+    std::vector<OBB> m_obbs;
+    ScreenTransform::Buffer m_transforms;
 
     std::vector<LabelEntry> m_labels;
     std::vector<LabelEntry> m_selectionLabels;

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -85,15 +85,15 @@ protected:
               tile(_tile),
               priority(_label->options().priority),
               proxy(_proxy),
-              transform(_screenTransform) {}
+              transformRange(_screenTransform) {}
 
         Label* label;
         Tile* tile;
         float priority;
         bool proxy;
 
-        Range transform;
-        Range obbs;
+        Range transformRange;
+        Range obbsRange;
     };
 
     static bool labelComparator(const LabelEntry& _a, const LabelEntry& _b);

--- a/core/src/labels/obbBuffer.h
+++ b/core/src/labels/obbBuffer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "obb.h"
+#include "util/types.h"
+
+namespace Tangram {
+
+struct OBBBuffer {
+
+    OBBBuffer(std::vector<isect2d::OBB<glm::vec2>>& _obbs, Range& _range, bool _initRange = false)
+        : obbs(_obbs), range(_range) {
+        if (_initRange) {
+            range.start = obbs.size();
+        }
+    }
+
+    auto begin() { return obbs.begin() + range.start; }
+    auto end() { return obbs.begin() + range.end(); }
+
+    void clear() {
+        range.length = 0;
+        obbs.resize(range.start);
+    }
+
+    void append(isect2d::OBB<glm::vec2> _obb) {
+        obbs.push_back(_obb);
+        range.length += 1;
+    }
+
+private:
+    std::vector<isect2d::OBB<glm::vec2>>& obbs;
+    Range& range;
+
+};
+
+}

--- a/core/src/labels/obbBuffer.h
+++ b/core/src/labels/obbBuffer.h
@@ -7,9 +7,9 @@ namespace Tangram {
 
 struct OBBBuffer {
 
-    OBBBuffer(std::vector<isect2d::OBB<glm::vec2>>& _obbs, Range& _range, bool _initRange = false)
+    OBBBuffer(std::vector<isect2d::OBB<glm::vec2>>& _obbs, Range& _range)
         : obbs(_obbs), range(_range) {
-        if (_initRange) {
+        if (!range.length) {
             range.start = obbs.size();
         }
     }

--- a/core/src/labels/screenTransform.h
+++ b/core/src/labels/screenTransform.h
@@ -1,37 +1,8 @@
 #pragma once
 
 #include "glm/vec2.hpp"
-#include "obb.h"
 
 namespace Tangram {
-
-struct LabelOBBs {
-
-    LabelOBBs(std::vector<isect2d::OBB<glm::vec2>>& _obbs, Range& _range, bool _initRange = false)
-        : obbs(_obbs), range(_range) {
-        if (_initRange) {
-            range.start = obbs.size();
-        }
-    }
-
-    auto begin() { return obbs.begin() + range.start; }
-    auto end() { return obbs.begin() + range.end(); }
-
-    void clear() {
-        range.length = 0;
-        obbs.resize(range.start);
-    }
-
-    void append(isect2d::OBB<glm::vec2> _obb) {
-        obbs.push_back(_obb);
-        range.length += 1;
-    }
-
-private:
-    std::vector<isect2d::OBB<glm::vec2>>& obbs;
-    Range& range;
-
-};
 
 // ScreenTransform is a view into ScreenTransform::Buffer
 struct ScreenTransform {

--- a/core/src/labels/screenTransform.h
+++ b/core/src/labels/screenTransform.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "glm/vec2.hpp"
+#include "obb.h"
+
+namespace Tangram {
+
+struct LabelOBBs {
+
+    LabelOBBs(std::vector<isect2d::OBB<glm::vec2>>& _obbs, Range& _range, bool _initRange = false)
+        : obbs(_obbs), range(_range) {
+        if (_initRange) {
+            range.start = obbs.size();
+        }
+    }
+
+    auto begin() { return obbs.begin() + range.start; }
+    auto end() { return obbs.begin() + range.end(); }
+
+    void clear() {
+        range.length = 0;
+        obbs.resize(range.start);
+    }
+
+    void append(isect2d::OBB<glm::vec2> _obb) {
+        obbs.push_back(_obb);
+        range.length += 1;
+    }
+
+private:
+    std::vector<isect2d::OBB<glm::vec2>>& obbs;
+    Range& range;
+
+};
+
+// ScreenTransform is a view into ScreenTransform::Buffer
+struct ScreenTransform {
+
+    // ScreenTransform::Buffer holds screen space coordinates of multiple labels
+    // (used by LabelCollider and Labels class)
+    struct Buffer {
+        std::vector<glm::vec3> points;
+        std::vector<glm::vec2> path;
+        void clear() {
+            points.clear();
+            path.clear();
+        }
+    };
+
+    ScreenTransform(Buffer& _transformBuffer, Range& _range, bool _initRange = false)
+        : buffer(_transformBuffer),
+          points(_transformBuffer.points),
+          range(_range) {
+
+        if (_initRange) {
+            range.start = points.size();
+        }
+    }
+
+    auto begin() { return points.begin() + range.start; }
+    auto end() { return points.begin() + range.end(); }
+
+    bool empty() const { return range.length == 0; }
+    size_t size() const { return range.length; }
+    void clear() {
+        range.length = 0;
+        points.resize(range.start);
+    }
+
+    auto operator[](size_t _pos) const { return points[range.start + _pos]; }
+
+    void push_back(glm::vec3 _p) {
+        points.push_back(_p);
+        range.length += 1;
+    }
+
+    void push_back(glm::vec2 _p) {
+        points.emplace_back(_p, 0);
+        range.length += 1;
+    }
+
+    // Get a temporary coordinate buffer (used for curved labels line smoothing)
+    std::vector<glm::vec2>& scratchBuffer() {
+        buffer.path.clear();
+        return buffer.path;
+    }
+
+private:
+    Buffer &buffer;
+    std::vector<glm::vec3>& points;
+    Range& range;
+};
+
+}

--- a/core/src/labels/screenTransform.h
+++ b/core/src/labels/screenTransform.h
@@ -18,12 +18,12 @@ struct ScreenTransform {
         }
     };
 
-    ScreenTransform(Buffer& _transformBuffer, Range& _range, bool _initRange = false)
+    ScreenTransform(Buffer& _transformBuffer, Range& _range)
         : buffer(_transformBuffer),
           points(_transformBuffer.points),
           range(_range) {
 
-        if (_initRange) {
+        if (!range.length) {
             range.start = points.size();
         }
     }

--- a/core/src/labels/spriteLabel.cpp
+++ b/core/src/labels/spriteLabel.cpp
@@ -2,6 +2,7 @@
 
 #include "gl/dynamicQuadMesh.h"
 #include "labels/screenTransform.h"
+#include "labels/obbBuffer.h"
 #include "log.h"
 #include "scene/spriteAtlas.h"
 #include "style/pointStyle.h"
@@ -175,7 +176,7 @@ bool SpriteLabel::updateScreenTransform(const glm::mat4& _mvp, const ViewState& 
     return true;
 }
 
-void SpriteLabel::obbs(ScreenTransform& _transform, LabelOBBs& _obbs) {
+void SpriteLabel::obbs(ScreenTransform& _transform, OBBBuffer& _obbs) {
     OBB obb;
 
     if (m_options.flat) {

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -45,7 +45,7 @@ public:
     bool updateScreenTransform(const glm::mat4& _mvp, const ViewState& _viewState,
                                const AABB* _bounds, ScreenTransform& _transform) override;
 
-    void obbs(ScreenTransform& _transform, LabelOBBs& _obbs) override;
+    void obbs(ScreenTransform& _transform, OBBBuffer& _obbs) override;
 
     void addVerticesToMesh(ScreenTransform& _transform, const glm::vec2& _screenSize) override;
 

--- a/core/src/labels/spriteLabel.h
+++ b/core/src/labels/spriteLabel.h
@@ -34,27 +34,34 @@ public:
         float extrudeScale;
     };
 
-    SpriteLabel(Label::WorldTransform _transform, glm::vec2 _size, Label::Options _options,
+    using Coordinates = glm::vec3;
+
+    SpriteLabel(Coordinates _coordinates, glm::vec2 _size, Label::Options _options,
                 SpriteLabel::VertexAttributes _attrib, Texture* _texture,
                 SpriteLabels& _labels, size_t _labelsPos);
 
-    void updateBBoxes(float _zoomFract) override;
-
     LabelType renderType() const override { return LabelType::icon; }
 
-protected:
+    bool updateScreenTransform(const glm::mat4& _mvp, const ViewState& _viewState,
+                               const AABB* _bounds, ScreenTransform& _transform) override;
 
-    void addVerticesToMesh() override;
+    void obbs(ScreenTransform& _transform, LabelOBBs& _obbs) override;
+
+    void addVerticesToMesh(ScreenTransform& _transform, const glm::vec2& _screenSize) override;
+
+    void applyAnchor(LabelProperty::Anchor _anchor) override;
 
     uint32_t selectionColor() override {
         return m_vertexAttrib.selectionColor;
     }
 
+    glm::vec2 modelCenter() const override {
+        return glm::vec2(m_coordinates);
+    }
+
 private:
 
-    void applyAnchor(LabelProperty::Anchor _anchor) override;
-
-    bool updateScreenTransform(const glm::mat4& _mvp, const ViewState& _viewState, bool _drawAllLabels) override;
+    const Coordinates m_coordinates;
 
     // Back-pointer to owning container and position
     const SpriteLabels& m_labels;
@@ -65,8 +72,6 @@ private:
     Texture* m_texture;
 
     VertexAttributes m_vertexAttrib;
-
-    std::array<glm::vec3, 4> m_projected;
 };
 
 struct SpriteQuad {

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -151,7 +151,7 @@ bool TextLabel::updateScreenTransform(const glm::mat4& _mvp, const ViewState& _v
     return false;
 }
 
-float TextLabel::worldLineLength2() const {
+float TextLabel::modelLineLength2() const {
     if (m_type != Type::line) { return 0.f; }
 
     return glm::length2(m_coordinates[0] - m_coordinates[1]);

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -8,6 +8,7 @@
 #include "text/fontContext.h"
 #include "util/geom.h"
 #include "view/view.h"
+#include "labels/obbBuffer.h"
 
 #include "glm/gtx/norm.hpp"
 
@@ -156,7 +157,7 @@ float TextLabel::worldLineLength2() const {
     return glm::length2(m_coordinates[0] - m_coordinates[1]);
 }
 
-void TextLabel::obbs(ScreenTransform& _transform, LabelOBBs& _obbs) {
+void TextLabel::obbs(ScreenTransform& _transform, OBBBuffer& _obbs) {
 
     glm::vec2 dim = m_dim - m_options.buffer;
 

--- a/core/src/labels/textLabel.cpp
+++ b/core/src/labels/textLabel.cpp
@@ -1,12 +1,15 @@
 #include "textLabel.h"
 
-#include "textLabels.h"
+#include "gl/dynamicQuadMesh.h"
+#include "labels/textLabels.h"
+#include "labels/screenTransform.h"
+#include "log.h"
 #include "style/textStyle.h"
 #include "text/fontContext.h"
-#include "gl/dynamicQuadMesh.h"
 #include "util/geom.h"
 #include "view/view.h"
-#include "log.h"
+
+#include "glm/gtx/norm.hpp"
 
 namespace Tangram {
 
@@ -14,17 +17,35 @@ using namespace LabelProperty;
 using namespace TextLabelProperty;
 
 const float TextVertex::position_scale = 4.0f;
+const float TextVertex::position_inv_scale = 0.25f;
 const float TextVertex::alpha_scale = 65535.0f;
 
-TextLabel::TextLabel(Label::WorldTransform _transform, Type _type, Label::Options _options,
-                     TextLabel::VertexAttributes _attrib,
-                     glm::vec2 _dim,  TextLabels& _labels, TextRange _textRanges,
-                     Align _preferedAlignment)
-    : Label(_transform, _dim, _type, _options),
+struct PointTransform {
+    ScreenTransform& m_transform;
+
+    PointTransform(ScreenTransform& _transform)
+        : m_transform(_transform) {}
+
+    void set(glm::vec2 _position, glm::vec2 _rotation) {
+        m_transform.push_back(_position);
+        m_transform.push_back(_rotation);
+    }
+
+    glm::vec2 position() const { return glm::vec2(m_transform[0]); }
+    glm::vec2 rotation() const { return glm::vec2(m_transform[1]); }
+};
+
+TextLabel::TextLabel(Coordinates _coordinates, Type _type, Label::Options _options,
+                     TextLabel::VertexAttributes _attrib, glm::vec2 _dim,
+                     TextLabels& _labels, TextRange _textRanges, Align _preferedAlignment)
+    : Label(_dim, _type, _options),
+      m_coordinates(_coordinates),
       m_textLabels(_labels),
       m_textRanges(_textRanges),
       m_fontAttrib(_attrib),
       m_preferedAlignment(_preferedAlignment) {
+
+    m_options.repeatDistance = 0;
 
     applyAnchor(m_options.anchors[0]);
 }
@@ -48,29 +69,43 @@ void TextLabel::applyAnchor(Anchor _anchor) {
     m_anchor = LabelProperty::anchorDirection(_anchor) * offset * 0.5f;
 }
 
-bool TextLabel::updateScreenTransform(const glm::mat4& _mvp, const ViewState& _viewState, bool _drawAllLabels) {
+bool TextLabel::updateScreenTransform(const glm::mat4& _mvp, const ViewState& _viewState,
+                                      const AABB* _bounds, ScreenTransform& _transform) {
+
     bool clipped = false;
 
-    switch (m_type) {
+    switch(m_type) {
         case Type::debug:
-        case Type::point:
-        {
-            glm::vec2 p0 = glm::vec2(m_worldTransform.position);
+        case Type::point: {
 
-            glm::vec2 position = worldToScreenSpace(_mvp, glm::vec4(p0, 0.0, 1.0),
-                                                    _viewState.viewportSize, clipped);
+            glm::vec2 p0 = m_coordinates[0];
+
+            glm::vec2 screenPosition = worldToScreenSpace(_mvp, glm::vec4(p0, 0.0, 1.0),
+                                                          _viewState.viewportSize, clipped);
+
             if (clipped) { return false; }
 
-            m_screenTransform.position = position + m_options.offset;
+            if (_bounds) {
+                auto aabb = m_options.anchors.extents(m_dim);
+                aabb.min += screenPosition + m_options.offset;
+                aabb.max += screenPosition + m_options.offset;
+                if (!aabb.intersect(*_bounds)) { return false; }
+            }
 
-            break;
+            m_screenCenter = screenPosition;
+
+            PointTransform(_transform).set(screenPosition + m_options.offset, glm::vec2{1, 0});
+
+            return true;
         }
-        case Type::line:
-        {
-            // project label position from mercator world space to screen coordinates
-            glm::vec2 p0 = m_worldTransform.positions[0];
-            glm::vec2 p2 = m_worldTransform.positions[1];
-            glm::vec2 position;
+        case Type::line: {
+
+            glm::vec2 rotation = {1, 0};
+
+            // project label position from mercator world space to screen
+            // coordinates
+            glm::vec2 p0 = m_coordinates[0];
+            glm::vec2 p2 = m_coordinates[1];
 
             glm::vec2 ap0 = worldToScreenSpace(_mvp, glm::vec4(p0, 0.0, 1.0),
                                                _viewState.viewportSize, clipped);
@@ -79,8 +114,13 @@ bool TextLabel::updateScreenTransform(const glm::mat4& _mvp, const ViewState& _v
 
             // check whether the label is behind the camera using the
             // perspective division factor
-            if (clipped) {
-                return false;
+            if (clipped) { return false; }
+
+            if (_bounds) {
+                AABB aabb;
+                aabb.include(ap0.x, ap0.y);
+                aabb.include(ap2.x, ap2.y);
+                if (!aabb.intersect(*_bounds)) { return false; }
             }
 
             float length = glm::length(ap2 - ap0);
@@ -88,59 +128,59 @@ bool TextLabel::updateScreenTransform(const glm::mat4& _mvp, const ViewState& _v
             // default heuristic : allow label to be 30% wider than segment
             float minLength = m_dim.x * 0.7;
 
-            if (!_drawAllLabels && length < minLength) {
-                return false;
-            }
+            if (length < minLength) { return false; }
 
             glm::vec2 p1 = glm::vec2(p2 + p0) * 0.5f;
 
-            glm::vec2 ap1 = worldToScreenSpace(_mvp, glm::vec4(p1, 0.0, 1.0),
-                                               _viewState.viewportSize, clipped);
-
             // Keep screen position center at world center (less sliding in tilted view)
-            position = ap1;
+            glm::vec2 screenPosition = worldToScreenSpace(_mvp, glm::vec4(p1, 0.0, 1.0),
+                                                          _viewState.viewportSize, clipped);
 
-            glm::vec2 rotation = (ap0.x <= ap2.x ? ap2 - ap0 : ap0 - ap2) / length;
-            rotation = glm::vec2{rotation.x, -rotation.y};
+            rotation = (ap0.x <= ap2.x ? ap2 - ap0 : ap0 - ap2) / length;
+            rotation = glm::vec2{ rotation.x, - rotation.y };
 
-            m_screenTransform.position = position + rotateBy(m_options.offset, rotation);
-            m_screenTransform.rotation = rotation;
+            m_screenCenter = screenPosition;
 
-            break;
+            PointTransform(_transform).set(screenPosition + rotateBy(m_options.offset, rotation), rotation);
+
+            return true;
         }
     }
 
-    return true;
+    return false;
 }
 
-void TextLabel::updateBBoxes(float _zoomFract) {
+float TextLabel::worldLineLength2() const {
+    if (m_type != Type::line) { return 0.f; }
+
+    return glm::length2(m_coordinates[0] - m_coordinates[1]);
+}
+
+void TextLabel::obbs(ScreenTransform& _transform, LabelOBBs& _obbs) {
 
     glm::vec2 dim = m_dim - m_options.buffer;
 
     if (m_occludedLastFrame) { dim += Label::activation_distance_threshold; }
 
-    // FIXME: Only for testing
-    if (state() == State::dead) { dim -= 4; }
+    PointTransform pointTransform(_transform);
+    auto rotation = pointTransform.rotation();
 
-    glm::vec2 screenPosition = m_screenTransform.position;
-    screenPosition += m_anchor;
+    auto obb = OBB(pointTransform.position() + m_anchor,
+                   glm::vec2{rotation.x, -rotation.y},
+                   dim.x, dim.y);
 
-    m_obb = OBB(screenPosition,
-                glm::vec2(m_screenTransform.rotation.x, -m_screenTransform.rotation.y),
-                dim.x, dim.y);
+    _obbs.append(obb);
+
 }
 
-void TextLabel::addVerticesToMesh() {
+void TextLabel::addVerticesToMesh(ScreenTransform& _transform, const glm::vec2& _screenSize) {
     if (!visibleState()) { return; }
-
-    glm::vec2 rotation = m_screenTransform.rotation;
-    bool rotate = (rotation.x != 1.f);
 
     TextVertex::State state {
         m_fontAttrib.selectionColor,
         m_fontAttrib.fill,
         m_fontAttrib.stroke,
-        uint16_t(m_screenTransform.alpha * TextVertex::alpha_scale),
+        uint16_t(m_alpha * TextVertex::alpha_scale),
         uint16_t(m_fontAttrib.fontScale),
     };
 
@@ -148,28 +188,53 @@ void TextLabel::addVerticesToMesh() {
     auto end = it + m_textRanges[m_textRangeIndex].length;
     auto& style = m_textLabels.style;
 
-    glm::vec2 screenPosition = m_screenTransform.position;
-    screenPosition += m_anchor;
-
-    glm::i16vec2 sp = glm::i16vec2(screenPosition * TextVertex::position_scale);
     auto& meshes = style.getMeshes();
+
+    PointTransform transform(_transform);
+
+    glm::vec2 rotation = transform.rotation();
+    bool rotate = (rotation.x != 1.f);
+
+    glm::vec2 screenPosition = transform.position();
+    screenPosition += m_anchor;
+    glm::i16vec2 sp = glm::i16vec2(screenPosition * TextVertex::position_scale);
+    std::array<glm::i16vec2, 4> vertexPosition;
+
+    // Expand screen bounding box by text height
+    // TODO: Better approximation.
+    glm::i16vec2 min(-m_dim.y * TextVertex::position_scale);
+    glm::i16vec2 max((_screenSize + m_dim.y) * TextVertex::position_scale);
 
     for (; it != end; ++it) {
         auto quad = *it;
+        bool visible = false;
 
-        if (it->atlas >= meshes.size()) {
-            LOGE("Accesing inconsistent quad mesh (id:%u, size:%u)",
-                 it->atlas, meshes.size());
-            break;
+        if (rotate) {
+            for (int i = 0; i < 4; i++) {
+                vertexPosition[i] = sp + glm::i16vec2{rotateBy(quad.quad[i].pos, rotation)};
+            }
+        } else {
+            for (int i = 0; i < 4; i++) {
+                vertexPosition[i] = sp + quad.quad[i].pos;
+            }
         }
+
+        for (int i = 0; i < 4; i++) {
+            if (!visible &&
+                vertexPosition[i].x > min.x &&
+                vertexPosition[i].x < max.x &&
+                vertexPosition[i].y > min.y &&
+                vertexPosition[i].y < max.y) {
+                visible = true;
+            }
+        }
+        if (!visible) { continue; }
+
         auto* quadVertices = meshes[it->atlas]->pushQuad();
+
         for (int i = 0; i < 4; i++) {
             TextVertex& v = quadVertices[i];
-            if (rotate) {
-                v.pos = sp + glm::i16vec2{rotateBy(quad.quad[i].pos, rotation)};
-            } else {
-                v.pos = sp + quad.quad[i].pos;
-            }
+            v.pos = vertexPosition[i];
             v.uv = quad.quad[i].uv;
             v.state = state;
         }

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -80,7 +80,7 @@ public:
         }
     }
 
-    float worldLineLength2() const override;
+    float modelLineLength2() const override;
 
 protected:
 

--- a/core/src/labels/textLabel.h
+++ b/core/src/labels/textLabel.h
@@ -58,7 +58,7 @@ public:
     bool updateScreenTransform(const glm::mat4& _mvp, const ViewState& _viewState,
                                const AABB* _bounds, ScreenTransform& _transform) override;
 
-    void obbs(ScreenTransform& _transform, LabelOBBs& _obbs) override;
+    void obbs(ScreenTransform& _transform, OBBBuffer& _obbs) override;
 
     void addVerticesToMesh(ScreenTransform& _transform, const glm::vec2& _screenSize) override;
 

--- a/core/src/selection/selectionQuery.cpp
+++ b/core/src/selection/selectionQuery.cpp
@@ -100,9 +100,9 @@ void SelectionQuery::process(const View& _view, const FrameBuffer& _framebuffer,
             return;
         }
 
-        LngLat coordinates = label.first->coordinates(*label.second, _view.getMapProjection());
+        auto coordinate = label.second->coordToLngLat(label.first->modelCenter());
 
-        LabelPickResult queryResult(label.first->renderType(), coordinates,
+        LabelPickResult queryResult(label.first->renderType(), LngLat{coordinate.x, coordinate.y},
                                     FeaturePickResult(props, {{m_position.x, m_position.y}}));
 
         cb(&queryResult);

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -464,9 +464,9 @@ bool PointStyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) 
         if (textStyleBuilder.prepareLabel(params, Label::Type::point)) {
 
             for (size_t i = 0; i < iconsCount; i++) {
-                auto& pLabel = m_labels[iconsStart + i];
-                auto p = pLabel->worldTransform();
-                textStyleBuilder.addLabel(params, Label::Type::point, p, _rule);
+                auto pLabel = static_cast<SpriteLabel*>(m_labels[iconsStart + i].get());
+                auto p = pLabel->modelCenter();
+                textStyleBuilder.addLabel(params, Label::Type::point, {{p, p}}, _rule);
 
                 bool definePriority = !_rule.contains(StyleParamKey::text_priority);
                 bool defineCollide = _rule.contains(StyleParamKey::collide);

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -539,7 +539,7 @@ bool TextStyleBuilder::prepareLabel(TextStyle::Parameters& _params, Label::Type 
 }
 
 void TextStyleBuilder::addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                                Label::WorldTransform _transform, const DrawRule& _rule) {
+                                TextLabel::Coordinates _coordinates, const DrawRule& _rule) {
 
     uint32_t selectionColor = 0;
 
@@ -551,7 +551,7 @@ void TextStyleBuilder::addLabel(const TextStyle::Parameters& _params, Label::Typ
         }
     }
 
-    m_labels.emplace_back(new TextLabel(_transform, _type, _params.labelOptions,
+    m_labels.emplace_back(new TextLabel(_coordinates, _type, _params.labelOptions,
                                         {m_attributes.fill,
                                          m_attributes.stroke,
                                          m_attributes.fontScale,

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -33,7 +33,7 @@ public:
 
     // Add label to the mesh using the prepared label data
     void addLabel(const TextStyle::Parameters& _params, Label::Type _type,
-                  Label::WorldTransform _transform, const DrawRule& _rule);
+                  TextLabel::Coordinates _coordinates, const DrawRule& _rule);
 
     void addLineTextLabels(const Feature& _feature, const TextStyle::Parameters& _params, const DrawRule& _rule);
 

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -132,6 +132,10 @@ bool FontContext::layoutText(TextStyle::Parameters& _params, const std::string& 
         LOGD("Empty text line");
         return false;
     }
+    if (line.missingGlyphs()) {
+        LOGD("Missing glyphs for %s", _text.c_str());
+        return false;
+    }
 
     line.setScale(_params.fontScale);
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -28,11 +28,11 @@ Tile::Tile(TileID _id, const MapProjection& _projection, const TileSource* _sour
 }
 
 
-glm::dvec2 Tile::coordToLngLat(const glm::vec2& _tileCoord, const MapProjection& _projection) const {
+glm::dvec2 Tile::coordToLngLat(const glm::vec2& _tileCoord) const {
     double scale = 1.0 / m_inverseScale;
 
     glm::dvec2 meters = glm::dvec2(_tileCoord) * scale + m_tileOrigin;
-    glm::dvec2 degrees = _projection.MetersToLonLat(meters);
+    glm::dvec2 degrees = m_projection->MetersToLonLat(meters);
 
     return {degrees.x, degrees.y};
 }

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -64,7 +64,7 @@ public:
 
     const glm::mat4& mvp() const { return m_mvp; }
 
-    glm::dvec2 coordToLngLat(const glm::vec2& _tileCoord, const MapProjection& _projection) const;
+    glm::dvec2 coordToLngLat(const glm::vec2& _tileCoord) const;
 
     void initGeometry(uint32_t _size);
 

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -3,6 +3,7 @@
 #include "labels/label.h"
 #include "view/view.h"
 #include "style/textStyle.h"
+#include "labels/screenTransform.h"
 #include "labels/textLabel.h"
 #include "labels/textLabels.h"
 #include "glm/mat4x4.hpp"
@@ -15,6 +16,14 @@ using namespace Tangram;
 glm::vec2 screenSize(500.f, 500.f);
 TextStyle dummyStyle("textStyle", nullptr);
 TextLabels dummy(dummyStyle);
+Label::AABB bounds(0.f, 0.f, 500.f, 500.f);
+
+struct TestTransform {
+    ScreenTransform::Buffer buffer;
+    Range range;
+    ScreenTransform transform;
+    TestTransform() : transform(buffer, range) {}
+};
 
 TextLabel makeLabel(glm::vec2 _transform, Label::Type _type) {
     Label::Options options;
@@ -26,7 +35,7 @@ TextLabel makeLabel(glm::vec2 _transform, Label::Type _type) {
 
     TextRange textRanges;
 
-    return TextLabel({glm::vec3(_transform, 0)}, _type, options,
+    return TextLabel({{glm::vec3(_transform, 0)}}, _type, options,
             {}, {0, 0}, dummy, textRanges,
             TextLabelProperty::Align::none);
 }
@@ -43,17 +52,18 @@ View makeView() {
 
 TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[Core][Label]" ) {
     View view = makeView();
+    TestTransform t1, t2;
 
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
     REQUIRE(l.state() == Label::State::none);
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), &bounds, t1.transform);
 
     REQUIRE(l.state() != Label::State::sleep);
     REQUIRE(l.state() == Label::State::none);
     REQUIRE(l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), &bounds, t2.transform);
     l.occlude(true);
     l.evalState(0);
 
@@ -62,19 +72,20 @@ TEST_CASE( "Ensure the transition from wait -> sleep when occlusion happens", "[
 
 TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens", "[Core][Label]" ) {
     View view = makeView();
+    TestTransform t1, t2;
 
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
     REQUIRE(l.state() == Label::State::none);
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), &bounds, t1.transform);
     l.occlude(false);
     l.evalState(0);
 
     REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), &bounds, t2.transform);
     l.evalState(1.f);
 
     REQUIRE(l.state() == Label::State::visible);
@@ -83,17 +94,18 @@ TEST_CASE( "Ensure the transition from wait -> visible when no occlusion happens
 
 TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]" ) {
     View view = makeView();
+    TestTransform t1, t2;
 
     TextLabel l(makeLabel({screenSize/2.f}, Label::Type::point));
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), &bounds, t1.transform);
     l.occlude(false);
     l.evalState(0);
 
     REQUIRE(l.state() == Label::State::fading_in);
     REQUIRE(l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), &bounds, t2.transform);
     l.occlude(true);
     l.evalState(1.f);
 
@@ -101,19 +113,20 @@ TEST_CASE( "Ensure the end state after occlusion is leep state", "[Core][Label]"
     REQUIRE(l.canOcclude());
 }
 
-TEST_CASE( "Ensure the out of screen state transition", "[Core][Label]" ) {
+TEST_CASE( "Ensure the sleep transition for out of screen labels", "[Core][Label]" ) {
     View view = makeView();
+    TestTransform t1, t2;
 
-    TextLabel l(makeLabel({screenSize*2.f}, Label::Type::point));
+    TextLabel l(makeLabel({screenSize*4.f}, Label::Type::point));
 
     REQUIRE(l.state() == Label::State::none);
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), 0);
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), &bounds, t1.transform);
 
-    REQUIRE(l.state() == Label::State::out_of_screen);
+    REQUIRE(l.state() == Label::State::sleep);
     REQUIRE(l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), view.state(), 0);
+    l.update(glm::ortho(0.f, screenSize.x * 4.f, screenSize.y * 4.f, 0.f, -1.f, 1.f), view.state(), &bounds, t2.transform);
     l.evalState(0);
     REQUIRE(l.state() != Label::State::none);
 
@@ -129,7 +142,8 @@ TEST_CASE( "Ensure debug labels are always visible and cannot occlude", "[Core][
     REQUIRE(l.state() == Label::State::visible);
     REQUIRE(!l.canOcclude());
 
-    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), 0);
+    TestTransform t1;
+    l.update(glm::ortho(0.f, screenSize.x, screenSize.y, 0.f, -1.f, 1.f), view.state(), &bounds, t1.transform);
     l.evalState(1.f);
 
     REQUIRE(l.state() == Label::State::visible);

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -114,7 +114,7 @@ TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
 
     struct TestTransform {
         ScreenTransform transform;
-        TestTransform(ScreenTransform::Buffer& _buffer, Range& _range) : transform(_buffer, _range, true) {}
+        TestTransform(ScreenTransform::Buffer& _buffer, Range& _range) : transform(_buffer, _range) {}
     };
 
     class TestLabels : public Labels {

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -125,7 +125,7 @@ TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
 
         ScreenTransform& addLabel(Label* _l, Tile* _t) {
             m_labels.push_back({_l, _t, false, {}});
-            tmpTransforms.emplace_back(m_transforms, m_labels.back().transform);
+            tmpTransforms.emplace_back(m_transforms, m_labels.back().transformRange);
             return tmpTransforms.back().transform;
         }
         void run(View& _v) { handleOcclusions(_v.state()); }


### PR DESCRIPTION
- rename WorldTransform -> *Label::Coordinates
  the coordinates are given in tile/model space, not world space
- test out-of-screen (+buffer) in updateScreenTransform
  check against maximum label bbox combining all anchors
- use shared buffer for label screen-transforms (ScreenTransform::Buffer)
- add wrappers to interpret buffer for the respective label-type
- use shared buffer for obbs in Labels and LabelCollider
  this change allows for multiple obbs per label
- simplify Label::canOcclude()