### PR TITLE
Fix view complete on tile cancel

### DIFF
--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -223,7 +223,7 @@ void TileManager::updateTileSet(TileSet& _tileSet, const ViewState& _view,
             if (entry.isReady()) {
                 m_tiles.push_back(entry.tile);
 
-                if (!entry.isLoading() &&
+                if (!entry.isInProgress() &&
                     (sourceGeneration < generation)) {
                     // Tile needs update - enqueue for loading
                     entry.task = _tileSet.source->createTask(visTileId);
@@ -240,14 +240,11 @@ void TileManager::updateTileSet(TileSet& _tileSet, const ViewState& _view,
                 enqueueTask(_tileSet, visTileId, _view);
             }
 
-            // - any tile which is not ready and not canceled is in progress
-            // - any tile which is currently loading including the ones needing updating
-            //   because of map invalidation (new source generation)
-            if ( (!entry.isCanceled() && !entry.isReady()) || entry.isLoading()) {
+            if (entry.isInProgress()) {
                 m_tilesInProgress++;
             }
 
-            if (newTiles && entry.isLoading()) {
+            if (newTiles && entry.isInProgress()) {
                 // check again for proxies
                 updateProxyTiles(_tileSet, visTileId, entry);
             }
@@ -330,7 +327,7 @@ void TileManager::updateTileSet(TileSet& _tileSet, const ViewState& _view,
              entry.task && entry.task->isCanceled());
 #endif
 
-        if (entry.isLoading()) {
+        if (entry.isInProgress()) {
             auto& id = it.first;
             auto& task = entry.task;
 
@@ -425,7 +422,7 @@ void TileManager::removeTile(TileSet& _tileSet, std::map<TileID, TileEntry>::ite
     auto& entry = _tileIt->second;
 
 
-    if (entry.isLoading()) {
+    if (entry.isInProgress()) {
         entry.clearTask();
 
         // 1. Remove from Datasource. Make sure to cancel

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -99,7 +99,7 @@ private:
         uint8_t m_proxies = 0;
 
         bool isReady() { return bool(tile); }
-        bool isLoading() { return bool(task) && !task->isCanceled(); }
+        bool isInProgress() { return bool(task) && !task->isCanceled(); }
 
         bool needsLoading() {
             //return !bool(task) || (task->needsLoading() && !task->isCanceled());


### PR DESCRIPTION
- was happening on platforms because both mobile platform demos, use clientdatasource which
initially has no geometry and hence have their respective tiles cancelled for loading.
- on desktop demos we are not using clientdatasource so this use case was not being hit.

fixes #1353 