### PR TITLE
Only build all iOS architectures on master builds for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,12 @@ endif
 # Build for iOS simulator architecture only
 ifdef TANGRAM_IOS_FRAMEWORK_SLIM
 	IOS_FRAMEWORK_PATH = ${IOS_FRAMEWORK_SIM_BUILD_DIR}/lib/${CONFIG}/TangramMap.framework
+	IOS_FRAMEWORK_DEVICE_ARCHS = ''
+	IOS_FRAMEWORK_SIM_ARCHS = 'x86_64'
 else
 	IOS_FRAMEWORK_PATH = ${IOS_FRAMEWORK_UNIVERSAL_BUILD_DIR}/${CONFIG}/TangramMap.framework
+	IOS_FRAMEWORK_DEVICE_ARCHS = 'armv7 armv7s arm64'
+	IOS_FRAMEWORK_SIM_ARCHS = 'i386 x86_64'
 endif
 
 BENCH_CMAKE_PARAMS = \
@@ -107,6 +111,8 @@ IOS_FRAMEWORK_CMAKE_PARAMS = \
         ${BUILD_TYPE} \
         ${CMAKE_OPTIONS} \
 	-DPLATFORM_TARGET=ios.framework \
+	-DIOS_SIMULATOR_ARCHS=${IOS_FRAMEWORK_SIM_ARCHS} \
+	-DIOS_DEVICE_ARCHS=${IOS_FRAMEWORK_DEVICE_ARCHS} \
 	-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_DIR}/iOS.toolchain.cmake \
 	-G Xcode
 
@@ -251,7 +257,7 @@ cmake-osx:
 	cmake ../.. ${DARWIN_CMAKE_PARAMS}
 
 IOS_BUILD = \
-	xcodebuild -target ${IOS_TARGET} ARCHS='i386 x86_64' ONLY_ACTIVE_ARCH=NO -sdk iphonesimulator -project ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ} -configuration ${CONFIG}
+	xcodebuild -target ${IOS_TARGET} ARCHS=${IOS_FRAMEWORK_SIM_ARCHS} ONLY_ACTIVE_ARCH=NO -sdk iphonesimulator -project ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ} -configuration ${CONFIG}
 
 ios: ${IOS_BUILD_DIR}/${IOS_XCODE_PROJ}
 ifeq (, $(shell which xcpretty))

--- a/circle.yml
+++ b/circle.yml
@@ -12,10 +12,10 @@ checkout:
     - gem install jazzy
 test:
   override:
-    - make ios
+    - if [ $CIRCLE_BRANCH = 'master' ]; then make ios; else make ios TANGRAM_IOS_FRAMEWORK_SLIM=1; fi
     - make ios-docs
   post:
-    - cd build/ios-framework-universal/Release &&
-      zip -r ${CIRCLE_ARTIFACTS}/framework.zip TangramMap.framework
-    - cd build/ &&
-      zip -r ${CIRCLE_ARTIFACTS}/docs.zip ios-docs
+    - if [ $CIRCLE_BRANCH = 'master' ]; then cd build/ios-framework-universal/Release &&
+      zip -r ${CIRCLE_ARTIFACTS}/framework.zip TangramMap.framework; fi
+    - if [ $CIRCLE_BRANCH = 'master' ]; then cd build/ &&
+      zip -r ${CIRCLE_ARTIFACTS}/docs.zip ios-docs; fi

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -45,6 +45,7 @@ Note on Code Signing and Provisioning Profiles:
 * For Simulator: Does not need any code signing identity, so you can ignore any provionining profile failures on target _tangram_ > _General_ > _Signing_.
 * For Device: You will have to modify the _Bundle Identifier_ under target _tangram_ > _General_ > _Identity_ > _Bundle Identifier_, to something other than `com.mapzen.tangram`, since this needs to be unique.
 
+For development, you can use the Makefile option `TANGRAM_IOS_FRAMEWORK_SLIM` to build for simulator only and faster your build times.
 
 ### iOS Binary Framework ###
 

--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -1,6 +1,6 @@
 include(${CMAKE_SOURCE_DIR}/toolchains/iOS.toolchain.cmake)
 
-message(STATUS "Build for iOS archs " ${CMAKE_OSX_ARCHITECTURES})
+message(STATUS "Build for iOS archs " ${IOS_ARCH})
 
 set(FRAMEWORK_NAME TangramMap)
 
@@ -24,9 +24,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}
 
 if(${IOS_PLATFORM} STREQUAL "SIMULATOR")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mios-simulator-version-min=6.0")
-    set(ARCH "i386 x86_64")
 else()
-    set(ARCH "armv7 armv7s arm64")
     if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fembed-bitcode")
         add_compile_options("-fembed-bitcode")
@@ -119,8 +117,8 @@ endif()
 
 set_xcode_property(${FRAMEWORK_NAME} SUPPORTED_PLATFORMS "iphonesimulator iphoneos")
 set_xcode_property(${FRAMEWORK_NAME} ONLY_ACTIVE_ARCH "NO")
-set_xcode_property(${FRAMEWORK_NAME} VALID_ARCHS "${ARCH}")
-set_xcode_property(${FRAMEWORK_NAME} ARCHS "${ARCH}")
+set_xcode_property(${FRAMEWORK_NAME} VALID_ARCHS "${IOS_ARCH}")
+set_xcode_property(${FRAMEWORK_NAME} ARCHS "${IOS_ARCH}")
 
 # Set RPATH to be within the application /Frameworks directory
 set_xcode_property(${FRAMEWORK_NAME} LD_DYLIB_INSTALL_NAME "@rpath/${FRAMEWORK_NAME}.framework/${FRAMEWORK_NAME}")

--- a/toolchains/iOS.toolchain.cmake
+++ b/toolchains/iOS.toolchain.cmake
@@ -146,13 +146,9 @@ set (CMAKE_OSX_SYSROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS su
 # set the architecture for iOS
 # NOTE: Currently both ARCHS_STANDARD_32_BIT and ARCHS_UNIVERSAL_IPHONE_OS set armv7 only, so set both manually
 if (${IOS_PLATFORM} STREQUAL "OS")
-	set (IOS_ARCH armv7 armv7s arm64)
+    set (IOS_ARCH ${IOS_DEVICE_ARCHS})
 else (${IOS_PLATFORM} STREQUAL "OS")
-    if (BUILD_IOS_FRAMEWORK)
-        set (IOS_ARCH i386 x86_64)
-    else()
-        set (IOS_ARCH i386)
-    endif()
+    set (IOS_ARCH ${IOS_SIMULATOR_ARCHS})
 endif (${IOS_PLATFORM} STREQUAL "OS")
 
 set (CMAKE_OSX_ARCHITECTURES ${IOS_ARCH} CACHE string  "Build architecture for iOS")


### PR DESCRIPTION
- Only build universal framework architectures on `master` builds.
- Add option to build for CI and dev `TANGRAM_IOS_FRAMEWORK_SLIM` for faster builds.

Reduces Circle CI builds from ~18mins to 5mins.