### PR TITLE
Override bytesFromFile for iOS platform to resolve bundle paths

### DIFF
--- a/ios/src/platform_ios.h
+++ b/ios/src/platform_ios.h
@@ -16,6 +16,7 @@ public:
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
     std::string stringFromFile(const char* _path) const override;
+    std::vector<char> bytesFromFile(const char* _path) const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
     bool startUrlRequest(const std::string& _url, UrlCallback _callback) override;

--- a/ios/src/platform_ios.mm
+++ b/ios/src/platform_ios.mm
@@ -85,6 +85,15 @@ void iOSPlatform::setContinuousRendering(bool _isContinuous) {
     [m_viewController setContinuous:_isContinuous];
 }
 
+std::vector<char> iOSPlatform::bytesFromFile(const char* _path) const {
+    NSString* path = resolvePath(_path);
+
+    if (!path) { return {}; }
+
+    auto data = Platform::bytesFromFile([path UTF8String]);
+    return data;
+}
+
 std::string iOSPlatform::stringFromFile(const char* _path) const {
     NSString* path = resolvePath(_path);
     std::string data;


### PR DESCRIPTION
Fixes issue https://github.com/mapzen/ios/issues/164.

Tested on the iOS SDK.