### PR TITLE
fix: straight label segment length

### DIFF
--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -259,8 +259,8 @@ bool TextStyleBuilder::addStraightTextLabels(const Line& _line, const TextStyle:
         }
 
         // place labels at segment-subdivisions
-        int run = merged > 0 ? 1 : 2;
-        segmentLength /= run;
+        int run = 1;
+        if (merged) { segmentLength = glm::length(p0 - p1); }
 
         while (segmentLength > minLength && run <= 4) {
             glm::vec2 a = p0;


### PR DESCRIPTION
For straight labels with merged line segments only the length of the last was used instead of the sum of the merged segments.

![shot-2017-02-10_13-55-16](https://cloud.githubusercontent.com/assets/1747/22827750/b121f52a-ef99-11e6-9afd-84ea3671930f.jpg)
![shot-2017-02-10_13-55-23](https://cloud.githubusercontent.com/assets/1747/22827751/b1400e98-ef99-11e6-8357-32150d808995.jpg)
