### PR TITLE
Add release buildType for tangram lib

### DIFF
--- a/android/tangram/build.gradle
+++ b/android/tangram/build.gradle
@@ -43,6 +43,11 @@ android {
         cmake.cppFlags '-g'
       }
     }
+    release {
+      externalNativeBuild {
+        cmake.cppFlags'-g0'
+      }
+    }
   }
   productFlavors {
     slim {


### PR DESCRIPTION
- to disable `-g` debug flag being set by the ndk default android cmake toolchain
- Refer: https://github.com/android-ndk/ndk/issues/243

TODO: Keep an eye for future versions of ndk/android-studio to add a fix for this