### PR TITLE
Style shader cache

### DIFF
--- a/core/src/debug/textDisplay.cpp
+++ b/core/src/debug/textDisplay.cpp
@@ -52,7 +52,7 @@ void TextDisplay::init() {
     )END";
 
     m_shader = std::make_unique<ShaderProgram>();
-    m_shader->setSourceStrings(fragShaderSrcStr, vertShaderSrcStr);
+    m_shader->setShaderSource(vertShaderSrcStr, fragShaderSrcStr);
 
     m_initialized = true;
 }

--- a/core/src/gl/primitives.cpp
+++ b/core/src/gl/primitives.cpp
@@ -38,8 +38,8 @@ void init() {
     if (!s_initialized) {
         s_shader = std::make_unique<ShaderProgram>();
 
-        s_shader->setSourceStrings(SHADER_SOURCE(debugPrimitive_fs),
-                                   SHADER_SOURCE(debugPrimitive_vs));
+        s_shader->setShaderSource(SHADER_SOURCE(debugPrimitive_vs),
+                                  SHADER_SOURCE(debugPrimitive_fs));
 
         s_layout = std::unique_ptr<VertexLayout>(new VertexLayout({
             {"a_position", 2, GL_FLOAT, false, 0},
@@ -48,8 +48,8 @@ void init() {
 
         s_textureShader = std::make_unique<ShaderProgram>();
 
-        s_textureShader->setSourceStrings(SHADER_SOURCE(debugTexture_fs),
-                                          SHADER_SOURCE(debugTexture_vs));
+        s_textureShader->setShaderSource(SHADER_SOURCE(debugTexture_vs),
+                                         SHADER_SOURCE(debugTexture_fs));
 
         s_textureLayout = std::unique_ptr<VertexLayout>(new VertexLayout({
             {"a_position", 2, GL_FLOAT, false, 0},

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -7,10 +7,6 @@
 #include "glm/gtc/type_ptr.hpp"
 #include "log.h"
 
-#include <sstream>
-#include <regex>
-#include <set>
-
 namespace Tangram {
 
 ShaderProgram::ShaderProgram() {
@@ -29,43 +25,6 @@ ShaderProgram::~ShaderProgram() {
         // so we un-set the current program in the render state.
         rs.shaderProgramUnset(glProgram);
     });
-}
-
-void ShaderProgram::setSourceStrings(const std::string& _fragSrc, const std::string& _vertSrc){
-    m_fragmentShaderSource = std::string(_fragSrc);
-    m_vertexShaderSource = std::string(_vertSrc);
-    m_needsBuild = true;
-}
-
-void ShaderProgram::addSourceBlock(const std::string& _tagName, const std::string& _glslSource, bool _allowDuplicate){
-
-    if (!_allowDuplicate) {
-        for (auto& source : m_sourceBlocks[_tagName]) {
-            if (_glslSource == source) {
-                return;
-            }
-        }
-    }
-
-    size_t start = 0;
-    std::string sourceBlock = _glslSource;
-
-    // Certain graphics drivers have issues with shaders having line continuation backslashes "\".
-    // Example raster.glsl was having issues on s6 and note2 because of the "\"s in the glsl file.
-    // This also makes sure if any "\"s are present in the shaders coming from style sheet will be
-    // taken care of.
-
-    // Replace blackslash+newline with spaces (simplification of regex "\\\\\\s*\\n")
-    while ((start = sourceBlock.find("\\\n", start)) != std::string::npos) {
-        sourceBlock.replace(start, 2, "  ");
-        start += 2;
-    }
-
-    m_sourceBlocks[_tagName].push_back(sourceBlock);
-    m_needsBuild = true;
-
-    //  TODO:
-    //          - add Global Blocks
 }
 
 GLint ShaderProgram::getAttribLocation(const std::string& _attribName) {
@@ -113,9 +72,8 @@ bool ShaderProgram::build(RenderState& rs) {
     GL::deleteProgram(m_glProgram);
     m_glProgram = 0;
 
-    // Inject source blocks
-    auto vertSrc = applySourceBlocks(m_vertexShaderSource, false);
-    auto fragSrc = applySourceBlocks(m_fragmentShaderSource, true);
+    auto& vertSrc = m_vertexShaderSource;
+    auto& fragSrc = m_fragmentShaderSource;
 
     // Compile vertex and fragment shaders
     GLint vertexShader = makeCompiledShader(rs, vertSrc, GL_VERTEX_SHADER);
@@ -239,74 +197,6 @@ GLuint ShaderProgram::makeCompiledShader(RenderState& rs, const std::string& _sr
     entry.first->second = shader;
 
     return shader;
-}
-
-std::string ShaderProgram::applySourceBlocks(const std::string& source, bool fragShader) const {
-
-    std::stringstream sourceOut;
-    std::set<std::string> pragmas;
-
-    sourceOut << "#define TANGRAM_EPSILON 0.00001\n";
-    sourceOut << "#define TANGRAM_WORLD_POSITION_WRAP 100000.\n";
-
-    if (fragShader) {
-        sourceOut << "#define TANGRAM_FRAGMENT_SHADER\n";
-    } else {
-        float depthDelta = 2.f / (1 << 16);
-        sourceOut << "#define TANGRAM_DEPTH_DELTA " << std::to_string(depthDelta) << '\n';
-        sourceOut << "#define TANGRAM_VERTEX_SHADER\n";
-    }
-
-    std::stringstream sourceIn(source);
-    std::string line;
-
-    while (std::getline(sourceIn, line)) {
-        if (line.empty()) {
-            continue;
-        }
-
-        sourceOut << line << '\n';
-
-        char pragmaName[128];
-        // NB: The initial whitespace is to skip any number of whitespace chars
-        if (sscanf(line.c_str(), " #pragma tangram:%127s", pragmaName) == 0) {
-            continue;
-        }
-
-        auto block = m_sourceBlocks.find(pragmaName);
-        if (block == m_sourceBlocks.end()) {
-            continue;
-        }
-
-        bool unique;
-        std::tie(std::ignore, unique) = pragmas.emplace(pragmaName);
-        if (!unique) {
-            continue;
-        }
-
-        // insert blocks
-        for (auto& s : block->second) {
-            sourceOut << s << '\n';
-        }
-    }
-
-    // for (auto& block : m_sourceBlocks) {
-    //     if (pragmas.find(block.first) == pragmas.end()) {
-    //         logMsg("Warning: expected pragma '%s' in shader source\n",
-    //                block.first.c_str());
-    //     }
-    // }
-
-    return sourceOut.str();
-}
-
-std::string ShaderProgram::getExtensionDeclaration(const std::string& _extension) {
-    std::ostringstream oss;
-    oss << "#if defined(GL_ES) == 0 || defined(GL_" << _extension << ")\n";
-    oss << "    #extension GL_" << _extension << " : enable\n";
-    oss << "    #define TANGRAM_EXTENSION_" << _extension << '\n';
-    oss << "#endif\n";
-    return oss.str();
 }
 
 void ShaderProgram::setUniformi(RenderState& rs, const UniformLocation& _loc, int _value) {

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -1,7 +1,6 @@
 #include "shaderProgram.h"
 
 #include "platform.h"
-#include "scene/light.h"
 #include "gl/disposer.h"
 #include "gl/error.h"
 #include "gl/renderState.h"
@@ -115,8 +114,6 @@ bool ShaderProgram::build(RenderState& rs) {
     m_glProgram = 0;
 
     // Inject source blocks
-    Light::assembleLights(m_sourceBlocks);
-
     auto vertSrc = applySourceBlocks(m_vertexShaderSource, false);
     auto fragSrc = applySourceBlocks(m_fragmentShaderSource, true);
 

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -2,6 +2,7 @@
 
 #include "gl.h"
 #include "gl/disposer.h"
+#include "gl/shaderSource.h"
 #include "uniform.h"
 #include "util/fastmap.h"
 
@@ -9,7 +10,6 @@
 
 #include <string>
 #include <vector>
-#include <map>
 #include <memory>
 
 namespace Tangram {
@@ -26,11 +26,11 @@ public:
     ShaderProgram();
     ~ShaderProgram();
 
-    // Set the vertex and fragment shader GLSL source to the given strings/
-    void setSourceStrings(const std::string& _fragSrc, const std::string& _vertSrc);
-
-    // Add a block of GLSL to be injected at "#pragma tangram: [_tagName]" in the shader sources.
-    void addSourceBlock(const std::string& _tagName, const std::string& _glslSource, bool _allowDuplicate = true);
+    void setShaderSource(const std::string& _vertSrc, const std::string& _fragSrc) {
+        m_fragmentShaderSource = _fragSrc;
+        m_vertexShaderSource = _vertSrc;
+        m_needsBuild = true;
+    }
 
     // Apply all source blocks to the source strings for this shader and attempt to compile
     // and then link the resulting vertex and fragment shaders; if compiling or linking fails
@@ -42,9 +42,6 @@ public:
     GLuint getGlProgram() const { return m_glProgram; };
 
     std::string getDescription() const { return m_description; }
-
-    const std::string& getFragmentShaderSource() const { return m_fragmentShaderSource; }
-    const std::string getVertexShaderSource() const { return applySourceBlocks(m_vertexShaderSource, false); }
 
     // Fetch the location of a shader attribute, caching the result.
     GLint getAttribLocation(const std::string& _attribName);
@@ -86,23 +83,7 @@ public:
     void setUniformMatrix3f(RenderState& rs, const UniformLocation& _loc, const glm::mat3& _value, bool transpose = false);
     void setUniformMatrix4f(RenderState& rs, const UniformLocation& _loc, const glm::mat4& _value, bool transpose = false);
 
-    static std::string getExtensionDeclaration(const std::string& _extension);
-
-    auto getSourceBlocks() const { return  m_sourceBlocks; }
-
     void setDescription(std::string _description) { m_description = _description; }
-
-    static std::string shaderSourceBlock(const unsigned char* data, size_t size) {
-        std::string block;
-        if (data[size - 1] == '\n') {
-            block.append(reinterpret_cast<const char*>(data), size);
-        } else {
-            block.reserve(size + 2);
-            block.append(reinterpret_cast<const char*>(data), size);
-            block += '\n';
-        }
-        return block;
-    }
 
     static GLuint makeLinkedShaderProgram(GLint _fragShader, GLint _vertShader);
     static GLuint makeCompiledShader(RenderState& rs, const std::string& _src, GLenum _type);
@@ -134,16 +115,10 @@ private:
     // An optional shader description printed on compile failure
     std::string m_description;
 
-    std::map<std::string, std::vector<std::string>> m_sourceBlocks;
-
     bool m_needsBuild = true;
 
     Disposer m_disposer;
 
-    std::string applySourceBlocks(const std::string& source, bool fragShader) const;
-
 };
-
-#define SHADER_SOURCE(NAME) ShaderProgram::shaderSourceBlock(NAME ## _data, NAME ## _size)
 
 }

--- a/core/src/gl/shaderProgram.h
+++ b/core/src/gl/shaderProgram.h
@@ -88,6 +88,9 @@ public:
     static GLuint makeLinkedShaderProgram(GLint _fragShader, GLint _vertShader);
     static GLuint makeCompiledShader(RenderState& rs, const std::string& _src, GLenum _type);
 
+    const std::string& vertexShaderSource() { return m_vertexShaderSource; }
+    const std::string& fragmentShaderSource() { return m_fragmentShaderSource; }
+
 private:
 
     // Get a uniform value from the cache, and returns false when it's a cache miss

--- a/core/src/gl/shaderSource.cpp
+++ b/core/src/gl/shaderSource.cpp
@@ -1,0 +1,119 @@
+#include "shaderSource.h"
+
+#include <set>
+#include <sstream>
+
+#include "shaders/selection_fs.h"
+
+namespace Tangram {
+
+void ShaderSource::setSourceStrings(const std::string& _fragSrc, const std::string& _vertSrc){
+    m_fragmentShaderSource = std::string(_fragSrc);
+    m_vertexShaderSource = std::string(_vertSrc);
+}
+
+void ShaderSource::addSourceBlock(const std::string& _tagName, const std::string& _glslSource, bool _allowDuplicate){
+
+    if (!_allowDuplicate) {
+        for (auto& source : m_sourceBlocks[_tagName]) {
+            if (_glslSource == source) {
+                return;
+            }
+        }
+    }
+
+    size_t start = 0;
+    std::string sourceBlock = _glslSource;
+
+    // Certain graphics drivers have issues with shaders having line continuation backslashes "\".
+    // Example raster.glsl was having issues on s6 and note2 because of the "\"s in the glsl file.
+    // This also makes sure if any "\"s are present in the shaders coming from style sheet will be
+    // taken care of.
+
+    // Replace blackslash+newline with spaces (simplification of regex "\\\\\\s*\\n")
+    while ((start = sourceBlock.find("\\\n", start)) != std::string::npos) {
+        sourceBlock.replace(start, 2, "  ");
+        start += 2;
+    }
+
+    m_sourceBlocks[_tagName].push_back(sourceBlock);
+}
+
+std::string ShaderSource::applySourceBlocks(const std::string& _source, bool _fragShader, bool _selection) const {
+
+    std::stringstream sourceOut;
+    std::set<std::string> pragmas;
+
+    sourceOut << "#define TANGRAM_EPSILON 0.00001\n";
+    sourceOut << "#define TANGRAM_WORLD_POSITION_WRAP 100000.\n";
+
+    if (_fragShader) {
+        sourceOut << "#define TANGRAM_FRAGMENT_SHADER\n";
+    } else {
+        float depthDelta = 2.f / (1 << 16);
+        sourceOut << "#define TANGRAM_DEPTH_DELTA " << std::to_string(depthDelta) << '\n';
+        sourceOut << "#define TANGRAM_VERTEX_SHADER\n";
+    }
+
+    if (_selection) {
+        sourceOut <<  "#define TANGRAM_FEATURE_SELECTION\n";
+    }
+
+    std::stringstream sourceIn(_source);
+    std::string line;
+
+    while (std::getline(sourceIn, line)) {
+        if (line.empty()) {
+            continue;
+        }
+
+        sourceOut << line << '\n';
+
+        char pragmaName[128];
+        // NB: The initial whitespace is to skip any number of whitespace chars
+        if (sscanf(line.c_str(), " #pragma tangram:%127s", pragmaName) == 0) {
+            continue;
+        }
+
+        auto block = m_sourceBlocks.find(pragmaName);
+        if (block == m_sourceBlocks.end()) {
+            continue;
+        }
+
+        bool unique;
+        std::tie(std::ignore, unique) = pragmas.emplace(pragmaName);
+        if (!unique) {
+            continue;
+        }
+
+        // insert blocks
+        for (auto& s : block->second) {
+            sourceOut << s << '\n';
+        }
+    }
+
+    // for (auto& block : m_sourceBlocks) {
+    //     if (pragmas.find(block.first) == pragmas.end()) {
+    //         logMsg("Warning: expected pragma '%s' in shader source\n",
+    //                block.first.c_str());
+    //     }
+    // }
+
+    return sourceOut.str();
+}
+
+void ShaderSource::addExtensionDeclaration(const std::string& _extension) {
+    std::ostringstream oss;
+    oss << "#if defined(GL_ES) == 0 || defined(GL_" << _extension << ")\n";
+    oss << "    #extension GL_" << _extension << " : enable\n";
+    oss << "    #define TANGRAM_EXTENSION_" << _extension << '\n';
+    oss << "#endif\n";
+
+    addSourceBlock("extensions", oss.str());
+}
+
+std::string ShaderSource::selectionFragmentSource() const {
+    return SHADER_SOURCE(selection_fs);
+}
+
+}

--- a/core/src/gl/shaderSource.cpp
+++ b/core/src/gl/shaderSource.cpp
@@ -1,4 +1,4 @@
-#include "shaderSource.h"
+#include "gl/shaderSource.h"
 
 #include <set>
 #include <sstream>
@@ -112,7 +112,7 @@ void ShaderSource::addExtensionDeclaration(const std::string& _extension) {
     addSourceBlock("extensions", oss.str());
 }
 
-std::string ShaderSource::selectionFragmentSource() const {
+std::string ShaderSource::buildSelectionFragmentSource() const {
     return SHADER_SOURCE(selection_fs);
 }
 

--- a/core/src/gl/shaderSource.h
+++ b/core/src/gl/shaderSource.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#define SHADER_SOURCE(NAME) ShaderSource::shaderSourceBlock(NAME ## _data, NAME ## _size)
+
+namespace Tangram {
+
+class ShaderSource {
+public:
+
+    // Set the vertex and fragment shader GLSL source to the given strings/
+    void setSourceStrings(const std::string& _vertSrc, const std::string& _fragSrc);
+
+    // Add a block of GLSL to be injected at "#pragma tangram: [_tagName]" in the shader sources.
+    void addSourceBlock(const std::string& _tagName, const std::string& _glslSource,
+                        bool _allowDuplicate = true);
+
+    void addExtensionDeclaration(const std::string& _extension);
+
+    const auto& getSourceBlocks() const { return m_sourceBlocks; }
+
+    // Build vertex shader source
+    std::string vertexSource() const {
+        return applySourceBlocks(m_vertexShaderSource, false);
+    }
+
+    // Build fragment shader source
+    std::string fragmentSource() const {
+        return applySourceBlocks(m_fragmentShaderSource, true);
+    }
+
+    // Build selection vertex shader source
+    std::string selectionVertexSource() const  {
+        return applySourceBlocks(m_vertexShaderSource, false, true);
+    }
+
+    // Build selection fragment shader source
+    std::string selectionFragmentSource() const;
+
+
+    static std::string shaderSourceBlock(const unsigned char* data, size_t size) {
+        std::string block;
+        if (data[size - 1] == '\n') {
+            block.append(reinterpret_cast<const char*>(data), size);
+        } else {
+            block.reserve(size + 2);
+            block.append(reinterpret_cast<const char*>(data), size);
+            block += '\n';
+        }
+        return block;
+    }
+
+private:
+
+    std::string applySourceBlocks(const std::string& _source, bool _fragShader,
+                                  bool _selection = false) const;
+
+    std::map<std::string, std::vector<std::string>> m_sourceBlocks;
+
+    std::string m_vertexShaderSource = "";
+    std::string m_fragmentShaderSource = "";
+};
+
+}

--- a/core/src/gl/shaderSource.h
+++ b/core/src/gl/shaderSource.h
@@ -23,22 +23,22 @@ public:
     const auto& getSourceBlocks() const { return m_sourceBlocks; }
 
     // Build vertex shader source
-    std::string vertexSource() const {
+    std::string buildVertexSource() const {
         return applySourceBlocks(m_vertexShaderSource, false);
     }
 
     // Build fragment shader source
-    std::string fragmentSource() const {
+    std::string buildFragmentSource() const {
         return applySourceBlocks(m_fragmentShaderSource, true);
     }
 
     // Build selection vertex shader source
-    std::string selectionVertexSource() const  {
+    std::string buildSelectionVertexSource() const  {
         return applySourceBlocks(m_vertexShaderSource, false, true);
     }
 
     // Build selection fragment shader source
-    std::string selectionFragmentSource() const;
+    std::string buildSelectionFragmentSource() const;
 
 
     static std::string shaderSourceBlock(const unsigned char* data, size_t size) {

--- a/core/src/scene/ambientLight.cpp
+++ b/core/src/scene/ambientLight.cpp
@@ -18,8 +18,7 @@ AmbientLight::AmbientLight(const std::string& _name, bool _dynamic) :
 
 AmbientLight::~AmbientLight() {}
 
-std::unique_ptr<LightUniforms> AmbientLight::injectOnProgram(ShaderProgram& _shader) {
-    injectSourceBlocks(_shader);
+std::unique_ptr<LightUniforms> AmbientLight::getUniforms() {
 
     if (!m_dynamic) { return nullptr; }
 

--- a/core/src/scene/ambientLight.cpp
+++ b/core/src/scene/ambientLight.cpp
@@ -23,11 +23,12 @@ std::unique_ptr<LightUniforms> AmbientLight::injectOnProgram(ShaderProgram& _sha
 
     if (!m_dynamic) { return nullptr; }
 
-    return std::make_unique<LightUniforms>(_shader, getUniformName());
+    return std::make_unique<LightUniforms>(getUniformName());
 }
 
-void AmbientLight::setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms) {
-    Light::setupProgram(rs, _view, _uniforms);
+void AmbientLight::setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                                LightUniforms& _uniforms) {
+    Light::setupProgram(rs, _view, _shader, _uniforms);
 }
 
 std::string AmbientLight::getClassBlock() {

--- a/core/src/scene/ambientLight.h
+++ b/core/src/scene/ambientLight.h
@@ -10,7 +10,8 @@ public:
     AmbientLight(const std::string& _name, bool _dynamic = false);
     virtual ~AmbientLight();
     
-    virtual void setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms) override;
+    virtual void setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                              LightUniforms& _uniforms) override;
 
     std::unique_ptr<LightUniforms> injectOnProgram(ShaderProgram& _shader) override;
 

--- a/core/src/scene/ambientLight.h
+++ b/core/src/scene/ambientLight.h
@@ -13,7 +13,7 @@ public:
     virtual void setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
                               LightUniforms& _uniforms) override;
 
-    std::unique_ptr<LightUniforms> injectOnProgram(ShaderProgram& _shader) override;
+    std::unique_ptr<LightUniforms> getUniforms() override;
 
 protected:
 

--- a/core/src/scene/directionalLight.cpp
+++ b/core/src/scene/directionalLight.cpp
@@ -23,8 +23,7 @@ void DirectionalLight::setDirection(const glm::vec3 &_dir) {
     m_direction = glm::normalize(_dir);
 }
 
-std::unique_ptr<LightUniforms> DirectionalLight::injectOnProgram(ShaderProgram& _shader) {
-    injectSourceBlocks(_shader);
+std::unique_ptr<LightUniforms> DirectionalLight::getUniforms() {
 
     if (!m_dynamic) { return nullptr; }
 

--- a/core/src/scene/directionalLight.cpp
+++ b/core/src/scene/directionalLight.cpp
@@ -28,20 +28,21 @@ std::unique_ptr<LightUniforms> DirectionalLight::injectOnProgram(ShaderProgram& 
 
     if (!m_dynamic) { return nullptr; }
 
-    return std::make_unique<Uniforms>(_shader, getUniformName());
+    return std::make_unique<Uniforms>(getUniformName());
 }
 
-void DirectionalLight::setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms) {
+void DirectionalLight::setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                                    LightUniforms& _uniforms) {
 
     glm::vec3 direction = m_direction;
     if (m_origin == LightOrigin::world) {
         direction = _view.getNormalMatrix() * direction;
     }
 
-    Light::setupProgram(rs, _view, _uniforms);
+    Light::setupProgram(rs, _view, _shader, _uniforms);
 
     auto& u = static_cast<DirectionalLight::Uniforms&>(_uniforms);
-    u.shader.setUniformf(rs, u.direction, direction);
+    _shader.setUniformf(rs, u.direction, direction);
 }
 
 std::string DirectionalLight::getClassBlock() {

--- a/core/src/scene/directionalLight.h
+++ b/core/src/scene/directionalLight.h
@@ -28,7 +28,7 @@ public:
     };
 
 
-    std::unique_ptr<LightUniforms> injectOnProgram(ShaderProgram& _shader) override;
+    std::unique_ptr<LightUniforms> getUniforms() override;
 
 protected:
 

--- a/core/src/scene/directionalLight.h
+++ b/core/src/scene/directionalLight.h
@@ -15,12 +15,13 @@ public:
     /*	Set the direction of the light */
     virtual void setDirection(const glm::vec3& _dir);
 
-    virtual void setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms) override;
+    virtual void setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                              LightUniforms& _uniforms) override;
 
     struct Uniforms : public LightUniforms {
 
-        Uniforms(ShaderProgram& _shader, const std::string& _name)
-            : LightUniforms(_shader, _name),
+        Uniforms(const std::string& _name)
+            : LightUniforms(_name),
               direction(_name+".direction") {}
 
         UniformLocation direction;

--- a/core/src/scene/light.cpp
+++ b/core/src/scene/light.cpp
@@ -60,10 +60,11 @@ void Light::injectSourceBlocks(ShaderProgram& _shader) {
     _shader.addSourceBlock("__lights_to_compute", getInstanceComputeBlock());
 }
 
-void Light::setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms) {
-    _uniforms.shader.setUniformf(rs, _uniforms.ambient, m_ambient);
-    _uniforms.shader.setUniformf(rs, _uniforms.diffuse, m_diffuse);
-    _uniforms.shader.setUniformf(rs, _uniforms.specular, m_specular);
+void Light::setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                         LightUniforms& _uniforms) {
+    _shader.setUniformf(rs, _uniforms.ambient, m_ambient);
+    _shader.setUniformf(rs, _uniforms.diffuse, m_diffuse);
+    _shader.setUniformf(rs, _uniforms.specular, m_specular);
 }
 
 void Light::assembleLights(std::map<std::string, std::vector<std::string>>& _sourceBlocks) {

--- a/core/src/scene/light.cpp
+++ b/core/src/scene/light.cpp
@@ -7,6 +7,7 @@
 #include "shaders/lights_glsl.h"
 
 #include <sstream>
+#include <set>
 
 namespace Tangram {
 
@@ -45,20 +46,6 @@ void Light::setOrigin(LightOrigin origin) {
     m_origin = origin;
 }
 
-void Light::injectSourceBlocks(ShaderProgram& _shader) {
-
-    // Inject all needed #defines for this light instance
-    _shader.addSourceBlock("defines", getInstanceDefinesBlock(), false);
-
-    if (m_dynamic) {
-        // If the light is dynamic, initialize it using the corresponding uniform at the start of main()
-        _shader.addSourceBlock("setup", getInstanceName() + " = " + getUniformName() + ";", false);
-    }
-
-    _shader.addSourceBlock("__lighting", getClassBlock(), false);
-    _shader.addSourceBlock("__lighting", getInstanceBlock());
-    _shader.addSourceBlock("__lights_to_compute", getInstanceComputeBlock());
-}
 
 void Light::setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
                          LightUniforms& _uniforms) {
@@ -67,38 +54,64 @@ void Light::setupProgram(RenderState& rs, const View& _view, ShaderProgram& _sha
     _shader.setUniformf(rs, _uniforms.specular, m_specular);
 }
 
-void Light::assembleLights(std::map<std::string, std::vector<std::string>>& _sourceBlocks) {
+auto Light::assembleLights(const std::vector<std::unique_ptr<Light>>& _lights) ->
+    std::map<std::string, std::string> {
 
     // Create strings to contain the assembled lighting source code
     std::stringstream lighting;
 
-    // Concatenate all strings at the "__lighting" keys
-    // (struct definitions and function definitions)
-    for (const auto& string : _sourceBlocks["__lighting"]) {
-        lighting << '\n';
-        lighting << string;
+    std::map<std::string, std::string> sourceBlocks;
+
+    std::set<std::string> lightClasses;
+    std::set<std::string> lightDefines;
+    std::set<std::string> lightSetup;
+
+    for (auto& light : _lights) {
+        lightDefines.insert(light->getInstanceDefinesBlock());
+        lightClasses.insert(light->getClassBlock());
+        if (light->isDynamic()) {
+            lightSetup.insert(light->getInstanceName() + " = " + light->getUniformName() + ";");
+        }
     }
 
+    for (auto& string: lightClasses) {
+        lighting << '\n' << string;
+    }
+
+    std::stringstream definesBlock;
+    for (auto& string: lightDefines) {
+        definesBlock << '\n' << string;
+    }
+    sourceBlocks["defines"] = definesBlock.str();
+
+    std::stringstream setupBlock;
+    for (auto& string: lightSetup) {
+        setupBlock << '\n' << string;
+    }
+    sourceBlocks["setup"] = setupBlock.str();
+
+    for (auto& light : _lights) {
+        lighting << '\n' << light->getInstanceBlock();
+    }
     // After lights definitions are all added, add the main lighting functions
     std::string lightingBlock = SHADER_SOURCE(lights_glsl);
 
     // The main lighting functions each contain a tag where all light instances should be computed;
-    // Insert all of our "lights_to_compute" at this tag
-
-    std::string tag = "#pragma tangram: lights_to_compute";
     std::stringstream lights;
-    for (const auto& string : _sourceBlocks["__lights_to_compute"]) {
-        lights << '\n';
-        lights << string;
+    for (auto& light : _lights) {
+        lights << '\n' << light->getInstanceComputeBlock();
     }
 
+    const std::string tag = "#pragma tangram: lights_to_compute";
     size_t pos = lightingBlock.find(tag) + tag.length();
     lightingBlock.insert(pos, lights.str());
 
     // Place our assembled lighting source code back into the map of "source blocks";
     // The assembled strings will then be injected into a shader at the "vertex_lighting"
     // and "fragment_lighting" tags
-    _sourceBlocks["lighting"] = { lighting.str() + lightingBlock  };
+    sourceBlocks["lighting"] = lighting.str() + lightingBlock;
+
+    return sourceBlocks;
 }
 
 LightType Light::getType() {

--- a/core/src/scene/light.h
+++ b/core/src/scene/light.h
@@ -93,21 +93,17 @@ public:
      * Inject the needed lines of GLSL code on the shader to make this light work
      * Returns LightUniforms for passing to setupProgram if this light is dynamic
      */
-    virtual std::unique_ptr<LightUniforms> injectOnProgram(ShaderProgram& _shader) = 0;
+    virtual std::unique_ptr<LightUniforms> getUniforms() = 0;
 
     /*  Pass the uniforms for this particular DYNAMICAL light on the passed shader */
     virtual void setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
                               LightUniforms& _uniforms);
 
     /*  STATIC Function that compose sourceBlocks with Lights on a ProgramShader */
-    static void assembleLights(std::map<std::string, std::vector<std::string>>& _sourceBlocks);
+    static std::map<std::string, std::string>  assembleLights(const std::vector<std::unique_ptr<Light>>& _lights);
 
+    bool isDynamic() const { return m_dynamic; }
 protected:
-
-    /*
-     * Inject the needed lines of GLSL code on the shader to make this light work
-     */
-    void injectSourceBlocks(ShaderProgram& _shader);
 
     /*  Get the uniform name of the DYNAMICAL light */
     virtual std::string getUniformName();

--- a/core/src/scene/light.h
+++ b/core/src/scene/light.h
@@ -38,15 +38,12 @@ static inline std::string lightOriginString(LightOrigin origin) {
 }
 
 struct LightUniforms {
-    LightUniforms(ShaderProgram& _shader, const std::string& _name)
-        : shader(_shader),
-          ambient(_name+".ambient"),
+    LightUniforms(const std::string& _name)
+        : ambient(_name+".ambient"),
           diffuse(_name+".diffuse"),
           specular(_name+".specular") {}
 
     virtual ~LightUniforms() {}
-
-    ShaderProgram& shader;
 
     UniformLocation ambient;
     UniformLocation diffuse;
@@ -99,7 +96,8 @@ public:
     virtual std::unique_ptr<LightUniforms> injectOnProgram(ShaderProgram& _shader) = 0;
 
     /*  Pass the uniforms for this particular DYNAMICAL light on the passed shader */
-    virtual void setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms);
+    virtual void setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                              LightUniforms& _uniforms);
 
     /*  STATIC Function that compose sourceBlocks with Lights on a ProgramShader */
     static void assembleLights(std::map<std::string, std::vector<std::string>>& _sourceBlocks);

--- a/core/src/scene/pointLight.cpp
+++ b/core/src/scene/pointLight.cpp
@@ -45,11 +45,12 @@ std::unique_ptr<LightUniforms> PointLight::injectOnProgram(ShaderProgram& _shade
 
     if (!m_dynamic) { return nullptr; }
 
-    return std::make_unique<Uniforms>(_shader, getUniformName());
+    return std::make_unique<Uniforms>(getUniformName());
 }
 
-void PointLight::setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms) {
-    Light::setupProgram(rs, _view, _uniforms);
+void PointLight::setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                              LightUniforms& _uniforms) {
+    Light::setupProgram(rs, _view, _shader, _uniforms);
 
     glm::vec4 position = glm::vec4(m_position.value, 0.0);
 
@@ -82,18 +83,18 @@ void PointLight::setupProgram(RenderState& rs, const View& _view, LightUniforms&
 
     auto& u = static_cast<Uniforms&>(_uniforms);
 
-    u.shader.setUniformf(rs, u.position, position);
+    _shader.setUniformf(rs, u.position, position);
 
     if (m_attenuation != 0.0) {
-        u.shader.setUniformf(rs, u.attenuation, m_attenuation);
+        _shader.setUniformf(rs, u.attenuation, m_attenuation);
     }
 
     if (m_innerRadius != 0.0) {
-        u.shader.setUniformf(rs, u.innerRadius, m_innerRadius);
+        _shader.setUniformf(rs, u.innerRadius, m_innerRadius);
     }
 
     if (m_outerRadius != 0.0) {
-        u.shader.setUniformf(rs, u.outerRadius, m_outerRadius);
+        _shader.setUniformf(rs, u.outerRadius, m_outerRadius);
     }
 }
 

--- a/core/src/scene/pointLight.cpp
+++ b/core/src/scene/pointLight.cpp
@@ -40,8 +40,7 @@ void PointLight::setRadius(float _inner, float _outer) {
     m_outerRadius = _outer;
 }
 
-std::unique_ptr<LightUniforms> PointLight::injectOnProgram(ShaderProgram& _shader) {
-    injectSourceBlocks(_shader);
+std::unique_ptr<LightUniforms> PointLight::getUniforms() {
 
     if (!m_dynamic) { return nullptr; }
 

--- a/core/src/scene/pointLight.h
+++ b/core/src/scene/pointLight.h
@@ -21,11 +21,12 @@ public:
     virtual void setRadius(float _outer);
     virtual void setRadius(float _inner, float _outer);
 
-    virtual void setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms) override;
+    virtual void setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                              LightUniforms& _uniforms) override;
 
     struct Uniforms : public LightUniforms {
-        Uniforms(ShaderProgram& _shader, const std::string& _name)
-            : LightUniforms(_shader, _name),
+        Uniforms(const std::string& _name)
+            : LightUniforms(_name),
               position(_name+".position"),
               attenuation(_name+".attenuation"),
               innerRadius(_name+".innerRadius"),

--- a/core/src/scene/pointLight.h
+++ b/core/src/scene/pointLight.h
@@ -40,7 +40,7 @@ public:
 
     auto getPosition() const -> UnitVec<glm::vec3> { return m_position; }
 
-    std::unique_ptr<LightUniforms> injectOnProgram(ShaderProgram& _shader) override;
+    std::unique_ptr<LightUniforms> getUniforms() override;
 
 protected:
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -72,6 +72,7 @@ public:
     auto& layers() { return m_layers; };
     auto& styles() { return m_styles; };
     auto& lights() { return m_lights; };
+    auto& lightBlocks() { return m_lightShaderBlocks; };
     auto& textures() { return m_textures; };
     auto& functions() { return m_jsFunctions; };
     auto& spriteAtlases() { return m_spriteAtlases; };
@@ -89,6 +90,7 @@ public:
     const auto& layers() const { return m_layers; };
     const auto& styles() const { return m_styles; };
     const auto& lights() const { return m_lights; };
+    const auto& lightBlocks() const { return m_lightShaderBlocks; };
     const auto& functions() const { return m_jsFunctions; };
     const auto& mapProjection() const { return m_mapProjection; };
     const auto& fontContext() const { return m_fontContext; }
@@ -140,7 +142,10 @@ private:
     std::vector<DataLayer> m_layers;
     std::vector<std::shared_ptr<TileSource>> m_tileSources;
     std::vector<std::unique_ptr<Style>> m_styles;
+
     std::vector<std::unique_ptr<Light>> m_lights;
+    std::map<std::string, std::string> m_lightShaderBlocks;
+
     std::unordered_map<std::string, std::shared_ptr<Texture>> m_textures;
     std::unordered_map<std::string, std::shared_ptr<SpriteAtlas>> m_spriteAtlases;
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -850,7 +850,7 @@ void SceneLoader::loadStyleProps(const std::shared_ptr<Platform>& platform, Styl
     }
 
     if (Node materialNode = styleNode["material"]) {
-        loadMaterial(platform, materialNode, *(style.getMaterial()), scene, style);
+        loadMaterial(platform, materialNode, style.getMaterial(), scene, style);
     }
 
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -295,7 +295,7 @@ void SceneLoader::loadShaderConfig(const std::shared_ptr<Platform>& platform, No
 
     if (!shaders) { return; }
 
-    auto& shader = *(style.getShaderProgram());
+    auto shader = style.getShaderProgram();
 
     if (Node extNode = shaders["extensions_mixed"]) {
         if (extNode.IsScalar()) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -10,7 +10,7 @@
 #include "data/networkDataSource.h"
 #include "data/rasterSource.h"
 #include "data/topoJsonSource.h"
-#include "gl/shaderProgram.h"
+#include "gl/shaderSource.h"
 #include "style/material.h"
 #include "style/polygonStyle.h"
 #include "style/polylineStyle.h"
@@ -295,14 +295,14 @@ void SceneLoader::loadShaderConfig(const std::shared_ptr<Platform>& platform, No
 
     if (!shaders) { return; }
 
-    auto shader = style.getShaderProgram();
+    auto& shader = style.getShaderSource();
 
     if (Node extNode = shaders["extensions_mixed"]) {
         if (extNode.IsScalar()) {
-            shader.addSourceBlock("extensions", ShaderProgram::getExtensionDeclaration(extNode.Scalar()));
+            shader.addExtensionDeclaration(extNode.Scalar());
         } else if (extNode.IsSequence()) {
             for (const auto& e : extNode) {
-                shader.addSourceBlock("extensions", ShaderProgram::getExtensionDeclaration(e.Scalar()));
+                shader.addExtensionDeclaration(e.Scalar());
             }
         }
     }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -262,6 +262,8 @@ bool SceneLoader::applyConfig(const std::shared_ptr<Platform>& _platform, const 
         _scene->lights().push_back(std::move(amb));
     }
 
+    _scene->lightBlocks() = Light::assembleLights(_scene->lights());
+
     if (Node camera = config["camera"]) {
         try { loadCamera(camera, _scene); }
         catch (YAML::RepresentationException e) {

--- a/core/src/scene/spotLight.cpp
+++ b/core/src/scene/spotLight.cpp
@@ -41,11 +41,12 @@ std::unique_ptr<LightUniforms> SpotLight::injectOnProgram(ShaderProgram& _shader
 
     if (!m_dynamic) { return nullptr; }
 
-    return std::make_unique<Uniforms>(_shader, getUniformName());
+    return std::make_unique<Uniforms>(getUniformName());
 }
 
-void SpotLight::setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms ) {
-    PointLight::setupProgram(rs, _view, _uniforms);
+void SpotLight::setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                             LightUniforms& _uniforms) {
+    PointLight::setupProgram(rs, _view, _shader, _uniforms);
 
     glm::vec3 direction = m_direction;
     if (m_origin == LightOrigin::world) {
@@ -53,9 +54,9 @@ void SpotLight::setupProgram(RenderState& rs, const View& _view, LightUniforms& 
     }
 
     auto& u = static_cast<Uniforms&>(_uniforms);
-    u.shader.setUniformf(rs, u.direction, direction);
-    u.shader.setUniformf(rs, u.spotCosCutoff, m_spotCosCutoff);
-    u.shader.setUniformf(rs, u.spotExponent, m_spotExponent);
+    _shader.setUniformf(rs, u.direction, direction);
+    _shader.setUniformf(rs, u.spotCosCutoff, m_spotCosCutoff);
+    _shader.setUniformf(rs, u.spotExponent, m_spotExponent);
 }
 
 std::string SpotLight::getClassBlock() {

--- a/core/src/scene/spotLight.cpp
+++ b/core/src/scene/spotLight.cpp
@@ -36,8 +36,7 @@ void SpotLight::setCutoffExponent(float _exponent) {
     m_spotExponent = _exponent;
 }
 
-std::unique_ptr<LightUniforms> SpotLight::injectOnProgram(ShaderProgram& _shader) {
-    injectSourceBlocks(_shader);
+std::unique_ptr<LightUniforms> SpotLight::getUniforms() {
 
     if (!m_dynamic) { return nullptr; }
 

--- a/core/src/scene/spotLight.h
+++ b/core/src/scene/spotLight.h
@@ -35,7 +35,7 @@ public:
         UniformLocation spotExponent;
     };
 
-    std::unique_ptr<LightUniforms> injectOnProgram(ShaderProgram& _shader) override;
+    std::unique_ptr<LightUniforms> getUniforms() override;
 
 protected:
     /*  GLSL block code with structs and need functions for this light type */

--- a/core/src/scene/spotLight.h
+++ b/core/src/scene/spotLight.h
@@ -19,12 +19,13 @@ public:
 
     virtual void setCutoffExponent(float _exponent);
 
-    virtual void setupProgram(RenderState& rs, const View& _view, LightUniforms& _uniforms) override;
+    virtual void setupProgram(RenderState& rs, const View& _view, ShaderProgram& _shader,
+                              LightUniforms& _uniforms) override;
 
     struct Uniforms : public PointLight::Uniforms {
 
-        Uniforms(ShaderProgram& _shader, const std::string& _name)
-            : PointLight::Uniforms(_shader, _name),
+        Uniforms(const std::string& _name)
+            : PointLight::Uniforms(_name),
             direction(_name+".direction"),
             spotCosCutoff(_name+".spotCosCutoff"),
             spotExponent(_name+".spotExponent") {}

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -38,8 +38,8 @@ void DebugStyle::constructVertexLayout() {
 
 void DebugStyle::constructShaderProgram() {
 
-    m_shaderProgram->setSourceStrings(SHADER_SOURCE(debug_fs),
-                                      SHADER_SOURCE(debug_vs));
+    m_shaderSource->setSourceStrings(SHADER_SOURCE(debug_fs),
+                                     SHADER_SOURCE(debug_vs));
 
 }
 

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -72,8 +72,7 @@ struct DebugStyleBuilder : public StyleBuilder {
 
     const Style& style() const override { return m_style; }
 
-    DebugStyleBuilder(const DebugStyle& _style)
-        : StyleBuilder(_style), m_style(_style) {}
+    DebugStyleBuilder(const DebugStyle& _style) : m_style(_style) {}
 
 };
 

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -2,6 +2,7 @@
 
 #include "platform.h"
 #include "gl/shaderProgram.h"
+#include "gl/shaderSource.h"
 #include "gl/texture.h"
 #include "gl/renderState.h"
 
@@ -152,10 +153,10 @@ std::string Material::getClassBlock() {
     return SHADER_SOURCE(material_glsl);
 }
 
-std::unique_ptr<MaterialUniforms> Material::injectOnProgram(ShaderProgram& _shader ) {
-    _shader.addSourceBlock("defines", getDefinesBlock(), false);
-    _shader.addSourceBlock("material", getClassBlock(), false);
-    _shader.addSourceBlock("setup", "material = u_material;", false);
+std::unique_ptr<MaterialUniforms> Material::injectOnProgram(ShaderSource& _source ) {
+    _source.addSourceBlock("defines", getDefinesBlock(), false);
+    _source.addSourceBlock("material", getClassBlock(), false);
+    _source.addSourceBlock("setup", "material = u_material;", false);
 
     if (m_bEmission || m_bAmbient || m_bDiffuse || m_bSpecular || m_normal_texture.tex) {
         return std::make_unique<MaterialUniforms>();

--- a/core/src/style/material.cpp
+++ b/core/src/style/material.cpp
@@ -158,66 +158,66 @@ std::unique_ptr<MaterialUniforms> Material::injectOnProgram(ShaderProgram& _shad
     _shader.addSourceBlock("setup", "material = u_material;", false);
 
     if (m_bEmission || m_bAmbient || m_bDiffuse || m_bSpecular || m_normal_texture.tex) {
-        return std::make_unique<MaterialUniforms>(_shader);
+        return std::make_unique<MaterialUniforms>();
     }
     return nullptr;
 }
 
-void Material::setupProgram(RenderState& rs, MaterialUniforms& _uniforms) {
+void Material::setupProgram(RenderState& rs, ShaderProgram& _shader, MaterialUniforms& _uniforms) {
 
     auto& u = _uniforms;
 
     if (m_bEmission) {
-        u.shader.setUniformf(rs, u.emission, m_emission);
+        _shader.setUniformf(rs, u.emission, m_emission);
 
         if (m_emission_texture.tex) {
             m_emission_texture.tex->update(rs, rs.nextAvailableTextureUnit());
             m_emission_texture.tex->bind(rs, rs.currentTextureUnit());
-            u.shader.setUniformi(rs, u.emissionTexture, rs.currentTextureUnit());
-            u.shader.setUniformf(rs, u.emissionScale, m_emission_texture.scale);
+            _shader.setUniformi(rs, u.emissionTexture, rs.currentTextureUnit());
+            _shader.setUniformf(rs, u.emissionScale, m_emission_texture.scale);
         }
     }
 
     if (m_bAmbient) {
-        u.shader.setUniformf(rs, u.ambient, m_ambient);
+        _shader.setUniformf(rs, u.ambient, m_ambient);
 
         if (m_ambient_texture.tex) {
             m_ambient_texture.tex->update(rs, rs.nextAvailableTextureUnit());
             m_ambient_texture.tex->bind(rs, rs.currentTextureUnit());
-            u.shader.setUniformi(rs, u.ambientTexture, rs.currentTextureUnit());
-            u.shader.setUniformf(rs, u.ambientScale, m_ambient_texture.scale);
+            _shader.setUniformi(rs, u.ambientTexture, rs.currentTextureUnit());
+            _shader.setUniformf(rs, u.ambientScale, m_ambient_texture.scale);
         }
     }
 
     if (m_bDiffuse) {
-        u.shader.setUniformf(rs, u.diffuse, m_diffuse);
+        _shader.setUniformf(rs, u.diffuse, m_diffuse);
 
         if (m_diffuse_texture.tex) {
             m_diffuse_texture.tex->update(rs, rs.nextAvailableTextureUnit());
             m_diffuse_texture.tex->bind(rs, rs.currentTextureUnit());
-            u.shader.setUniformi(rs, u.diffuseTexture, rs.currentTextureUnit());
-            u.shader.setUniformf(rs, u.diffuseScale, m_diffuse_texture.scale);
+            _shader.setUniformi(rs, u.diffuseTexture, rs.currentTextureUnit());
+            _shader.setUniformf(rs, u.diffuseScale, m_diffuse_texture.scale);
         }
     }
 
     if (m_bSpecular) {
-        u.shader.setUniformf(rs, u.specular, m_specular);
-        u.shader.setUniformf(rs, u.shininess, m_shininess);
+        _shader.setUniformf(rs, u.specular, m_specular);
+        _shader.setUniformf(rs, u.shininess, m_shininess);
 
         if (m_specular_texture.tex) {
             m_specular_texture.tex->update(rs, rs.nextAvailableTextureUnit());
             m_specular_texture.tex->bind(rs, rs.currentTextureUnit());
-            u.shader.setUniformi(rs, u.specularTexture, rs.currentTextureUnit());
-            u.shader.setUniformf(rs, u.specularScale, m_specular_texture.scale);
+            _shader.setUniformi(rs, u.specularTexture, rs.currentTextureUnit());
+            _shader.setUniformf(rs, u.specularScale, m_specular_texture.scale);
         }
     }
 
     if (m_normal_texture.tex) {
         m_normal_texture.tex->update(rs, rs.nextAvailableTextureUnit());
         m_normal_texture.tex->bind(rs, rs.currentTextureUnit());
-        u.shader.setUniformi(rs, u.normalTexture, rs.currentTextureUnit());
-        u.shader.setUniformf(rs, u.normalScale, m_normal_texture.scale);
-        u.shader.setUniformf(rs, u.normalAmount, m_normal_texture.amount);
+        _shader.setUniformi(rs, u.normalTexture, rs.currentTextureUnit());
+        _shader.setUniformf(rs, u.normalScale, m_normal_texture.scale);
+        _shader.setUniformf(rs, u.normalAmount, m_normal_texture.amount);
     }
 }
 

--- a/core/src/style/material.h
+++ b/core/src/style/material.h
@@ -18,6 +18,7 @@ namespace Tangram {
 class RenderState;
 class Texture;
 class ShaderProgram;
+class ShaderSource;
 
 enum class MappingType {
     uv,
@@ -102,7 +103,7 @@ public:
     void setNormal(MaterialTexture _normalTexture);
 
     /*  Inject the needed lines of GLSL code on the shader to make this material work */
-    virtual std::unique_ptr<MaterialUniforms> injectOnProgram(ShaderProgram& _shader);
+    virtual std::unique_ptr<MaterialUniforms> injectOnProgram(ShaderSource& _shader);
 
     /*  Method to pass it self as a uniform to the shader program */
     virtual void setupProgram(RenderState& rs, ShaderProgram& _shader,

--- a/core/src/style/material.h
+++ b/core/src/style/material.h
@@ -35,10 +35,6 @@ struct MaterialTexture {
 
 struct MaterialUniforms {
 
-    MaterialUniforms(ShaderProgram& _shader) : shader(_shader) {}
-
-    ShaderProgram& shader;
-
     UniformLocation emission{"u_material.emission"};
     UniformLocation emissionTexture{"material_emission_texture"};
     UniformLocation emissionScale{"u_material.emissionScale"};
@@ -109,7 +105,8 @@ public:
     virtual std::unique_ptr<MaterialUniforms> injectOnProgram(ShaderProgram& _shader);
 
     /*  Method to pass it self as a uniform to the shader program */
-    virtual void setupProgram(RenderState& rs, MaterialUniforms& _uniforms);
+    virtual void setupProgram(RenderState& rs, ShaderProgram& _shader,
+                              MaterialUniforms& _uniforms);
 
     bool hasEmission() const { return m_bEmission; }
     bool hasAmbient() const { return m_bAmbient; }

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -22,6 +22,14 @@ PointStyle::PointStyle(std::string _name, std::shared_ptr<FontContext> _fontCont
 
 PointStyle::~PointStyle() {}
 
+void PointStyle::build(const Scene& _scene) {
+    Style::build(_scene);
+
+    m_textStyle->build(_scene);
+
+    m_mesh = std::make_unique<DynamicQuadMesh<SpriteVertex>>(m_vertexLayout, m_drawMode);
+}
+
 void PointStyle::constructVertexLayout() {
 
     m_vertexLayout = std::shared_ptr<VertexLayout>(new VertexLayout({
@@ -32,19 +40,11 @@ void PointStyle::constructVertexLayout() {
         {"a_alpha", 1, GL_UNSIGNED_SHORT, true, 0},
         {"a_scale", 1, GL_UNSIGNED_SHORT, false, 0},
     }));
-
-    m_textStyle->constructVertexLayout();
 }
 
 void PointStyle::constructShaderProgram() {
-
-    m_shaderProgram->setSourceStrings(SHADER_SOURCE(point_fs),
-                                      SHADER_SOURCE(point_vs));
-
-    m_mesh = std::make_unique<DynamicQuadMesh<SpriteVertex>>(m_vertexLayout, m_drawMode);
-
-    m_textStyle->constructShaderProgram();
-    m_textStyle->constructSelectionShaderProgram();
+    m_shaderSource->setSourceStrings(SHADER_SOURCE(point_fs),
+                                     SHADER_SOURCE(point_vs));
 }
 
 void PointStyle::onBeginUpdate() {

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -56,6 +56,8 @@ public:
 
     virtual std::unique_ptr<StyleBuilder> createBuilder() const override;
 
+    virtual void build(const Scene& _scene) override;
+
     virtual void constructVertexLayout() override;
     virtual void constructShaderProgram() override;
 

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -35,7 +35,7 @@ struct PointStyleBuilder : public StyleBuilder {
 
     const Style& style() const override { return m_style; }
 
-    PointStyleBuilder(const PointStyle& _style) : StyleBuilder(_style), m_style(_style) {
+    PointStyleBuilder(const PointStyle& _style) : m_style(_style) {
         m_textStyleBuilder = m_style.textStyle().createBuilder();
     }
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -75,11 +75,11 @@ void PolygonStyle::constructVertexLayout() {
 
 void PolygonStyle::constructShaderProgram() {
 
-    m_shaderProgram->setSourceStrings(SHADER_SOURCE(polygon_fs),
+    m_shaderSource->setSourceStrings(SHADER_SOURCE(polygon_fs),
                                       SHADER_SOURCE(polygon_vs));
 
     if (m_texCoordsGeneration) {
-        m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_USE_TEX_COORDS\n");
+        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_USE_TEX_COORDS\n");
     }
 }
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -115,7 +115,7 @@ public:
 
     std::unique_ptr<StyledMesh> build() override;
 
-    PolygonStyleBuilder(const PolygonStyle& _style) : StyleBuilder(_style), m_style(_style) {}
+    PolygonStyleBuilder(const PolygonStyle& _style) : m_style(_style) {}
 
     void parseRule(const DrawRule& _rule, const Properties& _props);
 

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -185,7 +185,7 @@ public:
     std::unique_ptr<StyledMesh> build() override;
 
     PolylineStyleBuilder(const PolylineStyle& _style)
-        : StyleBuilder(_style), m_style(_style),
+        : m_style(_style),
           m_meshData(2) {}
 
     void addMesh(const Line& _line, const Parameters& _params);

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -111,6 +111,9 @@ void PolylineStyle::setDashBackgroundColor(const glm::vec4 _dashBackgroundColor)
 
 void PolylineStyle::constructShaderProgram() {
 
+    m_shaderSource->setSourceStrings(SHADER_SOURCE(polyline_fs),
+                                     SHADER_SOURCE(polyline_vs));
+
     if (m_dashArray.size() > 0) {
         TextureOptions options {GL_RGBA, GL_RGBA, {GL_NEAREST, GL_NEAREST}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}};
         // provides precision for dash patterns that are a fraction of line width
@@ -120,7 +123,7 @@ void PolylineStyle::constructShaderProgram() {
         m_texture->setData(pixels.data(), pixels.size());
 
         if (m_dashBackground) {
-            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_LINE_BACKGROUND_COLOR vec3(" +
+            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_LINE_BACKGROUND_COLOR vec3(" +
                 std::to_string(m_dashBackgroundColor.r) + ", " +
                 std::to_string(m_dashBackgroundColor.g) + ", " +
                 std::to_string(m_dashBackgroundColor.b) + ")\n");
@@ -128,21 +131,18 @@ void PolylineStyle::constructShaderProgram() {
     }
 
     if (m_dashArray.size() > 0 || m_texture) {
-        m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_LINE_TEXTURE\n", false);
-        m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_ALPHA_TEST 0.25\n", false);
+        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_LINE_TEXTURE\n", false);
+        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_ALPHA_TEST 0.25\n", false);
         if (m_dashArray.size() > 0) {
-            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE " +
+            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE " +
                                             std::to_string(dash_scale) + "\n", false);
         } else {
-            m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE 1.0\n", false);
+            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE 1.0\n", false);
         }
     }
 
-    m_shaderProgram->setSourceStrings(SHADER_SOURCE(polyline_fs),
-                                      SHADER_SOURCE(polyline_vs));
-
     if (m_texCoordsGeneration) {
-        m_shaderProgram->addSourceBlock("defines", "#define TANGRAM_USE_TEX_COORDS\n");
+        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_USE_TEX_COORDS\n");
     }
 }
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -192,7 +192,8 @@ void Style::setupRasters(const std::vector<std::shared_ptr<TileSource>>& _source
 }
 
 
-void Style::setupShaderUniforms(RenderState& rs, ShaderProgram& _program, const View& _view, Scene& _scene, UniformBlock& _uniforms) {
+void Style::setupShaderUniforms(RenderState& rs, ShaderProgram& _program, const View& _view,
+                                Scene& _scene, UniformBlock& _uniforms) {
 
     // Reset the currently used texture unit to 0
     rs.resetTextureUnit();
@@ -203,12 +204,12 @@ void Style::setupShaderUniforms(RenderState& rs, ShaderProgram& _program, const 
     _program.setUniformf(rs, _uniforms.uDevicePixelRatio, m_pixelScale);
 
     if (m_material.uniforms) {
-        m_material.material->setupProgram(rs, *m_material.uniforms);
+        m_material.material->setupProgram(rs, *m_shaderProgram, *m_material.uniforms);
     }
 
     // Set up lights
     for (const auto& light : m_lights) {
-        light.light->setupProgram(rs, _view, *light.uniforms);
+        light.light->setupProgram(rs, _view, *m_shaderProgram, *light.uniforms);
     }
 
     // Set Map Position

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -82,10 +82,13 @@ void Style::build(const Scene& _scene) {
 
     if (m_lightingType != LightingType::none) {
         for (auto& light : _scene.lights()) {
-            auto uniforms = light->injectOnProgram(*m_shaderProgram);
+            auto uniforms = light->getUniforms();
             if (uniforms) {
                 m_lights.emplace_back(light.get(), std::move(uniforms));
             }
+        }
+        for (auto& block : _scene.lightBlocks()) {
+            m_shaderProgram->addSourceBlock(block.first, block.second);
         }
     }
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -97,11 +97,6 @@ void Style::build(const Scene& _scene) {
     constructSelectionShaderProgram();
 }
 
-void Style::setMaterial(const std::shared_ptr<Material>& _material) {
-    m_material.material = _material;
-    m_material.uniforms.reset();
-}
-
 void Style::setLightingType(LightingType _type) {
     m_lightingType = _type;
 }

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -80,6 +80,13 @@ void Style::build(const Scene& _scene) {
 
     setupRasters(_scene.tileSources());
 
+    const auto& blocks = m_shaderSource->getSourceBlocks();
+    if (blocks.find("color") != blocks.end() ||
+        blocks.find("filter") != blocks.end() ||
+        blocks.find("raster") != blocks.end()) {
+        m_hasColorShaderBlock = true;
+    }
+
     std::string vertSrc = m_shaderSource->buildVertexSource();
     std::string fragSrc = m_shaderSource->buildFragmentSource();
 
@@ -119,6 +126,9 @@ void Style::build(const Scene& _scene) {
             m_selectionProgram->setShaderSource(vertSrc, fragSrc);
         }
     }
+
+    // Clear ShaderSource builder
+    m_shaderSource.reset();
 }
 
 void Style::setLightingType(LightingType _type) {
@@ -452,7 +462,7 @@ bool StyleBuilder::checkRule(const DrawRule& _rule) const {
     uint32_t checkOrder;
 
     if (!_rule.get(StyleParamKey::color, checkColor)) {
-        if (!m_hasColorShaderBlock) {
+        if (!style().hasColorShaderBlock()) {
             return false;
         }
     }
@@ -490,15 +500,6 @@ bool StyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) {
     }
 
     return added;
-}
-
-StyleBuilder::StyleBuilder(const Style& _style) {
-    const auto& blocks = _style.getShaderSource().getSourceBlocks();
-    if (blocks.find("color") != blocks.end() ||
-        blocks.find("filter") != blocks.end() ||
-        blocks.find("raster") != blocks.end()) {
-        m_hasColorShaderBlock = true;
-    }
 }
 
 bool StyleBuilder::addPoint(const Point& _point, const Properties& _props, const DrawRule& _rule) {

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -122,41 +122,38 @@ void Style::setupSceneShaderUniforms(RenderState& rs, Scene& _scene, UniformBloc
             texture->bind(rs, rs.currentTextureUnit());
 
             m_shaderProgram->setUniformi(rs, name, rs.currentTextureUnit());
-        } else {
+        } else if (value.is<bool>()) {
+            m_shaderProgram->setUniformi(rs, name, value.get<bool>());
+        } else if(value.is<float>()) {
+            m_shaderProgram->setUniformf(rs, name, value.get<float>());
+        } else if(value.is<glm::vec2>()) {
+            m_shaderProgram->setUniformf(rs, name, value.get<glm::vec2>());
+        } else if(value.is<glm::vec3>()) {
+            m_shaderProgram->setUniformf(rs, name, value.get<glm::vec3>());
+        } else if(value.is<glm::vec4>()) {
+            m_shaderProgram->setUniformf(rs, name, value.get<glm::vec4>());
+        } else if (value.is<UniformArray1f>()) {
+            m_shaderProgram->setUniformf(rs, name, value.get<UniformArray1f>());
+        } else if (value.is<UniformTextureArray>()) {
+            UniformTextureArray& textureUniformArray = value.get<UniformTextureArray>();
+            textureUniformArray.slots.clear();
 
-            if (value.is<bool>()) {
-                m_shaderProgram->setUniformi(rs, name, value.get<bool>());
-            } else if(value.is<float>()) {
-                m_shaderProgram->setUniformf(rs, name, value.get<float>());
-            } else if(value.is<glm::vec2>()) {
-                m_shaderProgram->setUniformf(rs, name, value.get<glm::vec2>());
-            } else if(value.is<glm::vec3>()) {
-                m_shaderProgram->setUniformf(rs, name, value.get<glm::vec3>());
-            } else if(value.is<glm::vec4>()) {
-                m_shaderProgram->setUniformf(rs, name, value.get<glm::vec4>());
-            } else if (value.is<UniformArray1f>()) {
-                m_shaderProgram->setUniformf(rs, name, value.get<UniformArray1f>());
-            } else if (value.is<UniformTextureArray>()) {
-                UniformTextureArray& textureUniformArray = value.get<UniformTextureArray>();
-                textureUniformArray.slots.clear();
+            for (const auto& textureName : textureUniformArray.names) {
+                std::shared_ptr<Texture> texture = _scene.getTexture(textureName);
 
-                for (const auto& textureName : textureUniformArray.names) {
-                    std::shared_ptr<Texture> texture = _scene.getTexture(textureName);
-
-                    if (!texture) {
-                        LOGN("Texture with texture name %s is not available to be sent as uniform",
-                            textureName.c_str());
-                        continue;
-                    }
-
-                    texture->update(rs, rs.nextAvailableTextureUnit());
-                    texture->bind(rs, rs.currentTextureUnit());
-
-                    textureUniformArray.slots.push_back(rs.currentTextureUnit());
+                if (!texture) {
+                    LOGN("Texture with texture name %s is not available to be sent as uniform",
+                         textureName.c_str());
+                    continue;
                 }
 
-                m_shaderProgram->setUniformi(rs, name, textureUniformArray);
+                texture->update(rs, rs.nextAvailableTextureUnit());
+                texture->bind(rs, rs.currentTextureUnit());
+
+                textureUniformArray.slots.push_back(rs.currentTextureUnit());
             }
+
+            m_shaderProgram->setUniformi(rs, name, textureUniformArray);
         }
     }
 }

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -474,7 +474,7 @@ bool StyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) {
 }
 
 StyleBuilder::StyleBuilder(const Style& _style) {
-    const auto& blocks = _style.getShaderProgram()->getSourceBlocks();
+    const auto& blocks = _style.getShaderProgram().getSourceBlocks();
     if (blocks.find("color") != blocks.end() ||
         blocks.find("filter") != blocks.end() ||
         blocks.find("raster") != blocks.end()) {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -173,25 +173,23 @@ private:
      */
     void setupSceneShaderUniforms(RenderState& rs, Scene& _scene, UniformBlock& _uniformBlock);
 
-    void setupShaderUniforms(RenderState& rs, ShaderProgram& _program, const View& _view, Scene& _scene,
-            UniformBlock& _uniformBlock);
+    void setupShaderUniforms(RenderState& rs, ShaderProgram& _program, const View& _view,
+                             Scene& _scene, UniformBlock& _uniformBlock);
 
     struct LightHandle {
         LightHandle(Light* _light, std::unique_ptr<LightUniforms> _uniforms);
-
         Light *light;
         std::unique_ptr<LightUniforms> uniforms;
     };
-    std::vector<LightHandle> m_lights;
 
 
     struct MaterialHandle {
         /* <Material> used for drawing meshes that use this style */
         std::shared_ptr<Material> material;
-
         std::unique_ptr<MaterialUniforms> uniforms;
     };
 
+    std::vector<LightHandle> m_lights;
     MaterialHandle m_material;
 
 public:

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -61,8 +61,6 @@ struct StyledMesh {
 class StyleBuilder {
 public:
 
-    StyleBuilder(const Style& _style);
-
     virtual ~StyleBuilder() = default;
 
     virtual void setup(const Tile& _tile) = 0;
@@ -90,10 +88,6 @@ public:
     virtual void addSelectionItems(LabelCollider& _layout) {}
 
     virtual const Style& style() const = 0;
-
-protected:
-    bool m_hasColorShaderBlock = false;
-
 };
 
 /* Means of constructing and rendering map geometry
@@ -143,6 +137,8 @@ protected:
 
     /* Whether the style should generate texture coordinates */
     bool m_texCoordsGeneration = false;
+
+    bool m_hasColorShaderBlock = false;
 
     RasterType m_rasterType = RasterType::none;
 
@@ -300,6 +296,8 @@ public:
     GLenum drawMode() const { return m_drawMode; }
     float pixelScale() const { return m_pixelScale; }
     const auto& vertexLayout() const { return m_vertexLayout; }
+
+    bool hasColorShaderBlock() const { return m_hasColorShaderBlock; }
 
 };
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -20,6 +20,7 @@ class Material;
 class RenderState;
 class Scene;
 class ShaderProgram;
+class ShaderSource;
 class Style;
 class Tile;
 class TileSource;
@@ -117,6 +118,8 @@ protected:
     /* Unique name for a style instance */
     std::string m_name;
     uint32_t m_id = 0;
+
+    std::unique_ptr<ShaderSource> m_shaderSource;
 
     /* <ShaderProgram> used to draw meshes using this style */
     std::shared_ptr<ShaderProgram> m_shaderProgram;
@@ -244,8 +247,6 @@ public:
      */
     virtual void constructShaderProgram() = 0;
 
-    void constructSelectionShaderProgram();
-
     /* Perform any setup needed before drawing each frame
      * _textUnit is the next available texture unit
      */
@@ -281,7 +282,7 @@ public:
 
     Material& getMaterial() { return *m_material.material; }
 
-    ShaderProgram& getShaderProgram() const { return *m_shaderProgram; }
+    ShaderSource& getShaderSource() const { return *m_shaderSource; }
 
     const std::string& getName() const { return m_name; }
     const uint32_t& getID() const { return m_id; }

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -279,7 +279,7 @@ public:
 
     void setID(uint32_t _id) { m_id = _id; }
 
-    std::shared_ptr<Material> getMaterial() { return m_material.material; }
+    Material& getMaterial() { return *m_material.material; }
 
     ShaderProgram& getShaderProgram() const { return *m_shaderProgram; }
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -29,21 +29,21 @@ struct DrawRule;
 struct LightUniforms;
 struct MaterialUniforms;
 
-enum class LightingType : char {
+enum class LightingType : uint8_t {
     none,
     vertex,
     fragment
 };
 
-enum class Blending : int8_t {
-    opaque = 0,
+enum class Blending : uint8_t {
+    opaque,
     add,
     multiply,
     inlay,
     overlay,
 };
 
-enum class RasterType {
+enum class RasterType : uint8_t {
     none,
     color,
     normal,

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -269,8 +269,6 @@ public:
 
     void setAnimated(bool _animated) { m_animated = _animated; }
 
-    void setMaterial(const std::shared_ptr<Material>& _material);
-
     virtual void setPixelScale(float _pixelScale) { m_pixelScale = _pixelScale; }
 
     void setRasterType(RasterType _rasterType) { m_rasterType = _rasterType; }

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -119,9 +119,9 @@ protected:
     uint32_t m_id = 0;
 
     /* <ShaderProgram> used to draw meshes using this style */
-    std::unique_ptr<ShaderProgram> m_shaderProgram;
+    std::shared_ptr<ShaderProgram> m_shaderProgram;
 
-    std::unique_ptr<ShaderProgram> m_selectionProgram;
+    std::shared_ptr<ShaderProgram> m_selectionProgram;
 
     /* <VertexLayout> shared between meshes using this style */
     std::shared_ptr<VertexLayout> m_vertexLayout;
@@ -283,7 +283,7 @@ public:
 
     std::shared_ptr<Material> getMaterial() { return m_material.material; }
 
-    const std::unique_ptr<ShaderProgram>& getShaderProgram() const { return m_shaderProgram; }
+    ShaderProgram& getShaderProgram() const { return *m_shaderProgram; }
 
     const std::string& getName() const { return m_name; }
     const uint32_t& getID() const { return m_id; }

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -38,16 +38,14 @@ void TextStyle::constructVertexLayout() {
 void TextStyle::constructShaderProgram() {
 
     if (m_sdf) {
-        m_shaderProgram->setSourceStrings(SHADER_SOURCE(sdf_fs),
-                                          SHADER_SOURCE(point_vs));
+        m_shaderSource->setSourceStrings(SHADER_SOURCE(sdf_fs),
+                                         SHADER_SOURCE(point_vs));
     } else {
-        m_shaderProgram->setSourceStrings(SHADER_SOURCE(text_fs),
-                                          SHADER_SOURCE(point_vs));
+        m_shaderSource->setSourceStrings(SHADER_SOURCE(text_fs),
+                                         SHADER_SOURCE(point_vs));
     }
 
-    std::string defines = "#define TANGRAM_TEXT\n";
-
-    m_shaderProgram->addSourceBlock("defines", defines);
+    m_shaderSource->addSourceBlock("defines", "#define TANGRAM_TEXT\n");
 }
 
 void TextStyle::onBeginUpdate() {
@@ -130,7 +128,7 @@ std::unique_ptr<StyleBuilder> TextStyle::createBuilder() const {
 
 DynamicQuadMesh<TextVertex>& TextStyle::getMesh(size_t id) const {
     if (id >= m_meshes.size()) {
-        LOGE("Accesing inconsistent quad mesh");
+        LOGE("Accessing inconsistent quad mesh");
         assert(false);
         return *m_meshes[0];
     }

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -33,9 +33,7 @@ namespace Tangram {
 
 const static std::string key_name("name");
 
-TextStyleBuilder::TextStyleBuilder(const TextStyle& _style)
-    : StyleBuilder(_style),
-      m_style(_style) {}
+TextStyleBuilder::TextStyleBuilder(const TextStyle& _style) : m_style(_style) {}
 
 void TextStyleBuilder::setup(const Tile& _tile){
     m_tileSize = _tile.getProjection()->TileSize();

--- a/tests/unit/sceneLoaderTests.cpp
+++ b/tests/unit/sceneLoaderTests.cpp
@@ -50,10 +50,10 @@ TEST_CASE("Correctly instantiate a style from a YAML configuration") {
 
     REQUIRE(styles[2]->isAnimated() == true);
 
-    REQUIRE(styles[2]->getMaterial()->hasEmission() == true);
-    REQUIRE(styles[2]->getMaterial()->hasDiffuse() == true);
-    REQUIRE(styles[2]->getMaterial()->hasAmbient() == false);
-    REQUIRE(styles[2]->getMaterial()->hasSpecular() == false);
+    REQUIRE(styles[2]->getMaterial().hasEmission() == true);
+    REQUIRE(styles[2]->getMaterial().hasDiffuse() == true);
+    REQUIRE(styles[2]->getMaterial().hasAmbient() == false);
+    REQUIRE(styles[2]->getMaterial().hasSpecular() == false);
 }
 
 TEST_CASE("Test light parameter parsing") {


### PR DESCRIPTION
This PR modifies `Style` to use the same ShaderProgram for styles with identical sources 

- refactor: build `Light` shader blocks only once
- refactor ShaderProgram, move template engine to ShaderSource. 