### PR TITLE
Platform memory warnings

### DIFF
--- a/core/include/tangram/tangram.h
+++ b/core/include/tangram/tangram.h
@@ -330,6 +330,9 @@ public:
     // Run this task asynchronously to Tangram's main update loop.
     void runAsyncTask(std::function<void()> _task);
 
+    // Send a signal to Tangram that the platform received a memory warning
+    void onMemoryWarning();
+
     std::shared_ptr<Platform>& getPlatform();
 
 private:

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -901,6 +901,10 @@ void Map::onMemoryWarning() {
     if (tileCache) {
         tileCache->clear();
     }
+
+    if (impl->scene && impl->scene->fontContext()) {
+        impl->scene->fontContext()->releaseFonts();
+    }
 }
 
 void setDebugFlag(DebugFlags _flag, bool _on) {

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -895,6 +895,14 @@ void Map::runAsyncTask(std::function<void()> _task) {
     }
 }
 
+void Map::onMemoryWarning() {
+    auto& tileCache = impl->tileManager.getTileCache();
+
+    if (tileCache) {
+        tileCache->clear();
+    }
+}
+
 void setDebugFlag(DebugFlags _flag, bool _on) {
 
     g_flags.set(_flag, _on);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -902,6 +902,10 @@ void Map::onMemoryWarning() {
         tileCache->clear();
     }
 
+    for (auto& tileSet : impl->tileManager.getTileSets()) {
+        tileSet.source->clearData();
+    }
+
     if (impl->scene && impl->scene->fontContext()) {
         impl->scene->fontContext()->releaseFonts();
     }

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -115,6 +115,8 @@ public:
 
     void setPixelScale(float _scale);
 
+    void releaseFonts();
+
 private:
 
     float m_sdfRadius;

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -529,4 +529,10 @@ extern "C" {
             Tangram::sceneUpdateErrorCallback(updateErrorCallbackRef, sceneUpdateErrorStatus);
         });
     }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeOnLowMemory(JNIEnv* jnienv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->onMemoryWarning();
+    }
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -882,6 +882,11 @@ public class MapController implements Renderer {
     // Package private methods
     // =======================
 
+    void onLowMemory() {
+        checkPointer(mapPointer);
+        nativeOnLowMemory(mapPointer);
+    }
+
     void removeTileSource(long sourcePtr) {
         checkPointer(mapPointer);
         checkPointer(sourcePtr);
@@ -1001,6 +1006,7 @@ public class MapController implements Renderer {
         System.loadLibrary("tangram");
     }
 
+    private synchronized native long nativeOnLowMemory(long mapPtr);
     private synchronized native long nativeInit(MapController instance, AssetManager assetManager);
     private synchronized native void nativeDispose(long mapPtr);
     private synchronized native void nativeLoadScene(long mapPtr, SceneUpdateErrorListener listener, String path, String[] updateStrings);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -171,7 +171,7 @@ public class MapView extends FrameLayout {
      * You must call this method from the parent Activity/Fragment's corresponding method.
      */
     public void onLowMemory() {
-
+        mapController.onLowMemory();
     }
 
 }

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -386,6 +386,9 @@ void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods
                 map->setPosition(8.82, 53.08);
                 map->setZoom(14);
                 break;
+            case GLFW_KEY_F3:
+                map->onMemoryWarning();
+                break;
         default:
                 break;
         }

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -410,7 +410,6 @@ void framebufferResizeCallback(GLFWwindow* window, int fWidth, int fHeight) {
     }
     map->setPixelScale(density);
     map->resize(fWidth, fHeight);
-
 }
 
 } // namespace GlfwApp

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -783,16 +783,9 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 {
     [super didReceiveMemoryWarning];
 
-    if ([self isViewLoaded] && ([[self view] window] == nil)) {
-        self.view = nil;
-
-        if ([EAGLContext currentContext] == self.context) {
-            [EAGLContext setCurrentContext:nil];
-        }
-        self.context = nil;
+    if (self.map) {
+        self.map->onMemoryWarning();
     }
-
-    // Dispose of any resources that can be recreated.
 }
 
 - (void)setupGL


### PR DESCRIPTION
Handle platform memory warning signals:
- Delete tile cache
- Release font resources that can be easily reloaded

Note for iOS: Since iOS 6 the view can't be dropped anymore, so we can reliably consider that we will still have a view when the signal is sent to `TGMapViewController`.

Fixes #1393 