### PR TITLE
setPixelScale does nothing if new value same as old

### DIFF
--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -672,6 +672,12 @@ void Map::setPixelScale(float _pixelsPerPoint) {
 
 void Map::Impl::setPixelScale(float _pixelsPerPoint) {
 
+    // If the pixel scale changes we need to re-build all the tiles.
+    // This is expensive, so first check whether the new value is different.
+    if (_pixelsPerPoint == view.pixelScale()) {
+        // Nothing to do!
+        return;
+    }
     view.setPixelScale(_pixelsPerPoint);
     scene->setPixelScale(_pixelsPerPoint);
     for (auto& style : scene->styles()) {


### PR DESCRIPTION
When Android resumes a GLSurfaceView it calls resize, which prompts tangram to set the display size and pixel density again. Calling setPixelSize would then clear the tile sets and caches because a change in pixel density requires re-styling the tile data. This resulted in a noticeable delay to map usability when the view was resumed and all tiles on screen were re-loaded. 

This fix just checks whether the call to setPixelScale is redundant, and if so does nothing, making the view resume from pause effectively instantaneously.