### PR TITLE
Add api key to iOS demo app

### DIFF
--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -177,7 +177,9 @@
 
 - (void)viewWillAppear:(BOOL)animated
 {
-    [super loadSceneFileAsync:@"https://tangrams.github.io/walkabout-style/walkabout-style.yaml"];
+    NSMutableArray<TGSceneUpdate *>* updates = [[NSMutableArray alloc]init];
+    [updates addObject:[[TGSceneUpdate alloc]initWithPath:@"global.sdk_mapzen_api_key" value:@"vector-tiles-tyHL4AY"]];
+    [super loadSceneFileAsync:@"https://tangrams.github.io/walkabout-style/walkabout-style.yaml" sceneUpdates:updates];
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION
Until we have zip support we use `github.io` url, then we can move to published version of mapzen website.