### PR TITLE
CMake helper function to get a local Mapzen API key

### DIFF
--- a/toolchains/darwin.cmake
+++ b/toolchains/darwin.cmake
@@ -14,12 +14,12 @@ set(CORE_COMPILE_DEFS PLATFORM_OSX)
 # Build core library with dependencies.
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
 
-check_mapzen_api_key()
-add_definitions( -DMAPZEN_API_KEY="$ENV{MAPZEN_API_KEY}" )
-
 if(APPLICATION)
 
   set(EXECUTABLE_NAME "tangram")
+
+  get_mapzen_api_key(MAPZEN_API_KEY)
+  add_definitions(-DMAPZEN_API_KEY="${MAPZEN_API_KEY}")
 
   find_package(OpenGL REQUIRED)
 

--- a/toolchains/iOS.cmake
+++ b/toolchains/iOS.cmake
@@ -18,7 +18,8 @@ foreach(_ext ${IOS_EXTENSIONS_FILES})
         ${PROJECT_SOURCE_DIR}/platforms/ios/demo/src/${_ext})
 endforeach()
 
-check_mapzen_api_key()
+get_mapzen_api_key(MAPZEN_API_KEY)
+add_definitions(-DMAPZEN_API_KEY="${MAPZEN_API_KEY}")
 
 # Generate demo app configuration plist file to inject API key
 configure_file(${PROJECT_SOURCE_DIR}/platforms/ios/demo/Config.plist.in

--- a/toolchains/linux.cmake
+++ b/toolchains/linux.cmake
@@ -34,12 +34,12 @@ set(CORE_COMPILE_DEFS PLATFORM_LINUX)
 # load core library
 add_subdirectory(${PROJECT_SOURCE_DIR}/core)
 
-check_mapzen_api_key()
-add_definitions( -DMAPZEN_API_KEY="$ENV{MAPZEN_API_KEY}" )
-
 if(APPLICATION)
 
   set(EXECUTABLE_NAME "tangram")
+
+  get_mapzen_api_key(MAPZEN_API_KEY)
+  add_definitions(-DMAPZEN_API_KEY="${MAPZEN_API_KEY}")
 
   find_package(OpenGL REQUIRED)
 

--- a/toolchains/raspberrypi.cmake
+++ b/toolchains/raspberrypi.cmake
@@ -10,8 +10,8 @@ check_unsupported_compiler_version()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
-check_mapzen_api_key()
-add_definitions( -DMAPZEN_API_KEY="$ENV{MAPZEN_API_KEY}" )
+get_mapzen_api_key(MAPZEN_API_KEY)
+add_definitions(-DMAPZEN_API_KEY="${MAPZEN_API_KEY}")
 
 # add sources and include headers
 find_sources_and_include_directories(

--- a/toolchains/utils.cmake
+++ b/toolchains/utils.cmake
@@ -22,9 +22,11 @@ function(check_unsupported_compiler_version)
 
 endfunction(check_unsupported_compiler_version)
 
-function(check_mapzen_api_key)
+function(get_mapzen_api_key KEY_RESULT)
 
-    if("$ENV{MAPZEN_API_KEY}" STREQUAL "")
+    set(${KEY_RESULT} $ENV{MAPZEN_API_KEY} PARENT_SCOPE)
+
+    if(${KEY_RESULT} STREQUAL "")
         message(SEND_ERROR
             "Make sure to provide an api key to build the demo application, "
             "you can create an API key at https://mapzen.com/developers. "
@@ -32,7 +34,7 @@ function(check_mapzen_api_key)
         return()
     endif()
 
-endfunction(check_mapzen_api_key)
+endfunction(get_mapzen_api_key)
 
 
 function(find_sources_and_include_directories HEADERS_PATH SOURCES_PATH)


### PR DESCRIPTION
 - Makes it easier to change the name or location of the local API key from just one place.
 - Moves API key checks into demo application build steps, where applicable.