### PR TITLE
Feature picking within a radius

### DIFF
--- a/android/tangram/src/main/cpp/jniExports.cpp
+++ b/android/tangram/src/main/cpp/jniExports.cpp
@@ -222,6 +222,12 @@ extern "C" {
         onUrlFailure(jniEnv, callbackPtr);
     }
 
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPickRadius(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radius) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setPickRadius(radius);
+    }
+
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickFeature(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jobject listener) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);

--- a/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -674,6 +674,15 @@ public class MapController implements Renderer {
     }
 
     /**
+     * Set the radius to use when picking features on the map. The default radius is 0.5 dp.
+     * @param radius The radius in dp (density-independent pixels).
+     */
+    public void setPickRadius(float radius) {
+        checkPointer(mapPointer);
+        nativeSetPickRadius(mapPointer, radius);
+    }
+
+    /**
      * Set a listener for feature pick events
      * @param listener The {@link FeaturePickListener} to call
      */
@@ -986,6 +995,7 @@ public class MapController implements Renderer {
     private synchronized native void nativeQueueSceneUpdate(long mapPtr, String componentPath, String componentValue);
     private synchronized native void nativeQueueSceneUpdates(long mapPtr, String[] updateStrings);
     private synchronized native void nativeApplySceneUpdates(long mapPtr);
+    private synchronized native void nativeSetPickRadius(long mapPtr, float radius);
     private synchronized native void nativePickFeature(long mapPtr, float posX, float posY, FeaturePickListener listener);
     private synchronized native void nativePickLabel(long mapPtr, float posX, float posY, LabelPickListener listener);
     private synchronized native void nativePickMarker(long mapPtr, float posX, float posY, MarkerPickListener listener);

--- a/core/src/gl/framebuffer.cpp
+++ b/core/src/gl/framebuffer.cpp
@@ -74,10 +74,10 @@ GLuint FrameBuffer::readAt(float _normalizedX, float _normalizedY) const {
 FrameBuffer::PixelRect FrameBuffer::readRect(float _normalizedX, float _normalizedY, float _normalizedW, float _normalizedH) const {
 
     PixelRect rect;
-    rect.left = floorf(_normalizedX * m_width);
-    rect.bottom = floorf(_normalizedY * m_height);
-    rect.width = ceilf(_normalizedW * m_width);
-    rect.height = ceilf(_normalizedH * m_height);
+    rect.left = fminf(fmaxf(floorf(_normalizedX * m_width), 0.f), m_width);
+    rect.bottom = fminf(fmaxf(floorf(_normalizedY * m_height), 0.f), m_height);
+    rect.width = fminf(fmaxf(ceilf(_normalizedW * m_width), 0.f), m_width - rect.left);
+    rect.height = fminf(fmaxf(ceilf(_normalizedH * m_height), 0.f), m_height - rect.bottom);
 
     rect.pixels.resize(rect.width * rect.height);
 

--- a/core/src/gl/framebuffer.cpp
+++ b/core/src/gl/framebuffer.cpp
@@ -71,6 +71,21 @@ GLuint FrameBuffer::readAt(float _normalizedX, float _normalizedY) const {
     return pixel;
 }
 
+FrameBuffer::PixelRect FrameBuffer::readRect(float _normalizedX, float _normalizedY, float _normalizedW, float _normalizedH) const {
+
+    PixelRect rect;
+    rect.left = _normalizedX * m_width;
+    rect.bottom =  _normalizedY * m_height;
+    rect.width = _normalizedW * m_width;
+    rect.height = _normalizedH * m_height;
+
+    rect.pixels.resize(rect.width * rect.height);
+
+    GL::readPixels(rect.left, rect.bottom, rect.width, rect.height, GL_RGBA, GL_UNSIGNED_BYTE, rect.pixels.data());
+
+    return rect;
+}
+
 void FrameBuffer::init(RenderState& _rs) {
 
     if (!Hardware::supportsGLRGBA8OES && m_colorRenderBuffer) {

--- a/core/src/gl/framebuffer.cpp
+++ b/core/src/gl/framebuffer.cpp
@@ -74,10 +74,10 @@ GLuint FrameBuffer::readAt(float _normalizedX, float _normalizedY) const {
 FrameBuffer::PixelRect FrameBuffer::readRect(float _normalizedX, float _normalizedY, float _normalizedW, float _normalizedH) const {
 
     PixelRect rect;
-    rect.left = _normalizedX * m_width;
-    rect.bottom =  _normalizedY * m_height;
-    rect.width = _normalizedW * m_width;
-    rect.height = _normalizedH * m_height;
+    rect.left = floorf(_normalizedX * m_width);
+    rect.bottom = floorf(_normalizedY * m_height);
+    rect.width = ceilf(_normalizedW * m_width);
+    rect.height = ceilf(_normalizedH * m_height);
 
     rect.pixels.resize(rect.width * rect.height);
 

--- a/core/src/gl/framebuffer.h
+++ b/core/src/gl/framebuffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "glm/vec4.hpp"
 #include "gl/disposer.h"
@@ -32,6 +33,13 @@ public:
     void bind(RenderState& _rs) const;
 
     GLuint readAt(float _normalizedX, float _normalizedY) const;
+
+    struct PixelRect {
+        std::vector<GLuint> pixels;
+        int32_t left = 0, bottom = 0, width = 0, height = 0;
+    };
+
+    PixelRect readRect(float _normalizedX, float _normalizedY, float _normalizedW, float _normalizedH) const;
 
     void drawDebug(RenderState& _rs, glm::vec2 _dim);
 

--- a/core/src/selection/selectionQuery.cpp
+++ b/core/src/selection/selectionQuery.cpp
@@ -23,8 +23,9 @@ QueryType SelectionQuery::type() const {
 void SelectionQuery::process(const View& _view, const FrameBuffer& _framebuffer, const MarkerManager& _markerManager,
                              const TileManager& _tileManager, const Labels& _labels, std::vector<SelectionColorRead>& _colorCache) const {
 
-    glm::vec2 windowCoordinates = _view.normalizedWindowCoordinates(m_position.x - m_radius, m_position.y + m_radius);
-    glm::vec2 windowSize = _view.normalizedWindowCoordinates(m_position.x + m_radius, m_position.y - m_radius) - windowCoordinates;
+    float radius = m_radius * _view.pixelScale();
+    glm::vec2 windowCoordinates = _view.normalizedWindowCoordinates(m_position.x - radius, m_position.y + radius);
+    glm::vec2 windowSize = _view.normalizedWindowCoordinates(m_position.x + radius, m_position.y - radius) - windowCoordinates;
 
     GLuint color = 0;
 

--- a/core/src/selection/selectionQuery.h
+++ b/core/src/selection/selectionQuery.h
@@ -22,13 +22,14 @@ using QueryCallback = variant<FeaturePickCallback, LabelPickCallback, MarkerPick
 
 struct SelectionColorRead {
     uint32_t color;
+    float radius;
     glm::vec2 position;
 };
 
 class SelectionQuery {
 
 public:
-    SelectionQuery(glm::vec2 _position, QueryCallback _queryCallback);
+    SelectionQuery(glm::vec2 _position, float _radius, QueryCallback _queryCallback);
 
     void process(const View& _view, const FrameBuffer& _framebuffer, const MarkerManager& _markerManager,
                  const TileManager& _tileManager, const Labels& _labels, std::vector<SelectionColorRead>& _cache) const;
@@ -37,6 +38,7 @@ public:
 
 private:
     glm::vec2 m_position;
+    float m_radius;
     QueryCallback m_queryCallback;
 
 };

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -80,6 +80,7 @@ public:
     std::unique_ptr<FrameBuffer> selectionBuffer = std::make_unique<FrameBuffer>(0, 0);
 
     bool cacheGlState = false;
+    float pickRadius = .5f;
 
     std::vector<SelectionQuery> selectionQueries;
 };
@@ -386,20 +387,24 @@ bool Map::update(float _dt) {
     return viewComplete;
 }
 
+void Map::setPickRadius(float _pixels) {
+    impl->pickRadius = _pixels;
+}
+
 void Map::pickFeatureAt(float _x, float _y, FeaturePickCallback _onFeaturePickCallback) {
-    impl->selectionQueries.push_back({{_x, _y}, _onFeaturePickCallback});
+    impl->selectionQueries.push_back({{_x, _y}, impl->pickRadius, _onFeaturePickCallback});
 
     requestRender();
 }
 
 void Map::pickLabelAt(float _x, float _y, LabelPickCallback _onLabelPickCallback) {
-    impl->selectionQueries.push_back({{_x, _y}, _onLabelPickCallback});
+    impl->selectionQueries.push_back({{_x, _y}, impl->pickRadius, _onLabelPickCallback});
 
     requestRender();
 }
 
 void Map::pickMarkerAt(float _x, float _y, MarkerPickCallback _onMarkerPickCallback) {
-    impl->selectionQueries.push_back({{_x, _y}, _onMarkerPickCallback});
+    impl->selectionQueries.push_back({{_x, _y}, impl->pickRadius, _onMarkerPickCallback});
 
     requestRender();
 }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -387,8 +387,8 @@ bool Map::update(float _dt) {
     return viewComplete;
 }
 
-void Map::setPickRadius(float _pixels) {
-    impl->pickRadius = _pixels;
+void Map::setPickRadius(float _radius) {
+    impl->pickRadius = _radius;
 }
 
 void Map::pickFeatureAt(float _x, float _y, FeaturePickCallback _onFeaturePickCallback) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -79,7 +79,7 @@ public:
     MarkerManager markerManager;
     std::unique_ptr<FrameBuffer> selectionBuffer = std::make_unique<FrameBuffer>(0, 0);
 
-    bool cacheGlState;
+    bool cacheGlState = false;
 
     std::vector<SelectionQuery> selectionQueries;
 };

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -274,6 +274,9 @@ public:
     // efficiency, but can cause errors if your application code makes OpenGL calls (false by default)
     void useCachedGlState(bool _use);
 
+    // Set the radius in pixels to use when picking features on the map (default is 0.5 pixels).
+    void setPickRadius(float _pixels);
+
     // Create a query to select a feature marked as 'interactive'. The query runs on the next frame.
     // Calls _onFeaturePickCallback once the query has completed, and returns the FeaturePickResult
     // with its associated properties or null if no feature was found.

--- a/core/src/tangram.h
+++ b/core/src/tangram.h
@@ -274,8 +274,8 @@ public:
     // efficiency, but can cause errors if your application code makes OpenGL calls (false by default)
     void useCachedGlState(bool _use);
 
-    // Set the radius in pixels to use when picking features on the map (default is 0.5 pixels).
-    void setPickRadius(float _pixels);
+    // Set the radius in logical pixels to use when picking features on the map (default is 0.5).
+    void setPickRadius(float _radius);
 
     // Create a query to select a feature marked as 'interactive'. The query runs on the next frame.
     // Calls _onFeaturePickCallback once the query has completed, and returns the FeaturePickResult

--- a/ios/src/TGMapViewController.h
+++ b/ios/src/TGMapViewController.h
@@ -145,6 +145,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Feature picking interface
 
+- (void)setPickRadius:(float)logicalPixels;
+
 - (void)pickFeatureAt:(CGPoint)screenPosition;
 
 - (void)pickLabelAt:(CGPoint)screenPosition;

--- a/ios/src/TGMapViewController.mm
+++ b/ios/src/TGMapViewController.mm
@@ -170,6 +170,13 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 
 #pragma mark Feature picking
 
+- (void)setPickRadius:(float)logicalPixels
+{
+    if (!self.map) { return; }
+
+    self.map->setPickRadius(logicalPixels);
+}
+
 - (void)pickFeatureAt:(CGPoint)screenPosition
 {
     if (!self.map) { return; }


### PR DESCRIPTION
Since fingers are not great at selecting a single pixel from a touchscreen, it can be useful to check over an area when picking features from the map.

This change add a configurable "pick radius", measured in logical pixels, used when selecting features, labels, or markers from the map. Instead of sampling a single pixel from the selection buffer, we now sample a block of pixels around the selected point in screen space and find the nearest non-zero selection color within the pick radius in that block. 

The default pick radius is 0.5 logical pixels, which usually results in sampling one pixel, as before.

After finding a well-tuned pick radius, touch screen apps should find that picking small features is much less frustrating now. However, it should be noted that there is a small added cost to sampling an area of pixels which rises quadratically with the radius. I have not yet profiled this cost!

Resolves: https://github.com/tangrams/tangram-es/issues/1065