### PR TITLE
missed pickMarkerAt Method in header file.

### DIFF
--- a/ios/src/TGMapViewController.h
+++ b/ios/src/TGMapViewController.h
@@ -149,6 +149,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)pickLabelAt:(CGPoint)screenPosition;
 
+- (void)pickMarkerAt:(CGPoint)screenPosition;
+
 #pragma mark Map View lifecycle
 
 - (void)requestRender;


### PR DESCRIPTION
I tried to use pickMarkerAt method. but Although this method is in tangram/core, objective-c file .mm, This wasn't in iOS/src/TGMapViewController.h . so when I use tangram.framework, that method not invoked. but when I add - (void)pickMarkerAt:(CGPoint)screenPosition; this in TGMapViewController.h, and then make again, then pickMarkerAt method called well so that selectMarker method called well. So I think you need to put - (void)pickMarkerAt:(CGPoint)screenPosition; in header file.
JinYongwHwa, my Coworker helps to find this one.