### PR TITLE
Handle empty and zero-area rings in centroid()

### DIFF
--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -411,8 +411,11 @@ bool PointStyleBuilder::addPolygon(const Polygon& _polygon, const Properties& _p
             labelPointsPlacing(line, uvsQuad, p, _rule);
         }
     } else {
-        glm::vec2 c = centroid(_polygon);
-        addLabel(Point{c,0}, uvsQuad, p, _rule);
+        glm::vec3 c;
+        if (!_polygon.empty()) {
+            c = centroid(_polygon.front().begin(), _polygon.front().end());
+        }
+        addLabel(c, uvsQuad, p, _rule);
     }
 
     return true;

--- a/core/src/util/geom.cpp
+++ b/core/src/util/geom.cpp
@@ -101,30 +101,6 @@ glm::vec2 worldToScreenSpace(const glm::mat4& _mvp, const glm::vec4& _worldPosit
     return clipToScreenSpace(clipCoords, _screenSize);
 }
 
-glm::vec2 centroid(const std::vector<std::vector<glm::vec3>>& _polygon) {
-
-    if (_polygon.empty()) {
-        return glm::vec2();
-    }
-
-    // We will consider only the outer ring of the polygon when calculating
-    // the centroid - holes will be ignored. It would be possible to transform
-    // a polygon with holes into a polygon that covers the same set of points
-    // without any holes, but that seems overly complex for our needs.
-    const auto& ring = _polygon.front();
-    glm::vec2 centroid;
-    float area = 0.f;
-
-    for (auto curr = ring.begin(), prev = ring.end() - 1; curr != ring.end(); prev = curr, ++curr) {
-        float a = (prev->x * curr->y - curr->x * prev->y);
-        centroid.x += (prev->x + curr->x) * a;
-        centroid.y += (prev->y + curr->y) * a;
-        area += a;
-    }
-
-    return centroid / (3.f * area);
-}
-
 // square distance from a point <_p> to a segment <_p1,_p2>
 // http://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment
 //

--- a/core/src/util/geom.h
+++ b/core/src/util/geom.h
@@ -84,6 +84,22 @@ float signedArea(InputIt _begin, InputIt _end) {
     return 0.5 * area;
 }
 
+/* Calculate the area centroid of a closed polygon given as a sequence of vectors.
+ * If the polygon has no area, the coordinates returned are NaN.
+ */
+template<class InputIt, class Vector = typename InputIt::value_type>
+Vector centroid(InputIt begin, InputIt end) {
+    Vector centroid;
+    float area = 0.f;
+    for (auto curr = begin, prev = end - 1; curr != end; prev = curr, ++curr) {
+        float a = (prev->x * curr->y - curr->x * prev->y);
+        centroid.x += (prev->x + curr->x) * a;
+        centroid.y += (prev->y + curr->y) * a;
+        area += a;
+    }
+    return centroid / (3.f * area);
+}
+
 /* Map a value from the range [_inputMin, _inputMax] into the range [_outputMin, _outputMax];
  * If _clamp is true, the output is strictly within the output range.
  * Ex: mapValue(5, 0, 10, 0, 360) == 180


### PR DESCRIPTION
https://github.com/tangrams/tangram-es/pull/1144#issuecomment-272017394

~If a polygon passed to `centroid()` has no rings or the first ring is empty, it returns `{0, 0}`. If the signed area of the first ring is zero, it returns the first point in the first ring.~

`centroid()` now takes a single ring as input, to clarify the functionality. Zero-area rings produce a centroid of { NAN, NAN }.