### PR TITLE
Resize the map when an accurate bounds is available

### DIFF
--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -120,7 +120,7 @@
     {
         if (!vc.markerPolygon) {
             vc.markerPolygon = [[TGMarker alloc] init];
-            vc.markerPolygon.styling = @"{ style: 'polygons', color: 'blue', order: 500 }";
+            vc.markerPolygon.stylingString = @"{ style: 'polygons', color: 'blue', order: 500 }";
 
             // Add the marker to the current view
             vc.markerPolygon.map = view;
@@ -143,7 +143,7 @@
     // Add point marker
     {
         TGMarker* markerPoint = [[TGMarker alloc] initWithMapView:view];
-        markerPoint.styling = @"{ style: 'points', color: 'white', size: [25px, 25px], collide: false }";
+        markerPoint.stylingString = @"{ style: 'points', color: 'white', size: [25px, 25px], collide: false }";
         markerPoint.point = coordinates;
     }
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -776,12 +776,6 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
     [EAGLContext setCurrentContext:self.context];
 
     self.map->setupGL();
-
-    int width = self.view.bounds.size.width;
-    int height = self.view.bounds.size.height;
-
-    self.map->resize(width * self.contentScaleFactor, height * self.contentScaleFactor);
-
     self.map->setPixelScale(self.contentScaleFactor);
 }
 
@@ -791,6 +785,13 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 
     delete self.map;
     self.map = nullptr;
+}
+
+-(void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+  int width = self.view.bounds.size.width;
+  int height = self.view.bounds.size.height;
+  self.map->resize(width * self.contentScaleFactor, height * self.contentScaleFactor);
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -787,8 +787,8 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
     self.map = nullptr;
 }
 
--(void)viewDidLayoutSubviews {
-  [super viewDidLayoutSubviews];
+-(void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
   int width = self.view.bounds.size.width;
   int height = self.view.bounds.size.height;
   self.map->resize(width * self.contentScaleFactor, height * self.contentScaleFactor);

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -788,10 +788,10 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 }
 
 -(void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-  int width = self.view.bounds.size.width;
-  int height = self.view.bounds.size.height;
-  self.map->resize(width * self.contentScaleFactor, height * self.contentScaleFactor);
+    [super viewWillLayoutSubviews];
+    int width = self.view.bounds.size.width;
+    int height = self.view.bounds.size.height;
+    self.map->resize(width * self.contentScaleFactor, height * self.contentScaleFactor);
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator


### PR DESCRIPTION
This fixes a bug which set the map's size before an accurate bounds was available. Previously the map was resized in `viewDidLoad` but now it is set in ~~`viewDidLayoutSubviews`~~ `viewWillLayoutSubviews`. When the `TGMapViewController` was a view controller within a `UITabBarViewController` without a transparent tab bar, the map's view would not be properly sized.

This [branch](https://github.com/tangrams/tangram-es/tree/pick-test) shows that bug manifesting. Clicking on the screen draws a marker above where you tap (which makes it appear unselectable because you have to tap below where the marker is drawn to trigger the selection delegate).

Closes #1377  

