### PR TITLE
fix: placement_min_length_ratio handling for spaced point sprites

### DIFF
--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<StyledMesh> DebugTextStyleBuilder::build() {
     }
 
     DrawRule rule({"", 0, {}}, "", 0);
-    addLabel(params, Label::Type::debug, { glm::vec3(0.5f, 0.5f, 0.f) }, rule);
+    addLabel(params, Label::Type::debug, { { glm::vec3(0.5f, 0.5f, 0.f) } }, rule);
 
     m_textLabels->setLabels(m_labels);
 

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -357,26 +357,29 @@ void PointStyleBuilder::labelPointsPlacing(const Line& _line, const glm::vec4& u
             LineSampler<std::vector<Point>> sampler;
 
             sampler.set(_line);
-            sampler.setMinSampleLength(minLineLength);
 
             float lineLength = sampler.sumLength();
-
             if (lineLength <= minLineLength) { break; }
 
             float spacing = params.placementSpacing * m_style.pixelScale() / View::s_pixelsPerTile;
             int numLabels = std::max(std::floor(lineLength / spacing), 1.0f);
             float remainderLength = lineLength - (numLabels - 1) * spacing;
             float distance = 0.5 * remainderLength;
-
             glm::vec2 p, r;
             sampler.advance(distance, p, r);
             do {
+
+                if (sampler.lengthToPrevSegment() < minLineLength*0.5 ||
+                    sampler.lengthToNextSegment() < minLineLength*0.5) {
+                    continue;
+                }
                 if (params.autoAngle) {
                     params.labelOptions.angle = RAD_TO_DEG * atan2(r.x, r.y);
                 }
+
                 addLabel({p.x, p.y, 0.f}, uvsQuad, params, _rule);
 
-            } while(sampler.advance(spacing, p, r));
+            } while (sampler.advance(spacing, p, r));
         }
         break;
         case LabelProperty::Placement::centroid:

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -83,6 +83,10 @@ std::unique_ptr<StyledMesh> PointStyleBuilder::build() {
 void PointStyleBuilder::setup(const Tile& _tile) {
     m_zoom = _tile.getID().z;
     m_styleZoom = _tile.getID().s;
+
+    // < 1.0 when overzooming a tile
+    m_tileScale = pow(2, _tile.getID().s - _tile.getID().z);
+
     m_spriteLabels = std::make_unique<SpriteLabels>(m_style);
 
     m_textStyleBuilder->setup(_tile);
@@ -318,8 +322,9 @@ void PointStyleBuilder::labelPointsPlacing(const Line& _line, const glm::vec4& u
         return RAD_TO_DEG * atan2(q[0] - p[0], q[1] - p[1]);
     };
 
-    float minLineLength = std::max(params.size.x, params.size.y) * params.placementMinLengthRatio *
-                            m_style.pixelScale() / View::s_pixelsPerTile;
+    float minLineLength = std::max(params.size.x, params.size.y) *
+        params.placementMinLengthRatio * m_style.pixelScale() /
+        (View::s_pixelsPerTile * m_tileScale);
 
     switch(params.placement) {
         case LabelProperty::Placement::vertex: {

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -64,6 +64,7 @@ private:
 
     float m_zoom = 0;
     float m_styleZoom = 0;
+    float m_tileScale = 1;
     std::unique_ptr<SpriteLabels> m_spriteLabels;
     std::unique_ptr<StyleBuilder> m_textStyleBuilder;
 

--- a/core/src/util/lineSampler.h
+++ b/core/src/util/lineSampler.h
@@ -125,17 +125,6 @@ struct LineSampler {
                 // length from cur to next point
                 float segmentLength = next.z - curr.z;
 
-                if (segmentLength <= m_minSampleLength) {
-                    if (m_curPoint >= m_points.size() - 2) {
-                        _point = glm::vec2(next);
-                        _rotation = (glm::vec2(next) - glm::vec2(curr)) / segmentLength;
-                        m_curAdvance = sumLength();
-                        return false;
-                    }
-                    m_curPoint += 1;
-                    continue;
-                }
-
                 if (length <= segmentLength) {
                     float f = length / segmentLength;
 
@@ -167,17 +156,6 @@ struct LineSampler {
                 // length from cur to next point
                 float segmentLength = next.z - curr.z;
 
-                if (segmentLength <= m_minSampleLength) {
-                    if (m_curPoint == 0) {
-                        _point = glm::vec2(curr);
-                        _rotation = (glm::vec2(next) - glm::vec2(curr)) / segmentLength;
-                        m_curAdvance = 0;
-                        return false;
-                    }
-                    m_curPoint -= 1;
-                    continue;
-                }
-
                 if (curr.z <= end) {
                     float f = length / segmentLength;
 
@@ -202,19 +180,23 @@ struct LineSampler {
         return false;
     }
 
-    void setMinSampleLength(float _minLength) {
-        m_minSampleLength = _minLength;
+    float lengthToNextSegment() {
+        if (m_curPoint >= m_points.size()-1) { return 0; }
+        return m_points[m_curPoint + 1].z - m_curAdvance;
+    }
+    float lengthToPrevSegment() {
+        if (m_curPoint >= m_points.size()) { return 0; }
+        return m_curAdvance - m_points[m_curPoint].z;
     }
 
     LineSampler(Points _points) : m_points(_points) { }
     LineSampler() { }
+
 private:
     Points m_points;
 
     size_t m_curPoint = 0;
     float m_curAdvance = 0.f;
-    float m_minSampleLength = 0.f;
-
 };
 
 }


### PR DESCRIPTION
https://github.com/tangrams/tangram-es/issues/1313

tested with:
```
        arrows:
            filter: { oneway: yes, shield_text: false, $zoom: { min: 8 }, name: "Eastern Parkway Service Rd." }
            draw:
                icons:
                    flat: true
                    priority: 0
                    sprite: arrow
                    size: [[17, 18px], [18, 20px], [20, 32px]]
                    placement: spaced
                    #placement_spacing: [[17, 70px], [20, 175px]]
                    placement_spacing: 10px
                    angle: auto
                points:
                    priority: 0
                    collide: false
                    color: red
                    size: 5px
                    placement: vertex
```