### PR TITLE
Android: add ability to perform UI thread tasks from native code

### DIFF
--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -192,15 +192,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
         Log.d("Tangram", "Picked: " + name);
         final String message = name;
-        runOnUiThread(new Runnable() {
-                          @Override
-                          public void run() {
-                              Toast.makeText(getApplicationContext(),
-                                      "Selected: " + message,
-                                      Toast.LENGTH_SHORT).show();
-                          }
-                      });
-
+        Toast.makeText(getApplicationContext(), "Selected: " + message, Toast.LENGTH_SHORT).show();
     }
 
     @Override
@@ -217,14 +209,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
         Log.d("Tangram", "Picked label: " + name);
         final String message = name;
-        runOnUiThread(new Runnable() {
-                          @Override
-                          public void run() {
-                              Toast.makeText(getApplicationContext(),
-                                      "Selected label: " + message,
-                                      Toast.LENGTH_SHORT).show();
-                          }
-                      });
+        Toast.makeText(getApplicationContext(), "Selected label: " + message, Toast.LENGTH_SHORT).show();
     }
 
     @Override
@@ -236,14 +221,7 @@ public class MainActivity extends Activity implements OnMapReadyCallback, TapRes
 
         Log.d("Tangram", "Picked marker: " + markerPickResult.getMarker().getMarkerId());
         final String message = String.valueOf(markerPickResult.getMarker().getMarkerId());
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                Toast.makeText(getApplicationContext(),
-                        "Selected Marker: " + message,
-                        Toast.LENGTH_SHORT).show();
-            }
-        });
+        Toast.makeText(getApplicationContext(), "Selected Marker: " + message, Toast.LENGTH_SHORT).show();
     }
 
     @Override

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -135,8 +135,9 @@ extern "C" {
         }
 
         auto updateErrorCallbackRef = jniEnv->NewGlobalRef(updateErrorCallback);
-        map->loadScene(resolveScenePath(cPath).c_str(), false, sceneUpdates, [updateErrorCallbackRef](auto sceneUpdateErrorStatus) {
-            Tangram::sceneUpdateErrorCallback(updateErrorCallbackRef, sceneUpdateErrorStatus);
+        map->loadScene(resolveScenePath(cPath).c_str(), false, sceneUpdates, [=](auto sceneUpdateErrorStatus) {
+            Tangram::AndroidPlatform& platform = static_cast<Tangram::AndroidPlatform&>(*map->getPlatform());
+            Tangram::sceneUpdateErrorCallback(platform, updateErrorCallbackRef, sceneUpdateErrorStatus);
         });
         jniEnv->ReleaseStringUTFChars(path, cPath);
     }
@@ -533,8 +534,9 @@ extern "C" {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto updateErrorCallbackRef = jniEnv->NewGlobalRef(updateErrorCallback);
-        map->applySceneUpdates([updateErrorCallbackRef](auto sceneUpdateErrorStatus) {
-            Tangram::sceneUpdateErrorCallback(updateErrorCallbackRef, sceneUpdateErrorStatus);
+        map->applySceneUpdates([=](auto sceneUpdateErrorStatus) {
+            Tangram::AndroidPlatform& platform = static_cast<Tangram::AndroidPlatform&>(*map->getPlatform());
+            Tangram::sceneUpdateErrorCallback(platform, updateErrorCallbackRef, sceneUpdateErrorStatus);
         });
     }
 

--- a/platforms/android/tangram/src/main/cpp/platform_android.cpp
+++ b/platforms/android/tangram/src/main/cpp/platform_android.cpp
@@ -433,7 +433,7 @@ void sceneUpdateErrorCallback(jobject updateCallbackRef, const SceneUpdateError&
     jniEnv->DeleteGlobalRef(updateCallbackRef);
 }
 
-void labelPickCallback(AndroidPlatform& platform, jobject listenerRef, const Tangram::LabelPickResult* labelPickResult) {
+void labelPickCallback(AndroidPlatform& platform, jobject listenerRef, const LabelPickResult* labelPickResult) {
 
     JniThreadBinding jniEnv(jvm);
 
@@ -469,7 +469,7 @@ void labelPickCallback(AndroidPlatform& platform, jobject listenerRef, const Tan
     });
 }
 
-void markerPickCallback(AndroidPlatform& platform, jobject listenerRef, jobject tangramRef, const Tangram::MarkerPickResult* markerPickResult) {
+void markerPickCallback(AndroidPlatform& platform, jobject listenerRef, jobject tangramRef, const MarkerPickResult* markerPickResult) {
 
     JniThreadBinding jniEnv(jvm);
     float position[2] = {0.0, 0.0};
@@ -503,7 +503,7 @@ void markerPickCallback(AndroidPlatform& platform, jobject listenerRef, jobject 
     });
 }
 
-void featurePickCallback(AndroidPlatform& platform, jobject listenerRef, const Tangram::FeaturePickResult* featurePickResult) {
+void featurePickCallback(AndroidPlatform& platform, jobject listenerRef, const FeaturePickResult* featurePickResult) {
 
     JniThreadBinding jniEnv(jvm);
 

--- a/platforms/android/tangram/src/main/cpp/platform_android.cpp
+++ b/platforms/android/tangram/src/main/cpp/platform_android.cpp
@@ -8,6 +8,8 @@
 #include "util/url.h"
 #include "tangram.h"
 
+#include <functional>
+
 #ifndef GL_GLEXT_PROTOTYPES
 #define GL_GLEXT_PROTOTYPES 1
 #endif
@@ -34,7 +36,6 @@
 
 static JavaVM* jvm = nullptr;
 // JNI Env bound on androids render thread (our native main thread)
-static jobject tangramInstance = nullptr;
 static jmethodID requestRenderMethodID = 0;
 static jmethodID setRenderModeMethodID = 0;
 static jmethodID startUrlRequestMID = 0;
@@ -48,7 +49,10 @@ static jmethodID labelPickResultInitMID = 0;
 static jmethodID markerPickResultInitMID = 0;
 static jmethodID onSceneUpdateErrorMID = 0;
 static jmethodID sceneUpdateErrorInitMID = 0;
+static jmethodID postOnUIThreadMID = 0;
+static jmethodID initUITaskMID = 0;
 
+static jclass UITaskClass = nullptr;
 static jclass labelPickResultClass = nullptr;
 static jclass sceneUpdateErrorClass = nullptr;
 static jclass markerPickResultClass = nullptr;
@@ -116,6 +120,13 @@ void setupJniEnv(JNIEnv* jniEnv) {
     hashmapInitMID = jniEnv->GetMethodID(hashmapClass, "<init>", "()V");
     hashmapPutMID = jniEnv->GetMethodID(hashmapClass, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
 
+    postOnUIThreadMID = jniEnv->GetMethodID(tangramClass, "postUIThreadTask", "(Ljava/lang/Runnable;)V");
+    if (UITaskClass) {
+        jniEnv->DeleteGlobalRef(UITaskClass);
+    }
+    UITaskClass = (jclass)jniEnv->NewGlobalRef(jniEnv->FindClass("com/mapzen/tangram/UITask"));
+    initUITaskMID = jniEnv->GetMethodID(UITaskClass, "<init>", "(J)V");
+
     markerByIDMID = jniEnv->GetMethodID(tangramClass, "markerById", "(J)Lcom/mapzen/tangram/Marker;");
 
     jclass markerPickListenerClass = jniEnv->FindClass("com/mapzen/tangram/MapController$MarkerPickListener");
@@ -168,6 +179,7 @@ public:
         status = jvm->GetEnv((void**)&jniEnv, JNI_VERSION_1_6);
         if (status == JNI_EDETACHED) { jvm->AttachCurrentThread(&jniEnv, NULL);}
     }
+
     ~JniThreadBinding() {
         if (status == JNI_EDETACHED) { jvm->DetachCurrentThread(); }
     }
@@ -279,6 +291,47 @@ void AndroidPlatform::setContinuousRendering(bool _isContinuous) {
     jniEnv->CallVoidMethod(m_tangramInstance, setRenderModeMethodID, _isContinuous ? 1 : 0);
 }
 
+ void AndroidPlatform::queueUITask(AndroidUITask _task) {
+
+     JniThreadBinding jniEnv(jvm);
+
+     bool pendingTasks = false;
+
+     {
+         std::lock_guard<std::mutex> guard(m_UIThreadTaskMutex);
+         pendingTasks = m_UITasks.size() > 0;
+         m_UITasks.push_front(_task);
+     }
+
+     if (!pendingTasks) {
+         jobject UITaskRunnable = jniEnv->NewObject(UITaskClass, initUITaskMID, m_mapPtr);
+
+         // Trigger an event for main thread to pick
+         jniEnv->CallVoidMethod(m_tangramInstance, postOnUIThreadMID, UITaskRunnable);
+     }
+}
+
+void AndroidPlatform::executeUITasks() {
+
+    JniThreadBinding jniEnv(jvm);
+
+    while (true) {
+        AndroidUITask task;
+        {
+            std::lock_guard<std::mutex> guard(m_UIThreadTaskMutex);
+
+            if (m_UITasks.empty()) {
+                break;
+            }
+
+            task = m_UITasks.back();
+            m_UITasks.pop_back();
+        }
+
+        task(jniEnv);
+    }
+}
+
 bool AndroidPlatform::bytesFromAssetManager(const char* _path, std::function<char*(size_t)> _allocator) const {
 
     AAsset* asset = AAssetManager_open(m_assetManager, _path, AASSET_MODE_UNKNOWN);
@@ -380,7 +433,7 @@ void sceneUpdateErrorCallback(jobject updateCallbackRef, const SceneUpdateError&
     jniEnv->DeleteGlobalRef(updateCallbackRef);
 }
 
-void labelPickCallback(jobject listener, const Tangram::LabelPickResult* labelPickResult) {
+void labelPickCallback(AndroidPlatform& platform, jobject listenerRef, const Tangram::LabelPickResult* labelPickResult) {
 
     JniThreadBinding jniEnv(jvm);
 
@@ -406,11 +459,17 @@ void labelPickCallback(jobject listener, const Tangram::LabelPickResult* labelPi
             labelPickResult->coordinates.latitude, labelPickResult->type, hashmap);
     }
 
-    jniEnv->CallVoidMethod(listener, onLabelPickMID, labelPickResultObject, position[0], position[1]);
-    jniEnv->DeleteGlobalRef(listener);
+    jobject labelPickResultRef = jniEnv->NewGlobalRef(labelPickResultObject);
+
+    platform.queueUITask([=](JNIEnv* _jniEnv) {
+        _jniEnv->CallVoidMethod(listenerRef, onLabelPickMID, labelPickResultRef, position[0], position[1]);
+
+        _jniEnv->DeleteGlobalRef(labelPickResultRef);
+        _jniEnv->DeleteGlobalRef(listenerRef);
+    });
 }
 
-void markerPickCallback(jobject listener, jobject tangramInstance, const Tangram::MarkerPickResult* markerPickResult) {
+void markerPickCallback(AndroidPlatform& platform, jobject listenerRef, jobject tangramRef, const Tangram::MarkerPickResult* markerPickResult) {
 
     JniThreadBinding jniEnv(jvm);
     float position[2] = {0.0, 0.0};
@@ -423,7 +482,8 @@ void markerPickCallback(jobject listener, jobject tangramInstance, const Tangram
         position[0] = markerPickResult->position[0];
         position[1] = markerPickResult->position[1];
 
-        marker = jniEnv->CallObjectMethod(tangramInstance, markerByIDMID, static_cast<jlong>(markerPickResult->id));
+        marker = jniEnv->CallObjectMethod(tangramRef, markerByIDMID, static_cast<jlong>(markerPickResult->id));
+        jniEnv->DeleteGlobalRef(tangramRef);
 
         if (marker) {
             markerPickResultObject = jniEnv->NewObject(markerPickResultClass,
@@ -433,12 +493,17 @@ void markerPickCallback(jobject listener, jobject tangramInstance, const Tangram
         }
     }
 
-    jniEnv->CallVoidMethod(listener, onMarkerPickMID, markerPickResultObject, position[0], position[1]);
-    jniEnv->DeleteGlobalRef(listener);
-    jniEnv->DeleteGlobalRef(tangramInstance);
+    jobject markerPickResultRef = jniEnv->NewGlobalRef(markerPickResultObject);
+
+    platform.queueUITask([=](JNIEnv* _jniEnv) {
+        _jniEnv->CallVoidMethod(listenerRef, onMarkerPickMID, markerPickResultRef, position[0], position[1]);
+
+        _jniEnv->DeleteGlobalRef(markerPickResultRef);
+        _jniEnv->DeleteGlobalRef(listenerRef);
+    });
 }
 
-void featurePickCallback(jobject listener, const Tangram::FeaturePickResult* featurePickResult) {
+void featurePickCallback(AndroidPlatform& platform, jobject listenerRef, const Tangram::FeaturePickResult* featurePickResult) {
 
     JniThreadBinding jniEnv(jvm);
 
@@ -458,8 +523,14 @@ void featurePickCallback(jobject listener, const Tangram::FeaturePickResult* fea
         }
     }
 
-    jniEnv->CallVoidMethod(listener, onFeaturePickMID, hashmap, position[0], position[1]);
-    jniEnv->DeleteGlobalRef(listener);
+    jobject hashmapRef = jniEnv->NewGlobalRef(hashmap);
+
+    platform.queueUITask([=](JNIEnv* _jniEnv) {
+        _jniEnv->CallVoidMethod(listenerRef, onFeaturePickMID, hashmapRef, position[0], position[1]);
+
+        _jniEnv->DeleteGlobalRef(hashmapRef);
+        _jniEnv->DeleteGlobalRef(listenerRef);
+    });
 }
 
 void initGLExtensions() {

--- a/platforms/android/tangram/src/main/cpp/platform_android.h
+++ b/platforms/android/tangram/src/main/cpp/platform_android.h
@@ -60,9 +60,9 @@ private:
 
 };
 
-void featurePickCallback(AndroidPlatform& platform, jobject listenerRef, const Tangram::FeaturePickResult* featurePickResult);
-void markerPickCallback(AndroidPlatform& platform, jobject listenerRef, jobject tangramRef, const Tangram::MarkerPickResult* markerPickResult);
-void labelPickCallback(AndroidPlatform& platform, jobject listenerRef, const Tangram::LabelPickResult* labelPickResult);
+void featurePickCallback(AndroidPlatform& platform, jobject listenerRef, const FeaturePickResult* featurePickResult);
+void markerPickCallback(AndroidPlatform& platform, jobject listenerRef, jobject tangramRef, const MarkerPickResult* markerPickResult);
+void labelPickCallback(AndroidPlatform& platform, jobject listenerRef, const LabelPickResult* labelPickResult);
 void sceneUpdateErrorCallback(jobject updateStatusCallbackRef, const SceneUpdateError& sceneUpdateErrorStatus);
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/platform_android.h
+++ b/platforms/android/tangram/src/main/cpp/platform_android.h
@@ -63,6 +63,6 @@ private:
 void featurePickCallback(AndroidPlatform& platform, jobject listenerRef, const FeaturePickResult* featurePickResult);
 void markerPickCallback(AndroidPlatform& platform, jobject listenerRef, jobject tangramRef, const MarkerPickResult* markerPickResult);
 void labelPickCallback(AndroidPlatform& platform, jobject listenerRef, const LabelPickResult* labelPickResult);
-void sceneUpdateErrorCallback(jobject updateStatusCallbackRef, const SceneUpdateError& sceneUpdateErrorStatus);
+void sceneUpdateErrorCallback(AndroidPlatform& platform, jobject updateCallbackRef, const SceneUpdateError& sceneUpdateError);
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -77,6 +77,7 @@ public class MapController implements Renderer {
      * Interface for a callback to receive information about features picked from the map
      * Triggered after a call of {@link #pickFeature(float, float)}
      * Listener should be set with {@link #setFeaturePickListener(FeaturePickListener)}
+     * The callback will be run on the main (UI) thread.
      */
     public interface FeaturePickListener {
         /**
@@ -91,6 +92,7 @@ public class MapController implements Renderer {
      * Interface for a callback to receive information about labels picked from the map
      * Triggered after a call of {@link #pickLabel(float, float)}
      * Listener should be set with {@link #setLabelPickListener(LabelPickListener)}
+     * The callback will be run on the main (UI) thread.
      */
     public interface LabelPickListener {
         /**
@@ -106,6 +108,7 @@ public class MapController implements Renderer {
      * Interface for a callback to receive the picked {@link Marker}
      * Triggered after a call of {@link #pickMarker(float, float)}
      * Listener should be set with {@link #setMarkerPickListener(MarkerPickListener)}
+     * The callback will be run on the main (UI) thread.
      */
     public interface MarkerPickListener {
         /**
@@ -129,6 +132,7 @@ public class MapController implements Renderer {
      * Interface for a callback to received additional error information in a {@link SceneUpdateError}
      * Triggered after a call of {@link #applySceneUpdates()} or {@link #loadSceneFile(String, List<SceneUpdate>)}
      * Listener should be set with {@link #setSceneUpdateErrorListener(SceneUpdateErrorListener)}
+     * The callback will be run on the main (UI) thread.
      */
     public interface SceneUpdateErrorListener {
         /**

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.opengl.GLSurfaceView;
 import android.opengl.GLSurfaceView.Renderer;
+import android.os.Handler;
 import android.util.DisplayMetrics;
 
 import com.mapzen.tangram.TouchInput.Gestures;
@@ -1093,6 +1094,7 @@ public class MapController implements Renderer {
     private boolean frameCaptureAwaitCompleteView;
     private Map<String, MapData> clientTileSources = new HashMap<>();
     private Map<Long, Marker> markers = new HashMap<>();
+    private Handler mainThreadHandler;
 
     // GLSurfaceView.Renderer methods
     // ==============================
@@ -1179,6 +1181,16 @@ public class MapController implements Renderer {
     String getFontFallbackFilePath(int importance, int weightHint) {
 
         return fontFileParser.getFontFallback(importance, weightHint);
+    }
+
+    // Main thread messaging
+    // =====================
+    void setMainThreadHandler(Handler mainThreadHandler) {
+        this.mainThreadHandler = mainThreadHandler;
+    }
+
+    void postUIThreadTask(Runnable task) {
+        mainThreadHandler.post(task);
     }
 
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -7,8 +7,8 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
+import android.os.Handler;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -104,7 +104,9 @@ public class MapView extends FrameLayout {
     }
 
     protected MapController getMapInstance() {
-        return MapController.getInstance(glSurfaceView);
+        MapController mapController = MapController.getInstance(glSurfaceView);
+        mapController.setMainThreadHandler(new Handler(getContext().getMainLooper()));
+        return mapController;
     }
 
     protected void configureGLSurfaceView() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/UITask.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/UITask.java
@@ -1,0 +1,21 @@
+package com.mapzen.tangram;
+
+/**
+ * {@code UITask} Task that picks up native code that will be run on UI thread.
+ */
+
+class UITask implements Runnable {
+
+    private long mapPtr;
+
+    UITask(long mapPtr) {
+        this.mapPtr = mapPtr;
+    }
+
+    @Override
+    public void run() {
+        nativeExecutePendingUITasks(mapPtr);
+    }
+
+    private synchronized native void nativeExecutePendingUITasks(long mapPtr);
+}


### PR DESCRIPTION
- Add ability to queue Android UI tasks from native code
- Update marker/label/feature pick events to queue their listener event callbacks

TODO:
- [x] Document behavior of pick events
- [x] Apply the same behavior to `sceneUpdateErrorCallback`

See https://github.com/tangrams/tangram-es/issues/1365 for more context.

Fixes https://github.com/tangrams/tangram-es/issues/1365.