### PR TITLE
Implement repeat group logic for point based styles

### DIFF
--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -34,7 +34,7 @@ public:
                  TextureOptions _options, bool genMipmap = false);
 
 
-    void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb);
+    void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
     virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask) override;
 

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -50,8 +50,8 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"placement_spacing", StyleParamKey::placement_spacing},
     {"placement_min_length_ratio", StyleParamKey::placement_min_length_ratio},
     {"priority", StyleParamKey::priority},
-    {"repeat_distance", StyleParamKey::text_repeat_distance},
-    {"repeat_group", StyleParamKey::text_repeat_group},
+    {"repeat_distance", StyleParamKey::repeat_distance},
+    {"repeat_group", StyleParamKey::repeat_group},
     {"size", StyleParamKey::size},
     {"sprite", StyleParamKey::sprite},
     {"sprite_default", StyleParamKey::sprite_default},
@@ -234,6 +234,7 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::sprite_default:
     case StyleParamKey::style:
     case StyleParamKey::outline_style:
+    case StyleParamKey::repeat_group:
     case StyleParamKey::text_repeat_group:
         return _value;
     case StyleParamKey::text_font_size: {
@@ -290,6 +291,7 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
 
         return Width(placementSpacing);
     }
+    case StyleParamKey::repeat_distance:
     case StyleParamKey::text_repeat_distance: {
         ValueUnitPair repeatDistance;
         repeatDistance.unit = Unit::pixel;
@@ -385,6 +387,7 @@ std::string StyleParam::toString() const {
         auto p = value.get<glm::vec2>();
         return k + "(" + std::to_string(p.x) + "px, " + std::to_string(p.y) + "px)";
     }
+    case StyleParamKey::repeat_group:
     case StyleParamKey::transition_hide_time:
     case StyleParamKey::text_transition_hide_time:
     case StyleParamKey::transition_show_time:
@@ -433,6 +436,7 @@ std::string StyleParam::toString() const {
     case StyleParamKey::color:
     case StyleParamKey::outline_color:
     case StyleParamKey::outline_style:
+    case StyleParamKey::repeat_distance:
     case StyleParamKey::text_font_fill:
     case StyleParamKey::text_font_stroke_color:
     case StyleParamKey::text_repeat_distance:

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -48,6 +48,8 @@ enum class StyleParamKey : uint8_t {
     placement_spacing,
     placement_min_length_ratio,
     priority,
+    repeat_distance,
+    repeat_group,
     text_order,
     text_priority,
     text_repeat_distance,

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -121,6 +121,10 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
     _rule.get(StyleParamKey::offset, p.labelOptions.offset);
 
     uint32_t priority;
+    size_t repeatGroupHash = 0;
+    std::string repeatGroup;
+    StyleParam::Width repeatDistance;
+
     if (_rule.get(StyleParamKey::priority, priority)) {
         p.labelOptions.priority = (float)priority;
     }
@@ -148,6 +152,21 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _prop
     _rule.get(StyleParamKey::transition_show_time, p.labelOptions.showTransition.time);
     _rule.get(StyleParamKey::flat, p.labelOptions.flat);
     _rule.get(StyleParamKey::anchor, p.labelOptions.anchors);
+
+    if (_rule.get(StyleParamKey::repeat_distance, repeatDistance)) {
+        p.labelOptions.repeatDistance = repeatDistance.value;
+    }
+
+    if (p.labelOptions.repeatDistance > 0.f) {
+        if (_rule.get(StyleParamKey::repeat_group, repeatGroup)) {
+            hash_combine(repeatGroupHash, repeatGroup);
+        } else {
+            repeatGroupHash = _rule.getParamSetHash();
+        }
+
+        p.labelOptions.repeatGroup = repeatGroupHash;
+        p.labelOptions.repeatDistance *= m_style.pixelScale();
+    }
 
     if (p.labelOptions.anchors.count == 0) {
         p.labelOptions.anchors.anchor = { {LabelProperty::Anchor::center} };


### PR DESCRIPTION
- fix: repeat group should only be applied when repeat distance is > 0
- alter repeat group application for text based styles to accomodate inheritance logic from parent
point style
- implement repeat group and repeat distance parsing for point based styles
- repeat distance is 0 by default for point based styles (unlike for text based styles, which has
256 as default repeat distance)

Refer other details of the concept: https://github.com/tangrams/tangram/pull/424

This PR branch is based on #1211