### PR TITLE
Parse and Implement px2 for layer filter

### DIFF
--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -364,7 +364,7 @@ struct matcher {
         return Value::visit(value, match_equal{f.value});
     }
     bool operator() (const Filter::Range& f) const {
-        auto scale = (f.hasSqArea) ? ctx.getSquareAreaScale() : 1.f;
+        auto scale = (f.hasPixelArea) ? ctx.getPixelAreaScale() : 1.f;
         auto& value = (f.keyword == FilterKeyword::undefined)
             ? props.get(f.key)
             : ctx.getKeyword(f.keyword);

--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -306,9 +306,10 @@ struct match_equal {
 
 struct match_range {
     const Filter::Range& f;
+    double scale = 1.f;
 
     bool operator() (const double& num) const {
-        return num >= f.min && num < f.max;
+        return num >= f.min * scale && num < f.max * scale;
     }
     bool operator() (const std::string&) const { return false; }
     bool operator() (const none_type&) const { return false; }
@@ -363,11 +364,11 @@ struct matcher {
         return Value::visit(value, match_equal{f.value});
     }
     bool operator() (const Filter::Range& f) const {
+        auto scale = (f.hasSqArea) ? ctx.getSquareAreaScale() : 1.f;
         auto& value = (f.keyword == FilterKeyword::undefined)
             ? props.get(f.key)
             : ctx.getKeyword(f.keyword);
-
-        return Value::visit(value, match_range{f});
+        return Value::visit(value, match_range{f, scale});
     }
     bool operator() (const Filter::Function& f) const {
         return ctx.evalFilter(f.id);

--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -306,7 +306,7 @@ struct match_equal {
 
 struct match_range {
     const Filter::Range& f;
-    double scale = 1.f;
+    double scale;
 
     bool operator() (const double& num) const {
         return num >= f.min * scale && num < f.max * scale;

--- a/core/src/scene/filters.h
+++ b/core/src/scene/filters.h
@@ -42,7 +42,7 @@ struct Filter {
         float min;
         float max;
         FilterKeyword keyword;
-        bool hasSqArea = false;
+        bool hasSqArea;
     };
     struct Existence {
         std::string key;

--- a/core/src/scene/filters.h
+++ b/core/src/scene/filters.h
@@ -42,7 +42,7 @@ struct Filter {
         float min;
         float max;
         FilterKeyword keyword;
-        bool hasSqArea;
+        bool hasPixelArea;
     };
     struct Existence {
         std::string key;

--- a/core/src/scene/filters.h
+++ b/core/src/scene/filters.h
@@ -42,6 +42,7 @@ struct Filter {
         float min;
         float max;
         FilterKeyword keyword;
+        bool hasSqArea = false;
     };
     struct Existence {
         std::string key;
@@ -88,8 +89,8 @@ struct Filter {
         }
     }
     // Create a 'range' filter
-    inline static Filter MatchRange(const std::string& k, float min, float max) {
-        return { Range{ k, min, max, keywordType(k) }};
+    inline static Filter MatchRange(const std::string& k, float min, float max, bool sqA) {
+        return { Range{ k, min, max, keywordType(k), sqA }};
     }
     // Create an 'existence' filter
     inline static Filter MatchExistence(const std::string& k, bool ex) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1324,39 +1324,39 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
     case NodeType::Map: {
         double minVal = -std::numeric_limits<double>::infinity();
         double maxVal = std::numeric_limits<double>::infinity();
-        bool hasMinSqArea = false;
-        bool hasMaxSqArea = false;
+        bool hasMinPixelArea = false;
+        bool hasMaxPixelArea = false;
 
         for (const auto& n : _node) {
             if (n.first.Scalar() == "min") {
-                if(!getFilterRangeValue(n.second, minVal, hasMinSqArea)) {
+                if(!getFilterRangeValue(n.second, minVal, hasMinPixelArea)) {
                     return Filter();
                 }
             } else if (n.first.Scalar() == "max") {
-                if (!getFilterRangeValue(n.second, maxVal, hasMaxSqArea)) {
+                if (!getFilterRangeValue(n.second, maxVal, hasMaxPixelArea)) {
                     return Filter();
                 }
             }
         }
 
         if (_node["max"].IsScalar() && _node["min"].IsScalar() &&
-                (hasMinSqArea != hasMaxSqArea)) { return Filter(); }
+                (hasMinPixelArea != hasMaxPixelArea)) { return Filter(); }
 
-        return Filter::MatchRange(_key, minVal, maxVal, hasMinSqArea | hasMaxSqArea);
+        return Filter::MatchRange(_key, minVal, maxVal, hasMinPixelArea | hasMaxPixelArea);
     }
     default:
         return Filter();
     }
 }
 
-bool SceneLoader::getFilterRangeValue(const Node& node, double& val, bool& hasSqArea) {
+bool SceneLoader::getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea) {
     if (!getDouble(node, val)) {
         auto strVal = node.Scalar();
         auto n = strVal.find("px2");
         if (n == std::string::npos) { return false; }
         try {
             val = std::stof(std::string(strVal, 0, n));
-            hasSqArea = true;
+            hasPixelArea = true;
         } catch (std::invalid_argument) { return false; }
     }
     return true;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1324,27 +1324,42 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
     case NodeType::Map: {
         double minVal = -std::numeric_limits<double>::infinity();
         double maxVal = std::numeric_limits<double>::infinity();
+        bool hasMinSqArea = false;
+        bool hasMaxSqArea = false;
 
-        for (const auto& valItr : _node) {
-            if (valItr.first.Scalar() == "min") {
-
-                if (!getDouble(valItr.second, minVal, "min")) {
+        for (const auto& n : _node) {
+            if (n.first.Scalar() == "min") {
+                if(!getFilterRangeValue(n.second, minVal, hasMinSqArea)) {
                     return Filter();
                 }
-            } else if (valItr.first.Scalar() == "max") {
-
-                if (!getDouble(valItr.second, maxVal, "max")) {
+            } else if (n.first.Scalar() == "max") {
+                if (!getFilterRangeValue(n.second, maxVal, hasMaxSqArea)) {
                     return Filter();
                 }
-            } else {
-                return Filter();
             }
         }
-        return Filter::MatchRange(_key, minVal, maxVal);
+
+        if (_node["max"].IsScalar() && _node["min"].IsScalar() &&
+                (hasMinSqArea != hasMaxSqArea)) { return Filter(); }
+
+        return Filter::MatchRange(_key, minVal, maxVal, hasMinSqArea | hasMaxSqArea);
     }
     default:
         return Filter();
     }
+}
+
+bool SceneLoader::getFilterRangeValue(const Node& node, double& val, bool& hasSqArea) {
+    if (!getDouble(node, val)) {
+        auto strVal = node.Scalar();
+        auto n = strVal.find("px2");
+        if (n == std::string::npos) { return false; }
+        try {
+            val = std::stof(std::string(strVal, 0, n));
+            hasSqArea = true;
+        } catch (std::invalid_argument) { return false; }
+    }
+    return true;
 }
 
 Filter SceneLoader::generateAnyFilter(Node _filter, Scene& scene) {

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -66,6 +66,7 @@ struct SceneLoader {
     static Filter generateAllFilter(Node filter, Scene& scene);
     static Filter generateNoneFilter(Node filter, Scene& scene);
     static Filter generatePredicate(Node filter, std::string _key);
+    static bool getFilterRangeValue(const Node& node, double& val, bool& hasSqArea);
     /* loads a texture with default texture properties */
     static bool loadTexture(const std::string& url, const std::shared_ptr<Scene>& scene);
     static std::shared_ptr<Texture> fetchTexture(const std::string& name, const std::string& url,

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -66,7 +66,7 @@ struct SceneLoader {
     static Filter generateAllFilter(Node filter, Scene& scene);
     static Filter generateNoneFilter(Node filter, Scene& scene);
     static Filter generatePredicate(Node filter, std::string _key);
-    static bool getFilterRangeValue(const Node& node, double& val, bool& hasSqArea);
+    static bool getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea);
     /* loads a texture with default texture properties */
     static bool loadTexture(const std::string& url, const std::shared_ptr<Scene>& scene);
     static std::shared_ptr<Texture> fetchTexture(const std::string& name, const std::string& url,

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -5,6 +5,7 @@
 #include "data/tileData.h"
 #include "scene/filters.h"
 #include "scene/scene.h"
+#include "util/mapProjection.h"
 #include "util/builders.h"
 #include "log.h"
 
@@ -275,6 +276,13 @@ void StyleContext::setKeyword(const std::string& _key, Value _val) {
     }
 
     entry = std::move(_val);
+}
+
+float StyleContext::getSquareAreaScale() {
+    // scale the filter value with pixelsPerMeter
+    // used with `px2` area filtering
+    double metersPerPixel = 2.f * MapProjection::HALF_CIRCUMFERENCE * exp2(-m_keywordZoom) / View::s_pixelsPerTile;
+    return metersPerPixel * metersPerPixel;
 }
 
 const Value& StyleContext::getKeyword(const std::string& _key) const {

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -278,7 +278,7 @@ void StyleContext::setKeyword(const std::string& _key, Value _val) {
     entry = std::move(_val);
 }
 
-float StyleContext::getSquareAreaScale() {
+float StyleContext::getPixelAreaScale() {
     // scale the filter value with pixelsPerMeter
     // used with `px2` area filtering
     double metersPerPixel = 2.f * MapProjection::HALF_CIRCUMFERENCE * exp2(-m_keywordZoom) / View::s_pixelsPerTile;

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -48,6 +48,9 @@ public:
     /* Called from Filter::eval */
     float getKeywordZoom() const { return m_keywordZoom; }
 
+    /* returns meters per pixels at current style zoom */
+    float getSquareAreaScale();
+
     const Value& getKeyword(FilterKeyword _key) const {
         return m_keywords[static_cast<uint8_t>(_key)];
     }

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -49,7 +49,7 @@ public:
     float getKeywordZoom() const { return m_keywordZoom; }
 
     /* returns meters per pixels at current style zoom */
-    float getSquareAreaScale();
+    float getPixelAreaScale();
 
     const Value& getKeyword(FilterKeyword _key) const {
         return m_keywords[static_cast<uint8_t>(_key)];

--- a/scenes/scene.yaml
+++ b/scenes/scene.yaml
@@ -135,14 +135,7 @@ layers:
         data: { source: osm }
         filter:
             - { $zoom: { min: 16 } }
-            #TODO: "px2" range unit support for ES, and remove extended any area filter
-            - any:
-                - { $zoom: { min: 9 }, area: { min: 10000000 } }
-                - { $zoom: { min: 10 }, area: { min: 3300000 } }
-                - { $zoom: { min: 12 }, area: { min: 1000000 } }
-                - { $zoom: { min: 13 }, area: { min: 10000 } }
-                - { $zoom: { min: 15 } }
-            #- { area: { min: 500px2 } }
+            - { area: { min: 500px2 } }
         areas:
             draw:
                 polygons:
@@ -468,8 +461,7 @@ layers:
                 kind: [park, cemetery, graveyard]
                 any:
                     - { $zoom: { min: 16 } }
-                    #TODO: "px2" range unit support for ES
-                    #- { area: { min: 500px2 } }
+                    - { area: { min: 500px2 } }
             draw:
                 icons:
                     sprite: tree


### PR DESCRIPTION
- Fixes #972 
For details on the usage of `px2` for filtering rules: https://github.com/tangrams/tangram/pull/395
