### PR TITLE
fix: android - 'use of deleted global reference'

### DIFF
--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -107,9 +107,13 @@ extern "C" {
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeDispose(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        Tangram::AndroidPlatform& androidPlatform = static_cast<Tangram::AndroidPlatform&>(*map->getPlatform());
-        androidPlatform.dispose(jniEnv);
+        // Don't dispose MapController ref before map is teared down,
+        // delete map or worker threads might call back to it (e.g. requestRender)
+        auto platform = map->getPlatform();
+
         delete map;
+
+        static_cast<Tangram::AndroidPlatform&>(*platform).dispose(jniEnv);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path, jobjectArray updateStrings) {


### PR DESCRIPTION
Maybe related to https://github.com/tangrams/tangram-es/issues/1379

I could reproduce this issue reliably by a few screen rotations when it caused to recreate the map while tiles being loaded.

```
03-16 11:50:19.183 11096 11231 F libc    : Fatal signal 6 (SIGABRT), code -6 in tid 11231 (Thread-36)
03-16 11:50:19.184   197   197 W         : debuggerd: handling request: pid=11096 uid=10065 gid=10065 tid=11231
03-16 11:50:19.270 11312 11312 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
03-16 11:50:19.270 11312 11312 F DEBUG   : LineageOS Version: '14.1-20170302-NIGHTLY-m7'
03-16 11:50:19.270 11312 11312 F DEBUG   : Build fingerprint: 'htc/m7_google/m7:5.1/LMY47O.H18/666675:user/release-keys'
03-16 11:50:19.270 11312 11312 F DEBUG   : Revision: '0'
03-16 11:50:19.270 11312 11312 F DEBUG   : ABI: 'arm'
03-16 11:50:19.270 11312 11312 F DEBUG   : pid: 11096, tid: 11231, name: Thread-36  >>> com.mapzen.tangram.android <<<
03-16 11:50:19.270 11312 11312 F DEBUG   : signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
03-16 11:50:19.274 11312 11312 F DEBUG   : Abort message: 'art/runtime/java_vm_ext.cc:470] JNI DETECTED ERROR IN APPLICATION: use of deleted global reference 0x20074e'
03-16 11:50:19.274 11312 11312 F DEBUG   :     r0 00000000  r1 00002bdf  r2 00000006  r3 00000008
03-16 11:50:19.274 11312 11312 F DEBUG   :     r4 9ae51978  r5 00000006  r6 9ae51920  r7 0000010c
03-16 11:50:19.274 11312 11312 F DEBUG   :     r8 00000000  r9 0000000a  sl 00000ada  fp 99467700
03-16 11:50:19.274 11312 11312 F DEBUG   :     ip 0000000b  sp 9ae50dd0  lr b66b1107  pc b66b3970  cpsr 600f0010
03-16 11:50:19.303 11312 11312 F DEBUG   :
03-16 11:50:19.303 11312 11312 F DEBUG   : backtrace:
03-16 11:50:19.303 11312 11312 F DEBUG   :     #00 pc 0004a970  /system/lib/libc.so (tgkill+12)
03-16 11:50:19.303 11312 11312 F DEBUG   :     #01 pc 00048103  /system/lib/libc.so (pthread_kill+34)
03-16 11:50:19.303 11312 11312 F DEBUG   :     #02 pc 0001d715  /system/lib/libc.so (raise+10)
03-16 11:50:19.303 11312 11312 F DEBUG   :     #03 pc 00019261  /system/lib/libc.so (__libc_android_abort+34)
03-16 11:50:19.303 11312 11312 F DEBUG   :     #04 pc 00017128  /system/lib/libc.so (abort+4)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #05 pc 0031b4b5  /system/lib/libart.so (_ZN3art7Runtime5AbortEPKc+328)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #06 pc 000b526b  /system/lib/libart.so (_ZN3art10LogMessageD2Ev+1134)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #07 pc 0023a609  /system/lib/libart.so (_ZN3art9JavaVMExt8JniAbortEPKcS2_+1584)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #08 pc 0023a8d3  /system/lib/libart.so (_ZN3art9JavaVMExt9JniAbortFEPKcS2_z+66)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #09 pc 003351f5  /system/lib/libart.so (_ZNK3art6Thread13DecodeJObjectEP8_jobject+240)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #10 pc 000ca345  /system/lib/libart.so (_ZN3art11ScopedCheck13CheckInstanceERNS_18ScopedObjectAccessENS0_12InstanceKindEP8_jobjectb+120)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #11 pc 000c98ed  /system/lib/libart.so (_ZN3art11ScopedCheck22CheckPossibleHeapValueERNS_18ScopedObjectAccessEcNS_12JniValueTypeE+184)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #12 pc 000c8d21  /system/lib/libart.so (_ZN3art11ScopedCheck5CheckERNS_18ScopedObjectAccessEbPKcPNS_12JniValueTypeE+800)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #13 pc 000ccecf  /system/lib/libart.so (_ZN3art8CheckJNI13CheckCallArgsERNS_18ScopedObjectAccessERNS_11ScopedCheckEP7_JNIEnvP8_jobjectP7_jclassP10_jmethodIDNS_10InvokeTypeEPKNS_7
VarArgsE+110)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #14 pc 000cc501  /system/lib/libart.so (_ZN3art8CheckJNI11CallMethodVEPKcP7_JNIEnvP8_jobjectP7_jclassP10_jmethodIDSt9__va_listNS_9Primitive4TypeENS_10InvokeTypeE+512)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #15 pc 000c26f9  /system/lib/libart.so (_ZN3art8CheckJNI15CallVoidMethodVEP7_JNIEnvP8_jobjectP10_jmethodIDSt9__va_list+44)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #16 pc 002077c1  /data/app/com.mapzen.tangram.android-2/lib/arm/libtangram.so (_ZN7_JNIEnv14CallVoidMethodEP8_jobjectP10_jmethodIDz+76)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #17 pc 0020772d  /data/app/com.mapzen.tangram.android-2/lib/arm/libtangram.so (_ZNK7Tangram15AndroidPlatform13requestRenderEv+64)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #18 pc 00294205  /data/app/com.mapzen.tangram.android-2/lib/arm/libtangram.so (_ZN7Tangram10TileWorker3runEPNS0_6WorkerE+1884)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #19 pc 002955c5  /data/app/com.mapzen.tangram.android-2/lib/arm/libtangram.so (_ZNSt6__ndk114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3
_EEEEMN7Tangram10TileWorkerEFvPNS8_6WorkerEEPS8_SA_EEEEEPvSF_+232)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #20 pc 00047bd3  /system/lib/libc.so (_ZL15__pthread_startPv+22)
03-16 11:50:19.304 11312 11312 F DEBUG   :     #21 pc 00019cbd  /system/lib/libc.so (__start_thread+6)
```