### PR TITLE
Remove tile side buffers for client data source tiles

### DIFF
--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -19,9 +19,19 @@
 
 namespace Tangram {
 
-static uint16_t tileBuffer = 0;
-
 using namespace mapbox;
+
+geojsonvt::Options options() {
+    geojsonvt::Options opt;
+    opt.maxZoom = 18;
+    opt.indexMaxZoom = 5;
+    opt.indexMaxPoints = 100000;
+    opt.solidChildren = true;
+    opt.tolerance = 3;
+    opt.extent = 4096;
+    opt.buffer = 0;
+    return opt;
+}
 
 struct ClientGeoJsonData {
     std::unique_ptr<geojsonvt::GeoJSONVT> tiles;
@@ -104,9 +114,7 @@ void ClientGeoJsonSource::addData(const std::string& _data) {
                              std::make_move_iterator(features.begin()),
                              std::make_move_iterator(features.end()));
 
-    geojsonvt::Options options;
-    options.buffer = tileBuffer;
-    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options);
+    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options());
     m_generation++;
 }
 
@@ -148,9 +156,7 @@ void ClientGeoJsonSource::addPoint(const Properties& _tags, LngLat _point) {
     m_store->features.emplace_back(geom, id);
     m_store->properties.emplace_back(_tags);
 
-    geojsonvt::Options options;
-    options.buffer = tileBuffer;
-    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options);
+    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options());
     m_generation++;
 }
 
@@ -169,9 +175,7 @@ void ClientGeoJsonSource::addLine(const Properties& _tags, const Coordinates& _l
     m_store->features.emplace_back(geom, id);
     m_store->properties.emplace_back(_tags);
 
-    geojsonvt::Options options;
-    options.buffer = tileBuffer;
-    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options);
+    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options());
     m_generation++;
 }
 
@@ -194,9 +198,7 @@ void ClientGeoJsonSource::addPoly(const Properties& _tags, const std::vector<Coo
     m_store->features.emplace_back(geom, id);
     m_store->properties.emplace_back(_tags);
 
-    geojsonvt::Options options;
-    options.buffer = tileBuffer;
-    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options);
+    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options());
     m_generation++;
 }
 

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -19,6 +19,8 @@
 
 namespace Tangram {
 
+static uint16_t tileBuffer = 0;
+
 using namespace mapbox;
 
 struct ClientGeoJsonData {
@@ -102,7 +104,9 @@ void ClientGeoJsonSource::addData(const std::string& _data) {
                              std::make_move_iterator(features.begin()),
                              std::make_move_iterator(features.end()));
 
-    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features);
+    geojsonvt::Options options;
+    options.buffer = tileBuffer;
+    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options);
     m_generation++;
 }
 
@@ -144,7 +148,9 @@ void ClientGeoJsonSource::addPoint(const Properties& _tags, LngLat _point) {
     m_store->features.emplace_back(geom, id);
     m_store->properties.emplace_back(_tags);
 
-    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features);
+    geojsonvt::Options options;
+    options.buffer = tileBuffer;
+    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options);
     m_generation++;
 }
 
@@ -163,7 +169,9 @@ void ClientGeoJsonSource::addLine(const Properties& _tags, const Coordinates& _l
     m_store->features.emplace_back(geom, id);
     m_store->properties.emplace_back(_tags);
 
-    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features);
+    geojsonvt::Options options;
+    options.buffer = tileBuffer;
+    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options);
     m_generation++;
 }
 
@@ -186,7 +194,9 @@ void ClientGeoJsonSource::addPoly(const Properties& _tags, const std::vector<Coo
     m_store->features.emplace_back(geom, id);
     m_store->properties.emplace_back(_tags);
 
-    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features);
+    geojsonvt::Options options;
+    options.buffer = tileBuffer;
+    m_store->tiles = std::make_unique<geojsonvt::GeoJSONVT>(m_store->features, options);
     m_generation++;
 }
 


### PR DESCRIPTION
Remove tile paddings from client data by setting tile buffer on each side to zero for GeoJSONVT option.

Fixes https://github.com/mapzen/android/issues/364