### PR TITLE
Fix #1394, #1391, #1370

### DIFF
--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -131,10 +131,10 @@
     {
         if (!vc.markerPolygon) {
             vc.markerPolygon = [[TGMarker alloc] init];
-            vc.markerPolygon.stylingString = @"{ style: 'polygons', color: 'blue', order: 500 }";
+            [vc.markerPolygon stylingString:@"{ style: 'polygons', color: 'blue', order: 500 }"];
 
             // Add the marker to the current view
-            vc.markerPolygon.map = view;
+            [vc.markerPolygon map:view];
         }
 
         static TGGeoPolygon* polygon = nil;
@@ -143,7 +143,7 @@
         if ([polygon count] == 0) {
             [polygon startPath:coordinates withSize:5];
         } else if ([polygon count] % 5 == 0) {
-            vc.markerPolygon.polygon = polygon;
+            [vc.markerPolygon polygon:polygon];
             [polygon removeAll];
             [polygon startPath:coordinates withSize:5];
         } else {
@@ -154,8 +154,8 @@
     // Add point marker
     {
         TGMarker* markerPoint = [[TGMarker alloc] initWithMapView:view];
-        markerPoint.stylingString = @"{ style: 'points', color: 'white', size: [25px, 25px], collide: false }";
-        markerPoint.point = coordinates;
+        [markerPoint stylingString:@"{ style: 'points', color: 'white', size: [25px, 25px], collide: false }"];
+        [markerPoint point:coordinates];
     }
 
     // Request feature picking

--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -131,10 +131,10 @@
     {
         if (!vc.markerPolygon) {
             vc.markerPolygon = [[TGMarker alloc] init];
-            [vc.markerPolygon stylingString:@"{ style: 'polygons', color: 'blue', order: 500 }"];
+            [vc.markerPolygon stylingString:@"{ style: 'polygons', color: 'blue', order: 500 }" error:nil];
 
             // Add the marker to the current view
-            [vc.markerPolygon map:view];
+            [vc.markerPolygon map:view error:nil];
         }
 
         static TGGeoPolygon* polygon = nil;
@@ -154,8 +154,8 @@
     // Add point marker
     {
         TGMarker* markerPoint = [[TGMarker alloc] initWithMapView:view];
-        [markerPoint stylingString:@"{ style: 'points', color: 'white', size: [25px, 25px], collide: false }"];
-        [markerPoint point:coordinates];
+        [markerPoint stylingString:@"{ style: 'points', color: 'white', size: [25px, 25px], collide: false }" error:nil];
+        [markerPoint point:coordinates error:nil];
     }
 
     // Request feature picking

--- a/platforms/ios/src/TangramMap/TGMarker.h
+++ b/platforms/ios/src/TangramMap/TGMarker.h
@@ -52,23 +52,26 @@ NS_ASSUME_NONNULL_BEGIN
  @param coordinates the longitude and latitude where the marker will be placed
  @param seconds the animation duration given in seconds
  @param ease the ease function to be used between animation timestep
- @return `YES` if this operation was successful, `NO` otherwise
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+ @return Whether the marker coordinates were set succesfully
 
  @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
-- (NSError *)pointEased:(TGGeoPoint)coordinates seconds:(float)seconds easeType:(TGEaseType)ease;
+- (BOOL)pointEased:(TGGeoPoint)coordinates seconds:(float)seconds easeType:(TGEaseType)ease error:(NSError **)error;
 
 /**
  Sets the styling for a marker with a string of YAML defining a 'draw rule'.
 
  See the more detailed scene <a href="https://mapzen.com/documentation/tangram/Styles-Overview/">documentation</a>
  to get more styling informations.
+ 
+ @param styling the styling to set to this marker
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+ @return Whether the marker styling string was set successfully
 
  @note Setting the stylingString will overwrite any previously set stylingString or stylingPath.
-
- @return An error if the marker can't be shown on the map
  */
-- (NSError *)stylingString:(NSString *)styling;
+- (BOOL)stylingString:(NSString *)styling error:(NSError **)error;
 
 /**
  Sets the styling for a marker with a path, delimited by '.' that specifies a 'draw rule' in the
@@ -77,52 +80,66 @@ NS_ASSUME_NONNULL_BEGIN
  See the more detailed scene <a href="https://mapzen.com/documentation/tangram/Styles-Overview/">documentation</a>
  to get more styling informations.
 
- @note Setting the stylingPath will overwrite any previously set stylingString or stylingPath.
+ @param path the styling path to set to this marker
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+ @return Whether the marker styling path was set successfully
 
- @return An error if the marker can't be shown on the map
+ @note Setting the stylingPath will overwrite any previously set stylingString or stylingPath.
  */
-- (NSError *)stylingPath:(NSString *)path;
+- (BOOL)stylingPath:(NSString *)path error:(NSError **)error;
 
 /**
  Sets a marker to be a single point geometry at a geographic coordinate.
 
- @note Markers can have their geometry set multiple time with possibly different geometry types.
+ @param coordinates the coordinates to set to this marker
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+ @return Whether the marker coordinates were set successfully
 
- @return An error if the marker can't be shown on the map
+ @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
-- (NSError *)point:(TGGeoPoint)coordinates;
+- (BOOL)point:(TGGeoPoint)coordinates error:(NSError **)error;
 
 /**
  Sets a marker styled to be a polyline (described in a `TGGeoPolyline`).
 
- @note Markers can have their geometry set multiple time wwith possibly different geometry types.
+ @param polyline the polyline geometry to set to this marker
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+ @return Whether the marker polyline was set successfully
 
- @return An error if the marker can't be shown on the map
+ @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
-- (NSError *)polyline:(TGGeoPolyline *)polyline;
+- (BOOL)polyline:(TGGeoPolyline *)polyline error:(NSError **)error;
 
 /**
  Sets a marker to be a polygon geometry (described in a `TGGeoPolygon`).
 
- @note Markers can have their geometry set multiple time with possibly different geometry types.
+ @param polygon the polygon geometry to set to this marker
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+ @return Whether the marker polygon was set successfully
 
- @return An error if the marker can't be shown on the map
+ @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
-- (NSError *)polygon:(TGGeoPolygon *)polygon;
+- (BOOL)polygon:(TGGeoPolygon *)polygon error:(NSError **)error;
 
 /**
  Adjusts marker visibility
  
- @return An error if the marker can't be shown on the map
+ @param visible whether the marker should be visible or not
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+
+ @return Whether the marker visibility order was set successfully
  */
-- (NSError *)visible:(BOOL)visible;
+- (BOOL)visible:(BOOL)visible error:(NSError **)error;
 
 /**
  Set the ordering of point marker object relative to other markers; higher values are drawn 'above'.
 
- @return An error if the marker can't be shown on the map
+ @param drawOrder the draw order to set to this marker
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+
+ @return Whether the marker draw order was set successfully
  */
-- (NSError *)drawOrder:(NSInteger)drawOrder;
+- (BOOL)drawOrder:(NSInteger)drawOrder error:(NSError **)error;
 
 /**
  Sets an icon loaded with a <a href="https://developer.apple.com/reference/uikit/uiimage">
@@ -139,9 +156,12 @@ NS_ASSUME_NONNULL_BEGIN
  @note An icon marker must be styled with a
  <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">point style</a>.
 
- @return An error if the marker can't be shown on the map
+ @param icon the icon image to set to this marker
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+
+ @return Whether the marker icon was set successfully
  */
-- (NSError *)icon:(UIImage *)icon;
+- (BOOL)icon:(UIImage *)icon error:(NSError **)error;
 
 /// Access the marker styling string (readonly)
 @property (readonly, nonatomic) NSString* stylingString;
@@ -169,9 +189,12 @@ NS_ASSUME_NONNULL_END
 
  A marker can be only active at at most one `TGMapViewController` at a time.
 
+ @param mapView the map view this marker should be added to, nil if it should be removed
+ @param error an error status pointer that will be assigned if non-nil and an error occured
+
  @return An error if the marker can't be shown on the map
  */
-- (NSError * _Nonnull)map:(nullable TGMapViewController *)mapView;
+- (BOOL)map:(nullable TGMapViewController *)mapView error:(NSError * _Nullable * _Nullable)error;
 
 /// Access the marker map view (readonly)
 @property (readonly, nonatomic) TGMapViewController* _Nullable map;

--- a/platforms/ios/src/TangramMap/TGMarker.h
+++ b/platforms/ios/src/TangramMap/TGMarker.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
-- (BOOL)setPointEased:(TGGeoPoint)coordinates seconds:(float)seconds easeType:(TGEaseType)ease;
+- (NSError *)pointEased:(TGGeoPoint)coordinates seconds:(float)seconds easeType:(TGEaseType)ease;
 
 /**
  Sets the styling for a marker with a string of YAML defining a 'draw rule'.
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note Setting the stylingString will overwrite any previously set stylingString or stylingPath.
  */
-@property (copy, nonatomic) NSString* stylingString;
+- (NSError *)stylingString:(NSString *)styling;
 
 /**
  Sets the styling for a marker with a path, delimited by '.' that specifies a 'draw rule' in the
@@ -77,38 +77,38 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note Setting the stylingPath will overwrite any previously set stylingString or stylingPath.
  */
-@property (copy, nonatomic) NSString* stylingPath;
+- (NSError *)stylingPath:(NSString *)path;
 
 /**
  Sets a marker to be a single point geometry at a geographic coordinate.
 
  @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
-@property (assign, nonatomic) TGGeoPoint point;
+- (NSError *)point:(TGGeoPoint)coordinates;
 
 /**
  Sets a marker styled to be a polyline (described in a `TGGeoPolyline`).
 
  @note Markers can have their geometry set multiple time wwith possibly different geometry types.
  */
-@property (strong, nonatomic) TGGeoPolyline* polyline;
+- (NSError *)polyline:(TGGeoPolyline *)polyline;
 
 /**
  Sets a marker to be a polygon geometry (described in a `TGGeoPolygon`).
 
  @note Markers can have their geometry set multiple time with possibly different geometry types.
  */
-@property (strong, nonatomic) TGGeoPolygon* polygon;
+- (NSError *)polygon:(TGGeoPolygon *)polygon;
 
 /**
  Adjusts marker visibility
  */
-@property (assign, nonatomic) BOOL visible;
+- (NSError *)visible:(BOOL)visible;
 
 /**
  Set the ordering of point marker object relative to other markers; higher values are drawn 'above'.
  */
-@property (assign, nonatomic) NSInteger drawOrder;
+- (NSError *)DrawOrder:(NSInteger)drawOrder;
 
 /**
  Sets an icon loaded with a <a href="https://developer.apple.com/reference/uikit/uiimage">
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
  @note An icon marker must be styled with a
  <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">point style</a>.
  */
-@property (strong, nonatomic) UIImage* icon;
+- (NSError *)icon:(UIImage *)icon;
 
 NS_ASSUME_NONNULL_END
 
@@ -134,6 +134,16 @@ NS_ASSUME_NONNULL_END
  Setting this property will add the marker to the map, and setting it to `nil` will remove the marker from it.
  A marker can be only active at at most one `TGMapViewController` at a time.
  */
-@property (weak, nonatomic) TGMapViewController* _Nullable map;
+- (NSError *)map:(TGMapViewController *)mapView;
+
+@property (readonly, nonatomic) TGMapViewController* map;
+@property (readonly, nonatomic) NSString* stylingString;
+@property (readonly, nonatomic) NSString* stylingPath;
+@property (readonly, nonatomic) TGGeoPoint point;
+@property (readonly, nonatomic) TGGeoPolyline* polyline;
+@property (readonly, nonatomic) TGGeoPolygon* polygon;
+@property (readonly, nonatomic) BOOL visible;
+@property (readonly, nonatomic) NSInteger drawOrder;
+@property (readonly, nonatomic) UIImage* icon;
 
 @end

--- a/platforms/ios/src/TangramMap/TGMarker.h
+++ b/platforms/ios/src/TangramMap/TGMarker.h
@@ -65,6 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
  to get more styling informations.
 
  @note Setting the stylingString will overwrite any previously set stylingString or stylingPath.
+
+ @return An error if the marker can't be shown on the map
  */
 - (NSError *)stylingString:(NSString *)styling;
 
@@ -76,6 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
  to get more styling informations.
 
  @note Setting the stylingPath will overwrite any previously set stylingString or stylingPath.
+
+ @return An error if the marker can't be shown on the map
  */
 - (NSError *)stylingPath:(NSString *)path;
 
@@ -83,6 +87,8 @@ NS_ASSUME_NONNULL_BEGIN
  Sets a marker to be a single point geometry at a geographic coordinate.
 
  @note Markers can have their geometry set multiple time with possibly different geometry types.
+
+ @return An error if the marker can't be shown on the map
  */
 - (NSError *)point:(TGGeoPoint)coordinates;
 
@@ -90,6 +96,8 @@ NS_ASSUME_NONNULL_BEGIN
  Sets a marker styled to be a polyline (described in a `TGGeoPolyline`).
 
  @note Markers can have their geometry set multiple time wwith possibly different geometry types.
+
+ @return An error if the marker can't be shown on the map
  */
 - (NSError *)polyline:(TGGeoPolyline *)polyline;
 
@@ -97,18 +105,24 @@ NS_ASSUME_NONNULL_BEGIN
  Sets a marker to be a polygon geometry (described in a `TGGeoPolygon`).
 
  @note Markers can have their geometry set multiple time with possibly different geometry types.
+
+ @return An error if the marker can't be shown on the map
  */
 - (NSError *)polygon:(TGGeoPolygon *)polygon;
 
 /**
  Adjusts marker visibility
+ 
+ @return An error if the marker can't be shown on the map
  */
 - (NSError *)visible:(BOOL)visible;
 
 /**
  Set the ordering of point marker object relative to other markers; higher values are drawn 'above'.
+
+ @return An error if the marker can't be shown on the map
  */
-- (NSError *)DrawOrder:(NSInteger)drawOrder;
+- (NSError *)drawOrder:(NSInteger)drawOrder;
 
 /**
  Sets an icon loaded with a <a href="https://developer.apple.com/reference/uikit/uiimage">
@@ -124,26 +138,42 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note An icon marker must be styled with a
  <a href="https://mapzen.com/documentation/tangram/Styles-Overview/#points">point style</a>.
+
+ @return An error if the marker can't be shown on the map
  */
 - (NSError *)icon:(UIImage *)icon;
+
+/// Access the marker styling string (readonly)
+@property (readonly, nonatomic) NSString* stylingString;
+/// Access the marker styling path (readonly)
+@property (readonly, nonatomic) NSString* stylingPath;
+/// Access the marker coordinate (readonly)
+@property (readonly, nonatomic) TGGeoPoint point;
+/// Access the marker polyline (readonly)
+@property (readonly, nonatomic) TGGeoPolyline* polyline;
+/// Access the marker polygon (readonly)
+@property (readonly, nonatomic) TGGeoPolygon* polygon;
+/// Access whether the marker visibility (readonly)
+@property (readonly, nonatomic) BOOL visible;
+/// Access the marker draw order (readonly)
+@property (readonly, nonatomic) NSInteger drawOrder;
+/// Access the marker icon (readonly)
+@property (readonly, nonatomic) UIImage* icon;
 
 NS_ASSUME_NONNULL_END
 
 /*
  The map this marker is on.
- Setting this property will add the marker to the map, and setting it to `nil` will remove the marker from it.
- A marker can be only active at at most one `TGMapViewController` at a time.
- */
-- (NSError *)map:(TGMapViewController *)mapView;
+ Setting the map view will add the marker to the map, and setting it to `nil`
+ will remove the marker from it.
 
-@property (readonly, nonatomic) TGMapViewController* map;
-@property (readonly, nonatomic) NSString* stylingString;
-@property (readonly, nonatomic) NSString* stylingPath;
-@property (readonly, nonatomic) TGGeoPoint point;
-@property (readonly, nonatomic) TGGeoPolyline* polyline;
-@property (readonly, nonatomic) TGGeoPolygon* polygon;
-@property (readonly, nonatomic) BOOL visible;
-@property (readonly, nonatomic) NSInteger drawOrder;
-@property (readonly, nonatomic) UIImage* icon;
+ A marker can be only active at at most one `TGMapViewController` at a time.
+
+ @return An error if the marker can't be shown on the map
+ */
+- (NSError * _Nonnull)map:(nullable TGMapViewController *)mapView;
+
+/// Access the marker map view (readonly)
+@property (readonly, nonatomic) TGMapViewController* _Nullable map;
 
 @end

--- a/platforms/ios/src/TangramMap/TGMarker.mm
+++ b/platforms/ios/src/TangramMap/TGMarker.mm
@@ -143,6 +143,8 @@ enum class TGMarkerType {
 
 - (void)setIcon:(UIImage *)icon
 {
+    _icon = icon;
+
     if (!tangramInstance) { return; }
 
     CGImage* cgImage = [icon CGImage];
@@ -190,7 +192,7 @@ enum class TGMarkerType {
     identifier = tangramInstance->markerAdd();
     [mapViewController addMarker:self withIdentifier:identifier];
 
-    if (!identifier) { return NO; }
+    if (!identifier) { return; }
 
     // Set the geometry type
     switch (type) {


### PR DESCRIPTION
- Change properties to functions for marker usage to be able to return error status
- Return `NSError*` from this new interface
- Leave placeholder for future enum error code that can be returned through marker usage

Fixes #1394 
Fixes #1391 
Fixes #1370 