### PR TITLE
Android add TLS 1.2 for pre-lollipop

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/HttpHandler.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/HttpHandler.java
@@ -1,14 +1,27 @@
 package com.mapzen.tangram;
 
+import android.os.Build;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
 import okhttp3.Cache;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import okhttp3.ConnectionSpec;
+import okhttp3.TlsVersion;
 
 /**
  * {@code HttpHandler} is a class for customizing HTTP requests for map resources, it can be
@@ -17,6 +30,67 @@ import java.util.concurrent.TimeUnit;
 public class HttpHandler {
 
     private OkHttpClient okClient;
+
+    /**
+     * Enables TLS v1.2 when creating SSLSockets.
+     * <p/>
+     * For some reason, android supports TLS v1.2 from API 16, but enables it by
+     * default only from API 20.
+     *
+     * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+     * @see SSLSocketFactory
+     */
+    private class Tls12SocketFactory extends SSLSocketFactory {
+        private final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+        final SSLSocketFactory delegate;
+
+        public Tls12SocketFactory(SSLSocketFactory base) {
+            this.delegate = base;
+        }
+
+        @Override
+        public String[] getDefaultCipherSuites() {
+            return delegate.getDefaultCipherSuites();
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return delegate.getSupportedCipherSuites();
+        }
+
+        @Override
+        public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+            return patch(delegate.createSocket(s, host, port, autoClose));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+            return patch(delegate.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+            return patch(delegate.createSocket(host, port, localHost, localPort));
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            return patch(delegate.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+            return patch(delegate.createSocket(address, port, localAddress, localPort));
+        }
+
+        private Socket patch(Socket s) {
+            if (s instanceof SSLSocket) {
+                ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+            }
+            return s;
+        }
+    }
 
     /**
      * Construct an {@code HttpHandler} with default options.
@@ -39,6 +113,27 @@ public class HttpHandler {
 
         if (directory != null && maxSize > 0) {
             builder.cache(new Cache(directory, maxSize));
+        }
+
+        if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22) {
+            try {
+                SSLContext sc = SSLContext.getInstance("TLSv1.2");
+                sc.init(null, null, null);
+                builder.sslSocketFactory(new Tls12SocketFactory(sc.getSocketFactory()));
+
+                ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                        .tlsVersions(TlsVersion.TLS_1_2)
+                        .build();
+
+                List<ConnectionSpec> specs = new ArrayList<>();
+                specs.add(cs);
+                specs.add(ConnectionSpec.COMPATIBLE_TLS);
+                specs.add(ConnectionSpec.CLEARTEXT);
+
+                builder.connectionSpecs(specs);
+            } catch (Exception exc) {
+                android.util.Log.e("Tangram", "Error while setting TLS 1.2", exc);
+            }
         }
 
         okClient = builder.build();


### PR DESCRIPTION
Same is needed for Pelias and Valhalla android clients. Also there seem to be Android 7.0 devices which lack to enable TLS 1.2 ..

http://stackoverflow.com/questions/39133437/sslhandshakeexception-handshake-failed-on-android-n-7-0
https://issuetracker.google.com/issues/37122132