### PR TITLE
Migrate 'visible' layer parameter to 'enabled'

### DIFF
--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -112,7 +112,7 @@ bool DrawRuleMergeSet::match(const Feature& _feature, const SceneLayer& _layer, 
     m_queuedLayers.clear();
 
     // If uber layer is marked not visible return immediately
-    if (!_layer.visible()) {
+    if (!_layer.enabled()) {
         return false;
     }
 
@@ -134,7 +134,7 @@ bool DrawRuleMergeSet::match(const Feature& _feature, const SceneLayer& _layer, 
         // Push each of the layer's matching sublayers onto the stack
         for (const auto& sublayer : layer.sublayers()) {
             // Skip matching this sublayer if marked not visible
-            if (!sublayer.visible()) {
+            if (!sublayer.enabled()) {
                 continue;
             }
 

--- a/core/src/scene/sceneLayer.cpp
+++ b/core/src/scene/sceneLayer.cpp
@@ -7,12 +7,12 @@ namespace Tangram {
 SceneLayer::SceneLayer(std::string _name, Filter _filter,
                        std::vector<DrawRuleData> _rules,
                        std::vector<SceneLayer> _sublayers,
-                       bool _visible) :
+                       bool _enabled) :
     m_filter(std::move(_filter)),
     m_name(_name),
     m_rules(_rules),
     m_sublayers(std::move(_sublayers)),
-    m_visible(_visible) {
+    m_enabled(_enabled) {
 
     setDepth(1);
 

--- a/core/src/scene/sceneLayer.h
+++ b/core/src/scene/sceneLayer.h
@@ -18,21 +18,21 @@ class SceneLayer {
     std::vector<DrawRuleData> m_rules;
     std::vector<SceneLayer> m_sublayers;
     size_t m_depth = 0;
-    bool m_visible;
+    bool m_enabled = true;
 
 public:
 
     SceneLayer(std::string _name, Filter _filter,
                std::vector<DrawRuleData> _rules,
                std::vector<SceneLayer> _sublayers,
-               bool _visible = true);
+               bool _enabled);
 
     const auto& name() const { return m_name; }
     const auto& filter() const { return m_filter; }
     const auto& rules() const { return m_rules; }
     const auto& sublayers() const { return m_sublayers; }
     const auto& depth() const { return m_depth; }
-    const auto& visible() const { return m_visible; }
+    const auto& enabled() const { return m_enabled; }
 
     void setDepth(size_t _d);
 };

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1674,7 +1674,7 @@ SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& layerName, c
     std::vector<SceneLayer> sublayers;
     std::vector<DrawRuleData> rules;
     Filter filter;
-    bool visible = true;
+    bool enabled = true;
 
     for (const auto& member : layer) {
 
@@ -1700,17 +1700,19 @@ SceneLayer SceneLoader::loadSublayer(Node layer, const std::string& layerName, c
                 LOGNode("Invalid 'filter' in layer '%s'", member.second, layerName.c_str());
                 return { layerName, {}, {}, {}, false };
             }
-        } else if (key == "properties") {
-            // TODO: ignored for now
         } else if (key == "visible") {
-            getBool(member.second, visible, "visible");
+            if (!layer["enabled"].IsDefined()) {
+                YAML::convert<bool>::decode(member.second, enabled);
+            }
+        } else if (key == "enabled") {
+            YAML::convert<bool>::decode(member.second, enabled);
         } else {
             // Member is a sublayer
             sublayers.push_back(loadSublayer(member.second, (layerName + DELIMITER + key), scene));
         }
     }
 
-    return { layerName, std::move(filter), rules, std::move(sublayers), visible };
+    return { layerName, std::move(filter), rules, std::move(sublayers), enabled };
 }
 
 void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, const std::shared_ptr<Scene>& scene) {

--- a/tests/unit/drawRuleTests.cpp
+++ b/tests/unit/drawRuleTests.cpp
@@ -50,9 +50,9 @@ DrawRuleData instance_c() {
 
 TEST_CASE("DrawRule correctly merges with another DrawRule", "[DrawRule]") {
 
-    const SceneLayer layer_a = { "a", Filter(), { instance_a() }, {} };
-    const SceneLayer layer_b = { "b", Filter(), { instance_b() }, {} };
-    const SceneLayer layer_c = { "c", Filter(), { instance_c() }, {} };
+    const SceneLayer layer_a = { "a", Filter(), { instance_a() }, {}, true };
+    const SceneLayer layer_b = { "b", Filter(), { instance_b() }, {}, true };
+    const SceneLayer layer_c = { "c", Filter(), { instance_c() }, {}, true };
 
     // For parameters contained in multiple rules, the parameter from the last rule
     // (by lexicographical order) should result.
@@ -163,8 +163,8 @@ TEST_CASE("DrawRule locates and outputs a parameter that it contains", "[DrawRul
 
     std::string str;
 
-    const SceneLayer layer_a = { "a", Filter(), { instance_a() }, {} };
-    const SceneLayer layer_b = { "b", Filter(), { instance_b() }, {} };
+    const SceneLayer layer_a = { "a", Filter(), { instance_a() }, {}, true };
+    const SceneLayer layer_b = { "b", Filter(), { instance_b() }, {}, true };
 
     DrawRuleMergeSet a;
     a.mergeRules(layer_a);
@@ -187,18 +187,18 @@ TEST_CASE("DrawRule locates and outputs a parameter that it contains", "[DrawRul
 TEST_CASE("DrawRule correctly reports that it doesn't contain a parameter", "[DrawRule]") {
     std::string str;
 
-    const SceneLayer layer_a = { "a", Filter(), { instance_a() }, {} };
+    const SceneLayer layer_a = { "a", Filter(), { instance_a() }, {}, true };
     DrawRuleMergeSet a;
     a.mergeRules(layer_a);
     REQUIRE(!a.matchedRules()[0].get(StyleParamKey::width, str)); REQUIRE(str == "");
 
 
-    const SceneLayer layer_b = { "b", Filter(), { instance_b() }, {} };
+    const SceneLayer layer_b = { "b", Filter(), { instance_b() }, {}, true };
     DrawRuleMergeSet b;
     b.mergeRules(layer_b);
     REQUIRE(!b.matchedRules()[0].get(StyleParamKey::join, str)); REQUIRE(str == "");
 
-    const SceneLayer layer_c = { "c", Filter(), { instance_c() }, {} };
+    const SceneLayer layer_c = { "c", Filter(), { instance_c() }, {}, true };
     DrawRuleMergeSet c;
     c.mergeRules(layer_c);
     REQUIRE(!c.matchedRules()[0].get(StyleParamKey::order, str)); REQUIRE(str == "");

--- a/tests/unit/layerTests.cpp
+++ b/tests/unit/layerTests.cpp
@@ -22,7 +22,7 @@ SceneLayer instance_a() {
 
     DrawRuleData rule = { "dg0", dg0, { { StyleParamKey::order, "value_a" } } };
 
-    return { "layer_a", f, { rule }, {} };
+    return { "layer_a", f, { rule }, {}, true };
 }
 
 SceneLayer instance_b() {
@@ -31,7 +31,7 @@ SceneLayer instance_b() {
 
     DrawRuleData rule = { "dg1", dg1, { { StyleParamKey::order, "value_b" } } };
 
-    return { "layer_b", f, { rule }, {} };
+    return { "layer_b", f, { rule }, {}, true };
 }
 
 SceneLayer instance_c() {
@@ -40,7 +40,7 @@ SceneLayer instance_c() {
 
     DrawRuleData rule = { "dg2", dg2, { { StyleParamKey::order, "value_c" } } };
 
-    return { "layer_c", f, { rule }, { instance_a(), instance_b() } };
+    return { "layer_c", f, { rule }, { instance_a(), instance_b() }, true };
 }
 
 SceneLayer instance_d() {
@@ -49,7 +49,7 @@ SceneLayer instance_d() {
 
     DrawRuleData rule = { "dg0", dg0, { { StyleParamKey::order, "value_d" } } };
 
-    return { "layer_d", f, { rule }, {} };
+    return { "layer_d", f, { rule }, {}, true };
 }
 
 SceneLayer instance_e() {
@@ -58,7 +58,7 @@ SceneLayer instance_e() {
 
     DrawRuleData rule = { "dg2", dg2, { { StyleParamKey::order, "value_e" } } };
 
-    return { "layer_e", f, { rule }, { instance_c(), instance_d() } };
+    return { "layer_e", f, { rule }, { instance_c(), instance_d() }, true };
 }
 
 SceneLayer instance_2() {
@@ -67,7 +67,7 @@ SceneLayer instance_2() {
 
     DrawRuleData rule = { "group2", group2, {} };
 
-    return { "subLayer2", f, { rule }, {} };
+    return { "subLayer2", f, { rule }, {}, true };
 }
 
 SceneLayer instance_1() {
@@ -76,7 +76,7 @@ SceneLayer instance_1() {
 
     DrawRuleData rule = { "group1", group1, {} };
 
-    return { "subLayer1", f, { rule }, {} };
+    return { "subLayer1", f, { rule }, {}, true };
 }
 
 SceneLayer instance() {
@@ -85,7 +85,7 @@ SceneLayer instance() {
 
     DrawRuleData rule = { "group1", group1, { {StyleParamKey::order, "a" } } };
 
-    return { "layer", f, { rule }, { instance_1(), instance_2() } };
+    return { "layer", f, { rule }, { instance_1(), instance_2() }, true };
 }
 
 TEST_CASE("SceneLayer", "[SceneLayer][Filter][DrawRule][Match][Merge]") {


### PR DESCRIPTION
'visible' will still be applied as before if 'enabled' is not present; in a future release 'visible' will be disregarded.

Resolves https://github.com/tangrams/tangram-es/issues/1388