### PR TITLE
Misc. render optimizations

### DIFF
--- a/core/shaders/point.vs
+++ b/core/shaders/point.vs
@@ -74,35 +74,26 @@ void main() {
     v_sdf_scale = a_scale / 64.0;
 
     if (u_pass == 0) {
-        // fill
         v_sdf_threshold = 0.5;
-        //v_alpha = 0.0;
-    } else if (a_stroke.a > 0.0) {
-        // stroke
-        // (0.5 / 3.0) <= sdf change by pixel distance to outline == 0.083
-        float sdf_pixel = 0.5/u_max_stroke_width;
-
-        // de-normalize [0..1] -> [0..max_stroke_width]
-        float stroke_width = a_stroke.a * u_max_stroke_width;
-
-        // scale to sdf pixel
-        stroke_width *= sdf_pixel;
-
-        // scale sdf (texture is scaled depeding on font size)
-        stroke_width /= v_sdf_scale;
-
-        v_sdf_threshold = max(0.5 - stroke_width, 0.0);
-
-        v_color.rgb = a_stroke.rgb;
     } else {
-        v_alpha = 0.0;
+        if ((a_stroke.a > 0.0)) {
+            float stroke_width_2;
+            stroke_width_2 = ((a_stroke.a * u_max_stroke_width) * (0.5 / u_max_stroke_width));
+            stroke_width_2 = (stroke_width_2 / v_sdf_scale);
+            v_sdf_threshold = max ((0.5 - stroke_width_2), 0.0);
+            v_color.xyz = a_stroke.xyz;
+        } else {
+            v_alpha = 0.0;
+        }
     }
 
-    vec4 position = vec4(vertex_pos, 0.0, 1.0);
+    vec4 position;
+    position.zw = vec2(0.0, 1.0);
+    position.xy = vertex_pos;
 
     #pragma tangram: position
 
-    gl_Position = u_ortho * position;
+    gl_Position = (u_ortho * position);
 
 #else
     v_texcoords = a_uv;

--- a/core/shaders/point.vs
+++ b/core/shaders/point.vs
@@ -44,7 +44,7 @@ varying vec4 v_color;
 varying vec2 v_texcoords;
 #ifdef TANGRAM_TEXT
 varying float v_sdf_threshold;
-varying float v_sdf_scale;
+varying float v_sdf_pixel;
 #endif
 varying float v_alpha;
 
@@ -71,16 +71,17 @@ void main() {
 #ifdef TANGRAM_TEXT
     vec2 vertex_pos = UNPACK_POSITION(a_position);
     v_texcoords = UNPACK_TEXTURE(a_uv);
-    v_sdf_scale = a_scale / 64.0;
+    float sdf_scale = a_scale / 64.0;
+    v_sdf_pixel = 0.5 / (u_max_stroke_width * sdf_scale);
 
     if (u_pass == 0) {
         v_sdf_threshold = 0.5;
     } else {
         if ((a_stroke.a > 0.0)) {
-            float stroke_width_2;
-            stroke_width_2 = ((a_stroke.a * u_max_stroke_width) * (0.5 / u_max_stroke_width));
-            stroke_width_2 = (stroke_width_2 / v_sdf_scale);
-            v_sdf_threshold = max ((0.5 - stroke_width_2), 0.0);
+            float stroke_width;
+            stroke_width = ((a_stroke.a * u_max_stroke_width) * (0.5 / u_max_stroke_width));
+            stroke_width = (stroke_width / sdf_scale);
+            v_sdf_threshold = max ((0.5 - stroke_width), 0.0);
             v_color.xyz = a_stroke.xyz;
         } else {
             v_alpha = 0.0;

--- a/core/shaders/sdf.fs
+++ b/core/shaders/sdf.fs
@@ -25,7 +25,7 @@ varying vec4 v_color;
 varying vec2 v_texcoords;
 varying float v_sdf_threshold;
 varying float v_alpha;
-varying float v_sdf_scale;
+varying float v_sdf_pixel;
 
 #pragma tangram: global
 
@@ -51,9 +51,8 @@ void main(void) {
     //   When the glyph is scaled down, 's' must be increased
     //   (used to interpolate 1px of the scaled glyph around v_sdf_threshold)
 
-    float sdf_pixel = 0.5 / (u_max_stroke_width * v_sdf_scale);
     float add_smooth = 0.25;
-    float filter_width = (sdf_pixel * (0.5 + add_smooth));
+    float filter_width = (v_sdf_pixel * (0.5 + add_smooth));
 
     float start = max(v_sdf_threshold - filter_width, 0.0);
     float end = v_sdf_threshold + filter_width;

--- a/core/src/gl/dynamicQuadMesh.h
+++ b/core/src/gl/dynamicQuadMesh.h
@@ -5,6 +5,7 @@
 #include "gl/renderState.h"
 #include "gl/shaderProgram.h"
 #include "gl/texture.h"
+#include "gl/hardware.h"
 #include "gl/vao.h"
 
 #include <memory>
@@ -100,6 +101,8 @@ bool DynamicQuadMesh<T>::draw(RenderState& rs, ShaderProgram& shader, bool useVa
 
 template<class T>
 bool DynamicQuadMesh<T>::draw(RenderState& rs, ShaderProgram& shader, int textureUnit, bool useVao) {
+    useVao = useVao && Hardware::supportsVAOs;
+
     if (m_nVertices == 0) { return false; }
 
     // Enable shader program

--- a/core/src/gl/vao.cpp
+++ b/core/src/gl/vao.cpp
@@ -7,7 +7,7 @@
 
 namespace Tangram {
 
-void Vao::initialize(RenderState& rs, ShaderProgram& _program, const std::vector<std::pair<uint32_t, uint32_t>>& _vertexOffsets,
+void Vao::initialize(RenderState& rs, ShaderProgram& _program, const VertexOffsets& _vertexOffsets,
                VertexLayout& _layout, GLuint _vertexBuffer, GLuint _indexBuffer) {
 
     m_glVAOs.resize(_vertexOffsets.size());

--- a/core/src/gl/vao.h
+++ b/core/src/gl/vao.h
@@ -10,11 +10,13 @@ class RenderState;
 class ShaderProgram;
 class VertexLayout;
 
+using VertexOffsets = std::vector<std::pair<uint32_t, uint32_t>>;
+
 class Vao {
 
 public:
 
-    void initialize(RenderState& rs, ShaderProgram& _program, const std::vector<std::pair<uint32_t, uint32_t>>& _vertexOffsets,
+    void initialize(RenderState& rs, ShaderProgram& _program, const VertexOffsets& _vertexOffsets,
                     VertexLayout& _layout, GLuint _vertexBuffer, GLuint _indexBuffer);
     bool isInitialized();
     void bind(unsigned int _index);

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -763,8 +763,12 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 
     GLKView* view = (GLKView *)self.view;
     view.context = self.context;
+
+    view.drawableColorFormat = GLKViewDrawableColorFormatRGBA8888;
     view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
-    view.drawableMultisample = GLKViewDrawableMultisample4X;
+    view.drawableStencilFormat = GLKViewDrawableStencilFormatNone;
+    view.drawableMultisample = GLKViewDrawableMultisampleNone;
+
     self.contentScaleFactor = view.contentScaleFactor;
 
     [self setupGestureRecognizers];


### PR DESCRIPTION
- Use vaos for first batch of dynamic buffer mesh (looking at the trace, vertex bytes offset is different only for specific use cases; when a mesh is too big, or when a texture is specific to a mesh through a bitmap marker. Since the byte vertex offset cannot be captured by the vertex array object, only use it when this offset is 0, which makes it being used most of the time)
- Optimize costly shaders (Shader program 60 on the screenshot 3.59ms -> 1.55ms): 
   - Offload some of costly shader work from fragment to vertex shader
   - Pass part of it through glsl optimizer and adapt to something still human readable
- Configure `GLKView` to disable stencil and use no msaa on iOS

For the same area on walkabout the frame rate time changed from ~6.3ms to ~3.8ms on iPhone 6S Plus:

<img width="813" alt="screen shot 2017-03-17 at 11 52 20 am" src="https://cloud.githubusercontent.com/assets/7061573/24051380/45c06f20-0b08-11e7-99c2-99db0ccdc710.png">
<img width="817" alt="screen shot 2017-03-17 at 11 52 37 am" src="https://cloud.githubusercontent.com/assets/7061573/24051382/478c7a88-0b08-11e7-8d5b-19f1ba17fe80.png">


