### PR TITLE
Compilation warnings

### DIFF
--- a/core/include/tangram/data/properties.h
+++ b/core/include/tangram/data/properties.h
@@ -40,7 +40,7 @@ struct Properties {
 
     std::string getAsString(const std::string& key) const;
 
-    const bool getAsString(const std::string& key, std::string& value) const;
+    bool getAsString(const std::string& key, std::string& value) const;
 
     std::string toJson() const;
 

--- a/core/include/tangram/tile/tileTask.h
+++ b/core/include/tangram/tile/tileTask.h
@@ -69,7 +69,7 @@ public:
     virtual void complete();
 
     // onDone for sub-tasks
-    virtual void complete(TileTask& _mainTask) {}
+    virtual void complete(TileTask& /*mainTask*/) {}
 
     int rawSource = 0;
 

--- a/core/include/tangram/tile/tileTask.h
+++ b/core/include/tangram/tile/tileTask.h
@@ -69,7 +69,7 @@ public:
     virtual void complete();
 
     // onDone for sub-tasks
-    virtual void complete(TileTask& /*mainTask*/) {}
+    virtual void complete(TileTask& /*_mainTask*/) {}
 
     int rawSource = 0;
 

--- a/core/include/tangram/util/variant.h
+++ b/core/include/tangram/util/variant.h
@@ -20,26 +20,26 @@ namespace Tangram {
 // Primarily used when duk evaluated jsFunction results in a a null or undefined value
 struct Undefined {
     template<typename T>
-    bool operator==(T const& rhs) const {
+    bool operator==(T const&) const {
         return false;
     }
-    bool operator==(Undefined const& rhs) const {
+    bool operator==(Undefined const&) const {
         return true;
     }
-    bool operator<(Undefined const& rhs) const {
+    bool operator<(Undefined const&) const {
         return false;
     }
 };
 
 struct none_type {
     template<typename T>
-    bool operator==(T const& rhs) const {
+    bool operator==(T const&) const {
         return false;
     }
-    bool operator==(none_type const& rhs) const {
+    bool operator==(none_type const&) const {
         return true;
     }
-    bool operator<(none_type const& rhs) const {
+    bool operator<(none_type const&) const {
         return false;
     }
 

--- a/core/src/data/properties.cpp
+++ b/core/src/data/properties.cpp
@@ -81,7 +81,7 @@ const std::string& Properties::getString(const std::string& key) const {
     return EMPTY_STRING;
 }
 
-const bool Properties::getAsString(const std::string& key, std::string& value) const {
+bool Properties::getAsString(const std::string& key, std::string& value) const {
     auto& it = get(key);
 
     if (it.is<std::string>()) {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -83,9 +83,9 @@ public:
 
     virtual bool checkRule(const DrawRule& _rule) const;
 
-    virtual void addLayoutItems(LabelCollider& _layout) {}
+    virtual void addLayoutItems(LabelCollider& /*_layout*/) {}
 
-    virtual void addSelectionItems(LabelCollider& _layout) {}
+    virtual void addSelectionItems(LabelCollider& /*_layout*/) {}
 
     virtual const Style& style() const = 0;
 };
@@ -231,7 +231,7 @@ public:
 
     virtual void onBeginUpdate() {}
 
-    virtual void onBeginFrame(RenderState& rs) {}
+    virtual void onBeginFrame(RenderState& /*rs*/) {}
 
     /* Create <VertexLayout> corresponding to this style; subclasses must
      * implement this and call it on construction


### PR DESCRIPTION
Fixed compilation warnings (seen in Android Studio) due to:
- returning const bool
- unused named function params