### PR TITLE
Use built-in SQLite3 on iOS instead of building our own

### DIFF
--- a/core/deps/CMakeLists.txt
+++ b/core/deps/CMakeLists.txt
@@ -84,5 +84,9 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/alfons)
 ###############
 set(SQLITECPP_RUN_CPPLINT OFF CACHE BOOL "")
 set(SQLITECPP_RUN_CPPCHECK OFF CACHE BOOL "")
+set(SQLITE_ENABLE_COLUMN_METADATA OFF CACHE BOOL "")
 
 add_subdirectory(SQLiteCpp)
+
+# Extensions aren't needed for MBTiles and aren't available in older versions of sqlite3.
+target_compile_definitions(SQLiteCpp PRIVATE SQLITE_OMIT_LOAD_EXTENSION)

--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -35,6 +35,9 @@ endif()
 
 set(FRAMEWORKS CoreGraphics CoreFoundation QuartzCore UIKit OpenGLES Security CFNetwork GLKit)
 
+# Tell SQLiteCpp to not build its own copy of SQLite, we will use the system library instead.
+set(SQLITECPP_INTERNAL_SQLITE OFF)
+
 # load core library
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
 
@@ -73,6 +76,9 @@ add_bundle_resources(RESOURCES "${PROJECT_SOURCE_DIR}/platforms/ios/framework/Mo
 
 add_library(${FRAMEWORK_NAME} SHARED ${SOURCES} ${HEADERS} ${RESOURCES})
 target_link_libraries(${FRAMEWORK_NAME} ${CORE_LIBRARY})
+
+# Link with SQLite, needed for MBTiles access.
+target_link_libraries(${FRAMEWORK_NAME} sqlite3)
 
 set(IOS_FRAMEWORK_RESOURCES ${PROJECT_SOURCE_DIR}/platforms/ios/framework/Info.plist)
 


### PR DESCRIPTION
Should reduce the framework size a little.