### PR TITLE
MarkerManager scene switching

### DIFF
--- a/core/src/labels/label.cpp
+++ b/core/src/labels/label.cpp
@@ -29,7 +29,6 @@ Label::Label(glm::vec2 _size, Type _type, Options _options)
 
     m_occludedLastFrame = false;
     m_occluded = false;
-    m_forceInvisible = false;
     m_relative = nullptr;
     m_anchorIndex = 0;
 }
@@ -77,10 +76,6 @@ void Label::enterState(const State& _state, float _alpha) {
 
 void Label::setAlpha(float _alpha) {
     m_alpha = CLAMP(_alpha, 0.0, 1.0);
-}
-
-void Label::setForceInvisible(bool visible) {
-    m_forceInvisible = visible;
 }
 
 void Label::resetState() {

--- a/core/src/labels/label.h
+++ b/core/src/labels/label.h
@@ -153,11 +153,6 @@ public:
 
     void setAlpha(float _alpha);
 
-    void setForceInvisible(bool visible);
-
-    // make the label not part of the visible set (used for marker visibility)
-    bool forceInvisible() { return m_forceInvisible; }
-
 protected:
 
     virtual void applyAnchor(LabelProperty::Anchor _anchor) = 0;
@@ -177,7 +172,6 @@ protected:
 
     bool m_occludedLastFrame;
     bool m_occluded;
-    bool m_forceInvisible;
 
     glm::vec2 m_screenCenter;
     float m_alpha;

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -102,7 +102,7 @@ std::pair<Label*, Tile*> Labels::getLabel(uint32_t _selectionColor) const {
 void Labels::updateLabels(const ViewState& _viewState, float _dt,
                           const std::vector<std::unique_ptr<Style>>& _styles,
                           const std::vector<std::shared_ptr<Tile>>& _tiles,
-                          const std::vector<std::unique_ptr<Marker>>& _markers,
+                          const std::vector<Marker*>& _markers,
                           bool _onlyRender) {
 
     if (!_onlyRender) { m_labels.clear(); }
@@ -411,7 +411,7 @@ bool Labels::withinRepeatDistance(Label *_label) {
 void Labels::updateLabelSet(const ViewState& _viewState, float _dt,
                             const std::vector<std::unique_ptr<Style>>& _styles,
                             const std::vector<std::shared_ptr<Tile>>& _tiles,
-                            const std::vector<std::unique_ptr<Marker>>& _markers,
+                            const std::vector<Marker*>& _markers,
                             TileCache& _cache) {
 
     m_transforms.clear();

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -50,7 +50,7 @@ void Labels::processLabelUpdate(const ViewState& viewState,
                       viewState.viewportSize.y);
 
     for (auto& label : labelMesh->getLabels()) {
-        if (!drawAll && (label->state() == Label::State::dead || label->forceInvisible()) ) {
+        if (!drawAll && (label->state() == Label::State::dead) ) {
             continue;
         }
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -38,7 +38,7 @@ public:
     void updateLabelSet(const ViewState& _viewState, float _dt,
                         const std::vector<std::unique_ptr<Style>>& _styles,
                         const std::vector<std::shared_ptr<Tile>>& _tiles,
-                        const std::vector<std::unique_ptr<Marker>>& _markers,
+                        const std::vector<Marker*>& _markers,
                         TileCache& _cache);
 
     /* onlyRender: when the view and tiles have not changed one does not need to update the set of
@@ -47,7 +47,7 @@ public:
     PERF_TRACE void updateLabels(const ViewState& _viewState, float _dt,
                                  const std::vector<std::unique_ptr<Style>>& _styles,
                                  const std::vector<std::shared_ptr<Tile>>& _tiles,
-                                 const std::vector<std::unique_ptr<Marker>>& _markers,
+                                 const std::vector<Marker*>& _markers,
                                  bool _onlyRender = true);
 
     bool needUpdate() const { return m_needUpdate; }

--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -39,8 +39,13 @@ bool Marker::evaluateRuleForContext(StyleContext& ctx) {
 }
 
 void Marker::setDrawRuleData(std::unique_ptr<DrawRuleData> drawRuleData) {
-    m_drawRuleData = std::move(drawRuleData);
-    m_drawRule = std::make_unique<DrawRule>(*m_drawRuleData, "", 0);
+    if (drawRuleData) {
+        m_drawRuleData = std::move(drawRuleData);
+        m_drawRule = std::make_unique<DrawRule>(*m_drawRuleData, "", 0);
+    } else {
+        m_drawRuleData.reset();
+        m_drawRule.reset();
+    }
 }
 
 void Marker::mergeRules(const SceneLayer& layer) {

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -314,6 +314,8 @@ const std::vector<std::unique_ptr<Marker>>& MarkerManager::markers() const {
 
 bool MarkerManager::buildStyling(Marker& marker) {
 
+    marker.setDrawRuleData(nullptr);
+
     if (!m_scene) { return false; }
 
     std::vector<StyleParam> params;
@@ -392,6 +394,9 @@ bool MarkerManager::buildStyling(Marker& marker) {
 }
 
 bool MarkerManager::buildGeometry(Marker& marker, int zoom) {
+
+    // Make sure old mesh gets invalidated
+    marker.setMesh(0, zoom, nullptr);
 
     auto feature = marker.feature();
     auto rule = marker.drawRule();

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -109,13 +109,6 @@ bool MarkerManager::setVisible(MarkerID markerID, bool visible) {
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
 
-    auto labelMesh = dynamic_cast<const LabelSet*>(marker->mesh());
-    if (labelMesh) {
-        for (auto& label : labelMesh->getLabels()) {
-            label->setForceInvisible(!visible);
-        }
-    }
-
     marker->setVisible(visible);
 
     m_dirty = true;

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "scene/styleContext.h"
 #include "scene/drawRule.h"
 #include "util/ease.h"
 #include "util/fastmap.h"
@@ -15,11 +14,14 @@ class MapProjection;
 class Marker;
 class Scene;
 class StyleBuilder;
+class StyleContext;
 
 class MarkerManager {
 
 public:
 
+    MarkerManager();
+    ~MarkerManager();
     // Set the Scene object whose styling information will be used to build markers.
     void setScene(std::shared_ptr<Scene> scene);
 
@@ -78,13 +80,13 @@ private:
     bool buildStyling(Marker& marker);
     bool buildGeometry(Marker& marker, int zoom);
 
-    StyleContext m_styleContext;
+    std::unique_ptr<StyleContext> m_styleContext;
     std::shared_ptr<Scene> m_scene;
     std::vector<std::unique_ptr<Marker>> m_markers;
     std::vector<std::string> m_jsFnList;
     fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilders;
     MapProjection* m_mapProjection = nullptr;
-    size_t m_jsFnIndex = 0;
+
     uint32_t m_idCounter = 0;
     int m_zoom = 0;
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -22,6 +22,7 @@ public:
 
     MarkerManager();
     ~MarkerManager();
+
     // Set the Scene object whose styling information will be used to build markers.
     void setScene(std::shared_ptr<Scene> scene);
 
@@ -69,7 +70,7 @@ public:
     // Rebuild all markers.
     void rebuildAll();
 
-    const std::vector<std::unique_ptr<Marker>>& markers() const;
+    auto& getVisibleMarkers() const { return m_visibleMarkers; }
 
     const Marker* getMarkerOrNullBySelectionColor(uint32_t selectionColor) const;
 
@@ -89,6 +90,9 @@ private:
 
     uint32_t m_idCounter = 0;
     int m_zoom = 0;
+    bool m_dirty = false;
+
+    std::vector<Marker*> m_visibleMarkers;
 
 };
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -372,7 +372,7 @@ bool Map::update(float _dt) {
         impl->tileManager.updateTileSets(impl->view.state(), impl->view.getVisibleTiles());
 
         auto& tiles = impl->tileManager.getVisibleTiles();
-        auto& markers = impl->markerManager.markers();
+        auto& markers = impl->markerManager.getVisibleMarkers();
 
         for (const auto& marker : markers) {
             marker->update(_dt, impl->view);
@@ -468,7 +468,7 @@ void Map::render() {
                 style->drawSelectionFrame(impl->renderState, *tile);
             }
 
-            for (const auto& marker : impl->markerManager.markers()) {
+            for (const auto& marker : impl->markerManager.getVisibleMarkers()) {
                 style->drawSelectionFrame(impl->renderState, *marker);
             }
         }
@@ -511,7 +511,7 @@ void Map::render() {
                 style->draw(impl->renderState, *tile);
             }
 
-            for (const auto& marker : impl->markerManager.markers()) {
+            for (const auto& marker : impl->markerManager.getVisibleMarkers()) {
                 style->draw(impl->renderState, *marker);
             }
 


### PR DESCRIPTION
This branch fixes some cases where references to the old scene could still be used:
- StyleBuilder of the old scene were not removed for styles with different names than the new scene
- If the marker geometry was not rebuild due to missing rules or for other reasons the old mesh still remained. This could lead to the crash reported in https://github.com/tangrams/tangram-es/issues/1474
