### PR TITLE
iOS cleanup public interface

### DIFF
--- a/platforms/ios/src/TangramMap/TGLabelPickResult+Internal.h
+++ b/platforms/ios/src/TangramMap/TGLabelPickResult+Internal.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  @note You shouldn't have to create a `TGLabelPickResult` yourself, those are returned as a result to
  a selection query on the `TGMapViewController` and initialized by the latter.
  */
-- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates type:(TGLabelType)type properties:(NSDictionary *)properties;
+- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates type:(TGLabelType)type properties:(TGFeatureProperties *)properties;
 
 NS_ASSUME_NONNULL_END
 

--- a/platforms/ios/src/TangramMap/TGLabelPickResult.h
+++ b/platforms/ios/src/TangramMap/TGLabelPickResult.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "TGGeoPoint.h"
+#import "TGMapData.h"
 
 /**
  A label type used to differentiate icon and text labels when selecting them on a map view
@@ -35,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) TGLabelType type;
 
 /// The set of data properties attached with the label
-@property (readonly, strong, nonatomic) NSDictionary* properties;
+@property (readonly, strong, nonatomic) TGFeatureProperties* properties;
 
 NS_ASSUME_NONNULL_END
 

--- a/platforms/ios/src/TangramMap/TGLabelPickResult.mm
+++ b/platforms/ios/src/TangramMap/TGLabelPickResult.mm
@@ -13,13 +13,13 @@
 
 @property (assign, nonatomic) TGGeoPoint coordinates;
 @property (assign, nonatomic) TGLabelType type;
-@property (strong, nonatomic) NSDictionary* properties;
+@property (strong, nonatomic) TGFeatureProperties* properties;
 
 @end
 
 @implementation TGLabelPickResult
 
-- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates type:(TGLabelType)type properties:(NSDictionary *)properties
+- (instancetype) initWithCoordinates:(TGGeoPoint)coordinates type:(TGLabelType)type properties:(TGFeatureProperties *)properties
 {
     self = [super init];
 

--- a/platforms/ios/src/TangramMap/TGMapData.h
+++ b/platforms/ios/src/TangramMap/TGMapData.h
@@ -14,7 +14,9 @@
 /**
  Dictionary of feature properties keyed by their property name
  */
-typedef NSDictionary<NSString *, NSString *> FeatureProperties;
+typedef NSDictionary<NSString *, NSString *> TGFeatureProperties;
+
+@class TGMapViewController;
 
 /**
  A `TGMapData` is a convenience class to display point, polygons or polylines from a dynamic data layer.
@@ -62,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param coordinates the geographic coordinates of the point to add to the data source
  @param properties the feature properties
  */
-- (void)addPoint:(TGGeoPoint)coordinates withProperties:(FeatureProperties *)properties;
+- (void)addPoint:(TGGeoPoint)coordinates withProperties:(TGFeatureProperties *)properties;
 
 /**
  Adds a polygon geometry to the data source.
@@ -70,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param polygon the polygon geometry to add to the data source
  @param properties the feature properties
  */
-- (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(FeatureProperties *)properties;
+- (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(TGFeatureProperties *)properties;
 
 /**
  Adds a polyline to the data source.
@@ -78,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param polyline the polyline geometry to add to the data source
  @param properties the feature properties
  */
-- (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(FeatureProperties *)properties;
+- (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(TGFeatureProperties *)properties;
 
 /**
  Adds features described in a GeoJSON string to the data source. The string must be formatted according

--- a/platforms/ios/src/TangramMap/TGMapData.mm
+++ b/platforms/ios/src/TangramMap/TGMapData.mm
@@ -22,7 +22,7 @@ typedef std::vector<Line> Polygon;
 
 @end
 
-static inline void tangramProperties(FeatureProperties* properties, Tangram::Properties& tgProperties)
+static inline void tangramProperties(TGFeatureProperties* properties, Tangram::Properties& tgProperties)
 {
     for (NSString* key in properties) {
         NSString* value = [properties objectForKey:key];
@@ -45,7 +45,7 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
     return self;
 }
 
-- (void)addPoint:(TGGeoPoint)coordinates withProperties:(FeatureProperties *)properties
+- (void)addPoint:(TGGeoPoint)coordinates withProperties:(TGFeatureProperties *)properties
 {
     if (!self.mapView) {
         return;
@@ -58,7 +58,7 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
     dataSource->addPoint(tgProperties, lngLat);
 }
 
-- (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(FeatureProperties *)properties
+- (void)addPolygon:(TGGeoPolygon *)polygon withProperties:(TGFeatureProperties *)properties
 {
     if (!self.mapView) {
         return;
@@ -87,7 +87,7 @@ static inline void tangramProperties(FeatureProperties* properties, Tangram::Pro
     dataSource->addPoly(tgProperties, tgPolygon);
 }
 
-- (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(FeatureProperties *)properties
+- (void)addPolyline:(TGGeoPolyline *)polyline withProperties:(TGFeatureProperties *)properties
 {
     if (!self.mapView) {
         return;

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -233,7 +233,7 @@ NS_ASSUME_NONNULL_END
 
  @note If no feature have been selected, `feature` will be `nil`, and `position` `(0, 0)`.
  */
-- (void)mapView:(nonnull TGMapViewController *)mapView didSelectFeature:(nullable NSDictionary *)feature atScreenPosition:(CGPoint)position;
+- (void)mapView:(nonnull TGMapViewController *)mapView didSelectFeature:(nullable TGFeatureProperties *)feature atScreenPosition:(CGPoint)position;
  /**
  Always called after the method `-[TGMapViewController pickLabelAt:]` is called on the map view.
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -262,7 +262,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
             return;
         }
 
-        NSMutableDictionary* dictionary = [[NSMutableDictionary alloc] init];
+        NSMutableDictionary* featureProperties = [[NSMutableDictionary alloc] init];
 
         const auto& properties = featureResult->properties;
         position = CGPointMake(featureResult->position[0] / self.contentScaleFactor,
@@ -271,10 +271,10 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
         for (const auto& item : properties->items()) {
             NSString* key = [NSString stringWithUTF8String:item.key.c_str()];
             NSString* value = [NSString stringWithUTF8String:properties->asString(item.value).c_str()];
-            dictionary[key] = value;
+            featureProperties[key] = value;
         }
 
-        [self.mapViewDelegate mapView:self didSelectFeature:dictionary atScreenPosition:position];
+        [self.mapViewDelegate mapView:self didSelectFeature:featureProperties atScreenPosition:position];
     });
 }
 
@@ -335,7 +335,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
             return;
         }
 
-        NSMutableDictionary* dictionary = [[NSMutableDictionary alloc] init];
+        NSMutableDictionary* featureProperties = [[NSMutableDictionary alloc] init];
 
         const auto& touchItem = labelPickResult->touchItem;
         const auto& properties = touchItem.properties;
@@ -345,13 +345,13 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
         for (const auto& item : properties->items()) {
             NSString* key = [NSString stringWithUTF8String:item.key.c_str()];
             NSString* value = [NSString stringWithUTF8String:properties->asString(item.value).c_str()];
-            dictionary[key] = value;
+            featureProperties[key] = value;
         }
 
         TGGeoPoint coordinates = TGGeoPointMake(labelPickResult->coordinates.longitude, labelPickResult->coordinates.latitude);
         TGLabelPickResult* tgLabelPickResult = [[TGLabelPickResult alloc] initWithCoordinates:coordinates
                                                                                          type:(TGLabelType)labelPickResult->type
-                                                                                   properties:dictionary];
+                                                                                   properties:featureProperties];
         [self.mapViewDelegate mapView:self didSelectLabel:tgLabelPickResult atScreenPosition:position];
     });
 }


### PR DESCRIPTION
- Always use strongly typed templates to unwrap types more easily in Swift.