### PR TITLE
Allow float values for dash parameter

### DIFF
--- a/core/shaders/polyline.fs
+++ b/core/shaders/polyline.fs
@@ -65,7 +65,7 @@ void main(void) {
     #endif
 
     #ifdef TANGRAM_LINE_TEXTURE
-        vec2 line_st = vec2(v_texcoord.x, fract(v_texcoord.y / u_texture_ratio));
+        vec2 line_st = vec2(v_texcoord.x, fract(v_texcoord.y * TANGRAM_DASHLINE_TEX_SCALE / u_texture_ratio));
         vec4 line_color = texture2D(u_texture, line_st);
 
         if (line_color.a < TANGRAM_ALPHA_TEST) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -792,9 +792,9 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, const std::shared
     if (Node dashNode = styleNode["dash"]) {
         if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&style)) {
             if (dashNode.IsSequence()) {
-                std::vector<int> dashValues;
+                std::vector<float> dashValues;
                 for (auto dashValue : dashNode) {
-                    dashValues.push_back(dashValue.as<int>());
+                    dashValues.push_back(dashValue.as<float>());
                 }
                 polylineStyle->setDashArray(dashValues);
                 polylineStyle->setTexCoordsGeneration(true);

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -123,7 +123,7 @@ void PolylineStyle::constructShaderProgram() {
             m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_LINE_BACKGROUND_COLOR vec3(" +
                 std::to_string(m_dashBackgroundColor.r) + ", " +
                 std::to_string(m_dashBackgroundColor.g) + ", " +
-                std::to_string(m_dashBackgroundColor.b) + ")");
+                std::to_string(m_dashBackgroundColor.b) + ")\n");
         }
     }
 
@@ -134,7 +134,7 @@ void PolylineStyle::constructShaderProgram() {
             m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE " +
                                                 std::to_string(dash_scale) + "\n", false);
         } else {
-            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE 1",
+            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE 1\n",
                                             false);
         }
     }

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -27,6 +27,7 @@ constexpr float extrusion_scale = 4096.0f;
 constexpr float position_scale = 8192.0f;
 constexpr float texture_scale = 8192.0f;
 constexpr float order_scale = 2.0f;
+constexpr float dash_scale = 20.f;
 
 namespace Tangram {
 
@@ -112,7 +113,8 @@ void PolylineStyle::constructShaderProgram() {
 
     if (m_dashArray.size() > 0) {
         TextureOptions options {GL_RGBA, GL_RGBA, {GL_NEAREST, GL_NEAREST}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}};
-        auto pixels = DashArray::render(m_dashArray);
+        // provides precision for dash patterns that are a fraction of line width
+        auto pixels = DashArray::render(m_dashArray, dash_scale);
 
         m_texture = std::make_shared<Texture>(1, pixels.size(), options);
         m_texture->setData(pixels.data(), pixels.size());
@@ -128,6 +130,13 @@ void PolylineStyle::constructShaderProgram() {
     if (m_dashArray.size() > 0 || m_texture) {
         m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_LINE_TEXTURE\n", false);
         m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_ALPHA_TEST 0.25\n", false);
+        if (m_dashArray.size() > 0) {
+            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE " +
+                                                std::to_string(dash_scale) + "\n", false);
+        } else {
+            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE 1",
+                                            false);
+        }
     }
 
     m_shaderProgram->setSourceStrings(SHADER_SOURCE(polyline_fs),

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -132,10 +132,9 @@ void PolylineStyle::constructShaderProgram() {
         m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_ALPHA_TEST 0.25\n", false);
         if (m_dashArray.size() > 0) {
             m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE " +
-                                                std::to_string(dash_scale) + "\n", false);
+                                            std::to_string(dash_scale) + "\n", false);
         } else {
-            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE 1\n",
-                                            false);
+            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE 1.0\n", false);
         }
     }
 

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -18,14 +18,14 @@ public:
     virtual void onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _scene) override;
     virtual ~PolylineStyle() {}
 
-    void setDashArray(std::vector<int> _dashArray) { m_dashArray = _dashArray; }
+    void setDashArray(std::vector<float> _dashArray) { m_dashArray = _dashArray; }
     void setTexture(std::shared_ptr<Texture>& _texture) { m_texture = _texture; }
 
     void setDashBackgroundColor(const glm::vec4 _dashBackgroundColor);
 
 private:
 
-    std::vector<int> m_dashArray;
+    std::vector<float> m_dashArray;
     std::shared_ptr<Texture> m_texture;
     bool m_dashBackground = false;
     glm::vec4 m_dashBackgroundColor;

--- a/core/src/util/dashArray.cpp
+++ b/core/src/util/dashArray.cpp
@@ -1,8 +1,9 @@
+#include <cmath>
 #include "dashArray.h"
 
 namespace Tangram {
 
-std::vector<unsigned int> DashArray::render(std::vector<int> _pattern,
+std::vector<unsigned int> DashArray::render(std::vector<float> _pattern, float _dashScale,
     unsigned int _dashColor, unsigned int _backgroundColor)
 {
     std::vector<unsigned int> dashArray;
@@ -11,7 +12,8 @@ std::vector<unsigned int> DashArray::render(std::vector<int> _pattern,
     }
 
     bool dash = true;
-    for (int segment : _pattern) {
+    for (auto& pat : _pattern) {
+        int segment = std::floor(pat * _dashScale);
         for (int i = 0; i < segment; ++i) {
             dashArray.push_back(dash ? _dashColor : _backgroundColor);
         }

--- a/core/src/util/dashArray.h
+++ b/core/src/util/dashArray.h
@@ -5,7 +5,7 @@
 namespace Tangram {
 
 struct DashArray {
-    static std::vector<unsigned int> render(std::vector<int> _pattern,
+    static std::vector<unsigned int> render(std::vector<float> _pattern, float _dashScale,
         unsigned int _dashColor = 0xffffffff,
         unsigned int _backgroundColor = 0x00000000);
 };

--- a/scenes/scene.yaml
+++ b/scenes/scene.yaml
@@ -73,7 +73,7 @@ styles:
         texture: pois
     dashed:
         base: lines
-        dash: [2, 1]
+        dash: [3.0, 0.3]
     transit-lines:
         base: lines
         blend: overlay


### PR DESCRIPTION
- Parse float values
- Scale dash values with a fixed scale factor "20" (In accordance with JS) before filling the dash
texture
- Make sure to adjust texture coordinate to account for the texture data
- fixes #951