### PR TITLE
Add Javadoc for com.mapzen.tangram.goemetry

### DIFF
--- a/platforms/android/tangram/gradle-mvn-push.gradle
+++ b/platforms/android/tangram/gradle-mvn-push.gradle
@@ -87,7 +87,6 @@ afterEvaluate { project ->
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     exclude '**/*.kt'
     exclude 'com/almeros/android/multitouch'
-    exclude 'com/mapzen/tangram/geometry'
 
     if (JavaVersion.current().isJava8Compatible()) {
       allprojects {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/geometry/Geometry.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/geometry/Geometry.java
@@ -4,8 +4,6 @@ import java.util.Map;
 
 /**
  * {@code Geometry} is an abstract container of LngLat points and associated properties.
- *
- * Users of Tangram do not need to use this class.
  */
 public abstract class Geometry {
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/geometry/Point.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/geometry/Point.java
@@ -6,8 +6,6 @@ import java.util.Map;
 
 /**
  * {@code Point} is a single LngLat and its properties.
- *
- * Users of Tangram do not need to use this class.
  */
 public class Point extends Geometry {
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/geometry/Polygon.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/geometry/Polygon.java
@@ -7,8 +7,6 @@ import java.util.Map;
 
 /**
  * {@code Polygon} is a sequence of rings of LngLat points and its properties.
- *
- * Users of Tangram do not need to use this class.
  */
 public class Polygon extends Geometry {
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/geometry/Polyline.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/geometry/Polyline.java
@@ -7,8 +7,6 @@ import java.util.Map;
 
 /**
  * {@code Polyline} is a sequence of LngLat points and its properties.
- *
- * Users of Tangram do not need to use this class.
  */
 public class Polyline extends Geometry {
 
@@ -23,5 +21,5 @@ public class Polyline extends Geometry {
             this.properties = getStringMapAsArray(properties);
         }
     }
-    
+
 }


### PR DESCRIPTION
The 'geometry' package is now used in the public interface, so the Javadoc should be treated accordingly.