### PR TITLE
replaced CMAKE_SOURCE_DIR with PROJECT_SOURCE_DIR for Android toolchain

### DIFF
--- a/toolchains/android.cmake
+++ b/toolchains/android.cmake
@@ -8,17 +8,16 @@ set(ANDROID_PROJECT_DIR ${PROJECT_SOURCE_DIR}/platforms/android/tangram)
 set(LIB_NAME tangram) # in order to have libtangram.so
 
 add_library(${LIB_NAME} SHARED
-  ${CMAKE_SOURCE_DIR}/platforms/common/platform_gl.cpp
-  ${CMAKE_SOURCE_DIR}/platforms/android/tangram/src/main/cpp/jniExports.cpp
-  ${CMAKE_SOURCE_DIR}/platforms/android/tangram/src/main/cpp/platform_android.cpp
-  ${CMAKE_SOURCE_DIR}/platforms/android/tangram/src/main/cpp/sqlite3ndk.cpp)
+  ${PROJECT_SOURCE_DIR}/platforms/common/platform_gl.cpp
+  ${PROJECT_SOURCE_DIR}/platforms/android/tangram/src/main/cpp/jniExports.cpp
+  ${PROJECT_SOURCE_DIR}/platforms/android/tangram/src/main/cpp/platform_android.cpp
+  ${PROJECT_SOURCE_DIR}/platforms/android/tangram/src/main/cpp/sqlite3ndk.cpp)
 
 target_include_directories(${LIB_NAME} PUBLIC
-  ${CMAKE_SOURCE_DIR}/core/deps/SQLiteCpp/sqlite3) # sqlite3ndk.cpp needs sqlite3.h
+  ${PROJECT_SOURCE_DIR}/core/deps/SQLiteCpp/sqlite3) # sqlite3ndk.cpp needs sqlite3.h
 
 target_link_libraries(${LIB_NAME}
   PUBLIC
   ${CORE_LIBRARY}
-  # android libaries
+  # android libraries
   GLESv2 log z atomic android)
-


### PR DESCRIPTION
Made a little change in cmake file for Android so the project could be included as part of a larger cmake based project. Alternatively, CMAKE_CURRENT_SOURCE_DIR works as well, but in this case I think PROJECT_SOURCE_DIR makes more sense, especially seeing how it's used in other cmake files.