### PR TITLE
points text required to optional

### DIFF
--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -88,7 +88,7 @@ public:
         float buffer = 0.f;
         size_t paramHash = 0; // the label hash based on its styling parameters
         LabelProperty::Anchors anchors;
-        bool required = true;
+        bool optional = false;
         bool flat = false;
         float angle = 0.f;
         uint32_t featureId = 0;

--- a/core/src/labels/labelCollider.cpp
+++ b/core/src/labels/labelCollider.cpp
@@ -217,7 +217,7 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
             // First check if the child is required is occluded
             if (label->parent()->isOccluded()) {
                 label->occlude();
-            } else if (label->options().required && label->isOccluded()) {
+            } else if (!label->options().optional && label->isOccluded()) {
                 label->parent()->occlude();
                 label->parent()->enterState(Label::State::dead, 0.0f);
             }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -332,9 +332,9 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
         } while (l->isOccluded() && l->nextAnchor());
 
         // At this point, the label has a parent that is visible,
-        // if it is a required label, turn the parent to occluded
+        // if it is not an optional label, turn the parent to occluded
         if (l->isOccluded()) {
-            if (l->parent() && l->options().required) {
+            if (l->parent() && !l->options().optional) {
                 l->parent()->occlude();
             }
         }

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -71,7 +71,7 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"text:priority", StyleParamKey::text_priority},
     {"text:repeat_distance", StyleParamKey::text_repeat_distance},
     {"text:repeat_group", StyleParamKey::text_repeat_group},
-    {"text:required", StyleParamKey::text_required},
+    {"text:optional", StyleParamKey::text_optional},
     {"text:text_source", StyleParamKey::text_source},
     {"text:text_wrap", StyleParamKey::text_wrap},
     {"text:transition:hide:time", StyleParamKey::text_transition_hide_time},
@@ -242,7 +242,7 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::text_visible:
     case StyleParamKey::outline_visible:
     case StyleParamKey::collide:
-    case StyleParamKey::text_required:
+    case StyleParamKey::text_optional:
     case StyleParamKey::text_collide:
         if (_value == "true") { return true; }
         if (_value == "false") { return false; }
@@ -381,7 +381,7 @@ std::string StyleParam::toString() const {
     case StyleParamKey::outline_visible:
     case StyleParamKey::centroid:
     case StyleParamKey::collide:
-    case StyleParamKey::text_required:
+    case StyleParamKey::text_optional:
     case StyleParamKey::text_collide:
         if (!value.is<bool>()) break;
         return k + std::to_string(value.get<bool>());

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -61,7 +61,7 @@ enum class StyleParamKey : uint8_t {
     transition_hide_time,
     transition_selected_time,
     transition_show_time,
-    text_required,
+    text_optional,
     text_transition_hide_time,
     text_transition_selected_time,
     text_transition_show_time,

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -394,7 +394,7 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         }
     }
 
-    _rule.get(StyleParamKey::text_required, p.labelOptions.required);
+    _rule.get(StyleParamKey::text_optional, p.labelOptions.optional);
 
     // TODO style option?
     p.labelOptions.buffer = p.fontSize * 0.25f;

--- a/scenes/scene.yaml
+++ b/scenes/scene.yaml
@@ -415,7 +415,6 @@ layers:
                 collide: true
                 transition: { show: { time: 0s }, hide: { time: 1s } }
                 text:
-                    required: true
                     interactive: true
                     font:
                         family: Open Sans
@@ -470,7 +469,6 @@ layers:
                     interactive: true
                     priority: 6
                     text:
-                        required: false
                         visible: false
 
             # add text label at higher zoom
@@ -481,7 +479,6 @@ layers:
                 draw:
                     icons:
                         text:
-                            required: true
                             visible: true
                             font:
                                 size: 12px


### PR DESCRIPTION
Depends on #1208 

To match modified behavior in JS and the [documentation](https://github.com/tangrams/tangram-docs/commit/b8509a7c84e8228de6cfe67aff47971c2c6ea1ce), the usage of `points:text:required` to `points:text:optional`.