### PR TITLE
iOS client data sources

### DIFF
--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -12,6 +12,8 @@
 @property (assign, nonatomic) TGMarker* markerPolygon;
 @property (strong, nonatomic) TGMapData* mapData;
 
+- (void)addAlert:(NSString *)message withTitle:(NSString *)title;
+
 @end
 
 @implementation MapViewControllerDelegate
@@ -51,12 +53,7 @@
         markerPickResult.marker.point.latitude,
         markerPickResult.marker.point.longitude];
 
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Marker pick callback"
-                                                    message:message
-                                                   delegate:nil
-                                          cancelButtonTitle:@"OK"
-                                          otherButtonTitles:nil];
-    [alert show];
+    [(MapViewController*)mapView addAlert:message withTitle:@"Marker pick callback"];
 }
 
 - (void)mapView:(TGMapViewController *)mapView didSelectLabel:(TGLabelPickResult *)labelPickResult atScreenPosition:(CGPoint)position
@@ -69,12 +66,7 @@
         NSLog(@"\t%@ -- %@", key, [[labelPickResult properties] objectForKey:key]);
 
         if ([key isEqualToString:@"name"]) {
-             UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Label selection callback"
-                                                             message:[[labelPickResult properties] objectForKey:key]
-                                                            delegate:nil
-                                                   cancelButtonTitle:@"OK"
-                                                   otherButtonTitles:nil];
-             [alert show];
+            [(MapViewController*)mapView addAlert:[[labelPickResult properties] objectForKey:key] withTitle:@"Label selection callback"];
         }
     }
 }
@@ -90,12 +82,7 @@
         NSLog(@"\t%@ -- %@", key, [feature objectForKey:key]);
 
         if ([key isEqualToString:@"name"]) {
-             UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Feature selection callback"
-                                                             message:[feature objectForKey:key]
-                                                            delegate:nil
-                                                   cancelButtonTitle:@"OK"
-                                                   otherButtonTitles:nil];
-             [alert show];
+            [(MapViewController*)mapView addAlert:[[feature objectForKey:key] objectForKey:key] withTitle:@"Feature selection callback"];
         }
     }
 }
@@ -174,6 +161,19 @@
 @end
 
 @implementation MapViewController
+
+- (void)addAlert:(NSString *)message withTitle:(NSString *)title
+{
+    UIAlertController *alert = [[UIAlertController alloc] init];
+
+    alert.title = title;
+    alert.message = message;
+
+    UIAlertAction* okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
+    [alert addAction:okAction];
+
+    [self presentViewController:alert animated:YES completion:nil];
+}
 
 - (void)viewWillAppear:(BOOL)animated
 {

--- a/platforms/ios/framework/TangramMap.h
+++ b/platforms/ios/framework/TangramMap.h
@@ -3,7 +3,8 @@
 //  TangramMap
 //
 //  Created by Matt Smollinger on 7/8/16.
-//
+//  Updated by Karim Naaji on 2/28/17.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
@@ -14,6 +15,16 @@ FOUNDATION_EXPORT double TangramMapVersionNumber;
 /// Project version string for TangramMap.
 FOUNDATION_EXPORT const unsigned char TangramMapVersionString[];
 
-// In this header, you should import all the public headers of your framework using statements like #import <TangramMap/PublicHeader.h>
-
 #import <TangramMap/TGMapViewController.h>
+#import <TangramMap/TGMapData.h>
+#import <TangramMap/TGGeoPoint.h>
+#import <TangramMap/TGGeoPolygon.h>
+#import <TangramMap/TGGeoPolyline.h>
+#import <TangramMap/TGEaseType.h>
+#import <TangramMap/TGHttpHandler.h>
+#import <TangramMap/TGMarker.h>
+#import <TangramMap/TGMapData.h>
+#import <TangramMap/TGSceneUpdate.h>
+#import <TangramMap/TGMarkerPickResult.h>
+#import <TangramMap/TGLabelPickResult.h>
+

--- a/platforms/ios/src/TangramMap/TGLabelPickResult+Internal.h
+++ b/platforms/ios/src/TangramMap/TGLabelPickResult+Internal.h
@@ -1,0 +1,32 @@
+//
+//  TGLabelPickResult+Internal.h
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/27/17.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+#import "TGLabelPickResult.h"
+
+@interface TGLabelPickResult ()
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Initializes a `TGLabelPickResult`.
+
+ @param coordinates the geographic coordinates of the label pick result
+ @param type the type of the label (text or icon)
+ @param properties the set of properties associated to this label, keyed by their name
+
+ @return an initialized `TGLabelPickResult`
+
+ @note You shouldn't have to create a `TGLabelPickResult` yourself, those are returned as a result to
+ a selection query on the `TGMapViewController` and initialized by the latter.
+ */
+- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates type:(TGLabelType)type properties:(NSDictionary *)properties;
+
+NS_ASSUME_NONNULL_END
+
+@end
+

--- a/platforms/ios/src/TangramMap/TGLabelPickResult.h
+++ b/platforms/ios/src/TangramMap/TGLabelPickResult.h
@@ -28,20 +28,6 @@ typedef NS_ENUM(NSInteger, TGLabelType) {
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- Initializes a `TGLabelPickResult`.
-
- @param coordinates the geographic coordinates of the label pick result
- @param type the type of the label (text or icon)
- @param properties the set of properties associated to this label, keyed by their name
-
- @return an initialized `TGLabelPickResult`
-
- @note You shouldn't have to create a `TGLabelPickResult` yourself, those are returned as a result to
- a selection query on the `TGMapViewController` and initialized by the latter.
- */
-- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates type:(TGLabelType)type properties:(NSDictionary *)properties;
-
 /// The geographic coordinates of the selected label
 @property (readonly, nonatomic) TGGeoPoint coordinates;
 

--- a/platforms/ios/src/TangramMap/TGLabelPickResult.h
+++ b/platforms/ios/src/TangramMap/TGLabelPickResult.h
@@ -9,8 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "TGGeoPoint.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 /**
  A label type used to differentiate icon and text labels when selecting them on a map view
  */
@@ -27,6 +25,8 @@ typedef NS_ENUM(NSInteger, TGLabelType) {
  See `-[TGMapViewController pickLabelAt:]` and `[TGMapViewDelegate mapView:didSelectLabel:atScreenPosition:]`.
  */
 @interface TGLabelPickResult : NSObject
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  Initializes a `TGLabelPickResult`.

--- a/platforms/ios/src/TangramMap/TGLabelPickResult.mm
+++ b/platforms/ios/src/TangramMap/TGLabelPickResult.mm
@@ -7,6 +7,7 @@
 //
 
 #import "TGLabelPickResult.h"
+#import "TGMarkerPickResult+Internal.h"
 
 @interface TGLabelPickResult ()
 

--- a/platforms/ios/src/TangramMap/TGMapData+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapData+Internal.h
@@ -1,0 +1,19 @@
+//
+//  TGMapData+Internal.h
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/24/16.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface TGMapData ()
+
+NS_ASSUME_NONNULL_BEGIN
+
+- (instancetype)initWithMapView:(TGMapViewController *)mapView name:(NSString *)name;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/platforms/ios/src/TangramMap/TGMapData+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapData+Internal.h
@@ -7,12 +7,14 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <memory>
+#import "data/clientGeoJsonSource.h"
 
 @interface TGMapData ()
 
 NS_ASSUME_NONNULL_BEGIN
 
-- (instancetype)initWithMapView:(TGMapViewController *)mapView name:(NSString *)name;
+- (instancetype)initWithMapView:(TGMapViewController *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::TileSource>)source;
 
 NS_ASSUME_NONNULL_END
 

--- a/platforms/ios/src/TangramMap/TGMapData.h
+++ b/platforms/ios/src/TangramMap/TGMapData.h
@@ -11,25 +11,67 @@
 #import "TGGeoPolygon.h"
 #import "TGGeoPolyline.h"
 
-@interface TGMapData : NSObject
-
+/*
+ Dictionary of feature properties keyed by their property name
+ */
 typedef NSDictionary<NSString *, NSString *> FeatureProperties;
+
+/*
+ A TGMapData is a convenience class to display point, polygons or polylines from a custom data source.
+ The data source will be styled according to the scene file using the provided data source name.
+ */
+@interface TGMapData : NSObject
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*
+ Adds a point coordinate to the data source.
+
+ @param coordinates the geographic coordinates of the point to add to the data source
+ @param properties the feature properties
+ */
 - (void)addPoint:(TGGeoPoint)coordinates withProperties:(FeatureProperties *)properties;
 
+/*
+ Adds a polygon geometry to the data source.
+
+ @param polygon the polygon geometry to add to the data source
+ @param properties the feature properties
+ */
 - (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(FeatureProperties *)properties;
 
+/*
+ Adds a polyline to the data source.
+
+ @param polyline the polyline geometry to add to the data source
+ @param properties the feature properties
+ */
 - (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(FeatureProperties *)properties;
 
+/*
+ Adds a GeoJSON string to the data source. The string must be formatted according to the
+ <a href="http://geojson.org/geojson-spec.html">GeoJSON specifications</a>.
+
+ @param data the GeoJSON formatted string to add to the data source
+ */
 - (void)addGeoJson:(NSString *)data;
 
+/*
+ Clears the data source from all the added features.
+ */
 - (void)clear;
 
-@property (readonly, nonatomic) TGMapViewController* map;
+/*
+ Definitely removes the data source from the map view.
+ */
+- (void)remove;
+
+/// The name of the data source
 @property (readonly, nonatomic) NSString* name;
 
 NS_ASSUME_NONNULL_END
+
+/// The map view this data source is on
+@property (readonly, nonatomic) TGMapViewController* map;
 
 @end

--- a/platforms/ios/src/TangramMap/TGMapData.h
+++ b/platforms/ios/src/TangramMap/TGMapData.h
@@ -11,20 +11,52 @@
 #import "TGGeoPolygon.h"
 #import "TGGeoPolyline.h"
 
-/*
+/**
  Dictionary of feature properties keyed by their property name
  */
 typedef NSDictionary<NSString *, NSString *> FeatureProperties;
 
-/*
- A TGMapData is a convenience class to display point, polygons or polylines from a custom data source.
- The data source will be styled according to the scene file using the provided data source name.
+/**
+ A `TGMapData` is a convenience class to display point, polygons or polylines from a dynamic data layer.
+ The data layer will be styled according to the scene file using the provided data layer name.
+
+ In your stylesheet, add a layer with the name of the data layer you want to add in your client application:
+
+ ```
+ layers:
+     mz_route_line_transit:
+        data: { source: mz_route_line_transit }
+     draw:
+        polylines:
+            color: function() { return feature.color || '#06a6d4'; }
+            order: 500
+            width: 10px
+ ```
+
+ In your implementation, to add a polyline fitting under the `mz_route_line_transit` layer:
+
+ ```swift
+ // Create a data layer in the TGMapViewController mapView
+ var dataLayer = mapView.addDataLayer(name: "mz_Route_line_transit");
+
+ var line = TGGeoPolyline()
+
+ // Add some coordinates to the polyline
+ line.add(latlon: TGGeoPointMake(longitude0, latitude0))
+ line.add(latlon: TGGeoPointMake(longitude1, latitude1))
+
+ // Set the data properties
+ var properties = ["type": "line", "color": "#D2655F"]
+
+ // Add the line to the data layer
+ dataLayer.add(polyline: line, properties: properties);
+ ```
  */
 @interface TGMapData : NSObject
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*
+/**
  Adds a point coordinate to the data source.
 
  @param coordinates the geographic coordinates of the point to add to the data source
@@ -32,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)addPoint:(TGGeoPoint)coordinates withProperties:(FeatureProperties *)properties;
 
-/*
+/**
  Adds a polygon geometry to the data source.
 
  @param polygon the polygon geometry to add to the data source
@@ -40,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(FeatureProperties *)properties;
 
-/*
+/**
  Adds a polyline to the data source.
 
  @param polyline the polyline geometry to add to the data source
@@ -48,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(FeatureProperties *)properties;
 
-/*
+/**
  Adds a GeoJSON string to the data source. The string must be formatted according to the
  <a href="http://geojson.org/geojson-spec.html">GeoJSON specifications</a>.
 
@@ -56,15 +88,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)addGeoJson:(NSString *)data;
 
-/*
+/**
  Clears the data source from all the added features.
  */
 - (void)clear;
 
-/*
+/**
  Definitely removes the data source from the map view.
+ Any future usage of this `MapData` object will be a no-op.
+
+ @return `YES` if removal was successful
  */
-- (void)remove;
+- (BOOL)remove;
 
 /// The name of the data source
 @property (readonly, nonatomic) NSString* name;
@@ -72,6 +107,6 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 /// The map view this data source is on
-@property (readonly, nonatomic) TGMapViewController* map;
+@property (readonly, nonatomic) TGMapViewController* _Nullable map;
 
 @end

--- a/platforms/ios/src/TangramMap/TGMapData.h
+++ b/platforms/ios/src/TangramMap/TGMapData.h
@@ -1,0 +1,35 @@
+//
+//  TGMapData.h
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/24/16.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "TGGeoPoint.h"
+#import "TGGeoPolygon.h"
+#import "TGGeoPolyline.h"
+
+@interface TGMapData : NSObject
+
+typedef NSDictionary<NSString *, NSString *> FeatureProperties;
+
+NS_ASSUME_NONNULL_BEGIN
+
+- (void)addPoint:(TGGeoPoint)coordinates withProperties:(FeatureProperties *)properties;
+
+- (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(FeatureProperties *)properties;
+
+- (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(FeatureProperties *)properties;
+
+- (void)addGeoJson:(NSString *)data;
+
+- (void)clear;
+
+@property (readonly, nonatomic) TGMapViewController* map;
+@property (readonly, nonatomic) NSString* name;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/platforms/ios/src/TangramMap/TGMapData.h
+++ b/platforms/ios/src/TangramMap/TGMapData.h
@@ -81,8 +81,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(FeatureProperties *)properties;
 
 /**
- Adds a GeoJSON string to the data source. The string must be formatted according to the
- <a href="http://geojson.org/geojson-spec.html">GeoJSON specifications</a>.
+ Adds features described in a GeoJSON string to the data source. The string must be formatted according
+ to the <a href="http://geojson.org/geojson-spec.html">GeoJSON specifications</a>.
 
  @param data the GeoJSON formatted string to add to the data source
  */

--- a/platforms/ios/src/TangramMap/TGMapData.mm
+++ b/platforms/ios/src/TangramMap/TGMapData.mm
@@ -1,0 +1,103 @@
+//
+//  TGMapData.mm
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/24/16.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+#import "TGMapViewController+Internal.h"
+#import <memory>
+#import <vector>
+
+@interface TGMapData () {
+    std::shared_ptr<Tangram::ClientGeoJsonSource> dataSource;
+}
+
+@property (copy, nonatomic) NSString* name;
+@property (weak, nonatomic) TGMapViewController* mapView;
+
+@end
+
+static inline void tangramProperties(FeatureProperties* properties, Tangram::Properties& tgProperties)
+{
+    for (NSString* key in properties) {
+        NSString* value = [properties objectForKey:key];
+        tgProperties.set(std::string([key UTF8String]), [value UTF8String]);
+    }
+}
+
+@implementation TGMapData
+
+- (instancetype)initWithMapView:(TGMapViewController *)mapView name:(NSString *)name
+{
+    self = [super init];
+
+    if (self) {
+        self.name = name;
+        self.mapView = mapView;
+
+        // Create client data source with Tangram
+        dataSource = [self.mapView createDataSource:name];
+    }
+
+    return self;
+}
+
+- (void)addPoint:(TGGeoPoint)coordinates withProperties:(FeatureProperties *)properties
+{
+    Tangram::Properties tgProperties;
+    tangramProperties(properties, tgProperties);
+
+    Tangram::LngLat lngLat(coordinates.longitude, coordinates.latitude);
+    dataSource->addPoint(tgProperties, lngLat);
+}
+
+- (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(FeatureProperties *)properties
+{
+    Tangram::Properties tgProperties;
+    tangramProperties(properties, tgProperties);
+
+    std::vector<std::vector<Tangram::LngLat>> tgPolygon;
+    Tangram::LngLat* coordinates = reinterpret_cast<Tangram::LngLat*>([polygon coordinates]);
+    int* rings = reinterpret_cast<int*>([polygon rings]);
+
+    size_t ringsCount = [polygon ringsCount];
+    size_t ringStart = 0;
+    size_t ringEnd = 0;
+
+    for (size_t i = 0; i < ringsCount; ++i) {
+        tgPolygon.emplace_back();
+        auto& polygonRing = tgPolygon.back();
+
+        ringEnd += rings[i];
+        polygonRing.insert(polygonRing.begin(), coordinates + ringStart, coordinates + ringEnd);
+        ringStart = ringEnd + 1;
+    }
+
+    dataSource->addPoly(tgProperties, tgPolygon);
+}
+
+- (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(FeatureProperties *)properties
+{
+    Tangram::Properties tgProperties;
+    tangramProperties(properties, tgProperties);
+
+    std::vector<Tangram::LngLat> tgPolyline;
+    Tangram::LngLat* coordinates = reinterpret_cast<Tangram::LngLat*>([polyline coordinates]);
+    tgPolyline.insert(tgPolyline.begin(), coordinates, coordinates + [polyline count]);
+    dataSource->addLine(tgProperties, tgPolyline);
+}
+
+- (void)addGeoJson:(NSString *)data
+{
+    std::string sourceData = std::string([data UTF8String]);
+    dataSource->addData(sourceData);
+}
+
+- (void)clear
+{
+    [self.mapView clearDataSource:dataSource];
+}
+
+@end

--- a/platforms/ios/src/TangramMap/TGMapData.mm
+++ b/platforms/ios/src/TangramMap/TGMapData.mm
@@ -46,6 +46,10 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
 
 - (void)addPoint:(TGGeoPoint)coordinates withProperties:(FeatureProperties *)properties
 {
+    if (!self.mapView) {
+        return;
+    }
+
     Tangram::Properties tgProperties;
     tangramProperties(properties, tgProperties);
 
@@ -55,6 +59,10 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
 
 - (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(FeatureProperties *)properties
 {
+    if (!self.mapView) {
+        return;
+    }
+
     Tangram::Properties tgProperties;
     tangramProperties(properties, tgProperties);
 
@@ -80,6 +88,10 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
 
 - (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(FeatureProperties *)properties
 {
+    if (!self.mapView) {
+        return;
+    }
+
     Tangram::Properties tgProperties;
     tangramProperties(properties, tgProperties);
 
@@ -91,13 +103,27 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
 
 - (void)addGeoJson:(NSString *)data
 {
+    if (!self.mapView) {
+        return;
+    }
+
     std::string sourceData = std::string([data UTF8String]);
     dataSource->addData(sourceData);
 }
 
 - (void)clear
 {
+    if (!self.mapView) {
+        return;
+    }
+
     [self.mapView clearDataSource:dataSource];
+}
+
+- (void)remove
+{
+    [self.mapView removeDataSource:dataSource];
+    self.mapView = nil;
 }
 
 @end

--- a/platforms/ios/src/TangramMap/TGMapData.mm
+++ b/platforms/ios/src/TangramMap/TGMapData.mm
@@ -29,16 +29,14 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
 
 @implementation TGMapData
 
-- (instancetype)initWithMapView:(TGMapViewController *)mapView name:(NSString *)name
+- (instancetype)initWithMapView:(TGMapViewController *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::ClientGeoJsonSource>)source
 {
     self = [super init];
 
     if (self) {
         self.name = name;
         self.mapView = mapView;
-
-        // Create client data source with Tangram
-        dataSource = [self.mapView createDataSource:name];
+        dataSource = source;
     }
 
     return self;
@@ -122,7 +120,11 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
 
 - (void)remove
 {
-    [self.mapView removeDataSource:dataSource];
+    if (!self.mapView) {
+        return;
+    }
+
+    [self.mapView removeDataSource:dataSource name:self.name];
     self.mapView = nil;
 }
 

--- a/platforms/ios/src/TangramMap/TGMapData.mm
+++ b/platforms/ios/src/TangramMap/TGMapData.mm
@@ -10,6 +10,9 @@
 #import <memory>
 #import <vector>
 
+typedef std::vector<Tangram::LngLat> Line;
+typedef std::vector<Line> Polygon;
+
 @interface TGMapData () {
     std::shared_ptr<Tangram::ClientGeoJsonSource> dataSource;
 }
@@ -64,7 +67,7 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
     Tangram::Properties tgProperties;
     tangramProperties(properties, tgProperties);
 
-    std::vector<std::vector<Tangram::LngLat>> tgPolygon;
+    Polygon tgPolygon;
     Tangram::LngLat* coordinates = reinterpret_cast<Tangram::LngLat*>([polygon coordinates]);
     int* rings = reinterpret_cast<int*>([polygon rings]);
 
@@ -93,7 +96,7 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
     Tangram::Properties tgProperties;
     tangramProperties(properties, tgProperties);
 
-    std::vector<Tangram::LngLat> tgPolyline;
+    Line tgPolyline;
     Tangram::LngLat* coordinates = reinterpret_cast<Tangram::LngLat*>([polyline coordinates]);
     tgPolyline.insert(tgPolyline.begin(), coordinates, coordinates + [polyline count]);
     dataSource->addLine(tgProperties, tgPolyline);

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -8,7 +8,9 @@
 
 #import "TGMapViewController.h"
 #import "tangram.h"
-
+#import "data/clientGeoJsonSource.h"
+#import <vector>
+#import <memory>
 
 @interface TGMapViewController ()
 
@@ -17,6 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addMarker:(TGMarker *)marker withIdentifier:(Tangram::MarkerID)identifier;
 
 - (void)removeMarker:(Tangram::MarkerID)identifier;
+
+- (std::shared_ptr<Tangram::ClientGeoJsonSource>)createDataSource:(NSString *)name;
+
+- (void)removeDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource;
+
+- (void)clearDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource;
 
 NS_ASSUME_NONNULL_END
 

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -20,9 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeMarker:(Tangram::MarkerID)identifier;
 
-- (std::shared_ptr<Tangram::ClientGeoJsonSource>)createDataSource:(NSString *)name;
+- (std::shared_ptr<Tangram::ClientGeoJsonSource>)getDataSource:(NSString *)name;
 
-- (void)removeDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource;
+- (BOOL)removeDataSource:(std::shared_ptr<Tangram::ClientGeoJsonSource>)tileSource name:(NSString *)name;
 
 - (void)clearDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource;
 

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -20,8 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeMarker:(Tangram::MarkerID)identifier;
 
-- (std::shared_ptr<Tangram::ClientGeoJsonSource>)getDataSource:(NSString *)name;
-
 - (BOOL)removeDataSource:(std::shared_ptr<Tangram::ClientGeoJsonSource>)tileSource name:(NSString *)name;
 
 - (void)clearDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource;

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -13,6 +13,7 @@
 
 @class TGMapViewController;
 
+#import "TGMapData.h"
 #import "TGGeoPoint.h"
 #import "TGGeoPolygon.h"
 #import "TGGeoPolyline.h"
@@ -346,6 +347,8 @@ NS_ASSUME_NONNULL_BEGIN
  of `TGHttpHandler`.
  */
 @property (strong, nonatomic) TGHttpHandler* httpHandler;
+
+- (nullable TGMapData *)addDataSource:(NSString *)name;
 
 #pragma mark Debug toggles
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -348,6 +348,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (strong, nonatomic) TGHttpHandler* httpHandler;
 
+/**
+ Adds a named data source to the map. See `TGMapData` for more details.
+
+ @param name the name of the data source.
+
+ @return the map data, nil if the data source can't be initialized
+ */
 - (nullable TGMapData *)addDataSource:(NSString *)name;
 
 #pragma mark Debug toggles

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -349,13 +349,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) TGHttpHandler* httpHandler;
 
 /**
- Adds a named data source to the map. See `TGMapData` for more details.
+ Adds a named data layer to the map. See `TGMapData` for more details.
 
- @param name the name of the data source.
+ @param name the name of the data layer.
 
  @return the map data, nil if the data source can't be initialized
+
+ @note You cannot create more than one data source with the same name, otherwise the same
+ object will be returned.
  */
-- (nullable TGMapData *)addDataSource:(NSString *)name;
+- (nullable TGMapData *)addDataLayer:(NSString *)name;
 
 #pragma mark Debug toggles
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -8,9 +8,10 @@
 //  Copyright (c) 2017 Mapzen. All rights reserved.
 //
 
-#import "TGMapViewController.h"
 #import "TGMapViewController+Internal.h"
 #import "TGMapData+Internal.h"
+#import "TGMarkerPickResult+Internal.h"
+#import "TGLabelPickResult+Internal.h"
 #import "TGHelpers.h"
 #import "platform_ios.h"
 #import "data/propertyItem.h"

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -10,6 +10,7 @@
 
 #import "TGMapViewController.h"
 #import "TGMapViewController+Internal.h"
+#import "TGMapData+Internal.h"
 #import "TGHelpers.h"
 #import "platform_ios.h"
 #import "data/propertyItem.h"
@@ -76,6 +77,38 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 - (void)toggleDebugFlag:(TGDebugFlag)debugFlag
 {
     Tangram::toggleDebugFlag((Tangram::DebugFlags)debugFlag);
+}
+
+- (TGMapData *)createDataSource:(NSString *)name
+{
+    if (!self.map) { return nil; }
+
+    TGMapData* clientData = [[TGMapData alloc] initWithMapView:self name:name];
+    return clientData;
+}
+
+- (std::shared_ptr<Tangram::ClientGeoJsonSource>)addDataSource:(NSString *)name
+{
+    if (!self.map) { return; }
+
+    std::string sourceName = std::string([name UTF8String]);
+    auto source = std::make_shared<Tangram::ClientGeoJsonSource>(self.map->getPlatform(), sourceName, "");
+    self.map->addTileSource(source);
+    return source;
+}
+
+- (void)removeDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource
+{
+    if (!self.map || !tileSource) { return; }
+
+    self.map->removeTileSource(*tileSource);
+}
+
+- (void)clearDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource
+{
+    if (!self.map || !tileSource) { return; }
+
+    self.map->clearTileSource(*tileSource, true, true);
 }
 
 #pragma mark Scene loading interface

--- a/platforms/ios/src/TangramMap/TGMarkerPickResult+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMarkerPickResult+Internal.h
@@ -1,0 +1,31 @@
+//
+//  TGMarkerPickResult+Internal.h
+//  TangramMap
+//
+//  Created by Karim Naaji on 2/27/17.
+//  Copyright (c) 2017 Mapzen. All rights reserved.
+//
+
+#import "TGMarkerPickResult.h"
+
+@interface TGMarkerPickResult ()
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Initializes a `TGMarkerPickResult`.
+
+ @param coordinates the geographic coordinates of the label pick result
+ @param marker the marker object selected
+
+ @return an initialized `TGMarkerPickResult`
+
+ @note You shouldn't have to create a `TGMarkerPickResult` yourself, those are returned as a result to
+ a selection query on the `TGMapViewController` and initialized by the latter.
+ */
+- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates marker:(TGMarker *)marker;
+
+NS_ASSUME_NONNULL_END
+
+@end
+

--- a/platforms/ios/src/TangramMap/TGMarkerPickResult.h
+++ b/platforms/ios/src/TangramMap/TGMarkerPickResult.h
@@ -19,19 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface TGMarkerPickResult : NSObject
 
-/**
- Initializes a `TGMarkerPickResult`.
-
- @param coordinates the geographic coordinates of the label pick result
- @param marker the marker object selected
-
- @return an initialized `TGMarkerPickResult`
-
- @note You shouldn't have to create a `TGMarkerPickResult` yourself, those are returned as a result to
- a selection query on the `TGMapViewController` and initialized by the latter.
- */
-- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates marker:(TGMarker *)marker;
-
 /// The geographic coordinates of the selected label
 @property (readonly, nonatomic) TGGeoPoint coordinates;
 

--- a/platforms/ios/src/TangramMap/TGMarkerPickResult.mm
+++ b/platforms/ios/src/TangramMap/TGMarkerPickResult.mm
@@ -7,6 +7,7 @@
 //
 
 #import "TGMarkerPickResult.h"
+#import "TGMarkerPickResult+Internal.h"
 
 @interface TGMarkerPickResult ()
 

--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -47,6 +47,7 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGGeoPolyline.mm
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGGeoPolygon.mm
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGHttpHandler.mm
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMapData.mm
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGSceneUpdate.mm
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGLabelPickResult.mm
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMarkerPickResult.mm
@@ -61,6 +62,7 @@ set(FRAMEWORK_HEADERS
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMarker.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGEaseType.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGSceneUpdate.h
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMapData.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGHttpHandler.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGLabelPickResult.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMarkerPickResult.h

--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -70,6 +70,10 @@ set(FRAMEWORK_HEADERS
 
 set(HEADERS
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/platform_ios.h
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMarkerPickResult+Internal.h
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGLabelPickResult+Internal.h
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+    ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGMapData+Internal.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGHelpers.h
     ${PROJECT_SOURCE_DIR}/platforms/ios/src/TangramMap/TGFontConverter.h
     ${FRAMEWORK_HEADERS})


### PR DESCRIPTION
- Adds client data source for points, polygons, and polylines under `TGMapData`.
- Update demo app to fix warnings.
- Update umbrella header to include all public header files to fix warnings.

See demo app for sample usage.