### PR TITLE
Scale SDF radius in FontContext with pixel scale

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -146,6 +146,7 @@ void Scene::setPixelScale(float _scale) {
     for (auto& style : m_styles) {
         style->setPixelScale(_scale);
     }
+    m_fontContext->setPixelScale(_scale);
 }
 
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -23,6 +23,10 @@ FontContext::FontContext() :
     m_atlas(*this, GlyphTexture::size, m_sdfRadius),
     m_batch(m_atlas, m_scratch) {}
 
+void FontContext::setPixelScale(float _scale) {
+    m_sdfRadius = SDF_WIDTH * _scale;
+}
+
 void FontContext::loadFonts() {
     auto fallbacks = systemFontFallbacksHandle();
 

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -117,6 +117,8 @@ public:
 
     void addFont(const FontDescription& _ft, alfons::InputSource _source);
 
+    void setPixelScale(float _scale);
+
 private:
 
     float m_sdfRadius;


### PR DESCRIPTION
This should drastically reduce the frequency of the familiar log message: `NOTIFY textStyleBuilder.cpp:506: stroke_width too large: 12.000000 / 2.000000`. 

In FontContext, the width of a text stroke in pixels is capped by the radius used when generating SDFs, which is initialized to a value of 6 pixels. This is large enough for most reasonable strokes, but previously it _did not_ scale with pixel density! This meant that on a 2x display our maximum stroke was 3 pixels, on 3x it was 2 pixels, etc. 

The change here applies the pixel scale to the SDF radius in FontContext, allowing for a much more reasonable range of stroke widths.