### PR TITLE
Disable VAOS for DynamicMesh

### DIFF
--- a/core/src/gl/dynamicQuadMesh.h
+++ b/core/src/gl/dynamicQuadMesh.h
@@ -109,6 +109,7 @@ bool DynamicQuadMesh<T>::draw(RenderState& rs, ShaderProgram& shader, int textur
         return false;
     }
 
+#ifdef DYNAMIC_MESH_VAOS
     useVao &= Hardware::supportsVAOs;
 
     if (useVao) {
@@ -120,6 +121,7 @@ bool DynamicQuadMesh<T>::draw(RenderState& rs, ShaderProgram& shader, int textur
                               m_glVertexBuffer, rs.getQuadIndexBuffer());
         }
     }
+#endif
 
     const size_t verticesIndexed = RenderState::MAX_QUAD_VERTICES;
     size_t vertexPos = 0;
@@ -153,12 +155,15 @@ bool DynamicQuadMesh<T>::draw(RenderState& rs, ShaderProgram& shader, int textur
         size_t verticesInBatch = std::min(vertexBatchEnd - vertexPos, verticesIndexed);
 
         // Set up and draw the batch.
+#ifdef DYNAMIC_MESH_VAOS
         if (useVao && vertexPos == 0) {
             // Use vao only for first batch of offsets, other vertices can use a
             // different stride so just reuse the vertex layout with a different
             // byte offset instead
             m_vaos.bind(0);
-        } else {
+        } else
+#endif
+        {
             rs.vertexBuffer(m_glVertexBuffer);
             rs.indexBuffer(rs.getQuadIndexBuffer());
 


### PR DESCRIPTION
- some drivers crash when using vaos together with dynamic vbos
   https://github.com/westnordost/StreetComplete/issues/130

The flickering effect before crashing makes it likely that it happens with drivers that store the absolute glVertexPointer address in VAO instead of determining the address from vbo address + byteoffset. So most likely a driver bug..

Should also fix https://github.com/tangrams/tangram-es/issues/1460