### PR TITLE
Fix android upload task

### DIFF
--- a/android/demo/build.gradle
+++ b/android/demo/build.gradle
@@ -24,6 +24,5 @@ android {
 }
 
 dependencies {
-  debugCompile project(path: ':tangram', configuration: 'slimDebug')
-  releaseCompile project(path: ':tangram', configuration: 'slimRelease')
+  compile project(path: ':tangram')
 }

--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -52,7 +52,12 @@ android {
       externalNativeBuild.cmake.abiFilters 'armeabi', 'arm64-v8a', 'x86'
     }
   }
-  publishNonDefault true
+
+  if (project.hasProperty('doFullRelease')) {
+    defaultPublishConfig 'fullRelease'
+  } else {
+    defaultPublishConfig 'slimDebug'
+  }
 }
 
 dependencies {

--- a/scripts/travis/script_deploy_android_snapshot.sh
+++ b/scripts/travis/script_deploy_android_snapshot.sh
@@ -12,6 +12,6 @@ if [ "${PLATFORM}" = "android" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ 
 
     cd "$TRAVIS_BUILD_DIR"/android
     git clone https://github.com/mapzen/android-config.git
-    ./gradlew uploadArchives -PsonatypeUsername="$SONATYPE_USERNAME" -PsonatypePassword="$SONATYPE_PASSWORD" -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password="$SIGNING_PASSWORD" -Psigning.secretKeyRingFile="$SIGNING_SECRET_KEY_RING_FILE"
+    ./gradlew uploadArchives -PdoFullRelease -PsonatypeUsername="$SONATYPE_USERNAME" -PsonatypePassword="$SONATYPE_PASSWORD" -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password="$SIGNING_PASSWORD" -Psigning.secretKeyRingFile="$SIGNING_SECRET_KEY_RING_FILE"
     cd "$TRAVIS_BUILD_DIR"
 fi


### PR DESCRIPTION
Android library snapshots are currently not usable with Maven. The 'build flavors' and 'build configurations' options available through the Android Gradle plugin can have very weird effects on the `uploadArchives` task that is typically used to publish Android libraries to Maven Central. 

Relevant docs: http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Library-Publication

When an Android library project declares multiple flavors and/or configurations, by default those options are not visible to projects that depend on the library (like our Android demo app depends on the Tangram Android library). A dependent project can typically only build and use the default 'release' configuration of the library it depends on. To change this, there is an option for library projects: `publishNonDefault true` which will 'publish' all library flavors and configurations for dependent projects to see and use. This is exactly what we want for configuring our demo app! We can now declare our dependency on the Tangram Android library with:
```
dependencies {
  debugCompile project(path: ':tangram', configuration: 'slimDebug')
  releaseCompile project(path: ':tangram', configuration: 'slimRelease')
}
```
Awesome! Being able to choose the 'debug' configuration of the library allows us to debug the library code and the 'slim' flavor keeps our build times down for iterative testing. This is the current state of the code.

Unfortunately, this configuration change also impacted the behavior of `uploadArchives`, but this went unnoticed during review because `uploadArchives` is only ever executed on the 'master' branch. To quote the end of the 'Library Publication' section of the documentation linked above:

> Important: When enabling publishing of non default, the Maven publishing plugin will publish these additional variants as extra packages (with classifier). This means that this is not really compatible with publishing to a maven repository. You should either publish a single variant to a repository OR enable all config publishing for inter-project dependencies.

Not awesome. I am now investigating ways to configure our projects and build scripts such that we can _both_:
1. Choose which configuration and flavor of the Tangram Android library is used when building the demo app, and
2. build and upload a single package to Maven Central using the 'fullRelease' configuration.
