### PR TITLE
With polygon geometry text style should be drawn at centroid

### DIFF
--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -430,11 +430,11 @@ bool PointStyleBuilder::addPolygon(const Polygon& _polygon, const Properties& _p
             labelPointsPlacing(line, uvsQuad, p, _rule);
         }
     } else {
-        glm::vec3 c;
         if (!_polygon.empty()) {
+            glm::vec3 c;
             c = centroid(_polygon.front().begin(), _polygon.front().end());
+            addLabel(c, uvsQuad, p, _rule);
         }
-        addLabel(c, uvsQuad, p, _rule);
     }
 
     return true;

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -189,11 +189,12 @@ bool TextStyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) {
 
     } else if (_feat.geometryType == GeometryType::polygons) {
 
-        for (auto& polygon : _feat.polygons) {
-            for (auto& line : polygon) {
-                for (auto& point : line) {
-                    addLabel(params, Label::Type::point, { point }, _rule);
-                }
+        const auto& polygons = _feat.polygons;
+        for (const auto& polygon : polygons) {
+            if (!polygon.empty()) {
+                glm::vec3 c;
+                c = centroid(polygon.front().begin(), polygon.front().end());
+                addLabel(params, Label::Type::point, { c }, _rule);
             }
         }
 


### PR DESCRIPTION
Based on the [documentation](https://mapzen.com/documentation/tangram/Styles-Overview/#text) for a polygon geometry text should be drawn at the centroid of the polygon. 

Also tested this in play for tangram js behavior.