### PR TITLE
Mbtiles platform asset paths

### DIFF
--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -53,7 +53,8 @@ public:
 
     // returns the path of an asset given the name of the asset
     // ios: returns absolute path of the asset in the asset bundle
-    // android: returns a tmp path where the asset file is extracted from the apk
+    // android: returns a tmp path where the asset file is extracted from the apk, given the path of
+    // the asset, OR absolute path of an external resource
     // other: returns the absolute path of the asset (should be by default)
     virtual std::string getAssetPath(const Tangram::Url& _path) const;
 

--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -14,9 +14,7 @@ using UrlCallback = std::function<void(std::vector<char>&&)>;
 
 using FontSourceLoader = std::function<std::vector<char>()>;
 
-namespace Tangram {
-    class Url;
-}
+class Url;
 
 struct FontSourceHandle {
     FontSourceHandle(std::string _path) : path(_path) {}

--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -14,6 +14,10 @@ using UrlCallback = std::function<void(std::vector<char>&&)>;
 
 using FontSourceLoader = std::function<std::vector<char>()>;
 
+namespace Tangram {
+    class Url;
+}
+
 struct FontSourceHandle {
     FontSourceHandle(std::string _path) : path(_path) {}
     FontSourceHandle(FontSourceLoader _loader) : load(_loader) {}
@@ -46,6 +50,12 @@ public:
     virtual void setContinuousRendering(bool _isContinuous);
 
     virtual bool isContinuousRendering() const;
+
+    // returns the path of an asset given the name of the asset
+    // ios: returns absolute path of the asset in the asset bundle
+    // android: returns a tmp path where the asset file is extracted from the apk
+    // other: returns the absolute path of the asset (should be by default)
+    virtual std::string getAssetPath(const Tangram::Url& _path) const;
 
     // Read a file as a string
     // Opens the file at the _path and returns a string with its contents.

--- a/core/src/data/mbtilesDataSource.cpp
+++ b/core/src/data/mbtilesDataSource.cpp
@@ -241,6 +241,11 @@ void MBTilesDataSource::openMBTiles(const std::shared_ptr<Platform>& _platform) 
         }
 
         auto mbTilesPath = _platform->getAssetPath(Url(m_path));
+        if (mbTilesPath.empty()) {
+            LOGW("Empty mbtiles asset path set.");
+            m_db.reset();
+            return;
+        }
         m_db = std::make_unique<SQLite::Database>(mbTilesPath, mode);
         LOG("SQLite database opened: %s", m_path.c_str());
 

--- a/core/src/data/mbtilesDataSource.cpp
+++ b/core/src/data/mbtilesDataSource.cpp
@@ -1,6 +1,7 @@
 #include "data/mbtilesDataSource.h"
 
 #include "util/asyncWorker.h"
+#include "util/url.h"
 #include "util/zlibHelper.h"
 #include "log.h"
 #include "platform.h"
@@ -125,7 +126,7 @@ MBTilesDataSource::MBTilesDataSource(std::shared_ptr<Platform> _platform, std::s
 
     m_worker = std::make_unique<AsyncWorker>();
 
-    openMBTiles();
+    openMBTiles(_platform);
 }
 
 MBTilesDataSource::~MBTilesDataSource() {
@@ -229,7 +230,7 @@ bool MBTilesDataSource::loadNextSource(std::shared_ptr<TileTask> _task, TileTask
     return next->loadTileData(_task, cb);
 }
 
-void MBTilesDataSource::openMBTiles() {
+void MBTilesDataSource::openMBTiles(const std::shared_ptr<Platform>& _platform) {
 
     try {
         auto mode = SQLite::OPEN_READONLY;
@@ -239,7 +240,8 @@ void MBTilesDataSource::openMBTiles() {
             mode = SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE;
         }
 
-        m_db = std::make_unique<SQLite::Database>(m_path, mode);
+        auto mbTilesPath = _platform->getAssetPath(Url(m_path));
+        m_db = std::make_unique<SQLite::Database>(mbTilesPath, mode);
         LOG("SQLite database opened: %s", m_path.c_str());
 
     } catch (std::exception& e) {

--- a/core/src/data/mbtilesDataSource.h
+++ b/core/src/data/mbtilesDataSource.h
@@ -31,7 +31,7 @@ private:
     void storeTileData(const TileID& _tileId, const std::vector<char>& _data);
     bool loadNextSource(std::shared_ptr<TileTask> _task, TileTaskCb _cb);
 
-    void openMBTiles();
+    void openMBTiles(const std::shared_ptr<Platform>& _platform);
     bool testSchema(SQLite::Database& db);
     void initSchema(SQLite::Database& db, std::string _name, std::string _mimeType);
 

--- a/core/src/platform.cpp
+++ b/core/src/platform.cpp
@@ -1,5 +1,6 @@
 #include "platform.h"
 #include "log.h"
+#include "util/url.h"
 
 #include <fstream>
 #include <string>
@@ -16,6 +17,10 @@ void Platform::setContinuousRendering(bool _isContinuous) {
 
 bool Platform::isContinuousRendering() const {
     return m_continuousRendering;
+}
+
+std::string Platform::getAssetPath(const Tangram::Url& _path) const {
+    return _path.path();
 }
 
 bool Platform::bytesFromFileSystem(const char* _path, std::function<char*(size_t)> _allocator) const {

--- a/platforms/android/tangram/src/main/cpp/platform_android.h
+++ b/platforms/android/tangram/src/main/cpp/platform_android.h
@@ -20,6 +20,7 @@ namespace Tangram {
 struct LabelPickResult;
 struct FeaturePickResult;
 struct MarkerPickResult;
+class Url;
 
 void featurePickCallback(jobject listener, const Tangram::FeaturePickResult* featurePickResult);
 void markerPickCallback(jobject listener, jobject tangramInstance, const Tangram::MarkerPickResult* markerPickResult);
@@ -34,6 +35,7 @@ public:
     void requestRender() const override;
     std::vector<char> bytesFromFile(const char* _path) const override;
     void setContinuousRendering(bool _isContinuous) override;
+    std::string getAssetPath(const Tangram::Url& _path) const override;
     std::string stringFromFile(const char* _path) const override;
     std::vector<char> systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1161,6 +1161,8 @@ public class MapController implements Renderer {
                 in.close();
                 out.flush();
                 out.close();
+            } else {
+                in.close();
             }
 
             return outFile.getAbsolutePath();

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1144,12 +1144,15 @@ public class MapController implements Renderer {
 
         String tmpDir = mapView.getContext().getExternalCacheDir().getAbsolutePath();
 
+        InputStream in = null;
+        OutputStream out = null;
+
         try {
-            InputStream in = assetManager.open(path);
+            in = assetManager.open(path);
             File outFile = new File(tmpDir, path);
 
             if (!outFile.exists()) {
-                OutputStream out = new FileOutputStream(outFile);
+                out = new FileOutputStream(outFile);
 
                 // Copy File
                 byte[] buffer = new byte[1024];
@@ -1158,17 +1161,20 @@ public class MapController implements Renderer {
                     out.write(buffer, 0, read);
                 }
 
-                in.close();
                 out.flush();
-                out.close();
-            } else {
-                in.close();
             }
 
             return outFile.getAbsolutePath();
         } catch (IOException e) {
             e.printStackTrace();
             return "";
+        } finally {
+            try {
+                if (in != null) { in.close(); }
+                if (out != null) { out.close(); }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
 
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -12,7 +12,11 @@ import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Response;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1132,6 +1136,32 @@ public class MapController implements Renderer {
     String getFontFallbackFilePath(int importance, int weightHint) {
 
         return fontFileParser.getFontFallback(importance, weightHint);
+    }
+
+    // Tmp Asset Path
+    // ==============
+    String copyAssetToTmpPath(String path) throws IOException {
+        String tmpDir = mapView.getContext().getExternalCacheDir().getAbsolutePath();
+        InputStream in = assetManager.open(path);
+        File outFile = new File(tmpDir, path);
+
+        if (!outFile.exists()) {
+            OutputStream out = new FileOutputStream(outFile);
+
+            // Copy File
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+
+            in.close();
+            out.flush();
+            out.close();
+        }
+
+        return outFile.getAbsolutePath();
+
     }
 
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1140,27 +1140,34 @@ public class MapController implements Renderer {
 
     // Tmp Asset Path
     // ==============
-    String copyAssetToTmpPath(String path) throws IOException {
+    String copyAssetToTmpPath(String path) {
+
         String tmpDir = mapView.getContext().getExternalCacheDir().getAbsolutePath();
-        InputStream in = assetManager.open(path);
-        File outFile = new File(tmpDir, path);
 
-        if (!outFile.exists()) {
-            OutputStream out = new FileOutputStream(outFile);
+        try {
+            InputStream in = assetManager.open(path);
+            File outFile = new File(tmpDir, path);
 
-            // Copy File
-            byte[] buffer = new byte[1024];
-            int read;
-            while ((read = in.read(buffer)) != -1) {
-                out.write(buffer, 0, read);
+            if (!outFile.exists()) {
+                OutputStream out = new FileOutputStream(outFile);
+
+                // Copy File
+                byte[] buffer = new byte[1024];
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                }
+
+                in.close();
+                out.flush();
+                out.close();
             }
 
-            in.close();
-            out.flush();
-            out.close();
+            return outFile.getAbsolutePath();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "";
         }
-
-        return outFile.getAbsolutePath();
 
     }
 

--- a/platforms/ios/src/TangramMap/platform_ios.h
+++ b/platforms/ios/src/TangramMap/platform_ios.h
@@ -10,6 +10,8 @@
 
 namespace Tangram {
 
+class Url;
+
 class iOSPlatform : public Platform {
 
 public:
@@ -17,6 +19,7 @@ public:
     iOSPlatform(TGMapViewController* _viewController);
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
+    std::string getAssetPath(const Tangram::Url& _path) const override;
     std::string stringFromFile(const char* _path) const override;
     std::vector<char> bytesFromFile(const char* _path) const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;

--- a/platforms/ios/src/TangramMap/platform_ios.mm
+++ b/platforms/ios/src/TangramMap/platform_ios.mm
@@ -98,9 +98,6 @@ std::vector<char> iOSPlatform::bytesFromFile(const char* _path) const {
 }
 
 std::string iOSPlatform::getAssetPath(const Tangram::Url& _path) const {
-    if (_path.isAbsolute()) {
-        return _path.path();
-    }
 
     NSString* path = resolvePath(_path.path().c_str());
     return [path UTF8String];

--- a/platforms/ios/src/TangramMap/platform_ios.mm
+++ b/platforms/ios/src/TangramMap/platform_ios.mm
@@ -12,6 +12,7 @@
 #import "TGFontConverter.h"
 #import "TGHttpHandler.h"
 #import "platform_ios.h"
+#import "util/url.h"
 #import "log.h"
 
 namespace Tangram {
@@ -94,6 +95,15 @@ std::vector<char> iOSPlatform::bytesFromFile(const char* _path) const {
 
     auto data = Platform::bytesFromFile([path UTF8String]);
     return data;
+}
+
+std::string iOSPlatform::getAssetPath(const Tangram::Url& _path) const {
+    if (_path.isAbsolute()) {
+        return _path.path();
+    }
+
+    NSString* path = resolvePath(_path.path().c_str());
+    return [path UTF8String];
 }
 
 std::string iOSPlatform::stringFromFile(const char* _path) const {


### PR DESCRIPTION
Addressed #1309 

Android platform:
- if the mbtiles path specified in the scene file is an apk asset path, then this file is copied at runtime to app's externalCacheDir (no special permission is required for this).
- if the mbtiles specified in the scene file is an absolute path on the device, `READ_EXTERNAL_STORAGE` permission is required both in the `AndroidManifest.xml` as well as during runtime using the following (post android M):
   ```
  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
           requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 1);
  }
   ```
   NOTE: from @ecgreb 
   > The permission READ_EXTERNAL_STORAGE should not be required if the mbtiles bundle is stored in the app's designated files folder accessed via Context.getExternalFilesDir(...).


iOS platform:
- if the mbtiles path specified in the scene file is app bundle path, then this file's path is resolved with the app's Bundle path which is then used to open the sqlite db.
- absolute path to an mbtiles works out of the box.

All other platforms:
The path to the mbtiles are resolved (relative to base scene yaml, or absolute path) automatically and works out of the box.
