### PR TITLE
[wip] Geojsonvt atomic updates

### DIFF
--- a/core/include/tangram/data/clientGeoJsonSource.h
+++ b/core/include/tangram/data/clientGeoJsonSource.h
@@ -32,6 +32,9 @@ public:
     void addLine(const Properties& _tags, const Coordinates& _line);
     void addPoly(const Properties& _tags, const std::vector<Coordinates>& _poly);
 
+    void edit(bool _clear = false);
+    void commit();
+
     virtual void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
     std::shared_ptr<TileTask> createTask(TileID _tileId, int _subTask) override;
 
@@ -44,6 +47,7 @@ protected:
                                             const MapProjection& _projection) const override;
 
     std::unique_ptr<ClientGeoJsonData> m_store;
+    std::unique_ptr<ClientGeoJsonData> m_edit;
 
     mutable std::mutex m_mutexStore;
     bool m_hasPendingData = false;

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -19,12 +19,19 @@ namespace Tangram {
 
 using namespace mapbox;
 
-const uint32_t indexMaxPoints = 100000;
-const double tolerance = 1E-8;
 const uint16_t tileExtent = 4096;
-const uint16_t tileBuffer = 0;
 
-const geojsonvt::Options tileOptions = { 18, 5, indexMaxPoints, false, tolerance, tileExtent, tileBuffer };
+geojsonvt::Options tileOptions() {
+    geojsonvt::Options options;
+    options.maxZoom = 18;
+    options.indexMaxZoom = 5;
+    options.indexMaxPoints = 100000;
+    options.solidChildren = true;
+    options.tolerance = 3;
+    options.extent = tileExtent;
+    options.buffer = 0;
+    return options;
+}
 
 struct ClientGeoJsonData {
     std::unique_ptr<geojsonvt::GeoJSONVT> tiles;
@@ -109,7 +116,7 @@ void ClientGeoJsonSource::addData(const std::string& _data) {
                            std::make_move_iterator(features.end()));
 
     if (!m_edit) {
-        store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(store->features, tileOptions);
+        store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(store->features, tileOptions());
         m_generation++;
         m_mutexStore.unlock();
     }
@@ -157,7 +164,7 @@ void ClientGeoJsonSource::edit(bool _clear) {
 void ClientGeoJsonSource::commit() {
     if (!m_edit) { return; }
 
-    m_edit->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_edit->features, tileOptions);
+    m_edit->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_edit->features, tileOptions());
 
     std::lock_guard<std::mutex> lock(m_mutexStore);
 
@@ -177,7 +184,7 @@ void ClientGeoJsonSource::addPoint(const Properties& _tags, LngLat _point) {
     store->properties.emplace_back(_tags);
 
     if (!m_edit) {
-        store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(store->features, tileOptions);
+        store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(store->features, tileOptions());
         m_generation++;
         m_mutexStore.unlock();
     }
@@ -198,7 +205,7 @@ void ClientGeoJsonSource::addLine(const Properties& _tags, const Coordinates& _l
     store->properties.emplace_back(_tags);
 
     if (!m_edit) {
-        store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(store->features, tileOptions);
+        store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(store->features, tileOptions());
         m_generation++;
         m_mutexStore.unlock();
     }
@@ -223,7 +230,7 @@ void ClientGeoJsonSource::addPoly(const Properties& _tags, const std::vector<Coo
     store->properties.emplace_back(_tags);
 
     if (!m_edit) {
-        store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(store->features, tileOptions);
+        store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(store->features, tileOptions());
         m_generation++;
         m_mutexStore.unlock();
     }

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -396,8 +396,7 @@ extern "C" {
 
         assert(mapPtr > 0);
         assert(sourcePtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(map->getPlatform(), sourcePtr);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
 
         size_t n_points = jniEnv->GetArrayLength(jcoordinates) / 2;
         size_t n_rings = (jrings == NULL) ? 0 : jniEnv->GetArrayLength(jrings);

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -391,6 +391,20 @@ extern "C" {
         map->clearTileSource(*source, true, true);
     }
 
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeEditFeatures(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr, jboolean clear) {
+        assert(mapPtr > 0);
+        assert(sourcePtr > 0);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
+        source->edit(clear);
+    }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeCommitFeatures(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+        assert(mapPtr > 0);
+        assert(sourcePtr > 0);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
+        source->commit();
+    }
+
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddFeature(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr,
         jdoubleArray jcoordinates, jintArray jrings, jobjectArray jproperties) {
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -868,6 +868,18 @@ public class MapController implements Renderer {
         nativeAddFeature(mapPointer, sourcePtr, coordinates, rings, properties);
     }
 
+    void editFeatures(long sourcePtr, boolean clear) {
+        checkPointer(mapPointer);
+        checkPointer(sourcePtr);
+        nativeEditFeatures(mapPointer, sourcePtr, clear);
+    }
+
+    void commitFeatures(long sourcePtr) {
+        checkPointer(mapPointer);
+        checkPointer(sourcePtr);
+        nativeCommitFeatures(mapPointer, sourcePtr);
+    }
+
     void addGeoJson(long sourcePtr, String geoJson) {
         checkPointer(mapPointer);
         checkPointer(sourcePtr);
@@ -1023,6 +1035,8 @@ public class MapController implements Renderer {
     synchronized native void nativeClearTileSource(long mapPtr, long sourcePtr);
     synchronized native void nativeAddFeature(long mapPtr, long sourcePtr, double[] coordinates, int[] rings, String[] properties);
     synchronized native void nativeAddGeoJson(long mapPtr, long sourcePtr, String geoJson);
+    synchronized native void nativeEditFeatures(long mapPtr, long sourcePtr, boolean clear);
+    synchronized native void nativeCommitFeatures(long mapPtr, long sourcePtr);
 
     native void nativeSetDebugFlag(int flag, boolean on);
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -117,4 +117,24 @@ public class MapData {
         return this;
     }
 
+    /**
+     * Turn on edit mode. In edit mode multiple features can be added
+     * without updating the map view. Use 'commit()' to end edit mode.
+     * @param clear previous map features
+     * @return This object, for chaining.
+     */
+    public MapData edit(boolean clear) {
+        map.editFeatures(pointer, clear);
+        return this;
+    }
+
+    /**
+     * Update map with added features since the last call to 'edit()'.
+     * @return This object, for chaining.
+     */
+    public MapData commit() {
+        map.commitFeatures(pointer);
+        return this;
+    }
+
 }


### PR DESCRIPTION
This PR adds edit/commit functions to ClientGeoJsonSource.
After a call to `edit()` multiple features can be added without triggering a map update for each feature. The changes become visible on the call to `commit()`
This way GeoJSONVT tiles are updated only once when adding a bunch of features.