### PR TITLE
Use NSThread to set thread priority on OS X and iOS

### DIFF
--- a/platforms/ios/src/TangramMap/platform_ios.mm
+++ b/platforms/ios/src/TangramMap/platform_ios.mm
@@ -1,12 +1,8 @@
 #ifdef PLATFORM_IOS
 
 #import <UIKit/UIKit.h>
-#import <utility>
 #import <cstdio>
 #import <cstdarg>
-#import <fstream>
-#import <regex>
-#import <iostream>
 
 #import "TGMapViewController.h"
 #import "TGFontConverter.h"
@@ -65,7 +61,10 @@ void logMsg(const char* fmt, ...) {
 }
 
 void setCurrentThreadPriority(int priority) {
-    // No-op
+    // POSIX thread priority is between -20 (highest) and 19 (lowest),
+    // NSThread priority is between 0.0 (lowest) and 1.0 (highest).
+    double p = (20 - priority) / 40.0;
+    [[NSThread currentThread] setThreadPriority:p];
 }
 
 void initGLExtensions() {

--- a/platforms/osx/src/platform_osx.mm
+++ b/platforms/osx/src/platform_osx.mm
@@ -1,14 +1,7 @@
 #ifdef PLATFORM_OSX
 
-#import <utility>
 #import <cstdio>
 #import <cstdarg>
-#import <fstream>
-#import <regex>
-
-#include <mutex>
-#include <sys/resource.h>
-#include <sys/syscall.h>
 
 #include "platform_osx.h"
 #include "gl/hardware.h"
@@ -30,8 +23,10 @@ void logMsg(const char* fmt, ...) {
 }
 
 void setCurrentThreadPriority(int priority) {
-    int tid = syscall(SYS_gettid);
-    setpriority(PRIO_PROCESS, tid, priority);
+    // POSIX thread priority is between -20 (highest) and 19 (lowest),
+    // NSThread priority is between 0.0 (lowest) and 1.0 (highest).
+    double p = (20 - priority) / 40.0;
+    [[NSThread currentThread] setThreadPriority:p];
 }
 
 void initGLExtensions() {


### PR DESCRIPTION
The previous use of `syscall` is now deprecated on OS X (as of 10.12, I think) and iOS had a no-op for this function. 

I referred to these pages for translating priority values:
https://linux.die.net/man/2/setpriority
https://developer.apple.com/reference/foundation/thread/1407523-setthreadpriority