### PR TITLE
Fix iOS framework version injection

### DIFF
--- a/platforms/ios/framework/Info.plist
+++ b/platforms/ios/framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.4-dev</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/platforms/ios/release-checklist.md
+++ b/platforms/ios/release-checklist.md
@@ -6,19 +6,18 @@
 - Have ownership privileges to update the cocoapods trunk spec
 
 ## Steps
-1. Go into the Info.plist located at https://github.com/tangrams/tangram-es/blob/master/ios/framework/Info.plist
-and update the version tag for the release you're doing. Submit this as a PR for release.
-2. Once #1's PR merges, tag that commit with the same version.
-3. Build the iOS universal framework for release ( `make clean  && make ios-framework-universal RELEASE=1` ).
-4. Take the *universal* framework file and copy it into a branch on the framework holding repo
+1. Update the version tag `${FRAMEWORK_VERSION}` that gets injected through CMake to the .plist file
+of the framework for the release you're doing. Submit this as a PR for release.
+2. Build the iOS universal framework for release ( `make clean  && make ios-framework-universal RELEASE=1` ).
+3. Take the *universal* framework file and copy it into a branch on the framework holding repo
 (https://github.com/tangrams/ios-framework). Submit this for PR following the convention seen in other
 PRs for release notes ( https://github.com/tangrams/ios-framework/pull/17 )
-5. Once #5's PR merges to master, tag the release with the same version number as #2.
-6. Update the Tangram-es.podspec file version number with that same tag, and run `pod spec lint` to
+4. Once #5's PR merges to master, tag the release with the same version number as #2.
+5. Update the Tangram-es.podspec file version number with that same tag, and run `pod spec lint` to
 make sure everything is happy. Fix issues if not happy (eventually we should document known possible
 issues). Submit to PR once lint is clean.
-7. Once #6 PR merges, push the updated pod spec to trunk: `pod trunk push Tangram-es.podspec`
-8. Submit a PR to increment the version number for #1's plist file. We add `-dev` to the end of the
+6. Once #6 PR merges, push the updated pod spec to trunk: `pod trunk push Tangram-es.podspec`
+7. Submit a PR to increment the version number for #1's plist file. We add `-dev` to the end of the
 version numbers while in development.
-9. Before publishing the Tangram release, add the zipped version of both Debug and Release flavors
+8. Before publishing the Tangram release, add the zipped version of both Debug and Release flavors
 to the Download attachments of the release.

--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -1,5 +1,7 @@
 include(${CMAKE_SOURCE_DIR}/toolchains/iOS.toolchain.cmake)
 
+set(FRAMEWORK_VERSION "0.6.4-dev")
+
 message(STATUS "Build for iOS archs " ${IOS_ARCH})
 
 set(FRAMEWORK_NAME TangramMap)
@@ -131,6 +133,7 @@ set_xcode_property(${FRAMEWORK_NAME} ONLY_ACTIVE_ARCH "NO")
 set_xcode_property(${FRAMEWORK_NAME} VALID_ARCHS "${IOS_ARCH}")
 set_xcode_property(${FRAMEWORK_NAME} ARCHS "${IOS_ARCH}")
 set_xcode_property(${FRAMEWORK_NAME} DEFINES_MODULE "YES")
+set_xcode_property(${FRAMEWORK_NAME} CURRENT_PROJECT_VERSION "${FRAMEWORK_VERSION}")
 
 # Set RPATH to be within the application /Frameworks directory
 set_xcode_property(${FRAMEWORK_NAME} LD_DYLIB_INSTALL_NAME "@rpath/${FRAMEWORK_NAME}.framework/${FRAMEWORK_NAME}")


### PR DESCRIPTION
At deployment time we only update the value of `CFBundleShortVersionString` explicitly to the framework version number and leave `CFBundleVersion` to `$(CURRENT_PROJECT_VERSION)`. Unfortunately this value was not set through `set_xcode_property` in CMake and was left blank.

This PR changes slightly the deployment process to update the framework value directly in CMake and then sets the value of the XCode property `CURRENT_PROJECT_VERSION` accordingly which is then set on both `CFBundleShortVersionString` and `CFBundleVersion`.