### PR TITLE
Allow null nodes to be overridden during import merging.

### DIFF
--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -4,8 +4,8 @@
 #include "platform.h"
 #include "scene/sceneLoader.h"
 
-#include <regex>
 #include "yaml-cpp/yaml.h"
+#include <cassert>
 
 using YAML::Node;
 using YAML::NodeType;
@@ -314,6 +314,7 @@ void Importer::mergeMapFields(Node& target, const Node& import) {
         }
 
         switch(dest.Type()) {
+            case NodeType::Null:
             case NodeType::Scalar:
             case NodeType::Sequence:
                 dest = source;
@@ -329,6 +330,9 @@ void Importer::mergeMapFields(Node& target, const Node& import) {
                 break;
             }
             default:
+                // NodeType::Undefined is handled above by checking (!dest).
+                // All types are handled, so this should never be reached.
+                assert(false);
                 break;
         }
     }

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -264,3 +264,26 @@ TEST_CASE("Sequence overwrites map", "[import][core]") {
     CHECK(root["a"].IsSequence());
     CHECK(root["a"].size() == 2);
 }
+
+TEST_CASE("Scalar and null overwrite correctly", "[import][core]") {
+    std::shared_ptr<Platform> platform = std::make_shared<MockPlatform>();
+    std::unordered_map<Url, std::string> testScenes;
+    testScenes["/base.yaml"] = R"END(
+        import: [scalar.yaml, null.yaml]
+        scalar_at_end: scalar
+        null_at_end: null
+    )END";
+    testScenes["/scalar.yaml"] = R"END(
+            null_at_end: scalar
+    )END";
+
+    testScenes["/null.yaml"] = R"END(
+            scalar_at_end: null
+    )END";
+
+    TestImporter importer(testScenes);
+    auto root = importer.applySceneImports(platform, "base.yaml", "/");
+
+    CHECK(root["scalar_at_end"].Scalar() == "scalar");
+    CHECK(root["null_at_end"].IsNull());
+}


### PR DESCRIPTION
Due to a missing `case` for `NodeType::Null`, any node defined as `null` or empty in an imported scene file could never be overwritten by parent scene files.