### PR TITLE
Implement style's default draw rules

### DIFF
--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -406,6 +406,9 @@ bool MarkerManager::buildGeometry(Marker& marker, int zoom) {
         }
     }
 
+    // Apply defaul draw rules defined for this style
+    styler->style().applyDefaultDrawRules(*rule);
+
     m_styleContext->setKeywordZoom(zoom);
 
     bool valid = marker.evaluateRuleForContext(*m_styleContext);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -902,6 +902,18 @@ void SceneLoader::loadStyleProps(const std::shared_ptr<Platform>& platform, Styl
         loadMaterial(platform, materialNode, style.getMaterial(), scene, style);
     }
 
+    if (const Node& drawNode = styleNode["draw"]) {
+        std::vector<StyleParam> params;
+        int ruleID = scene->addIdForName(style.getName());
+        parseStyleParams(drawNode, scene, "", params);
+        /*Note:  ruleID and name is immaterial here, as these are only used for rule merging, but
+         * style's default styling rules are applied post rule merging for any style parameter which
+         * was not assigned during merging step.
+         */
+        auto rule = std::make_unique<DrawRuleData>(style.getName(), ruleID, std::move(params));
+        style.setDefaultDrawRule(std::move(rule));
+    }
+
 }
 
 bool SceneLoader::loadStyle(const std::shared_ptr<Platform>& platform, const std::string& name, Node config, const std::shared_ptr<Scene>& scene) {

--- a/core/src/scene/styleMixer.cpp
+++ b/core/src/scene/styleMixer.cpp
@@ -103,6 +103,7 @@ void StyleMixer::applyStyleMixins(Node _style, const std::vector<Node>& _mixins)
 
     // Merge map fields with newer values taking precedence.
     mergeMapFieldTakingLast("material", _style, _mixins);
+    mergeMapFieldTakingLast("draw", _style, _mixins);
 
     // Produce a list of all 'mixins' with shader nodes and merge those separately.
     std::vector<Node> shaderMixins;

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -459,6 +459,21 @@ void Style::setDefaultDrawRule(std::unique_ptr<DrawRuleData>&& _rule) {
     m_defaultDrawRule = std::move(_rule);
 }
 
+void Style::applyDefaultDrawRules(DrawRule& _rule) const {
+    if (m_defaultDrawRule) {
+        for (auto& param : m_defaultDrawRule->parameters) {
+            auto key = static_cast<uint8_t>(param.key);
+            if (!_rule.active[key]) {
+                _rule.active[key] = true;
+                // NOTE: layername and layer depth are actually immaterial here, since these are
+                // only used during layer draw rules merging. Adding a default string for
+                // debugging purposes.
+                _rule.params[key] = { &param, "default_style_draw_rule", 0 };
+            }
+        }
+    }
+}
+
 bool StyleBuilder::checkRule(const DrawRule& _rule) const {
 
     uint32_t checkColor;

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -6,7 +6,6 @@
 #include "gl/mesh.h"
 #include "log.h"
 #include "marker/marker.h"
-#include "scene/drawRule.h"
 #include "scene/light.h"
 #include "scene/scene.h"
 #include "scene/spriteAtlas.h"
@@ -454,6 +453,10 @@ void Style::draw(RenderState& rs, const Marker& marker) {
     if (!mesh->draw(rs, *m_shaderProgram)) {
         LOGN("Mesh built by style %s cannot be drawn", m_name.c_str());
     }
+}
+
+void Style::setDefaultDrawRule(std::unique_ptr<DrawRuleData>&& _rule) {
+    m_defaultDrawRule = std::move(_rule);
 }
 
 bool StyleBuilder::checkRule(const DrawRule& _rule) const {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -3,6 +3,7 @@
 #include "data/tileData.h"
 #include "gl.h"
 #include "gl/uniform.h"
+#include "scene/drawRule.h"
 #include "util/fastmap.h"
 
 #include <memory>
@@ -122,6 +123,9 @@ protected:
 
     /* <VertexLayout> shared between meshes using this style */
     std::shared_ptr<VertexLayout> m_vertexLayout;
+
+    /* Stores default style draw rules*/
+    std::unique_ptr<DrawRuleData> m_defaultDrawRule = nullptr;
 
     /* <LightingType> to determine how lighting will be calculated for this style */
     LightingType m_lightingType = LightingType::fragment;
@@ -290,6 +294,9 @@ public:
     void setupRasters(const std::vector<std::shared_ptr<TileSource>>& _sources);
 
     std::vector<StyleUniform>& styleUniforms() { return m_mainUniforms.styleUniforms; }
+
+    void setDefaultDrawRule(std::unique_ptr<DrawRuleData>&& _rule);
+    const auto& defaultDrawRule() const { return m_defaultDrawRule; }
 
     virtual std::unique_ptr<StyleBuilder> createBuilder() const = 0;
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -296,7 +296,7 @@ public:
     std::vector<StyleUniform>& styleUniforms() { return m_mainUniforms.styleUniforms; }
 
     void setDefaultDrawRule(std::unique_ptr<DrawRuleData>&& _rule);
-    const auto& defaultDrawRule() const { return m_defaultDrawRule; }
+    void applyDefaultDrawRules(DrawRule& _rule) const;
 
     virtual std::unique_ptr<StyleBuilder> createBuilder() const = 0;
 

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -54,6 +54,19 @@ void TileBuilder::applyStyling(const Feature& _feature, const SceneLayer& _layer
             continue;
         }
 
+        if (style->style().defaultDrawRule()) {
+            for (auto& param : style->style().defaultDrawRule()->parameters) {
+                auto key = static_cast<uint8_t>(param.key);
+                if (!rule.active[key]) {
+                    rule.active[key] = true;
+                    // NOTE: layername and layer depth are actually immaterial here, since these are
+                    // only used during layer draw rules merging. Adding a default string for
+                    // debugging purposes.
+                    rule.params[key] = { &param, "default_style_draw_rule", 0 };
+                }
+            }
+        }
+
         if (!m_ruleSet.evaluateRuleForContext(rule, m_styleContext)) {
             continue;
         }

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -54,18 +54,8 @@ void TileBuilder::applyStyling(const Feature& _feature, const SceneLayer& _layer
             continue;
         }
 
-        if (style->style().defaultDrawRule()) {
-            for (auto& param : style->style().defaultDrawRule()->parameters) {
-                auto key = static_cast<uint8_t>(param.key);
-                if (!rule.active[key]) {
-                    rule.active[key] = true;
-                    // NOTE: layername and layer depth are actually immaterial here, since these are
-                    // only used during layer draw rules merging. Adding a default string for
-                    // debugging purposes.
-                    rule.params[key] = { &param, "default_style_draw_rule", 0 };
-                }
-            }
-        }
+        // Apply defaul draw rules defined for this style
+        style->style().applyDefaultDrawRules(rule);
 
         if (!m_ruleSet.evaluateRuleForContext(rule, m_styleContext)) {
             continue;

--- a/scenes/scene.yaml
+++ b/scenes/scene.yaml
@@ -84,8 +84,13 @@ styles:
                 filter: |
                     color.rgb *= 1.25; // pump up the colors
                     color.a = 0.5;     // translucent
-
-
+        draw: # default draw parameters
+            color: function() { return feature.colour || 'gray'; }
+            width: 6px
+            outline:
+                color: [.8, .8, .8]
+                width: 1px
+            interactive: true
 
 sources:
     osm:
@@ -691,16 +696,4 @@ layers:
             lines:
                 style: transit-lines
                 order: 400
-                color: gray
-                width: 6px
-                outline:
-                    color: [.8, .8, .8]
-                    width: 1px
-                interactive: true
-
-        colored:
-            filter: { colour: true }
-            draw:
-                lines:
-                    color: function() { return feature.colour; }
 


### PR DESCRIPTION
Style's default draw rules are applied for any style property which is not set/active during draw
rule merging step.

- Adds scene parsing for style's default draw rule
- Update default demo scene file to include a use case of default draw rules (refer transit-lines
style)

Closes #1338 