### PR TITLE
Add Marker helper class to iOS SDK

### DIFF
--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -112,8 +112,10 @@
     {
         if (!vc.markerPolyline) {
             vc.markerPolyline = [[TGMarker alloc] init];
-            vc.markerPolyline.map = view;
             vc.markerPolyline.styling = @"{ style: 'lines', color: 'red', width: 20px, order: 500 }";
+
+            // Add the marker to the current view
+            vc.markerPolyline.map = view;
         }
 
         static TGGeoPolyline* line = nil;
@@ -131,8 +133,10 @@
     {
         if (!vc.markerPolygon) {
             vc.markerPolygon = [[TGMarker alloc] init];
-            vc.markerPolygon.map = view;
             vc.markerPolygon.styling = @"{ style: 'polygons', color: 'blue', order: 500 }";
+
+            // Add the marker to the current view
+            vc.markerPolygon.map = view;
         }
 
         static TGGeoPolygon* polygon = nil;
@@ -151,8 +155,7 @@
 
     // Add point marker
     {
-        TGMarker* markerPoint = [[TGMarker alloc] init];
-        markerPoint.map = view;
+        TGMarker* markerPoint = [[TGMarker alloc] initWithMapView:view];
         markerPoint.styling = @"{ style: 'points', color: 'white', size: [25px, 25px], collide: false }";
         markerPoint.point = coordinate;
     }
@@ -160,6 +163,7 @@
     // Request feature picking
     [vc pickFeatureAt:location];
     [vc pickLabelAt:location];
+    // [vc pickMarkerAt:location];
 }
 
 - (void)mapView:(TGMapViewController *)view recognizer:(UIGestureRecognizer *)recognizer didRecognizeLongPressGesture:(CGPoint)location

--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -9,8 +9,8 @@
 
 @interface MapViewController ()
 
-@property (assign, nonatomic) TGMapMarkerId polyline;
-@property (assign, nonatomic) TGMapMarkerId polygon;
+@property (assign, nonatomic) TGMarker* markerPolyline;
+@property (assign, nonatomic) TGMarker* markerPolygon;
 
 @end
 
@@ -43,7 +43,9 @@
         return;
     }
 
-    NSString* message = [NSString stringWithFormat:@"Marker %d", markerPickResult.identifier];
+    NSString* message = [NSString stringWithFormat:@"Marker %f %f",
+        markerPickResult.marker.point.latitude,
+        markerPickResult.marker.point.longitude];
 
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Marker pick callback"
                                                     message:message
@@ -108,9 +110,10 @@
 
     // Add polyline marker
     {
-        if (!vc.polyline) {
-            vc.polyline = [vc markerAdd];
-            [vc markerSetStyling:vc.polyline styling:@"{ style: 'lines', color: 'red', width: 20px, order: 500 }"];
+        if (!vc.markerPolyline) {
+            vc.markerPolyline = [[TGMarker alloc] init];
+            vc.markerPolyline.map = view;
+            vc.markerPolyline.styling = @"{ style: 'lines', color: 'red', width: 20px, order: 500 }";
         }
 
         static TGGeoPolyline* line = nil;
@@ -118,7 +121,7 @@
 
         if ([line count] > 0) {
             [line addPoint:coordinate];
-            [vc markerSetPolyline:vc.polyline polyline:line];
+            vc.markerPolyline.polyline = line;
         } else {
             [line addPoint:coordinate];
         }
@@ -126,9 +129,10 @@
 
     // Add polygon marker
     {
-        if (!vc.polygon) {
-            vc.polygon = [vc markerAdd];
-            [vc markerSetStyling:vc.polygon styling:@" { style: 'polygons', color: 'blue', order: 500 } "];
+        if (!vc.markerPolygon) {
+            vc.markerPolygon = [[TGMarker alloc] init];
+            vc.markerPolygon.map = view;
+            vc.markerPolygon.styling = @"{ style: 'polygons', color: 'blue', order: 500 }";
         }
 
         static TGGeoPolygon* polygon = nil;
@@ -137,7 +141,7 @@
         if ([polygon count] == 0) {
             [polygon startPath:coordinate withSize:5];
         } else if ([polygon count] % 5 == 0) {
-            [vc markerSetPolygon:vc.polygon polygon:polygon];
+            vc.markerPolygon.polygon = polygon;
             [polygon removeAll];
             [polygon startPath:coordinate withSize:5];
         } else {
@@ -147,9 +151,10 @@
 
     // Add point marker
     {
-        TGMapMarkerId mid = [vc markerAdd];
-        [vc markerSetStyling:mid styling:@"{ style: 'points', color: 'white', size: [25px, 25px], order:500, collide: false }"];
-        [vc markerSetPoint:mid coordinates:coordinate];
+        TGMarker* markerPoint = [[TGMarker alloc] init];
+        markerPoint.map = view;
+        markerPoint.styling = @"{ style: 'points', color: 'white', size: [25px, 25px], collide: false }";
+        markerPoint.point = coordinate;
     }
 
     // Request feature picking
@@ -177,9 +182,6 @@
 
     self.mapViewDelegate = [[MapViewControllerDelegate alloc] init];
     self.gestureDelegate = [[MapViewControllerRecognizerDelegate alloc] init];
-
-    self.polyline = 0;
-    self.polygon = 0;
 }
 
 - (void)didReceiveMemoryWarning

--- a/platforms/ios/src/TangramMap/TGEaseType.h
+++ b/platforms/ios/src/TangramMap/TGEaseType.h
@@ -1,0 +1,22 @@
+//
+//  TGEaseType.h
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/21/17.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+/**
+ These enumerations describe an ease type function to be used for camera or other transition animation.
+ The function is being used to interpolate between the start and end position of the animation.
+ */
+typedef NS_ENUM(NSInteger, TGEaseType) {
+    /// Linear ease type `f(t) = t`
+    TGEaseTypeLinear = 0,
+    /// Cube ease type `f(t) = (-2 * t + 3) * t * t`
+    TGEaseTypeCubic,
+    /// Quint ease type `f(t) = (6 * t * t - 15 * t + 10) * t * t * t`
+    TGEaseTypeQuint,
+    /// Sine ease type `f(t) = 0.5 - 0.5 * cos(PI * t)`
+    TGEaseTypeSine,
+};

--- a/platforms/ios/src/TangramMap/TGGeoPolygon.h
+++ b/platforms/ios/src/TangramMap/TGGeoPolygon.h
@@ -12,7 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Helper class to contain a polygon geometry for use in `-[TGMapViewController markerSetPolygon:polygon:]`.
+ Helper class to contain a polygon geometry for use in `-[TGMarker polygon]`.
 
  The polygon winding order and internal polygons must be set according to the <a href="http://geojson.org/geojson-spec.html#polygon">
  GeoJSON specification</a>.

--- a/platforms/ios/src/TangramMap/TGGeoPolygon.h
+++ b/platforms/ios/src/TangramMap/TGGeoPolygon.h
@@ -83,6 +83,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)removeAll;
 
+- (instancetype)userData;
+
 NS_ASSUME_NONNULL_END
 
 @end

--- a/platforms/ios/src/TangramMap/TGGeoPolygon.h
+++ b/platforms/ios/src/TangramMap/TGGeoPolygon.h
@@ -83,8 +83,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)removeAll;
 
-- (instancetype)userData;
-
 NS_ASSUME_NONNULL_END
 
 @end

--- a/platforms/ios/src/TangramMap/TGGeoPolyline.h
+++ b/platforms/ios/src/TangramMap/TGGeoPolyline.h
@@ -12,13 +12,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Helper class to contain a polyline geometry for use in `-[TGMapViewController markerSetPolyline:polyline:]`.
+ Helper class to contain a polyline geometry for use in `-[TGMarker polyline]`.
 
  Set the geometry of a marker to a polyline along the given coordinates; _coordinates is a
  pointer to a sequence of _count LngLats; markers can have their geometry set multiple times
  with possibly different geometry types; returns true if the marker ID was found and
  successfully updated, otherwise returns false.
-
  */
 @interface TGGeoPolyline : NSObject
 

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -9,8 +9,20 @@
 #import "TGMapViewController.h"
 #import "tangram.h"
 
+
 @interface TGMapViewController ()
+
+NS_ASSUME_NONNULL_BEGIN
+
+- (void)addMarker:(TGMarker *)marker withIdentifier:(Tangram::MarkerID)identifier;
+
+- (void)removeMarker:(Tangram::MarkerID)identifier;
+
+NS_ASSUME_NONNULL_END
+
+- (TGMarker *)getMarker:(Tangram::MarkerID)identifier;
 
 @property (assign, nonatomic, nullable) Tangram::Map* map;
 
 @end
+

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -1,0 +1,16 @@
+//
+//  TGMapViewController+Internal.h
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/17/17.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+#import "TGMapViewController.h"
+#import "tangram.h"
+
+@interface TGMapViewController ()
+
+@property (assign, nonatomic, nullable) Tangram::Map* map;
+
+@end

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -20,8 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
-- (TGMarker *)getMarker:(Tangram::MarkerID)identifier;
-
 @property (assign, nonatomic, nullable) Tangram::Map* map;
 
 @end

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -330,6 +330,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) float rotation;
 /// Assign a tilt angle in radians to the map view camera
 @property (assign, nonatomic) float tilt;
+/// Access the markers added to this map view
+@property (readonly, nonatomic) NSArray<TGMarker *>* markers;
 
 /**
  Assign `TGHttpHandler` for network request management.
@@ -486,7 +488,8 @@ NS_ASSUME_NONNULL_BEGIN
  To set a marker interactive, you must set it when styling it:
 
  ```swift
- markerSetStyling(markerIdentifier, styling: "{ style: 'points', interactive : true,  color: 'white', size: [30px, 30px], order: 500 }")
+ TGMarker marker;
+ marker.styling = "{ style: 'points', interactive : true,  color: 'white', size: [30px, 30px], order: 500 }"
  ```
 
  @param screenPosition the logical pixels screen position used for the feature selection query
@@ -495,6 +498,13 @@ NS_ASSUME_NONNULL_BEGIN
  `[TGMapViewDelegate mapView:didSelectMarker:atScreenPosition:]`.
  */
 - (void)pickMarkerAt:(CGPoint)screenPosition;
+
+#pragma mark Marker access
+
+/**
+ Removes all the markers added to the map view.
+ */
+- (void)markerRemoveAll;
 
 #pragma mark Map View lifecycle
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -19,6 +19,7 @@
 #import "TGSceneUpdate.h"
 #import "TGHttpHandler.h"
 #import "TGLabelPickResult.h"
+#import "TGMarker.h"
 #import "TGMarkerPickResult.h"
 
 /**
@@ -32,21 +33,6 @@ typedef NS_ENUM(NSInteger, TGCameraType) {
     TGCameraTypeIsometric,
     /// Type for a <a href="https://mapzen.com/documentation/tangram/Cameras-Overview/#flat-camera">flat camera</a>
     TGCameraTypeFlat,
-};
-
-/**
- These enumerations describe an ease type function to be used for camera or other transition animation.
- The function is being used to interpolate between the start and end position of the animation.
- */
-typedef NS_ENUM(NSInteger, TGEaseType) {
-    /// Linear ease type `f(t) = t`
-    TGEaseTypeLinear = 0,
-    /// Cube ease type `f(t) = (-2 * t + 3) * t * t`
-    TGEaseTypeCubic,
-    /// Quint ease type `f(t) = (6 * t * t - 15 * t + 10) * t * t * t`
-    TGEaseTypeQuint,
-    /// Sine ease type `f(t) = 0.5 - 0.5 * cos(PI * t)`
-    TGEaseTypeSine,
 };
 
 /// Debug flags to render additional information about various map components
@@ -384,136 +370,6 @@ NS_ASSUME_NONNULL_BEGIN
  @param debugFlag the debug flag to toggle the status of
  */
 - (void)toggleDebugFlag:(TGDebugFlag)debugFlag;
-
-#pragma mark Marker interface
-
-/**
- Removes all the markers added to the map view.
- */
-- (void)markerRemoveAll;
-
-/**
- Creates a marker identifier which can be used to dynamically add points and polylines
- to the map.
-
- Example on how to add a point to the map for a geographic coordinate.
-
- ```swift
- var identifier = view.markerAdd()
- view.markerSetStyling(identifier, styling: "{ style: 'points', color: 'white', size: [25px, 25px], order:500 }")
- view.markerSetPoint(identifier, coordinates: TGGeoPointMake(longitude, latitude))
- ```
-
- @return a marker identifier, 0 if adding a marker failed
- @note The marker should be appropriately styled using `-markerSetStyling:styling:`
- and a type must be set (point, polyline, polygon) through `markerSetPoint*`, `markerSetPolyline` or `markerSetPolygon`
- for it to be visible.
-
- @note May return 0 if adding a marker failed, a marker identifier of 0 is non-valid.
- */
-- (TGMapMarkerId)markerAdd;
-
-/**
- Sets the styling for a marker identifier.
-
- See the more detailed scene <a href="https://mapzen.com/documentation/tangram/Styles-Overview/">documentation</a>
- to get more styling informations.
-
- @param identifier the marker identifier created with `-markerAdd`
- @param styling the styling string in YAML syntax to set to the marker
-
- @return `YES` if this operation was successful, `NO` otherwise
-
- @note It is possible to update the marker styling multiple times.
- */
-- (BOOL)markerSetStyling:(TGMapMarkerId)identifier styling:(NSString *)styling;
-
-/**
- Sets a marker to be a single point geometry at a geographic coordinate.
-
- @param identifier the marker identifier created with `-markerAdd`
- @param the longitude and latitude where the marker will be placed
- @return `YES` if this operation was successful, `NO` otherwise
-
- @note Markers can have their geometry set multiple time with possibly different geometry types.
- */
-- (BOOL)markerSetPoint:(TGMapMarkerId)identifier coordinates:(TGGeoPoint)coordinate;
-
-/**
- Similar to `-[TGMapViewController markerSetPoint:coordinates:]` except that the point will transition to the
- geographic coordinate with a transition of time `seconds` and with an ease type function of type `ease`
- (See `TGEaseType`) from its previous coordinate, if a point geometry hasn't been set any coordinate yet,
- this method will act as `-markerSetPoint:coordinates:`.
-
- @param identifier the marker identifier created with `-markerAdd`
- @param the longitude and latitude where the marker will be placed
- @param seconds the animation duration given in seconds
- @param ease the ease function to be used between animation timestep
- @return `YES` if this operation was successful, `NO` otherwise
-
- @note Markers can have their geometry set multiple time with possibly different geometry types.
- */
-- (BOOL)markerSetPointEased:(TGMapMarkerId)identifier coordinates:(TGGeoPoint)coordinate seconds:(float)seconds easeType:(TGEaseType)ease;
-
-/**
- Sets a marker styled to be a polyline (described in a `TGGeoPolyline`).
-
- @param identifier the marker identifier created with `-markerAdd`
- @oaram polyline the polyline geometry to use for this marker
- @return `YES` if this operation was successful, `NO` otherwise
-
- @note Markers can have their geometry set multiple time wwith possibly different geometry types.
- */
-- (BOOL)markerSetPolyline:(TGMapMarkerId)identifier polyline:(TGGeoPolyline *)polyline;
-
-/**
- Sets a marker to be a polygon geometry (described in a `TGGeoPolygon`).
-
- @param identifier the marker identifier created with `-[TGMapViewController markerAdd]`
- @param polygon the polygon geometry to use for this marker
- @return `YES` if this operation was successful, `NO` otherwise
-
- @note Markers can have their geometry set multiple time with possibly different geometry types.
- */
-- (BOOL)markerSetPolygon:(TGMapMarkerId)identifier polygon:(TGGeoPolygon *)polygon;
-
-/**
- Adjusts marker visibility
-
- @param identifier the marker identifier created with `- markerAdd`
- @param whether the marker is set to visible
- @return `YES` if this operation was successful, `NO` otherwise
- */
-- (BOOL)markerSetVisible:(TGMapMarkerId)identifier visible:(BOOL)visible;
-
-/**
- Sets an image loaded with a <a href="https://developer.apple.com/reference/uikit/uiimage">
- UIImage</a> to a marker styled with a <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">
- points style</a>.
-
- ```swift
- var identifier = view.markerAdd()
- view.markerSetStyling(identifier, styling: "{ style: 'points', color: 'white', size: [25px, 25px], order:500 }")
- view.markerSetPoint(identifier, coordinates: TGGeoPointMake(longitude, latitude))
- view.markerSetImage(identifier, image: UIIMage(name: "marker-image.png"))
- ```
-
- @param identifier the marker identifier created with `-markerAdd`
- @param the `UIImage` that will be used to be displayed on the marker
- @return `YES` if this operation was successful, `NO` otherwise
-
- @note An image marker must be styled with a
- <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">point style</a>.
- */
-- (BOOL)markerSetImage:(TGMapMarkerId)identifier image:(UIImage *)image;
-
-/**
- Removes a marker for a marker identifier.
-
- @param identifier the marker identifier created with `-markerAdd`
- @return `YES` if removal was succesful, `NO` otherwise
- */
-- (BOOL)markerRemove:(TGMapMarkerId)identifier;
 
 #pragma mark Scene loading - updates interface
 

--- a/platforms/ios/src/TangramMap/TGMarker.h
+++ b/platforms/ios/src/TangramMap/TGMarker.h
@@ -95,6 +95,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL visible;
 
 /**
+ Set the ordering of point marker object relative to other markers; higher values are drawn 'above'.
+ */
+@property (assign, nonatomic) NSInteger drawOrder;
+
+/**
  Sets an icon loaded with a <a href="https://developer.apple.com/reference/uikit/uiimage">
  UIImage</a> to a marker styled with a <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">
  points style</a>.

--- a/platforms/ios/src/TangramMap/TGMarker.h
+++ b/platforms/ios/src/TangramMap/TGMarker.h
@@ -18,23 +18,38 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ Marker interface that makes you able to add icons, polylines and polygons to the map view.
+
+ The marker style should defined using the <a href="https://mapzen.com/documentation/tangram/Styles-Overview">
+ Tangram YAML syntax</a>.
+ */
 @interface TGMarker : NSObject
 
 /*
- TODO
+ Initializes a `TGMarker`.
+
+ @note the marker will not be visible on any map view, if you want to add this marker to a view make sure
+ to set a map view to this marker object with `-[TGMarker map]`, style it and set its geometry.
  */
 - (instancetype)init;
 
+/*
+ Initializes a `TGMarker` and adds it to the map view.
+
+ @param mapView the map view to add this marker to
+
+ @note the marker will not be visible on the map view until you set its styling and set its geometry.
+ */
 - (instancetype)initWithMapView:(TGMapViewController *)mapView;
 
 /**
- Similar to `-[TGMapViewController markerSetPoint:coordinates:]` except that the point will transition to the
+ Similar to `-[TGMarker point]` except that the point will transition to the
  geographic coordinate with a transition of time `seconds` and with an ease type function of type `ease`
  (See `TGEaseType`) from its previous coordinate, if a point geometry hasn't been set any coordinate yet,
- this method will act as `-markerSetPoint:coordinates:`.
+ this method will act as `-[TGMarker point]`.
 
- @param identifier the marker identifier created with `-markerAdd`
- @param the longitude and latitude where the marker will be placed
+ @param coordinates the longitude and latitude where the marker will be placed
  @param seconds the animation duration given in seconds
  @param ease the ease function to be used between animation timestep
  @return `YES` if this operation was successful, `NO` otherwise
@@ -44,15 +59,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)setPointEased:(TGGeoPoint)coordinates seconds:(float)seconds easeType:(TGEaseType)ease;
 
 /**
- Sets the styling for a marker identifier.
+ Sets the styling for a marker.
 
  See the more detailed scene <a href="https://mapzen.com/documentation/tangram/Styles-Overview/">documentation</a>
  to get more styling informations.
-
- @param identifier the marker identifier created with `-markerAdd`
- @param styling the styling string in YAML syntax to set to the marker
-
- @return `YES` if this operation was successful, `NO` otherwise
 
  @note It is possible to update the marker styling multiple times.
  */
@@ -61,20 +71,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Sets a marker to be a single point geometry at a geographic coordinate.
 
- @param identifier the marker identifier created with `-markerAdd`
- @param the longitude and latitude where the marker will be placed
- @return `YES` if this operation was successful, `NO` otherwise
-
  @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
 @property (assign, nonatomic) TGGeoPoint point;
 
 /**
  Sets a marker styled to be a polyline (described in a `TGGeoPolyline`).
-
- @param identifier the marker identifier created with `-markerAdd`
- @oaram polyline the polyline geometry to use for this marker
- @return `YES` if this operation was successful, `NO` otherwise
 
  @note Markers can have their geometry set multiple time wwith possibly different geometry types.
  */
@@ -83,46 +85,36 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Sets a marker to be a polygon geometry (described in a `TGGeoPolygon`).
 
- @param identifier the marker identifier created with `-[TGMapViewController markerAdd]`
- @param polygon the polygon geometry to use for this marker
- @return `YES` if this operation was successful, `NO` otherwise
-
  @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
 @property (strong, nonatomic) TGGeoPolygon* polygon;
 
 /**
  Adjusts marker visibility
-
- @param identifier the marker identifier created with `- markerAdd`
- @param whether the marker is set to visible
- @return `YES` if this operation was successful, `NO` otherwise
  */
 @property (assign, nonatomic) BOOL visible;
 
 /**
- Sets an image loaded with a <a href="https://developer.apple.com/reference/uikit/uiimage">
+ Sets an icon loaded with a <a href="https://developer.apple.com/reference/uikit/uiimage">
  UIImage</a> to a marker styled with a <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">
  points style</a>.
 
  ```swift
- var identifier = view.markerAdd()
- view.markerSetStyling(identifier, styling: "{ style: 'points', color: 'white', size: [25px, 25px], order:500 }")
- view.markerSetPoint(identifier, coordinates: TGGeoPointMake(longitude, latitude))
- view.markerSetImage(identifier, image: UIIMage(name: "marker-image.png"))
+ TGMarker marker;
+ marker.styling = "{ style: 'points', color: 'white', size: [25px, 25px], order:500 }"
+ marker.point = TGGeoPointMake(longitude, latitude)
+ marker.icon = UIIMage(name: "marker-icon.png")
  ```
 
- @param identifier the marker identifier created with `-markerAdd`
- @param the `UIImage` that will be used to be displayed on the marker
- @return `YES` if this operation was successful, `NO` otherwise
-
- @note An image marker must be styled with a
+ @note An icon marker must be styled with a
  <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">point style</a>.
  */
-@property (strong, nonatomic) UIImage * icon;
+@property (strong, nonatomic) UIImage* icon;
 
 /*
- TODO
+ The map this marker is on.
+ Setting this property will add the marker to the map, and setting it to `nil` will remove the marker from it.
+ A marker can be only active at at most one `TGMapViewController` at a time.
  */
 @property (weak, nonatomic) TGMapViewController* map;
 

--- a/platforms/ios/src/TangramMap/TGMarker.h
+++ b/platforms/ios/src/TangramMap/TGMarker.h
@@ -1,0 +1,129 @@
+//
+//  TGMarker.h
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/17/17.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "TGGeoPoint.h"
+#import "TGGeoPolygon.h"
+#import "TGGeoPolyline.h"
+#import "TGEaseType.h"
+
+@class TGMapViewController;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TGMarker : NSObject
+
+/*
+ TODO
+ */
+- (instancetype)init;
+
+/**
+ Similar to `-[TGMapViewController markerSetPoint:coordinates:]` except that the point will transition to the
+ geographic coordinate with a transition of time `seconds` and with an ease type function of type `ease`
+ (See `TGEaseType`) from its previous coordinate, if a point geometry hasn't been set any coordinate yet,
+ this method will act as `-markerSetPoint:coordinates:`.
+
+ @param identifier the marker identifier created with `-markerAdd`
+ @param the longitude and latitude where the marker will be placed
+ @param seconds the animation duration given in seconds
+ @param ease the ease function to be used between animation timestep
+ @return `YES` if this operation was successful, `NO` otherwise
+
+ @note Markers can have their geometry set multiple time with possibly different geometry types.
+ */
+- (BOOL)setPointEased:(TGGeoPoint)coordinates seconds:(float)seconds easeType:(TGEaseType)ease;
+
+/**
+ Sets the styling for a marker identifier.
+
+ See the more detailed scene <a href="https://mapzen.com/documentation/tangram/Styles-Overview/">documentation</a>
+ to get more styling informations.
+
+ @param identifier the marker identifier created with `-markerAdd`
+ @param styling the styling string in YAML syntax to set to the marker
+
+ @return `YES` if this operation was successful, `NO` otherwise
+
+ @note It is possible to update the marker styling multiple times.
+ */
+@property (copy, nonatomic) NSString* styling;
+
+/**
+ Sets a marker to be a single point geometry at a geographic coordinate.
+
+ @param identifier the marker identifier created with `-markerAdd`
+ @param the longitude and latitude where the marker will be placed
+ @return `YES` if this operation was successful, `NO` otherwise
+
+ @note Markers can have their geometry set multiple time with possibly different geometry types.
+ */
+@property (assign, nonatomic) TGGeoPoint point;
+
+/**
+ Sets a marker styled to be a polyline (described in a `TGGeoPolyline`).
+
+ @param identifier the marker identifier created with `-markerAdd`
+ @oaram polyline the polyline geometry to use for this marker
+ @return `YES` if this operation was successful, `NO` otherwise
+
+ @note Markers can have their geometry set multiple time wwith possibly different geometry types.
+ */
+@property (strong, nonatomic) TGGeoPolyline* polyline;
+
+/**
+ Sets a marker to be a polygon geometry (described in a `TGGeoPolygon`).
+
+ @param identifier the marker identifier created with `-[TGMapViewController markerAdd]`
+ @param polygon the polygon geometry to use for this marker
+ @return `YES` if this operation was successful, `NO` otherwise
+
+ @note Markers can have their geometry set multiple time with possibly different geometry types.
+ */
+@property (strong, nonatomic) TGGeoPolygon* polygon;
+
+/**
+ Adjusts marker visibility
+
+ @param identifier the marker identifier created with `- markerAdd`
+ @param whether the marker is set to visible
+ @return `YES` if this operation was successful, `NO` otherwise
+ */
+@property (assign, nonatomic) BOOL visible;
+
+/**
+ Sets an image loaded with a <a href="https://developer.apple.com/reference/uikit/uiimage">
+ UIImage</a> to a marker styled with a <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">
+ points style</a>.
+
+ ```swift
+ var identifier = view.markerAdd()
+ view.markerSetStyling(identifier, styling: "{ style: 'points', color: 'white', size: [25px, 25px], order:500 }")
+ view.markerSetPoint(identifier, coordinates: TGGeoPointMake(longitude, latitude))
+ view.markerSetImage(identifier, image: UIIMage(name: "marker-image.png"))
+ ```
+
+ @param identifier the marker identifier created with `-markerAdd`
+ @param the `UIImage` that will be used to be displayed on the marker
+ @return `YES` if this operation was successful, `NO` otherwise
+
+ @note An image marker must be styled with a
+ <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">point style</a>.
+ */
+@property (strong, nonatomic) UIImage * icon;
+
+/*
+ TODO
+ */
+@property (weak, nonatomic) TGMapViewController* map;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/platforms/ios/src/TangramMap/TGMarker.h
+++ b/platforms/ios/src/TangramMap/TGMarker.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)init;
 
+- (instancetype)initWithMapView:(TGMapViewController *)mapView;
+
 /**
  Similar to `-[TGMapViewController markerSetPoint:coordinates:]` except that the point will transition to the
  geographic coordinate with a transition of time `seconds` and with an ease type function of type `ease`

--- a/platforms/ios/src/TangramMap/TGMarker.h
+++ b/platforms/ios/src/TangramMap/TGMarker.h
@@ -116,13 +116,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (strong, nonatomic) UIImage* icon;
 
+NS_ASSUME_NONNULL_END
+
 /*
  The map this marker is on.
  Setting this property will add the marker to the map, and setting it to `nil` will remove the marker from it.
  A marker can be only active at at most one `TGMapViewController` at a time.
  */
-@property (weak, nonatomic) TGMapViewController* map;
-
-NS_ASSUME_NONNULL_END
+@property (weak, nonatomic) TGMapViewController* _Nullable map;
 
 @end

--- a/platforms/ios/src/TangramMap/TGMarker.mm
+++ b/platforms/ios/src/TangramMap/TGMarker.mm
@@ -21,6 +21,7 @@ enum class TGMarkerType {
 
 @interface TGMarker () {
     Tangram::Map* tangramInstance;
+    TGMapViewController* mapViewController;
     Tangram::MarkerID identifier;
     TGMarkerType type;
 }
@@ -34,8 +35,21 @@ enum class TGMarkerType {
     self = [super init];
 
     if (self) {
-        self.visible = YES;
         type = TGMarkerType::none;
+        self.visible = YES;
+    }
+
+    return self;
+}
+
+- (instancetype)initWithMapView:(TGMapViewController *)mapView
+{
+    self = [super init];
+
+    if (self) {
+        type = TGMarkerType::none;
+        self.visible = YES;
+        self.map = mapView;
     }
 
     return self;
@@ -135,20 +149,24 @@ enum class TGMarkerType {
     if (!mapView && tangramInstance && identifier) {
         tangramInstance->markerRemove(identifier);
         tangramInstance = nullptr;
+        mapViewController = nil;
         return;
     }
 
     if (![mapView map] || [mapView map] == tangramInstance) { return; }
 
     // Removes the marker from the previous map view
-    if (tangramInstance) {
+    if (tangramInstance && mapViewController) {
         tangramInstance->markerRemove(identifier);
+        [mapViewController removeMarker:identifier];
     }
 
     tangramInstance = [mapView map];
+    mapViewController = mapView;
 
     // Create a new marker identifier for this view
     identifier = tangramInstance->markerAdd();
+    [mapViewController addMarker:self withIdentifier:identifier];
 
     if (!identifier) { return NO; }
 

--- a/platforms/ios/src/TangramMap/TGMarker.mm
+++ b/platforms/ios/src/TangramMap/TGMarker.mm
@@ -1,0 +1,185 @@
+//
+//  TGMarker.mm
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/17/17.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+#import "TGMarker.h"
+#import "TGMapViewController.h"
+#import "TGMapViewController+Internal.h"
+#import "TGHelpers.h"
+#import "tangram.h"
+
+enum class TGMarkerType {
+    point,
+    polygon,
+    polyline,
+    none,
+};
+
+@interface TGMarker () {
+    Tangram::Map* tangramInstance;
+    Tangram::MarkerID identifier;
+    TGMarkerType type;
+}
+
+@end
+
+@implementation TGMarker
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (self) {
+        self.visible = YES;
+        type = TGMarkerType::none;
+    }
+
+    return self;
+}
+
+- (void)setStyling:(NSString *)styling
+{
+    _styling = styling;
+
+    if (!tangramInstance || !identifier) { return; }
+
+    tangramInstance->markerSetStyling(identifier, [styling UTF8String]);
+}
+
+- (void)setPoint:(TGGeoPoint)coordinates
+{
+    _point = coordinates;
+    type = TGMarkerType::point;
+
+    if (!tangramInstance || !identifier) { return; }
+
+    Tangram::LngLat lngLat(coordinates.longitude, coordinates.latitude);
+
+    tangramInstance->markerSetPoint(identifier, lngLat);
+}
+
+- (BOOL)setPointEased:(TGGeoPoint)coordinates seconds:(float)seconds easeType:(TGEaseType)ease
+{
+    _point = coordinates;
+    type = TGMarkerType::point;
+
+    if (!tangramInstance || !identifier) { return; }
+
+    Tangram::LngLat lngLat(coordinates.longitude, coordinates.latitude);
+
+    tangramInstance->markerSetPointEased(identifier, lngLat, seconds, [TGHelpers convertEaseTypeFrom:ease]);
+}
+
+- (void)setPolyline:(TGGeoPolyline *)polyline
+{
+    _polyline = polyline;
+    type = TGMarkerType::polyline;
+
+    if (polyline.count < 2 || !tangramInstance || !identifier) { return; }
+
+    tangramInstance->markerSetPolyline(identifier, reinterpret_cast<Tangram::LngLat*>([polyline coordinates]), polyline.count);
+}
+
+- (void)setPolygon:(TGGeoPolygon *)polygon
+{
+    _polygon = polygon;
+    type = TGMarkerType::polygon;
+
+    if (polygon.count < 3 || !tangramInstance || !identifier) { return; }
+
+    auto coords = reinterpret_cast<Tangram::LngLat*>([polygon coordinates]);
+
+    tangramInstance->markerSetPolygon(identifier, coords, [polygon rings], [polygon ringsCount]);
+}
+
+- (void)setVisible:(BOOL)visible
+{
+    _visible = visible;
+
+    if (!tangramInstance || !identifier) { return; }
+
+    tangramInstance->markerSetVisible(identifier, visible);
+}
+
+- (void)setIcon:(UIImage *)icon
+{
+    if (!tangramInstance) { return; }
+
+    CGImage* cgImage = [icon CGImage];
+    size_t w = CGImageGetHeight(cgImage);
+    size_t h = CGImageGetWidth(cgImage);
+    std::vector<unsigned int> bitmap;
+
+    bitmap.resize(w * h);
+
+    CGColorSpaceRef colorSpace = CGImageGetColorSpace(cgImage);
+    CGContextRef cgContext = CGBitmapContextCreate(bitmap.data(), w, h, 8, w * 4, colorSpace, kCGImageAlphaPremultipliedLast);
+
+    // Flip image upside down-horizontally
+    CGAffineTransform flipAffineTransform = CGAffineTransformMake(1, 0, 0, -1, 0, h);
+    CGContextConcatCTM(cgContext, flipAffineTransform);
+
+    CGContextDrawImage(cgContext, CGRectMake(0, 0, w, h), cgImage);
+    CGContextRelease(cgContext);
+
+    tangramInstance->markerSetBitmap(identifier, w, h, bitmap.data());
+}
+
+- (void)setMap:(TGMapViewController *)mapView
+{
+    // remove marker from current view
+    if (!mapView && tangramInstance && identifier) {
+        tangramInstance->markerRemove(identifier);
+        tangramInstance = nullptr;
+        return;
+    }
+
+    if (![mapView map] || [mapView map] == tangramInstance) { return; }
+
+    // Removes the marker from the previous map view
+    if (tangramInstance) {
+        tangramInstance->markerRemove(identifier);
+    }
+
+    tangramInstance = [mapView map];
+
+    // Create a new marker identifier for this view
+    identifier = tangramInstance->markerAdd();
+
+    if (!identifier) { return NO; }
+
+    // Set the geometry type
+    switch (type) {
+        case TGMarkerType::point: {
+            [self setPoint:self.point];
+
+            if (self.icon) {
+                [self setIcon:self.icon];
+            }
+        }
+        break;
+        case TGMarkerType::polygon: {
+            [self setPolygon:self.polygon];
+        }
+        break;
+        case TGMarkerType::polyline: {
+            [self setPolyline:self.polyline];
+        }
+        case TGMarkerType::none:
+        break;
+    }
+
+    // Update styling
+    if (self.styling) {
+        tangramInstance->markerSetStyling(identifier, [self.styling UTF8String]);
+    }
+
+    tangramInstance->markerSetVisible(identifier, self.visible);
+}
+
+@end
+

--- a/platforms/ios/src/TangramMap/TGMarker.mm
+++ b/platforms/ios/src/TangramMap/TGMarker.mm
@@ -37,6 +37,7 @@ enum class TGMarkerType {
     if (self) {
         type = TGMarkerType::none;
         self.visible = YES;
+        self.drawOrder = 0;
     }
 
     return self;
@@ -49,6 +50,7 @@ enum class TGMarkerType {
     if (self) {
         type = TGMarkerType::none;
         self.visible = YES;
+        self.drawOrder = 0;
         self.map = mapView;
     }
 
@@ -117,6 +119,15 @@ enum class TGMarkerType {
     if (!tangramInstance || !identifier) { return; }
 
     tangramInstance->markerSetVisible(identifier, visible);
+}
+
+- (void)setDrawOrder:(NSInteger)drawOrder
+{
+    _drawOrder = drawOrder;
+
+    if (!tangramInstance || !identifier) { return; }
+
+    tangramInstance->markerSetDrawOrder(identifier, (int)drawOrder);
 }
 
 - (void)setIcon:(UIImage *)icon
@@ -197,6 +208,7 @@ enum class TGMarkerType {
     }
 
     tangramInstance->markerSetVisible(identifier, self.visible);
+    tangramInstance->markerSetDrawOrder(identifier, (int)self.drawOrder);
 }
 
 @end

--- a/platforms/ios/src/TangramMap/TGMarkerPickResult.h
+++ b/platforms/ios/src/TangramMap/TGMarkerPickResult.h
@@ -8,14 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import "TGGeoPoint.h"
+#import "TGMarker.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-/**
- A marker identifier for use in the <a href="Classes/TGMapViewController.html#/Marker%20interface">marker interface</a>.
- A marker identifier of 0 is non-valid.
- */
-typedef uint32_t TGMapMarkerId;
 
 /**
  Data structure holding the result of a marker selection that occured on the map view.
@@ -35,13 +30,13 @@ typedef uint32_t TGMapMarkerId;
  @note You shouldn't have to create a `TGMarkerPickResult` yourself, those are returned as a result to
  a selection query on the `TGMapViewController` and initialized by the latter.
  */
-- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates identifier:(TGMapMarkerId)identifier;
+- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates marker:(TGMarker *)marker;
 
 /// The geographic coordinates of the selected label
 @property (readonly, nonatomic) TGGeoPoint coordinates;
 
 /// The identifier of the selected marker
-@property (readonly, nonatomic) TGMapMarkerId identifier;
+@property (readonly, nonatomic) TGMarker* marker;
 
 NS_ASSUME_NONNULL_END
 

--- a/platforms/ios/src/TangramMap/TGMarkerPickResult.h
+++ b/platforms/ios/src/TangramMap/TGMarkerPickResult.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  Initializes a `TGMarkerPickResult`.
 
  @param coordinates the geographic coordinates of the label pick result
- @param identifier the marker identifier
+ @param marker the marker object selected
 
  @return an initialized `TGMarkerPickResult`
 
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The geographic coordinates of the selected label
 @property (readonly, nonatomic) TGGeoPoint coordinates;
 
-/// The identifier of the selected marker
+/// The selected marker
 @property (readonly, nonatomic) TGMarker* marker;
 
 NS_ASSUME_NONNULL_END

--- a/platforms/ios/src/TangramMap/TGMarkerPickResult.mm
+++ b/platforms/ios/src/TangramMap/TGMarkerPickResult.mm
@@ -11,13 +11,13 @@
 @interface TGMarkerPickResult ()
 
 @property (assign, nonatomic) TGGeoPoint coordinates;
-@property (weak, nonatomic) TGMarker* marker;
+@property (strong, nonatomic) TGMarker* marker;
 
 @end
 
 @implementation TGMarkerPickResult
 
-- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates identifier:(TGMarker *)marker
+- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates marker:(TGMarker *)marker
 {
     self = [super init];
 

--- a/platforms/ios/src/TangramMap/TGMarkerPickResult.mm
+++ b/platforms/ios/src/TangramMap/TGMarkerPickResult.mm
@@ -11,19 +11,19 @@
 @interface TGMarkerPickResult ()
 
 @property (assign, nonatomic) TGGeoPoint coordinates;
-@property (assign, nonatomic) TGMapMarkerId identifier;
+@property (weak, nonatomic) TGMarker* marker;
 
 @end
 
 @implementation TGMarkerPickResult
 
-- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates identifier:(TGMapMarkerId)identifier
+- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates identifier:(TGMarker *)marker
 {
     self = [super init];
 
     if (self) {
         self.coordinates = coordinates;
-        self.identifier = identifier;
+        self.marker = marker;
     }
 
     return self;

--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -50,6 +50,7 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGSceneUpdate.mm
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGLabelPickResult.mm
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMarkerPickResult.mm
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMarker.mm
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMapViewController.mm)
 
 set(FRAMEWORK_HEADERS
@@ -57,6 +58,8 @@ set(FRAMEWORK_HEADERS
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGGeoPolyline.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGGeoPolygon.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGGeoPoint.h
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMarker.h
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGEaseType.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGSceneUpdate.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGHttpHandler.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGLabelPickResult.h


### PR DESCRIPTION
- Add `TGMarker` class and update interface to not use marker identifiers and simplify interface.
- Add missing `drawOrder` from interface.
- Add private/internal interface with framework only visibility for `TGMapViewController`.
- Add `markers` accessor to retrieve all marker objects added to a `TGMapViewController`.