### PR TITLE
fix #1361 - push null for empty nodes

### DIFF
--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -144,6 +144,7 @@ void StyleContext::parseSceneGlobals(const YAML::Node& node) {
             break;
         }
     default:
+        duk_push_null(m_ctx);
         break;
     }
 }


### PR DESCRIPTION
https://github.com/tangrams/tangram-es/issues/1361

Fix for handling of Null yaml nodes: https://github.com/tangrams/walkabout-style/blob/gh-pages/layers/bike-interlay.yaml#L631