### PR TITLE
Gl context loss

### DIFF
--- a/android/tangram/src/main/cpp/platform_android.cpp
+++ b/android/tangram/src/main/cpp/platform_android.cpp
@@ -204,8 +204,6 @@ std::vector<FontSourceHandle> systemFontFallbacksHandle() {
     std::string fallbackPath = fontFallbackPath(importance, weightHint);
 
     while (!fallbackPath.empty()) {
-        LOG("Loading font %s", fallbackPath.c_str());
-
         handles.emplace_back(fallbackPath);
 
         fallbackPath = fontFallbackPath(importance++, weightHint);

--- a/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -172,6 +172,7 @@ public class MapController implements Renderer {
         mapView = view;
         view.setRenderer(this);
         view.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
+        view.setPreserveEGLContextOnPause(true);
 
         // Set a default HTTPHandler
         httpHandler = new HttpHandler();

--- a/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -251,7 +251,6 @@ public class MapController implements Renderer {
      * @param sceneUpdates List of {@code SceneUpdate}
      */
     public void loadSceneFile(String path, List<SceneUpdate> sceneUpdates) {
-
         String[] updateStrings = bundleSceneUpdates(sceneUpdates);
         scenePath = path;
         checkPointer(mapPointer);

--- a/core/src/gl/dynamicQuadMesh.h
+++ b/core/src/gl/dynamicQuadMesh.h
@@ -81,8 +81,6 @@ void DynamicQuadMesh<T>::upload(RenderState& rs) {
 
     if (m_nVertices == 0 || m_isUploaded) { return; }
 
-    MeshBase::checkValidity(rs);
-
     // Generate vertex buffer, if needed
     if (m_glVertexBuffer == 0) {
         GL::genBuffers(1, &m_glVertexBuffer);

--- a/core/src/gl/framebuffer.cpp
+++ b/core/src/gl/framebuffer.cpp
@@ -12,7 +12,6 @@ namespace Tangram {
 
 FrameBuffer::FrameBuffer(int _width, int _height, bool _colorRenderBuffer) :
     m_glFrameBufferHandle(0),
-    m_generation(-1),
     m_valid(false),
     m_colorRenderBuffer(_colorRenderBuffer),
     m_width(_width), m_height(_height) {
@@ -145,22 +144,17 @@ void FrameBuffer::init(RenderState& _rs) {
         m_valid = true;
     }
 
-    m_generation = _rs.generation();
-
     m_disposer = Disposer(_rs);
 }
 
 FrameBuffer::~FrameBuffer() {
 
-    int generation = m_generation;
     GLuint glHandle = m_glFrameBufferHandle;
 
     m_disposer([=](RenderState& rs) {
-        if (rs.isValidGeneration(generation)) {
-            rs.framebufferUnset(glHandle);
+        rs.framebufferUnset(glHandle);
 
-            GL::deleteFramebuffers(1, &glHandle);
-        }
+        GL::deleteFramebuffers(1, &glHandle);
     });
 }
 

--- a/core/src/gl/framebuffer.h
+++ b/core/src/gl/framebuffer.h
@@ -49,8 +49,6 @@ private:
 
     GLuint m_glColorRenderBufferHandle;
 
-    int m_generation;
-
     bool m_valid;
 
     bool m_colorRenderBuffer;

--- a/core/src/gl/mesh.h
+++ b/core/src/gl/mesh.h
@@ -76,8 +76,6 @@ public:
 
 protected:
 
-    int m_generation; // Generation in which this mesh's GL handles were created
-
     // Used in draw for legth and offsets: sumIndices, sumVertices
     // needs to be set by compile()
     std::vector<std::pair<uint32_t, uint32_t>> m_vertexOffsets;
@@ -108,8 +106,6 @@ protected:
     GLintptr m_dirtyOffset;
 
     Disposer m_disposer;
-
-    bool checkValidity(RenderState& rs);
 
     size_t compileIndices(const std::vector<std::pair<uint32_t, uint32_t>>& _offsets,
                           const std::vector<uint16_t>& _indices, size_t _offset);

--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -95,19 +95,6 @@ void RenderState::cacheDefaultFramebuffer() {
     GL::getIntegerv(GL_FRAMEBUFFER_BINDING, &m_defaultFramebuffer);
 }
 
-void RenderState::increaseGeneration() {
-    generateQuadIndexBuffer();
-    m_validGeneration++;
-}
-
-bool RenderState::isValidGeneration(int _generation) {
-    return _generation == m_validGeneration;
-}
-
-int RenderState::generation() {
-    return m_validGeneration;
-}
-
 int RenderState::nextAvailableTextureUnit() {
     if (m_nextTextureUnit >= Hardware::maxCombinedTextureUnits) {
         LOGE("Too many combined texture units are being used");

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -31,12 +31,6 @@ public:
     // Reset the render states.
     void invalidate();
 
-    int generation();
-
-    void increaseGeneration();
-
-    bool isValidGeneration(int _generation);
-
     // Get the texture slot from a texture unit from 0 to TANGRAM_MAX_TEXTURE_UNIT-1.
     static GLuint getTextureUnit(GLuint _unit);
 
@@ -119,7 +113,6 @@ public:
 
 private:
 
-    int m_validGeneration = 0;
     uint32_t m_nextTextureUnit = 0;
 
     GLuint m_quadIndexBuffer = 0;

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -53,7 +53,7 @@ public:
     GLint getUniformLocation(const UniformLocation& _uniformName);
 
     // Return true if this object represents a valid OpenGL shader program.
-    bool isValid(RenderState& rs) const { return m_glProgram != 0; };
+    bool isValid() const { return m_glProgram != 0; };
 
     // Bind the program in OpenGL if it is not already bound; If the shader sources
     // have been modified since the last time build() was called, also calls build().
@@ -123,7 +123,6 @@ private:
         return false;
     }
 
-    int m_generation = -1;
     GLuint m_glProgram = 0;
 
     fastmap<std::string, GLint> m_attribMap;
@@ -140,8 +139,6 @@ private:
     bool m_needsBuild = true;
 
     Disposer m_disposer;
-
-    void checkValidity(RenderState& rs);
 
     std::string applySourceBlocks(const std::string& source, bool fragShader) const;
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -79,7 +79,7 @@ public:
                     uint16_t _width, uint16_t _height, uint16_t _stride);
 
     /* Checks whether the texture has valid data and has been successfully uploaded to GPU */
-    bool isValid(RenderState& rs) const;
+    bool isValid() const;
 
     typedef std::pair<GLuint, GLuint> TextureSlot;
 
@@ -95,7 +95,6 @@ public:
 protected:
 
     void generate(RenderState& rs, GLuint _textureUnit);
-    void checkValidity(RenderState& rs);
 
     TextureOptions m_options;
     std::vector<GLuint> m_data;
@@ -113,8 +112,6 @@ protected:
     unsigned int m_height;
 
     GLenum m_target;
-
-    int m_generation;
 
     Disposer m_disposer;
 

--- a/core/src/gl/textureCube.cpp
+++ b/core/src/gl/textureCube.cpp
@@ -65,8 +65,6 @@ void TextureCube::load(const std::string& _file) {
 
 void TextureCube::update(RenderState& rs, GLuint _textureUnit) {
 
-    checkValidity(rs);
-
     if (m_glHandle != 0 || m_faces.size() == 0) { return; }
 
     generate(rs, _textureUnit);

--- a/core/src/gl/uniform.h
+++ b/core/src/gl/uniform.h
@@ -38,7 +38,6 @@ private:
     const std::string name;
 
     mutable int location = -1;
-    mutable int generation = -1;
 
     friend class ShaderProgram;
 };

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -67,7 +67,9 @@ void TextStyle::onBeginFrame(RenderState& rs) {
     // Upload meshes and textures
     m_context->updateTextures(rs);
 
-    for (auto& mesh : m_meshes) { mesh->upload(rs); }
+    for (auto& mesh : m_meshes) {
+        mesh->upload(rs);
+    }
 }
 
 void TextStyle::onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _scene) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -831,15 +831,16 @@ void Map::setupGL() {
 
     LOG("setup GL");
 
+    impl->renderState.invalidate();
+
     impl->tileManager.clearTileSets();
 
     impl->markerManager.rebuildAll();
 
-    // Reconfigure the render states. Increases context 'generation'.
-    // The OpenGL context has been destroyed since the last time resources were
-    // created, so we invalidate all data that depends on OpenGL object handles.
-    impl->renderState.increaseGeneration();
-    impl->renderState.invalidate();
+    if (impl->selectionBuffer->valid()) {
+        impl->selectionBuffer = std::make_unique<FrameBuffer>(impl->selectionBuffer->getWidth(),
+                                                              impl->selectionBuffer->getHeight());
+    }
 
     // Set default primitive render color
     Primitives::setColor(impl->renderState, 0xffffff);
@@ -849,7 +850,6 @@ void Map::setupGL() {
     Hardware::loadCapabilities();
 
     Hardware::printAvailableExtensions();
-
 }
 
 void Map::useCachedGlState(bool _useCache) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -106,7 +106,7 @@ void FontContext::updateTextures(RenderState& rs) {
     std::lock_guard<std::mutex> lock(m_textureMutex);
 
     for (auto& gt : m_textures) {
-        if (gt.dirty || !gt.texture.isValid(rs)) {
+        if (gt.dirty) {
             gt.dirty = false;
             auto td = reinterpret_cast<const GLuint*>(gt.texData.data());
             gt.texture.update(rs, 0, td);


### PR DESCRIPTION
Revisit a little bit our context loss on Android:
- Remove index generation that was being used to track whenever a new context is created
- gl objects no longer retain the memory
- Reload entirely the scene `onSurfaceCreated` whenever the map view has not been destroyed

Fixes #1206 