### PR TITLE
Scene sets the pixel scale of its Styles

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -141,4 +141,11 @@ std::shared_ptr<TileSource> Scene::getTileSource(const std::string& name) {
     return nullptr;
 }
 
+void Scene::setPixelScale(float _scale) {
+    m_pixelScale = _scale;
+    for (auto& style : m_styles) {
+        style->setPixelScale(_scale);
+    }
+}
+
 }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -118,7 +118,7 @@ public:
     std::shared_ptr<Texture> getTexture(const std::string& name) const;
 
     float pixelScale() { return m_pixelScale; }
-    void setPixelScale(float _scale) { m_pixelScale = _scale; }
+    void setPixelScale(float _scale);
 
     std::atomic_ushort pendingTextures{0};
     std::atomic_ushort pendingFonts{0};

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -157,7 +157,6 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
     tileManager.setTileSources(_scene->tileSources());
     tileWorker.setScene(_scene);
     markerManager.setScene(_scene);
-    setPixelScale(view.pixelScale());
 
     bool animated = scene->animated() == Scene::animate::yes;
 
@@ -685,9 +684,7 @@ void Map::Impl::setPixelScale(float _pixelsPerPoint) {
     }
     view.setPixelScale(_pixelsPerPoint);
     scene->setPixelScale(_pixelsPerPoint);
-    for (auto& style : scene->styles()) {
-        style->setPixelScale(_pixelsPerPoint);
-    }
+
     // Tiles must be rebuilt to apply the new pixel scale to labels.
     tileManager.clearTileSets();
 


### PR DESCRIPTION
The Scene 'owns' its Styles, so when setting a pixel scale for the Scene, it should be applied to Styles in the Scene too.

This fixes a previous inconsistency: the correct pixel scale was set on the Scene in `Map::Impl::setScene`, but the Styles in the Scene would still have their default pixel scale.

This solves the same problem as https://github.com/tangrams/tangram-es/pull/1252, but I think this refactoring could spare us from similar problems in the future.