### PR TITLE
Scaled tiles

### DIFF
--- a/core/include/tangram/data/clientGeoJsonSource.h
+++ b/core/include/tangram/data/clientGeoJsonSource.h
@@ -20,7 +20,7 @@ public:
 
     ClientGeoJsonSource(std::shared_ptr<Platform> _platform, const std::string& _name, const std::string& _url,
                         int32_t _minDisplayZoom = -1, int32_t _maxDisplayZoom = -1, int32_t _maxZoom = 18,
-                        int32_t _tileScale = 0);
+                        int32_t _zoomBias = 0);
     ~ClientGeoJsonSource();
 
     // http://www.iana.org/assignments/media-types/application/geo+json

--- a/core/include/tangram/data/clientGeoJsonSource.h
+++ b/core/include/tangram/data/clientGeoJsonSource.h
@@ -19,7 +19,8 @@ class ClientGeoJsonSource : public TileSource {
 public:
 
     ClientGeoJsonSource(std::shared_ptr<Platform> _platform, const std::string& _name, const std::string& _url,
-                        int32_t _minDisplayZoom = -1, int32_t _maxDisplayZoom = -1, int32_t _maxZoom = 18);
+                        int32_t _minDisplayZoom = -1, int32_t _maxDisplayZoom = -1, int32_t _maxZoom = 18,
+                        int32_t _tileScale = 0);
     ~ClientGeoJsonSource();
 
     // http://www.iana.org/assignments/media-types/application/geo+json

--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -54,7 +54,8 @@ public:
      * and zoom level of tiles to produce their URL.
      */
     TileSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
-               int32_t _minDisplayZoom = -1, int32_t _maxDisplayZoom = -1, int32_t _maxZoom = 18);
+               int32_t _minDisplayZoom = -1, int32_t _maxDisplayZoom = -1, int32_t _maxZoom = 18,
+               int32_t _tileScale = 0);
 
     virtual ~TileSource();
 
@@ -96,6 +97,7 @@ public:
     int32_t minDisplayZoom() const { return m_minDisplayZoom; }
     int32_t maxDisplayZoom() const { return m_maxDisplayZoom; }
     int32_t maxZoom() const { return m_maxZoom; }
+    int32_t tileScale() const { return m_tileScale; }
 
     bool isActiveForZoom(const float _zoom) const {
         return _zoom >= m_minDisplayZoom && (m_maxDisplayZoom == -1 || _zoom <= m_maxDisplayZoom);
@@ -132,6 +134,9 @@ protected:
 
     // Maximum zoom for which tiles will be requested
     int32_t m_maxZoom;
+
+    // Pixel at which the data source tiles are fetched
+    int32_t m_tileScale;
 
     // Unique id for TileSource
     int32_t m_id;

--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -22,6 +22,13 @@ class TileSource : public std::enable_shared_from_this<TileSource> {
 
 public:
 
+    /* Calculate the zoom level bias to be applied given tileSize in pixel units.
+     * 256  pixel -> 0
+     * 512  pixel -> 1
+     * 1024 pixel -> 2
+     */
+    static int32_t zoomBiasFromTileSize(int32_t tileSize);
+
     struct DataSource {
         virtual ~DataSource() {}
 
@@ -55,7 +62,7 @@ public:
      */
     TileSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
                int32_t _minDisplayZoom = -1, int32_t _maxDisplayZoom = -1, int32_t _maxZoom = 18,
-               int32_t _tileScale = 0);
+               int32_t _zoomBias = 0);
 
     virtual ~TileSource();
 
@@ -97,7 +104,7 @@ public:
     int32_t minDisplayZoom() const { return m_minDisplayZoom; }
     int32_t maxDisplayZoom() const { return m_maxDisplayZoom; }
     int32_t maxZoom() const { return m_maxZoom; }
-    int32_t tileScale() const { return m_tileScale; }
+    int32_t zoomBias() const { return m_zoomBias; }
 
     bool isActiveForZoom(const float _zoom) const {
         return _zoom >= m_minDisplayZoom && (m_maxDisplayZoom == -1 || _zoom <= m_maxDisplayZoom);
@@ -135,8 +142,11 @@ protected:
     // Maximum zoom for which tiles will be requested
     int32_t m_maxZoom;
 
-    // Pixel at which the data source tiles are fetched
-    int32_t m_tileScale;
+    // controls the zoom level for the tiles of the tilesource to scale the tiles to
+    // apt pixel
+    // 0: 256 pixel tiles
+    // 1: 512 pixel tiles
+    int32_t m_zoomBias;
 
     // Unique id for TileSource
     int32_t m_id;

--- a/core/include/tangram/tile/tileID.h
+++ b/core/include/tangram/tile/tileID.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <string>
 
@@ -56,15 +57,17 @@ struct TileID {
         return TileID(x >> over, y >> over, _maxZoom, s, wrap);
     }
 
-    TileID scaled(int32_t _tileScale) const {
-        if (_tileScale <= 0) { return *this; }
+    TileID zoomBiasAdjusted(int32_t _zoomBias) const {
+        assert(_zoomBias >= 0);
 
-        auto scaledZ = std::max(0, z - _tileScale);
-        return TileID(x >> _tileScale, y >> _tileScale, scaledZ, z, wrap);
+        if (!_zoomBias) { return *this; }
+
+        auto scaledZ = std::max(0, z - _zoomBias);
+        return TileID(x >> _zoomBias, y >> _zoomBias, scaledZ, z, wrap);
     }
 
-    TileID getParent(int32_t _tileScale = 0) const {
-        if (s > (z + _tileScale)) {
+    TileID getParent(int32_t _zoomBias = 0) const {
+        if (s > (z + _zoomBias)) {
             // Over-zoomed, keep the same data coordinates
             return TileID(x, y, z, s - 1, wrap);
         }

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -48,9 +48,9 @@ std::shared_ptr<TileTask> ClientGeoJsonSource::createTask(TileID _tileId, int _s
 ClientGeoJsonSource::ClientGeoJsonSource(std::shared_ptr<Platform> _platform,
                                          const std::string& _name, const std::string& _url,
                                          int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
-                                         int32_t _tileScale)
+                                         int32_t _zoomBias)
 
-    : TileSource(_name, nullptr, _minDisplayZoom, _maxDisplayZoom, _maxZoom, _tileScale),
+    : TileSource(_name, nullptr, _minDisplayZoom, _maxDisplayZoom, _maxZoom, _zoomBias),
       m_platform(_platform) {
 
     // TODO: handle network url for client datasource data

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -47,9 +47,10 @@ std::shared_ptr<TileTask> ClientGeoJsonSource::createTask(TileID _tileId, int _s
 // TODO: pass scene's resourcePath to constructor to be used with `stringFromFile`
 ClientGeoJsonSource::ClientGeoJsonSource(std::shared_ptr<Platform> _platform,
                                          const std::string& _name, const std::string& _url,
-                                         int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom)
+                                         int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
+                                         int32_t _tileScale)
 
-    : TileSource(_name, nullptr, _minDisplayZoom, _maxDisplayZoom, _maxZoom),
+    : TileSource(_name, nullptr, _minDisplayZoom, _maxDisplayZoom, _maxZoom, _tileScale),
       m_platform(_platform) {
 
     // TODO: handle network url for client datasource data

--- a/core/src/data/memoryCacheDataSource.cpp
+++ b/core/src/data/memoryCacheDataSource.cpp
@@ -30,7 +30,8 @@ struct RawCache {
         if (m_maxUsage <= 0) { return false; }
 
         std::lock_guard<std::mutex> lock(m_mutex);
-        TileID id(_task.tileId().x, _task.tileId().y, _task.tileId().z);
+        const auto& taskTileID = _task.tileId();
+        TileID id(taskTileID.x, taskTileID.y, taskTileID.z);
 
         auto it = m_cacheMap.find(id);
         if (it != m_cacheMap.end()) {

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -69,8 +69,8 @@ public:
 
 RasterSource::RasterSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
                            int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
-                           TextureOptions _options, bool _genMipmap)
-    : TileSource(_name, std::move(_sources), _minDisplayZoom, _maxDisplayZoom, _maxZoom),
+                           int32_t _tileScale, TextureOptions _options, bool _genMipmap)
+    : TileSource(_name, std::move(_sources), _minDisplayZoom, _maxDisplayZoom, _maxZoom, _tileScale),
       m_texOptions(_options),
       m_genMipmap(_genMipmap) {
 
@@ -148,7 +148,8 @@ std::shared_ptr<TileTask> RasterSource::createTask(TileID _tileId, int _subTask)
 }
 
 Raster RasterSource::getRaster(const TileTask& _task) {
-    TileID id(_task.tileId().x, _task.tileId().y, _task.tileId().z);
+    const auto& taskTileID = _task.tileId();
+    TileID id(taskTileID.x, taskTileID.y, taskTileID.z);
 
     auto texIt = m_textures.find(id);
     if (texIt != m_textures.end()) {

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -69,8 +69,8 @@ public:
 
 RasterSource::RasterSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
                            int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
-                           int32_t _tileScale, TextureOptions _options, bool _genMipmap)
-    : TileSource(_name, std::move(_sources), _minDisplayZoom, _maxDisplayZoom, _maxZoom, _tileScale),
+                           int32_t _zoomBias, TextureOptions _options, bool _genMipmap)
+    : TileSource(_name, std::move(_sources), _minDisplayZoom, _maxDisplayZoom, _maxZoom, _zoomBias),
       m_texOptions(_options),
       m_genMipmap(_genMipmap) {
 

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -30,7 +30,7 @@ public:
 
     RasterSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
                  int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
-                 TextureOptions _options, bool genMipmap = false);
+                 int32_t _tileScale, TextureOptions _options, bool genMipmap = false);
 
     // TODO Is this always PNG or can it also be JPEG?
     virtual const char* mimeType() const override { return "image/png"; };

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -30,7 +30,7 @@ public:
 
     RasterSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
                  int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
-                 int32_t _tileScale, TextureOptions _options, bool genMipmap = false);
+                 int32_t _zoomBias, TextureOptions _options, bool genMipmap = false);
 
     // TODO Is this always PNG or can it also be JPEG?
     virtual const char* mimeType() const override { return "image/png"; };

--- a/core/src/data/tileSource.cpp
+++ b/core/src/data/tileSource.cpp
@@ -9,6 +9,7 @@
 #include "tile/tile.h"
 #include "tile/tileTask.h"
 #include "log.h"
+#include "util/geom.h"
 
 #include <atomic>
 #include <functional>
@@ -17,12 +18,12 @@ namespace Tangram {
 
 TileSource::TileSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
                        int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
-                       int32_t _tileScale) :
+                       int32_t _zoomBias) :
     m_name(_name),
     m_minDisplayZoom(_minDisplayZoom),
     m_maxDisplayZoom(_maxDisplayZoom),
     m_maxZoom(_maxZoom),
-    m_tileScale(_tileScale),
+    m_zoomBias(_zoomBias),
     m_sources(std::move(_sources)) {
 
     static std::atomic<int32_t> s_serial;
@@ -32,6 +33,20 @@ TileSource::TileSource(const std::string& _name, std::unique_ptr<DataSource> _so
 
 TileSource::~TileSource() {
     clearData();
+}
+
+int32_t TileSource::zoomBiasFromTileSize(int32_t tileSize) {
+    const auto BaseTileSize = 256;
+
+    // zero tileSize (log(0) is undefined)
+    if (!tileSize) { return 0; }
+
+    if (isPowerOfTwo(tileSize)) {
+        return std::log(static_cast<float>(tileSize)/static_cast<float>(BaseTileSize)) / std::log(2);
+    }
+
+    LOGW("Illegal tile_size defined. Must be power of 2. Default tileSize of 256px set");
+    return 0;
 }
 
 const char* TileSource::mimeType() const {

--- a/core/src/data/tileSource.cpp
+++ b/core/src/data/tileSource.cpp
@@ -16,11 +16,13 @@
 namespace Tangram {
 
 TileSource::TileSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
-                       int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom) :
+                       int32_t _minDisplayZoom, int32_t _maxDisplayZoom, int32_t _maxZoom,
+                       int32_t _tileScale) :
     m_name(_name),
     m_minDisplayZoom(_minDisplayZoom),
     m_maxDisplayZoom(_maxDisplayZoom),
     m_maxZoom(_maxZoom),
+    m_tileScale(_tileScale),
     m_sources(std::move(_sources)) {
 
     static std::atomic<int32_t> s_serial;

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -23,6 +23,8 @@
 #include "glm/gtx/rotate_vector.hpp"
 #include "glm/gtx/norm.hpp"
 
+#include <cassert>
+
 namespace Tangram {
 
 Labels::Labels()
@@ -220,10 +222,11 @@ void Labels::skipTransitions(const std::shared_ptr<Scene>& _scene,
         std::shared_ptr<Tile> proxy;
 
         const auto& source = _scene->getTileSource(tile->sourceID());
+        if (!source) { continue; }
 
         if (m_lastZoom < _currentZoom) {
             // zooming in, add the one cached parent tile
-            proxy = findProxy(tile->sourceID(), tileID.getParent(source->tileScale()), _tiles, _cache);
+            proxy = findProxy(tile->sourceID(), tileID.getParent(source->zoomBias()), _tiles, _cache);
             if (proxy) { skipTransitions(styles, *tile, *proxy); }
         } else {
             // zooming out, add the 4 cached children tiles

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -25,7 +25,7 @@ class Marker;
 class Tile;
 class Style;
 class Scene;
-class TileCache;
+class TileManager;
 
 class Labels {
 
@@ -40,7 +40,7 @@ public:
                         const std::shared_ptr<Scene>& _scene,
                         const std::vector<std::shared_ptr<Tile>>& _tiles,
                         const std::vector<std::unique_ptr<Marker>>& _markers,
-                        TileCache& _cache);
+                        TileManager& tileManager);
 
     /* onlyRender: when the view and tiles have not changed one does not need to update the set of
      * active labels. We just need to render these the labels in this case
@@ -64,7 +64,7 @@ protected:
 
     void skipTransitions(const std::shared_ptr<Scene>& _scene,
                          const std::vector<std::shared_ptr<Tile>>& _tiles,
-                         TileCache& _cache, float _currentZoom) const;
+                         TileManager& _tileManager, float _currentZoom) const;
 
     PERF_TRACE void skipTransitions(const std::vector<const Style*>& _styles, Tile& _tile, Tile& _proxy) const;
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -24,6 +24,7 @@ class FontContext;
 class Marker;
 class Tile;
 class Style;
+class Scene;
 class TileCache;
 
 class Labels {
@@ -36,7 +37,7 @@ public:
     void drawDebug(RenderState& rs, const View& _view);
 
     void updateLabelSet(const ViewState& _viewState, float _dt,
-                        const std::vector<std::unique_ptr<Style>>& _styles,
+                        const std::shared_ptr<Scene>& _scene,
                         const std::vector<std::shared_ptr<Tile>>& _tiles,
                         const std::vector<std::unique_ptr<Marker>>& _markers,
                         TileCache& _cache);
@@ -61,7 +62,7 @@ protected:
     using CollisionPairs = std::vector<isect2d::ISect2D<glm::vec2>::Pair>;
 
 
-    void skipTransitions(const std::vector<std::unique_ptr<Style>>& _styles,
+    void skipTransitions(const std::shared_ptr<Scene>& _scene,
                          const std::vector<std::shared_ptr<Tile>>& _tiles,
                          TileCache& _cache, float _currentZoom) const;
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -134,6 +134,15 @@ std::shared_ptr<Texture> Scene::getTexture(const std::string& textureName) const
     return texIt->second;
 }
 
+std::shared_ptr<TileSource> Scene::getTileSource(int32_t id) {
+    auto it = std::find_if(m_tileSources.begin(), m_tileSources.end(),
+                           [&](auto& s){ return s->id() == id; });
+    if (it != m_tileSources.end()) {
+        return *it;
+    }
+    return nullptr;
+}
+
 std::shared_ptr<TileSource> Scene::getTileSource(const std::string& name) {
     auto it = std::find_if(m_tileSources.begin(), m_tileSources.end(),
                            [&](auto& s){ return s->name() == name; });

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -129,6 +129,7 @@ public:
     void animated(bool animated) { m_animated = animated ? yes : no; }
     animate animated() const { return m_animated; }
 
+    std::shared_ptr<TileSource> getTileSource(int32_t id);
     std::shared_ptr<TileSource> getTileSource(const std::string& name);
 
     std::shared_ptr<Texture> getTexture(const std::string& name) const;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -983,6 +983,7 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
     int32_t minDisplayZoom = -1;
     int32_t maxDisplayZoom = -1;
     int32_t maxZoom = 18;
+    int32_t tileScale = 0; // Equivalent of tileSize of 256px
 
     if (auto typeNode = source["type"]) {
         type = typeNode.Scalar();
@@ -998,6 +999,15 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
     }
     if (auto maxZoomNode = source["max_zoom"]) {
         maxZoom = maxZoomNode.as<int32_t>(maxZoom);
+    }
+    if (auto tileSizeNode = source["tile_size"]) {
+        const auto BaseTileSize = 256;
+        auto tileSize = tileSizeNode.as<int32_t>();
+        if (tileSize && !( tileSize & (tileSize - 1))) {
+            tileScale = std::log(static_cast<float>(tileSize)/static_cast<float>(BaseTileSize)) / std::log(2);
+        } else {
+            LOGW("Illegal tile_size defined. Must be power of 2. Default tileSize of 256px set");
+        }
     }
 
     // Parse and append any URL parameters.
@@ -1075,7 +1085,7 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
     std::shared_ptr<TileSource> sourcePtr;
 
     if (type == "GeoJSON" && !tiled) {
-        sourcePtr = std::make_shared<ClientGeoJsonSource>(platform, name, url, minDisplayZoom, maxDisplayZoom, maxZoom);
+        sourcePtr = std::make_shared<ClientGeoJsonSource>(platform, name, url, minDisplayZoom, maxDisplayZoom, maxZoom, tileScale);
     } else if (type == "Raster") {
         TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
         bool generateMipmaps = false;
@@ -1086,11 +1096,11 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
         }
 
         sourcePtr = std::make_shared<RasterSource>(name, std::move(rawSources),
-                                                   minDisplayZoom, maxDisplayZoom, maxZoom,
+                                                   minDisplayZoom, maxDisplayZoom, maxZoom, tileScale,
                                                    options, generateMipmaps);
     } else {
         sourcePtr = std::make_shared<TileSource>(name, std::move(rawSources),
-                                                 minDisplayZoom, maxDisplayZoom, maxZoom);
+                                                 minDisplayZoom, maxDisplayZoom, maxZoom, tileScale);
 
         if (type == "GeoJSON") {
             sourcePtr->setFormat(TileSource::Format::GeoJson);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -5,6 +5,7 @@
 #include "data/mbtilesDataSource.h"
 #include "data/networkDataSource.h"
 #include "data/rasterSource.h"
+#include "data/tileSource.h"
 #include "gl/shaderSource.h"
 #include "log.h"
 #include "platform.h"
@@ -983,7 +984,7 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
     int32_t minDisplayZoom = -1;
     int32_t maxDisplayZoom = -1;
     int32_t maxZoom = 18;
-    int32_t tileScale = 0; // Equivalent of tileSize of 256px
+    int32_t zoomBias = 0;
 
     if (auto typeNode = source["type"]) {
         type = typeNode.Scalar();
@@ -1001,13 +1002,7 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
         maxZoom = maxZoomNode.as<int32_t>(maxZoom);
     }
     if (auto tileSizeNode = source["tile_size"]) {
-        const auto BaseTileSize = 256;
-        auto tileSize = tileSizeNode.as<int32_t>();
-        if (tileSize && !( tileSize & (tileSize - 1))) {
-            tileScale = std::log(static_cast<float>(tileSize)/static_cast<float>(BaseTileSize)) / std::log(2);
-        } else {
-            LOGW("Illegal tile_size defined. Must be power of 2. Default tileSize of 256px set");
-        }
+        zoomBias = TileSource::zoomBiasFromTileSize(tileSizeNode.as<int32_t>());
     }
 
     // Parse and append any URL parameters.
@@ -1085,7 +1080,7 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
     std::shared_ptr<TileSource> sourcePtr;
 
     if (type == "GeoJSON" && !tiled) {
-        sourcePtr = std::make_shared<ClientGeoJsonSource>(platform, name, url, minDisplayZoom, maxDisplayZoom, maxZoom, tileScale);
+        sourcePtr = std::make_shared<ClientGeoJsonSource>(platform, name, url, minDisplayZoom, maxDisplayZoom, maxZoom, zoomBias);
     } else if (type == "Raster") {
         TextureOptions options = {GL_RGBA, GL_RGBA, {GL_LINEAR, GL_LINEAR}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE} };
         bool generateMipmaps = false;
@@ -1096,11 +1091,11 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
         }
 
         sourcePtr = std::make_shared<RasterSource>(name, std::move(rawSources),
-                                                   minDisplayZoom, maxDisplayZoom, maxZoom, tileScale,
+                                                   minDisplayZoom, maxDisplayZoom, maxZoom, zoomBias,
                                                    options, generateMipmaps);
     } else {
         sourcePtr = std::make_shared<TileSource>(name, std::move(rawSources),
-                                                 minDisplayZoom, maxDisplayZoom, maxZoom, tileScale);
+                                                 minDisplayZoom, maxDisplayZoom, maxZoom, zoomBias);
 
         if (type == "GeoJSON") {
             sourcePtr->setFormat(TileSource::Format::GeoJson);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -385,7 +385,7 @@ bool Map::update(float _dt) {
             for (const auto& tile : tiles) {
                 tile->update(_dt, impl->view);
             }
-            impl->labels.updateLabelSet(impl->view.state(), _dt, impl->scene->styles(), tiles, markers,
+            impl->labels.updateLabelSet(impl->view.state(), _dt, impl->scene, tiles, markers,
                                         *impl->tileManager.getTileCache());
         } else {
             impl->labels.updateLabels(impl->view.state(), _dt, impl->scene->styles(), tiles, markers);

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -358,7 +358,7 @@ bool Map::update(float _dt) {
 
     impl->inputHandler.update(_dt);
 
-    impl->view.update();
+    impl->view.update(impl->scene->tileSources());
 
     impl->markerManager.update(static_cast<int>(impl->view.getZoom()));
 

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -386,7 +386,7 @@ bool Map::update(float _dt) {
                 tile->update(_dt, impl->view);
             }
             impl->labels.updateLabelSet(impl->view.state(), _dt, impl->scene, tiles, markers,
-                                        *impl->tileManager.getTileCache());
+                                        impl->tileManager);
         } else {
             impl->labels.updateLabels(impl->view.state(), _dt, impl->scene->styles(), tiles, markers);
         }

--- a/core/src/tangram.cpp
+++ b/core/src/tangram.cpp
@@ -358,7 +358,7 @@ bool Map::update(float _dt) {
 
     impl->inputHandler.update(_dt);
 
-    impl->view.update(impl->scene->tileSources());
+    impl->view.update();
 
     impl->markerManager.update(static_cast<int>(impl->view.getZoom()));
 
@@ -369,7 +369,7 @@ bool Map::update(float _dt) {
     {
         std::lock_guard<std::mutex> lock(impl->tilesMutex);
 
-        impl->tileManager.updateTileSets(impl->view.state(), impl->view.getVisibleTiles());
+        impl->tileManager.updateTileSets(impl->view);
 
         auto& tiles = impl->tileManager.getVisibleTiles();
         auto& markers = impl->markerManager.markers();

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -50,7 +50,7 @@ void TileManager::setTileSources(const std::vector<std::shared_ptr<TileSource>>&
         m_tileSets.begin(), m_tileSets.end(),
         [&](auto& tileSet) {
             if (!tileSet.clientTileSource) {
-                LOGD("remove source %s", tileSet.source->name().c_str());
+                LOGN("Remove source %s", tileSet.source->name().c_str());
                 return true;
             }
             // Clear cache
@@ -69,9 +69,7 @@ void TileManager::setTileSources(const std::vector<std::shared_ptr<TileSource>>&
                          [&](const TileSet& a) {
                              return a.source->name() == source->name();
                          }) == m_tileSets.end()) {
-
-            LOGD("add source %s", source->name().c_str());
-
+            LOGN("add source %s", source->name().c_str());
             m_tileSets.push_back({ source, false });
         } else {
             LOGW("Duplicate named datasource (not added): %s", source->name().c_str());
@@ -153,8 +151,11 @@ void TileManager::updateTileSets(const View& _view) {
 
     // Make m_tiles an unique list of tiles for rendering sorted from
     // high to low zoom-levels.
-    std::sort(m_tiles.begin(), m_tiles.end(), [](auto& a, auto& b){
-            return a->getID() < b->getID(); });
+    std::sort(m_tiles.begin(), m_tiles.end(), [](auto& a, auto& b) {
+            return a->sourceID() == b->sourceID() ?
+                a->getID() < b->getID() :
+                a->sourceID() < b->sourceID(); }
+        );
 
     // Remove duplicates: Proxy tiles could have been added more than once
     m_tiles.erase(std::unique(m_tiles.begin(), m_tiles.end()), m_tiles.end());

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -117,7 +117,7 @@ void TileManager::clearTileSet(int32_t _sourceId) {
     m_tileSetChanged = true;
 }
 
-void TileManager::updateTileSets(View& _view) {
+void TileManager::updateTileSets(const View& _view) {
 
     m_tiles.clear();
     m_tilesInProgress = 0;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -77,6 +77,15 @@ void TileManager::setTileSources(const std::vector<std::shared_ptr<TileSource>>&
     }
 }
 
+std::shared_ptr<TileSource> TileManager::getClientTileSource(int32_t sourceID) {
+    for (const auto& tileSet : m_tileSets) {
+        if (tileSet.clientTileSource && tileSet.source->id() == sourceID) {
+            return tileSet.source;
+        }
+    }
+    return nullptr;
+}
+
 void TileManager::addClientTileSource(std::shared_ptr<TileSource> _tileSource) {
     m_tileSets.push_back({ _tileSource, true });
 }

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -117,7 +117,7 @@ void TileManager::clearTileSet(int32_t _sourceId) {
 }
 
 void TileManager::updateTileSets(const ViewState& _view,
-                                 const std::set<TileID>& _visibleTiles) {
+                                 const std::unordered_map<std::string, std::set<TileID>>& _visibleTiles) {
     m_tiles.clear();
     m_tilesInProgress = 0;
     m_tileSetChanged = false;
@@ -125,7 +125,9 @@ void TileManager::updateTileSets(const ViewState& _view,
     for (auto& tileSet : m_tileSets) {
         // check if tile set is active for zoom (zoom might be below min_zoom)
         if (tileSet.source->isActiveForZoom(_view.zoom)) {
-            updateTileSet(tileSet, _view, _visibleTiles);
+            auto it = _visibleTiles.find(tileSet.source->name());
+            if (it == _visibleTiles.end()) { continue; }
+            updateTileSet(tileSet, _view, it->second);
         }
     }
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -21,6 +21,7 @@ namespace Tangram {
 
 class TileSource;
 class TileCache;
+class View;
 struct ViewState;
 
 /* Singleton container of <TileSet>s
@@ -42,8 +43,7 @@ public:
     void setTileSources(const std::vector<std::shared_ptr<TileSource>>& _sources);
 
     /* Updates visible tile set and load missing tiles */
-    void updateTileSets(const ViewState& _view,
-                        const std::unordered_map<int32_t, std::set<TileID>>& _visibleTiles);
+    void updateTileSets(View& _view);
 
     void clearTileSets();
 
@@ -71,7 +71,7 @@ public:
      */
     void setCacheSize(size_t _cacheSize);
 
-private:
+protected:
 
     enum class ProxyID : uint8_t {
         no_proxies = 0,
@@ -195,12 +195,15 @@ private:
             : source(_source), clientTileSource(_clientSource) {}
 
         std::shared_ptr<TileSource> source;
+
+        std::set<TileID> visibleTiles;
         std::map<TileID, TileEntry> tiles;
+
         int64_t sourceGeneration = 0;
         bool clientTileSource;
     };
 
-    void updateTileSet(TileSet& tileSet, const ViewState& _view, const std::set<TileID>& _visibleTiles);
+    void updateTileSet(TileSet& tileSet, const ViewState& _view);
 
     void enqueueTask(TileSet& _tileSet, const TileID& _tileID, const ViewState& _view);
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -57,6 +57,8 @@ public:
         return m_tilesInProgress > 0;
     }
 
+    std::shared_ptr<TileSource> getClientTileSource(int32_t sourceID);
+
     void addClientTileSource(std::shared_ptr<TileSource> _source);
 
     bool removeClientTileSource(TileSource& _source);

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -6,7 +6,6 @@
 #include "tile/tileID.h"
 #include "tile/tileTask.h"
 #include "tile/tileWorker.h"
-#include "util/fastmap.h"
 
 #include <map>
 #include <memory>
@@ -14,6 +13,7 @@
 #include <tuple>
 #include <set>
 #include <vector>
+#include <unordered_map>
 
 class Platform;
 
@@ -42,7 +42,8 @@ public:
     void setTileSources(const std::vector<std::shared_ptr<TileSource>>& _sources);
 
     /* Updates visible tile set and load missing tiles */
-    void updateTileSets(const ViewState& _view, const std::set<TileID>& _visibleTiles);
+    void updateTileSets(const ViewState& _view,
+                        const std::unordered_map<std::string, std::set<TileID>>& _visibleTiles);
 
     void clearTileSets();
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -13,7 +13,6 @@
 #include <tuple>
 #include <set>
 #include <vector>
-#include <unordered_map>
 
 class Platform;
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -43,7 +43,7 @@ public:
     void setTileSources(const std::vector<std::shared_ptr<TileSource>>& _sources);
 
     /* Updates visible tile set and load missing tiles */
-    void updateTileSets(View& _view);
+    void updateTileSets(const View& _view);
 
     void clearTileSets();
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -43,7 +43,7 @@ public:
 
     /* Updates visible tile set and load missing tiles */
     void updateTileSets(const ViewState& _view,
-                        const std::unordered_map<std::string, std::set<TileID>>& _visibleTiles);
+                        const std::unordered_map<int32_t, std::set<TileID>>& _visibleTiles);
 
     void clearTileSets();
 

--- a/core/src/util/inputHandler.cpp
+++ b/core/src/util/inputHandler.cpp
@@ -51,8 +51,8 @@ void InputHandler::handleTapGesture(float _posX, float _posY) {
 
     onGesture();
 
-    double viewCenterX = 0.5 * m_view.getWidth();
-    double viewCenterY = 0.5 * m_view.getHeight();
+    float viewCenterX = 0.5f * m_view.getWidth();
+    float viewCenterY = 0.5f * m_view.getHeight();
 
     m_view.screenToGroundPlane(viewCenterX, viewCenterY);
     m_view.screenToGroundPlane(_posX, _posY);

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -479,10 +479,10 @@ void View::updateTiles(const std::vector<std::shared_ptr<TileSource>>& tileSourc
     // Scan options - avoid heap allocation for std::function
     // [1] http://www.drdobbs.com/cpp/efficient-use-of-lambda-expressions-and/232500059?pgno=2
     struct ScanParams {
-        ScanParams(std::unordered_map<std::string, std::set<TileID>>& _tiles, int _zoom)
+        ScanParams(std::unordered_map<int32_t, std::set<TileID>>& _tiles, int _zoom)
             : tiles(_tiles), zoom(_zoom) {}
 
-        std::unordered_map<std::string, std::set<TileID>>& tiles;
+        std::unordered_map<int32_t, std::set<TileID>>& tiles;
         int zoom;
         int maxZoom = int(s_maxZoom);
 
@@ -537,7 +537,11 @@ void View::updateTiles(const std::vector<std::shared_ptr<TileSource>>& tileSourc
 
         if (tile != opt.last) {
             for (const auto& source : tileSources) {
-                opt.tiles[source->name()].emplace(tile.x, tile.y, tile.z, tile.z, tile.w);
+                auto tileScale = source->tileScale();
+                auto maxZoom = source->maxZoom();
+                // Insert scaled and maxZoom mapped tileID in the visible set
+                auto tileID = TileID(tile.x, tile.y, tile.z, tile.z, tile.w);
+                opt.tiles[source->id()].insert(tileID.scaled(tileScale).withMaxSourceZoom(maxZoom));
                 opt.last = tile;
             }
         }

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -175,14 +175,14 @@ public:
      * @return the un-normalized distance 'into the screen' to the ground plane
      * (if < 0, intersection is behind the screen)
      */
-    double screenToGroundPlane(double& _screenX, double& _screenY);
     double screenToGroundPlane(float& _screenX, float& _screenY);
+    double screenToGroundPlane(double& _screenX, double& _screenY);
 
     /* Gets the screen position from a latitude/longitude */
     glm::vec2 lonLatToScreenPosition(double lon, double lat, bool& clipped) const;
 
     /* Returns the set of all tiles visible at the current position and zoom */
-    void getVisibleTiles(const std::function<void(TileID)>& _tileCb);
+    void getVisibleTiles(const std::function<void(TileID)>& _tileCb) const;
 
     /* Returns true if the view properties have changed since the last call to update() */
     bool changedOnLastUpdate() const { return m_changed; }
@@ -203,6 +203,8 @@ public:
 protected:
 
     void updateMatrices();
+
+    double screenToGroundPlaneInternal(double& _screenX, double& _screenY) const;
 
     std::shared_ptr<MapProjection> m_projection;
     std::shared_ptr<Stops> m_fovStops;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -7,9 +7,8 @@
 #include "glm/mat4x4.hpp"
 #include "glm/vec4.hpp"
 #include "glm/vec3.hpp"
-#include <set>
+#include <functional>
 #include <memory>
-#include <unordered_map>
 
 namespace Tangram {
 
@@ -134,7 +133,7 @@ public:
     /* Get the current pitch angle in radians */
     float getPitch() const { return m_pitch; }
 
-    /* Updates the view and projection matrices if properties have changed  */
+    /* Updates the view and projection matrices if properties have changed */
     void update(bool _constrainToWorldBounds = true);
 
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -183,7 +183,7 @@ public:
     glm::vec2 lonLatToScreenPosition(double lon, double lat, bool& clipped) const;
 
     /* Returns the set of all tiles visible at the current position and zoom */
-    const std::unordered_map<std::string, std::set<TileID>>& getVisibleTiles() { return m_visibleTiles; }
+    const std::unordered_map<int32_t, std::set<TileID>>& getVisibleTiles() { return m_visibleTiles; }
 
     /* Returns true if the view properties have changed since the last call to update() */
     bool changedOnLastUpdate() const { return m_changed; }
@@ -209,7 +209,7 @@ protected:
     std::shared_ptr<MapProjection> m_projection;
     std::shared_ptr<Stops> m_fovStops;
     std::shared_ptr<Stops> m_maxPitchStops;
-    std::unordered_map<std::string, std::set<TileID>> m_visibleTiles;
+    std::unordered_map<int32_t, std::set<TileID>> m_visibleTiles;
 
     ViewConstraint m_constraint;
 

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -20,7 +20,6 @@ enum class CameraType : uint8_t {
 };
 
 struct Stops;
-class TileSource;
 
 struct ViewState {
     const MapProjection* mapProjection;
@@ -135,8 +134,8 @@ public:
     /* Get the current pitch angle in radians */
     float getPitch() const { return m_pitch; }
 
-    /* Updates the view and projection matrices if properties have changed */
-    void update(const std::vector<std::shared_ptr<TileSource>>& tileSources, bool _constrainToWorldBounds = true);
+    /* Updates the view and projection matrices if properties have changed  */
+    void update(bool _constrainToWorldBounds = true);
 
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
     const glm::dvec3& getPosition() const { return m_pos; }
@@ -183,7 +182,7 @@ public:
     glm::vec2 lonLatToScreenPosition(double lon, double lat, bool& clipped) const;
 
     /* Returns the set of all tiles visible at the current position and zoom */
-    const std::unordered_map<int32_t, std::set<TileID>>& getVisibleTiles() { return m_visibleTiles; }
+    void getVisibleTiles(const std::function<void(TileID)>& _tileCb);
 
     /* Returns true if the view properties have changed since the last call to update() */
     bool changedOnLastUpdate() const { return m_changed; }
@@ -204,12 +203,10 @@ public:
 protected:
 
     void updateMatrices();
-    void updateTiles(const std::vector<std::shared_ptr<TileSource>>& tileSources);
 
     std::shared_ptr<MapProjection> m_projection;
     std::shared_ptr<Stops> m_fovStops;
     std::shared_ptr<Stops> m_maxPitchStops;
-    std::unordered_map<int32_t, std::set<TileID>> m_visibleTiles;
 
     ViewConstraint m_constraint;
 

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -9,6 +9,7 @@
 #include "glm/vec3.hpp"
 #include <set>
 #include <memory>
+#include <unordered_map>
 
 namespace Tangram {
 
@@ -19,6 +20,7 @@ enum class CameraType : uint8_t {
 };
 
 struct Stops;
+class TileSource;
 
 struct ViewState {
     const MapProjection* mapProjection;
@@ -134,7 +136,7 @@ public:
     float getPitch() const { return m_pitch; }
 
     /* Updates the view and projection matrices if properties have changed */
-    void update(bool _constrainToWorldBounds = true);
+    void update(const std::vector<std::shared_ptr<TileSource>>& tileSources, bool _constrainToWorldBounds = true);
 
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
     const glm::dvec3& getPosition() const { return m_pos; }
@@ -181,7 +183,7 @@ public:
     glm::vec2 lonLatToScreenPosition(double lon, double lat, bool& clipped) const;
 
     /* Returns the set of all tiles visible at the current position and zoom */
-    const std::set<TileID>& getVisibleTiles() { return m_visibleTiles; }
+    const std::unordered_map<std::string, std::set<TileID>>& getVisibleTiles() { return m_visibleTiles; }
 
     /* Returns true if the view properties have changed since the last call to update() */
     bool changedOnLastUpdate() const { return m_changed; }
@@ -202,12 +204,12 @@ public:
 protected:
 
     void updateMatrices();
-    void updateTiles();
+    void updateTiles(const std::vector<std::shared_ptr<TileSource>>& tileSources);
 
     std::shared_ptr<MapProjection> m_projection;
     std::shared_ptr<Stops> m_fovStops;
     std::shared_ptr<Stops> m_maxPitchStops;
-    std::set<TileID> m_visibleTiles;
+    std::unordered_map<std::string, std::set<TileID>> m_visibleTiles;
 
     ViewConstraint m_constraint;
 

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -45,7 +45,7 @@ View makeView() {
 
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update(false);
+    view.update({}, false);
 
     return view;
 }

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -45,7 +45,7 @@ View makeView() {
 
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update({}, false);
+    view.update(false);
 
     return view;
 }

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -107,7 +107,7 @@ TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
     View view(256, 256);
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update({}, false);
+    view.update(false);
 
     Tile tile({0,0,0}, view.getMapProjection());
     tile.update(0, view);

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -107,7 +107,7 @@ TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
     View view(256, 256);
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update(false);
+    view.update({}, false);
 
     Tile tile({0,0,0}, view.getMapProjection());
     tile.update(0, view);

--- a/tests/unit/tileIDTests.cpp
+++ b/tests/unit/tileIDTests.cpp
@@ -48,7 +48,7 @@ TEST_CASE( "Create TileIDs and find their parents and children", "[Core][TileID]
     std::set<TileID> children;
 
     for (int i = 0; i < 4; i++) {
-        children.insert(a.getChild(i));
+        children.insert(a.getChild(i, 5));
     }
 
     std::set<TileID> requiredChildren = { TileID(2, 4, 4), TileID(3, 4, 4), TileID(2, 5, 4), TileID(3, 5, 4) };
@@ -91,5 +91,56 @@ TEST_CASE("TileID correctly applies source zoom limits", "[Core][TileID]") {
     REQUIRE(c == TileID(2, 1, 4, 5, 0));
     REQUIRE(d == TileID(2, 1, 4, 4, 0));
     REQUIRE(e == TileID(1, 0, 3, 3, 0));
+
+    //Child tiles
+    auto f = TileID(2, 1, 4, 4, 0);
+    auto g = f.getChild(0, 5);
+    auto h = g.getChild(0, 5);
+    auto i = h.getChild(0, 5);
+    REQUIRE(g == TileID(4, 2, 5, 5, 0));
+    REQUIRE(h == TileID(4, 2, 5, 6, 0));
+    REQUIRE(i == TileID(4, 2, 5, 7, 0));
+}
+
+TEST_CASE("TileID correctly applies source zoom limits for scaled tiles", "[Core][TileID]") {
+    // maxZoom: 6, scale: 1
+    auto aScaled = TileID(8, 4, 6);
+    aScaled = aScaled.scaled(1);
+    aScaled = aScaled.withMaxSourceZoom(6);
+    auto aScaledMax5 = aScaled.withMaxSourceZoom(5);
+    auto aScaledMax4 = aScaled.withMaxSourceZoom(4);
+
+    REQUIRE(aScaled ==  TileID(4, 2, 5, 6, 0));
+    REQUIRE(aScaledMax5 == TileID(4, 2, 5, 6, 0));
+    REQUIRE(aScaledMax4 == TileID(2, 1, 4, 6, 0));
+
+    auto b = aScaled.getParent(1);
+    auto c = aScaledMax5.getParent(1);
+    auto d = aScaledMax4.getParent(1);
+    REQUIRE(b == TileID(2, 1, 4, 5, 0));
+    REQUIRE(c == TileID(2, 1, 4, 5, 0));
+    REQUIRE(d == TileID(2, 1, 4, 5, 0));
+
+    auto e = b.getParent(1); // grand parent of original aScaled tile
+    auto f = e.getParent(1); // grand grand
+    auto g = f.getParent(1); // grand grand grand
+    REQUIRE(e == TileID(1, 0, 3, 4, 0));
+    REQUIRE(f == TileID(0, 0, 2, 3, 0));
+    REQUIRE(g == TileID(0, 0, 1, 2, 0));
+
+    // child tiles
+    b = aScaled.getChild(0, 6);
+    c = aScaledMax5.getChild(0, 5);
+    d = aScaledMax4.getChild(0, 4);
+    REQUIRE(b == TileID(8, 4, 6, 7, 0));
+    REQUIRE(c == TileID(4, 2, 5, 7, 0));
+    REQUIRE(d == TileID(2, 1, 4, 7, 0));
+
+    e = b.getChild(0, 6);
+    f = e.getChild(0, 6);
+    g = f.getChild(0, 6);
+    REQUIRE(e == TileID(8, 4, 6, 8, 0));
+    REQUIRE(f == TileID(8, 4, 6, 9, 0));
+    REQUIRE(g == TileID(8, 4, 6, 10, 0));
 
 }

--- a/tests/unit/tileIDTests.cpp
+++ b/tests/unit/tileIDTests.cpp
@@ -105,7 +105,7 @@ TEST_CASE("TileID correctly applies source zoom limits", "[Core][TileID]") {
 TEST_CASE("TileID correctly applies source zoom limits for scaled tiles", "[Core][TileID]") {
     // maxZoom: 6, scale: 1
     auto aScaled = TileID(8, 4, 6);
-    aScaled = aScaled.scaled(1);
+    aScaled = aScaled.zoomBiasAdjusted(1);
     aScaled = aScaled.withMaxSourceZoom(6);
     auto aScaledMax5 = aScaled.withMaxSourceZoom(5);
     auto aScaledMax4 = aScaled.withMaxSourceZoom(4);

--- a/tests/unit/tileManagerTests.cpp
+++ b/tests/unit/tileManagerTests.cpp
@@ -81,7 +81,7 @@ struct TestTileSource : TileSource {
 
     int tileTaskCount = 0;
 
-    TestTileSource() : TileSource("", nullptr) {
+    TestTileSource() : TileSource("test", nullptr) {
         m_generateGeometry = true;
     }
 
@@ -115,7 +115,7 @@ TEST_CASE( "Use proxy Tile - Dont remove proxy if it is now visible", "[TileMana
     tileManager.setTileSources(sources);
 
     /// Start loading tile 0/0/0
-    std::set<TileID> visibleTiles_1 = { TileID{0,0,0} };
+    std::unordered_map<int32_t, std::set<TileID>> visibleTiles_1 = { {0, {TileID{0,0,0}}} };
     tileManager.updateTileSets(viewState, visibleTiles_1);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
@@ -123,7 +123,7 @@ TEST_CASE( "Use proxy Tile - Dont remove proxy if it is now visible", "[TileMana
     REQUIRE(worker.processedCount == 0);
 
     /// Start loading tile 0/0/1 - uses 0/0/0 as proxy
-    std::set<TileID> visibleTiles_2 = { TileID{0,0,1} };
+    std::unordered_map<int32_t, std::set<TileID>> visibleTiles_2 = { {0, {TileID{0,0,1}}} };
     tileManager.updateTileSets(viewState, visibleTiles_2);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
@@ -170,7 +170,7 @@ TEST_CASE( "Load visible Tile", "[TileManager][updateTileSets]" ) {
     std::vector<std::shared_ptr<TileSource>> sources = { source };
     tileManager.setTileSources(sources);
 
-    std::set<TileID> visibleTiles = { TileID{0,0,0} };
+    std::unordered_map<int32_t, std::set<TileID>> visibleTiles = { {1, {TileID{0,0,0}}} };
     tileManager.updateTileSets(viewState, visibleTiles);
     worker.processTask();
 
@@ -195,7 +195,7 @@ TEST_CASE( "Use proxy Tile", "[TileManager][updateTileSets]" ) {
     std::vector<std::shared_ptr<TileSource>> sources = { source };
     tileManager.setTileSources(sources);
 
-    std::set<TileID> visibleTiles = { TileID{0,0,0} };
+    std::unordered_map<int32_t, std::set<TileID>> visibleTiles = { {2, {TileID{0,0,0}}} };
     tileManager.updateTileSets(viewState, visibleTiles);
     worker.processTask();
 
@@ -203,7 +203,7 @@ TEST_CASE( "Use proxy Tile", "[TileManager][updateTileSets]" ) {
     REQUIRE(source->tileTaskCount == 1);
     REQUIRE(worker.processedCount == 1);
 
-    std::set<TileID> visibleTiles2 = { TileID{0,0,1} };
+    std::unordered_map<int32_t, std::set<TileID>> visibleTiles2 = { {2, {TileID{0,0,1}}} };
     tileManager.updateTileSets(viewState, visibleTiles2);
     worker.processTask();
 
@@ -234,7 +234,7 @@ TEST_CASE( "Use proxy Tile - circular proxies", "[TileManager][updateTileSets]" 
     tileManager.setTileSources(sources);
 
     /// Start loading tile 0/0/0
-    std::set<TileID> visibleTiles_1 = { TileID{0,0,0} };
+    std::unordered_map<int32_t, std::set<TileID>> visibleTiles_1 = { {3, {TileID{0,0,0}}} };
     tileManager.updateTileSets(viewState, visibleTiles_1);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
@@ -242,7 +242,7 @@ TEST_CASE( "Use proxy Tile - circular proxies", "[TileManager][updateTileSets]" 
     REQUIRE(worker.processedCount == 0);
 
     /// Start loading tile 0/0/1 - add 0/0/0 as proxy
-    std::set<TileID> visibleTiles_2 = { TileID{0,0,1} };
+    std::unordered_map<int32_t, std::set<TileID>> visibleTiles_2 = { {3, {TileID{0,0,1}}} };
     tileManager.updateTileSets(viewState, visibleTiles_2);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);

--- a/tests/unit/tileManagerTests.cpp
+++ b/tests/unit/tileManagerTests.cpp
@@ -106,25 +106,56 @@ struct TestTileSource : TileSource {
     }
 };
 
+class TestTileManager : public TileManager {
+public:
+    using Base = TileManager;
+    using Base::Base;
+
+    void updateTiles(const ViewState& _view, std::set<TileID> _visibleTiles) {
+        // Mimic TileManager::updateTileSets(View& _view)
+        m_tiles.clear();
+        m_tilesInProgress = 0;
+        m_tileSetChanged = false;
+
+        TileSet& tileSet = m_tileSets[0];
+
+        tileSet.visibleTiles = _visibleTiles;
+
+        TileManager::updateTileSet(tileSet, _view);
+
+        loadTiles();
+
+        // Make m_tiles an unique list of tiles for rendering sorted from
+        // high to low zoom-levels.
+        std::sort(m_tiles.begin(), m_tiles.end(), [](auto& a, auto& b){
+                return a->getID() < b->getID(); });
+
+        // Remove duplicates: Proxy tiles could have been added more than once
+        m_tiles.erase(std::unique(m_tiles.begin(), m_tiles.end()), m_tiles.end());
+
+    }
+};
+
 TEST_CASE( "Use proxy Tile - Dont remove proxy if it is now visible", "[TileManager][updateTileSets]" ) {
     TestTileWorker worker;
-    TileManager tileManager(std::make_shared<MockPlatform>(), worker);
+    TestTileManager tileManager(std::make_shared<MockPlatform>(), worker);
 
     auto source = std::make_shared<TestTileSource>();
     std::vector<std::shared_ptr<TileSource>> sources = { source };
     tileManager.setTileSources(sources);
 
     /// Start loading tile 0/0/0
-    std::unordered_map<int32_t, std::set<TileID>> visibleTiles_1 = { {0, {TileID{0,0,0}}} };
-    tileManager.updateTileSets(viewState, visibleTiles_1);
+    std::set<TileID> visibleTiles_1 = {TileID{0,0,0}};
+    tileManager.updateTiles(viewState, visibleTiles_1);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
     REQUIRE(source->tileTaskCount == 1);
     REQUIRE(worker.processedCount == 0);
 
     /// Start loading tile 0/0/1 - uses 0/0/0 as proxy
-    std::unordered_map<int32_t, std::set<TileID>> visibleTiles_2 = { {0, {TileID{0,0,1}}} };
-    tileManager.updateTileSets(viewState, visibleTiles_2);
+    std::set<TileID> visibleTiles_2 = {TileID{0,0,1}};
+
+    tileManager.updateTiles(viewState, visibleTiles_2);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
     REQUIRE(source->tileTaskCount == 2);
@@ -134,7 +165,7 @@ TEST_CASE( "Use proxy Tile - Dont remove proxy if it is now visible", "[TileMana
     worker.processTask(1);
 
     /// Go back to tile 0/0/0 - uses 0/0/1 as proxy
-    tileManager.updateTileSets(viewState, visibleTiles_1);
+    tileManager.updateTiles(viewState, visibleTiles_1);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 1);
     REQUIRE(source->tileTaskCount == 2);
@@ -144,7 +175,7 @@ TEST_CASE( "Use proxy Tile - Dont remove proxy if it is now visible", "[TileMana
 
     // Process tile task 0/0/0
     worker.processTask(0);
-    tileManager.updateTileSets(viewState, visibleTiles_1);
+    tileManager.updateTiles(viewState, visibleTiles_1);
     REQUIRE(tileManager.getVisibleTiles().size() == 1);
     REQUIRE(tileManager.getVisibleTiles()[0]->isProxy() == false);
     REQUIRE(tileManager.getVisibleTiles()[0]->getID() == TileID(0,0,0));
@@ -164,21 +195,21 @@ TEST_CASE( "Real TileWorker Initialization", "[TileManager][Constructor]" ) {
 
 TEST_CASE( "Load visible Tile", "[TileManager][updateTileSets]" ) {
     TestTileWorker worker;
-    TileManager tileManager(std::make_shared<MockPlatform>(), worker);
+    TestTileManager tileManager(std::make_shared<MockPlatform>(), worker);
 
     auto source = std::make_shared<TestTileSource>();
     std::vector<std::shared_ptr<TileSource>> sources = { source };
     tileManager.setTileSources(sources);
 
-    std::unordered_map<int32_t, std::set<TileID>> visibleTiles = { {1, {TileID{0,0,0}}} };
-    tileManager.updateTileSets(viewState, visibleTiles);
+    std::set<TileID> visibleTiles = {TileID{0,0,0}};
+    tileManager.updateTiles(viewState, visibleTiles);
     worker.processTask();
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
     REQUIRE(source->tileTaskCount == 1);
     REQUIRE(worker.processedCount == 1);
 
-    tileManager.updateTileSets(viewState, visibleTiles);
+    tileManager.updateTiles(viewState, visibleTiles);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 1);
     REQUIRE(source->tileTaskCount == 1);
@@ -189,22 +220,22 @@ TEST_CASE( "Load visible Tile", "[TileManager][updateTileSets]" ) {
 
 TEST_CASE( "Use proxy Tile", "[TileManager][updateTileSets]" ) {
     TestTileWorker worker;
-    TileManager tileManager(std::make_shared<MockPlatform>(), worker);
+    TestTileManager tileManager(std::make_shared<MockPlatform>(), worker);
 
     auto source = std::make_shared<TestTileSource>();
     std::vector<std::shared_ptr<TileSource>> sources = { source };
     tileManager.setTileSources(sources);
 
-    std::unordered_map<int32_t, std::set<TileID>> visibleTiles = { {2, {TileID{0,0,0}}} };
-    tileManager.updateTileSets(viewState, visibleTiles);
+    std::set<TileID> visibleTiles = {TileID{0,0,0}};
+    tileManager.updateTiles(viewState, visibleTiles);
     worker.processTask();
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
     REQUIRE(source->tileTaskCount == 1);
     REQUIRE(worker.processedCount == 1);
 
-    std::unordered_map<int32_t, std::set<TileID>> visibleTiles2 = { {2, {TileID{0,0,1}}} };
-    tileManager.updateTileSets(viewState, visibleTiles2);
+    std::set<TileID> visibleTiles2 = {TileID{0,0,1}};
+    tileManager.updateTiles(viewState, visibleTiles2);
     worker.processTask();
 
     REQUIRE(tileManager.getVisibleTiles().size() == 1);
@@ -213,7 +244,7 @@ TEST_CASE( "Use proxy Tile", "[TileManager][updateTileSets]" ) {
     REQUIRE(source->tileTaskCount == 2);
     REQUIRE(worker.processedCount == 2);
 
-    tileManager.updateTileSets(viewState, visibleTiles2);
+    tileManager.updateTiles(viewState, visibleTiles2);
     worker.processTask();
 
     REQUIRE(tileManager.getVisibleTiles().size() == 1);
@@ -227,23 +258,23 @@ TEST_CASE( "Use proxy Tile", "[TileManager][updateTileSets]" ) {
 
 TEST_CASE( "Use proxy Tile - circular proxies", "[TileManager][updateTileSets]" ) {
     TestTileWorker worker;
-    TileManager tileManager(std::make_shared<MockPlatform>(), worker);
+    TestTileManager tileManager(std::make_shared<MockPlatform>(), worker);
 
     auto source = std::make_shared<TestTileSource>();
     std::vector<std::shared_ptr<TileSource>> sources = { source };
     tileManager.setTileSources(sources);
 
     /// Start loading tile 0/0/0
-    std::unordered_map<int32_t, std::set<TileID>> visibleTiles_1 = { {3, {TileID{0,0,0}}} };
-    tileManager.updateTileSets(viewState, visibleTiles_1);
+    std::set<TileID> visibleTiles_1 = {TileID{0,0,0}};
+    tileManager.updateTiles(viewState, visibleTiles_1);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
     REQUIRE(source->tileTaskCount == 1);
     REQUIRE(worker.processedCount == 0);
 
     /// Start loading tile 0/0/1 - add 0/0/0 as proxy
-    std::unordered_map<int32_t, std::set<TileID>> visibleTiles_2 = { {3, {TileID{0,0,1}}} };
-    tileManager.updateTileSets(viewState, visibleTiles_2);
+    std::set<TileID> visibleTiles_2 = {TileID{0,0,1}};
+    tileManager.updateTiles(viewState, visibleTiles_2);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
     REQUIRE(source->tileTaskCount == 2);
@@ -251,7 +282,7 @@ TEST_CASE( "Use proxy Tile - circular proxies", "[TileManager][updateTileSets]" 
 
     /// Go back to tile 0/0/0
     /// NB: does not add 0/0/1 as proxy, since no newTiles were loaded
-    tileManager.updateTileSets(viewState, visibleTiles_1);
+    tileManager.updateTiles(viewState, visibleTiles_1);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 0);
     REQUIRE(source->tileTaskCount == 2);
@@ -264,7 +295,7 @@ TEST_CASE( "Use proxy Tile - circular proxies", "[TileManager][updateTileSets]" 
     REQUIRE(worker.tasks[1]->isCanceled() == true);
 
     worker.processTask();
-    tileManager.updateTileSets(viewState, visibleTiles_1);
+    tileManager.updateTiles(viewState, visibleTiles_1);
 
     REQUIRE(tileManager.getVisibleTiles().size() == 1);
     REQUIRE(tileManager.getVisibleTiles()[0]->isProxy() == false);


### PR DESCRIPTION
Ok this is much better now.

- visible tile ids (scale and max zoom adjusted) are stored per datasource 
- Does not unnecessarily bloat TileID struct
- getParent and getChild TileID takes into account a datasource' tileScale and maxZoom respectively.

Addressed #1435 
- label pipeline modified a bit to include the set of datasources to help find parent and child tiles.