### PR TITLE
Scene complete callback

### DIFF
--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -65,20 +65,19 @@ struct SceneUpdate {
 };
 
 enum Error {
+    none,
     scene_update_path_not_found,
     scene_update_path_yaml_syntax_error,
     scene_update_value_yaml_syntax_error,
 };
 
-struct SceneUpdateError {
+struct SceneError {
     SceneUpdate update;
     Error error;
 };
 
-using SceneUpdateErrorCallback = std::function<void(const SceneUpdateError&)>;
-
-// Function type for a mapReady callback
-using MapReady = std::function<void(void*)>;
+// Function type for a sceneReady callback
+using SceneReadyCallback = std::function<void(bool success, const SceneError&)>;
 
 enum class EaseType : char {
     linear = 0,
@@ -99,17 +98,15 @@ public:
     // Any pending scene update will be cleared
     void loadSceneAsync(const char* _scenePath,
                         bool _useScenePosition = false,
-                        MapReady _onMapReady = nullptr,
-                        void *_onMapReadyUserData = nullptr,
-                        const std::vector<SceneUpdate>& sceneUpdates = {},
-                        SceneUpdateErrorCallback _onSceneUpdateError = nullptr);
+                        SceneReadyCallback _onSceneReady = nullptr,
+                        const std::vector<SceneUpdate>& sceneUpdates = {});
 
     // Load the scene at the given absolute file path synchronously
     // Any pending scene update will be cleared
     void loadScene(const char* _scenePath,
                    bool _useScenePosition = false,
-                   const std::vector<SceneUpdate>& sceneUpdates = {},
-                   SceneUpdateErrorCallback _onSceneUpdateError = nullptr);
+                   SceneReadyCallback _onSceneReady = nullptr,
+                   const std::vector<SceneUpdate>& sceneUpdates = {});
 
     // Request an update to the scene configuration; the path is a series of yaml keys
     // separated by a '.' and the value is a string of yaml to replace the current value
@@ -118,7 +115,7 @@ public:
     void queueSceneUpdate(const std::vector<SceneUpdate>& sceneUpdates);
 
     // Apply all previously requested scene updates
-    void applySceneUpdates(SceneUpdateErrorCallback _onSceneUpdateError = nullptr);
+    void applySceneUpdates(SceneReadyCallback _onSceneReady = nullptr);
 
     // Set an MBTiles SQLite database file for a DataSource in the scene.
     void setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath);

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -98,14 +98,12 @@ public:
     // Any pending scene update will be cleared
     void loadSceneAsync(const char* _scenePath,
                         bool _useScenePosition = false,
-                        SceneReadyCallback _onSceneReady = nullptr,
                         const std::vector<SceneUpdate>& sceneUpdates = {});
 
     // Load the scene at the given absolute file path synchronously
     // Any pending scene update will be cleared
     void loadScene(const char* _scenePath,
                    bool _useScenePosition = false,
-                   SceneReadyCallback _onSceneReady = nullptr,
                    const std::vector<SceneUpdate>& sceneUpdates = {});
 
     // Request an update to the scene configuration; the path is a series of yaml keys
@@ -114,8 +112,10 @@ public:
     void queueSceneUpdate(const char* _path, const char* _value);
     void queueSceneUpdate(const std::vector<SceneUpdate>& sceneUpdates);
 
+    void setSceneReadyListener(SceneReadyCallback _onSceneReady);
+
     // Apply all previously requested scene updates
-    void applySceneUpdates(SceneReadyCallback _onSceneReady = nullptr);
+    void applySceneUpdates();
 
     // Set an MBTiles SQLite database file for a DataSource in the scene.
     void setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath);

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -76,8 +76,10 @@ struct SceneError {
     Error error;
 };
 
+using SceneID = int32_t;
+
 // Function type for a sceneReady callback
-using SceneReadyCallback = std::function<void(bool success, const SceneError&)>;
+using SceneReadyCallback = std::function<void(SceneID id, bool success, const SceneError&)>;
 
 enum class EaseType : char {
     linear = 0,
@@ -96,15 +98,15 @@ public:
 
     // Load the scene at the given absolute file path asynchronously
     // Any pending scene update will be cleared
-    void loadSceneAsync(const char* _scenePath,
-                        bool _useScenePosition = false,
-                        const std::vector<SceneUpdate>& sceneUpdates = {});
+    SceneID loadSceneAsync(const char* _scenePath,
+                           bool _useScenePosition = false,
+                           const std::vector<SceneUpdate>& sceneUpdates = {});
 
     // Load the scene at the given absolute file path synchronously
     // Any pending scene update will be cleared
-    void loadScene(const char* _scenePath,
-                   bool _useScenePosition = false,
-                   const std::vector<SceneUpdate>& sceneUpdates = {});
+    SceneID loadScene(const char* _scenePath,
+                      bool _useScenePosition = false,
+                      const std::vector<SceneUpdate>& sceneUpdates = {});
 
     // Request an update to the scene configuration; the path is a series of yaml keys
     // separated by a '.' and the value is a string of yaml to replace the current value
@@ -115,7 +117,7 @@ public:
     void setSceneReadyListener(SceneReadyCallback _onSceneReady);
 
     // Apply all previously requested scene updates
-    void applySceneUpdates();
+    SceneID applySceneUpdates();
 
     // Set an MBTiles SQLite database file for a DataSource in the scene.
     void setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath);

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -108,16 +108,12 @@ public:
                       bool _useScenePosition = false,
                       const std::vector<SceneUpdate>& sceneUpdates = {});
 
+    void setSceneReadyListener(SceneReadyCallback _onSceneReady);
+
     // Request an update to the scene configuration; the path is a series of yaml keys
     // separated by a '.' and the value is a string of yaml to replace the current value
     // at the given path in the scene
-    void queueSceneUpdate(const char* _path, const char* _value);
-    void queueSceneUpdate(const std::vector<SceneUpdate>& sceneUpdates);
-
-    void setSceneReadyListener(SceneReadyCallback _onSceneReady);
-
-    // Apply all previously requested scene updates
-    SceneID applySceneUpdates();
+    SceneID updateSceneAsync(const std::vector<SceneUpdate>& sceneUpdates);
 
     // Set an MBTiles SQLite database file for a DataSource in the scene.
     void setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath);

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -69,6 +69,7 @@ enum Error {
     scene_update_path_not_found,
     scene_update_path_yaml_syntax_error,
     scene_update_value_yaml_syntax_error,
+    no_valid_scene,
 };
 
 struct SceneError {
@@ -79,7 +80,7 @@ struct SceneError {
 using SceneID = int32_t;
 
 // Function type for a sceneReady callback
-using SceneReadyCallback = std::function<void(SceneID id, bool success, const SceneError&)>;
+using SceneReadyCallback = std::function<void(SceneID id, const SceneError*)>;
 
 enum class EaseType : char {
     linear = 0,

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -97,24 +97,27 @@ public:
     Map(std::shared_ptr<Platform> _platform);
     ~Map();
 
-    // Load the scene at the given absolute file path asynchronously
-    // Any pending scene update will be cleared
+    // Load the scene at the given absolute file path asynchronously.
     SceneID loadSceneAsync(const char* _scenePath,
                            bool _useScenePosition = false,
                            const std::vector<SceneUpdate>& sceneUpdates = {});
 
     // Load the scene at the given absolute file path synchronously
-    // Any pending scene update will be cleared
     SceneID loadScene(const char* _scenePath,
                       bool _useScenePosition = false,
                       const std::vector<SceneUpdate>& sceneUpdates = {});
 
-    void setSceneReadyListener(SceneReadyCallback _onSceneReady);
-
-    // Request an update to the scene configuration; the path is a series of yaml keys
-    // separated by a '.' and the value is a string of yaml to replace the current value
-    // at the given path in the scene
+    // Request updates to the current scene configuration. This reloads the
+    // scene with the updated configuration.
+    // The SceneUpdate path is a series of yaml keys separated by a '.' and the
+    // value is a string of yaml to replace the current value at the given path
+    // in the scene.
     SceneID updateSceneAsync(const std::vector<SceneUpdate>& sceneUpdates);
+
+    // Set listener for scene load events. The callback receives the SceneID
+    // of the loaded scene and SceneError in case loading was not successful.
+    // The callback may be be called from the main or worker thread.
+    void setSceneReadyListener(SceneReadyCallback _onSceneReady);
 
     // Set an MBTiles SQLite database file for a DataSource in the scene.
     void setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath);

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -182,7 +182,7 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
 
 // NB: Not thread-safe. Must be called on the main/render thread!
 // (Or externally synchronized with main/render thread)
-void Map::loadScene(const char* _scenePath, bool _useScenePosition,
+SceneID Map::loadScene(const char* _scenePath, bool _useScenePosition,
                     const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene file: %s", _scenePath);
@@ -203,15 +203,16 @@ void Map::loadScene(const char* _scenePath, bool _useScenePosition,
 
     if (impl->onSceneReady) {
         if (scene->errors.empty()) {
-            impl->onSceneReady(true, {});
+            impl->onSceneReady(scene->id, true, {});
         } else {
-            impl->onSceneReady(false, scene->errors.front());
+            impl->onSceneReady(scene->id, false, scene->errors.front());
         }
     }
+    return scene->id;
 }
 
-void Map::loadSceneAsync(const char* _scenePath, bool _useScenePosition,
-                         const std::vector<SceneUpdate>& _sceneUpdates) {
+SceneID Map::loadSceneAsync(const char* _scenePath, bool _useScenePosition,
+                            const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene file (async): %s", _scenePath);
 
@@ -235,7 +236,7 @@ void Map::loadSceneAsync(const char* _scenePath, bool _useScenePosition,
                             impl->nextScene.reset();
                         } else {
                             // loadScene[Async] was called in the meantime.
-                            if (impl->onSceneReady) { impl->onSceneReady(false, {}); }
+                            if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, false, {}); }
                             return;
                         }
                     }
@@ -246,10 +247,12 @@ void Map::loadSceneAsync(const char* _scenePath, bool _useScenePosition,
                         applySceneUpdates();
                     }
 
-                    if (impl->onSceneReady) { impl->onSceneReady(newSceneLoaded, {}); }
+                    if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, newSceneLoaded, {}); }
                 });
             platform->requestRender();
         });
+
+    return nextScene->id;
 }
 
 void Map::queueSceneUpdate(const char* _path, const char* _value) {
@@ -270,17 +273,17 @@ std::shared_ptr<Platform>& Map::getPlatform() {
     return platform;
 }
 
-void Map::applySceneUpdates() {
+SceneID Map::applySceneUpdates() {
 
     std::shared_ptr<Scene> nextScene;
     std::vector<SceneUpdate> updates;
     {
         std::lock_guard<std::mutex> lock(impl->sceneMutex);
-        if (impl->sceneUpdates.empty()) { return; }
+        if (impl->sceneUpdates.empty()) { return -1; }
 
         if (impl->nextScene) {
             // Changes are automatically applied once the scene is loaded
-            return;
+            return impl->nextScene->id;
         }
         LOG("Applying %d scene updates", impl->sceneUpdates.size());
 
@@ -301,7 +304,7 @@ void Map::applySceneUpdates() {
                 if (impl->onSceneReady) {
                     SceneError err;
                     if (!nextScene->errors.empty()) { err = nextScene->errors.front(); }
-                    impl->onSceneReady(false, err);
+                    impl->onSceneReady(nextScene->id, false, err);
                 }
                 return;
             }
@@ -315,7 +318,7 @@ void Map::applySceneUpdates() {
                             impl->nextScene.reset();
                         } else {
                             // loadScene[Async] was called in the meantime.
-                            if (impl->onSceneReady) { impl->onSceneReady(false, {}); }
+                            if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, false, {}); }
                             return;
                         }
                     }
@@ -324,10 +327,12 @@ void Map::applySceneUpdates() {
                         impl->setScene(s);
                         applySceneUpdates();
                     }
-                    if (impl->onSceneReady) { impl->onSceneReady(true, {}); }
+                    if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, true, {}); }
                 });
             platform->requestRender();
         });
+
+    return nextScene->id;
 }
 
 void Map::setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath) {

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -203,9 +203,9 @@ SceneID Map::loadScene(const char* _scenePath, bool _useScenePosition,
 
     if (impl->onSceneReady) {
         if (scene->errors.empty()) {
-            impl->onSceneReady(scene->id, true, {});
+            impl->onSceneReady(scene->id, nullptr);
         } else {
-            impl->onSceneReady(scene->id, false, scene->errors.front());
+            impl->onSceneReady(scene->id, &(scene->errors.front()));
         }
     }
     return scene->id;
@@ -229,7 +229,7 @@ SceneID Map::loadSceneAsync(const char* _scenePath, bool _useScenePosition,
                 if (impl->onSceneReady) {
                     SceneError err;
                     if (!nextScene->errors.empty()) { err = nextScene->errors.front(); }
-                    impl->onSceneReady(nextScene->id, false, err);
+                    impl->onSceneReady(nextScene->id, &err);
                 }
                 impl->sceneLoadTasks--;
                 return;
@@ -247,7 +247,7 @@ SceneID Map::loadSceneAsync(const char* _scenePath, bool _useScenePosition,
                         auto s = nextScene;
                         impl->setScene(s);
                     }
-                    if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, true, {}); }
+                    if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, nullptr); }
                 });
             impl->sceneLoadTasks--;
 
@@ -277,7 +277,10 @@ SceneID Map::updateSceneAsync(const std::vector<SceneUpdate>& _sceneUpdates) {
     runAsyncTask([nextScene, updates = std::move(updates), this](){
 
             if (!impl->lastValidScene) {
-                if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, false, {}); }
+                if (impl->onSceneReady) {
+                    SceneError err {{}, Error::no_valid_scene};
+                    impl->onSceneReady(nextScene->id, &err);
+                }
                 impl->sceneLoadTasks--;
                 return;
             }
@@ -293,7 +296,7 @@ SceneID Map::updateSceneAsync(const std::vector<SceneUpdate>& _sceneUpdates) {
                 if (impl->onSceneReady) {
                     SceneError err;
                     if (!nextScene->errors.empty()) { err = nextScene->errors.front(); }
-                    impl->onSceneReady(nextScene->id, false, err);
+                    impl->onSceneReady(nextScene->id, &err);
                 }
                 impl->sceneLoadTasks--;
                 return;
@@ -314,7 +317,7 @@ SceneID Map::updateSceneAsync(const std::vector<SceneUpdate>& _sceneUpdates) {
                         auto s = nextScene;
                         impl->setScene(s);
                     }
-                    if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, true, {}); }
+                    if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, nullptr); }
                 });
             impl->sceneLoadTasks--;
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -25,6 +25,8 @@ namespace Tangram {
 
 static std::atomic<int32_t> s_serial;
 
+Scene::Scene() : id(s_serial++) {}
+
 Scene::Scene(std::shared_ptr<const Platform> _platform, const std::string& _path)
     : id(s_serial++),
       m_path(_path),
@@ -58,9 +60,9 @@ Scene::Scene(std::shared_ptr<const Platform> _platform, const std::string& _path
     m_mapProjection.reset(new MercatorProjection());
 }
 
-Scene::Scene(const Scene& _other)
-    : id(s_serial++),
-      m_featureSelection(std::make_unique<FeatureSelection>()) {
+void Scene::copyConfig(const Scene& _other) {
+
+    m_featureSelection.reset(new FeatureSelection());
 
     m_config = _other.m_config;
     m_fontContext = _other.m_fontContext;

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -17,6 +17,7 @@
 #include "yaml-cpp/yaml.h"
 #include "util/yamlHelper.h"
 
+#include "map.h" // SceneError
 
 namespace Tangram {
 
@@ -139,6 +140,8 @@ public:
 
     std::atomic_ushort pendingTextures{0};
     std::atomic_ushort pendingFonts{0};
+
+    std::vector<SceneError> errors;
 
 private:
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -67,9 +67,13 @@ public:
         yes, no, none
     };
 
+    Scene();
     Scene(std::shared_ptr<const Platform> _platform, const std::string& _path = "");
-    Scene(const Scene& _other);
+    Scene(const Scene& _other) = delete;
+
     ~Scene();
+
+    void copyConfig(const Scene& _other);
 
     auto& camera() { return m_camera; }
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -43,10 +43,11 @@ struct SceneLoader {
     using Node = YAML::Node;
 
     static bool loadScene(const std::shared_ptr<Platform>& _platform, std::shared_ptr<Scene> _scene,
-                          const std::vector<SceneUpdate>& updates = {}, SceneUpdateErrorCallback _onSceneUpdateError = nullptr);
+                          const std::vector<SceneUpdate>& updates = {});
+
     static bool applyConfig(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
     static bool applyUpdates(const std::shared_ptr<Platform>& platform, Scene& scene,
-                             const std::vector<SceneUpdate>& updates, SceneUpdateErrorCallback onSceneUpdateError = nullptr);
+                             const std::vector<SceneUpdate>& updates);
     static void applyGlobals(Node root, Scene& scene);
 
     /*** all public for testing ***/

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -15,7 +15,6 @@ import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.MapController.FeaturePickListener;
 import com.mapzen.tangram.MapController.LabelPickListener;
 import com.mapzen.tangram.MapController.MarkerPickListener;
-import com.mapzen.tangram.MapController.SceneUpdateErrorListener;
 import com.mapzen.tangram.MapController.ViewCompleteListener;
 import com.mapzen.tangram.MapData;
 import com.mapzen.tangram.MapView;
@@ -23,7 +22,6 @@ import com.mapzen.tangram.MapView.OnMapReadyCallback;
 import com.mapzen.tangram.Marker;
 import com.mapzen.tangram.MarkerPickResult;
 import com.mapzen.tangram.SceneUpdate;
-import com.mapzen.tangram.SceneUpdateError;
 import com.mapzen.tangram.TouchInput.DoubleTapResponder;
 import com.mapzen.tangram.TouchInput.LongPressResponder;
 import com.mapzen.tangram.TouchInput.TapResponder;
@@ -40,7 +38,7 @@ import okhttp3.CacheControl;
 import okhttp3.HttpUrl;
 
 public class MainActivity extends AppCompatActivity implements OnMapReadyCallback, TapResponder,
-        DoubleTapResponder, LongPressResponder, FeaturePickListener, LabelPickListener, MarkerPickListener, SceneUpdateErrorListener {
+        DoubleTapResponder, LongPressResponder, FeaturePickListener, LabelPickListener, MarkerPickListener {
 
     private static final String MAPZEN_API_KEY = BuildConfig.MAPZEN_API_KEY;
 
@@ -141,7 +139,6 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         map.setFeaturePickListener(this);
         map.setLabelPickListener(this);
         map.setMarkerPickListener(this);
-        map.setSceneUpdateErrorListener(this);
 
         map.setViewCompleteListener(new ViewCompleteListener() {
                 public void onViewComplete() {
@@ -269,13 +266,6 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         Log.d("Tangram", "Picked marker: " + markerPickResult.getMarker().getMarkerId());
         final String message = String.valueOf(markerPickResult.getMarker().getMarkerId());
         Toast.makeText(getApplicationContext(), "Selected Marker: " + message, Toast.LENGTH_SHORT).show();
-    }
-
-    @Override
-    public void onSceneUpdateError(SceneUpdateError sceneUpdateError) {
-        Log.d("Tangram", "Scene update errors "
-                + sceneUpdateError.getSceneUpdate().toString()
-                + " " + sceneUpdateError.getError().toString());
     }
 }
 

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -18,10 +18,10 @@ import com.mapzen.tangram.MapController.MarkerPickListener;
 import com.mapzen.tangram.MapController.ViewCompleteListener;
 import com.mapzen.tangram.MapData;
 import com.mapzen.tangram.MapView;
-import com.mapzen.tangram.MapView.OnMapReadyCallback;
 import com.mapzen.tangram.Marker;
 import com.mapzen.tangram.MarkerPickResult;
 import com.mapzen.tangram.SceneUpdate;
+import com.mapzen.tangram.SceneUpdateError;
 import com.mapzen.tangram.TouchInput.DoubleTapResponder;
 import com.mapzen.tangram.TouchInput.LongPressResponder;
 import com.mapzen.tangram.TouchInput.TapResponder;
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.CacheControl;
 import okhttp3.HttpUrl;
 
-public class MainActivity extends AppCompatActivity implements OnMapReadyCallback, TapResponder,
+public class MainActivity extends AppCompatActivity implements MapController.SceneLoadListener, TapResponder,
         DoubleTapResponder, LongPressResponder, FeaturePickListener, LabelPickListener, MarkerPickListener {
 
     private static final String MAPZEN_API_KEY = BuildConfig.MAPZEN_API_KEY;
@@ -99,7 +99,26 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         // set previously we want to apply it again. The text is restored in onRestoreInstanceState,
         // which occurs after onCreate and onStart, but before onPostCreate, so we get the URL here.
         String sceneUrl = sceneSelector.getCurrentString();
-        view.getMapAsync(this, sceneUrl, sceneUpdates);
+
+        map = view.getMap(this);
+        map.loadSceneFile(sceneUrl, sceneUpdates);
+
+        map.setZoom(16);
+        map.setPosition(new LngLat(-74.00976419448854, 40.70532700869127));
+        map.setHttpHandler(getHttpHandler());
+        map.setTapResponder(this);
+        map.setDoubleTapResponder(this);
+        map.setLongPressResponder(this);
+        map.setFeaturePickListener(this);
+        map.setLabelPickListener(this);
+        map.setMarkerPickListener(this);
+
+        map.setViewCompleteListener(new ViewCompleteListener() {
+            public void onViewComplete() {
+                Log.d("Tangram", "View complete");
+            }});
+
+        markers = map.addDataLayer("touch");
     }
 
     @Override
@@ -128,23 +147,15 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
 
     @Override
-    public void onMapReady(MapController mapController) {
-        map = mapController;
-        map.setZoom(16);
-        map.setPosition(new LngLat(-74.00976419448854, 40.70532700869127));
-        map.setHttpHandler(getHttpHandler());
-        map.setTapResponder(this);
-        map.setDoubleTapResponder(this);
-        map.setLongPressResponder(this);
-        map.setFeaturePickListener(this);
-        map.setLabelPickListener(this);
-        map.setMarkerPickListener(this);
+    public void onSceneReady(int sceneId) {
+        Log.d("Tangram", "onSceneReady!");
+    }
 
-        map.setViewCompleteListener(new ViewCompleteListener() {
-                public void onViewComplete() {
-                    Log.d("Tangram", "View complete");
-                }});
-        markers = map.addDataLayer("touch");
+    @Override
+    public void onSceneError(int sceneId, SceneUpdateError sceneUpdateError) {
+        Log.d("Tangram", "Scene update errors "
+                + sceneUpdateError.getSceneUpdate().toString()
+                + " " + sceneUpdateError.getError().toString());
     }
 
     HttpHandler getHttpHandler() {

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -20,8 +20,8 @@ import com.mapzen.tangram.MapData;
 import com.mapzen.tangram.MapView;
 import com.mapzen.tangram.Marker;
 import com.mapzen.tangram.MarkerPickResult;
+import com.mapzen.tangram.SceneError;
 import com.mapzen.tangram.SceneUpdate;
-import com.mapzen.tangram.SceneUpdateError;
 import com.mapzen.tangram.TouchInput.DoubleTapResponder;
 import com.mapzen.tangram.TouchInput.LongPressResponder;
 import com.mapzen.tangram.TouchInput.TapResponder;
@@ -147,15 +147,13 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
 
 
     @Override
-    public void onSceneReady(int sceneId) {
+    public void onSceneReady(int sceneId, SceneError sceneError) {
         Log.d("Tangram", "onSceneReady!");
-    }
-
-    @Override
-    public void onSceneError(int sceneId, SceneUpdateError sceneUpdateError) {
-        Log.d("Tangram", "Scene update errors "
-                + sceneUpdateError.getSceneUpdate().toString()
-                + " " + sceneUpdateError.getError().toString());
+        if (sceneError != null) {
+            Log.d("Tangram", "Scene update errors "
+                    + sceneError.getSceneUpdate().toString()
+                    + " " + sceneError.getError().toString());
+        }
     }
 
     HttpHandler getHttpHandler() {

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -148,8 +148,15 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
 
     @Override
     public void onSceneReady(int sceneId, SceneError sceneError) {
+
         Log.d("Tangram", "onSceneReady!");
-        if (sceneError != null) {
+        if (sceneError == null) {
+            Toast.makeText(this, "Scene ready: " + sceneId, Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, "Scene load error: " + sceneId + " "
+                    + sceneError.getSceneUpdate().toString()
+                    + " " + sceneError.getError().toString(), Toast.LENGTH_SHORT).show();
+
             Log.d("Tangram", "Scene update errors "
                     + sceneError.getSceneUpdate().toString()
                     + " " + sceneError.getError().toString());

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -44,7 +44,7 @@ static jmethodID onLabelPickMID = 0;
 static jmethodID onMarkerPickMID = 0;
 static jmethodID labelPickResultInitMID = 0;
 static jmethodID markerPickResultInitMID = 0;
-static jmethodID onSceneUpdateErrorMID = 0;
+static jmethodID sceneReadyCallbackMID = 0;
 static jmethodID sceneUpdateErrorInitMID = 0;
 
 static jclass labelPickResultClass = nullptr;
@@ -81,6 +81,7 @@ void setupJniEnv(JNIEnv* jniEnv) {
     getFontFallbackFilePath = jniEnv->GetMethodID(tangramClass, "getFontFallbackFilePath", "(II)Ljava/lang/String;");
     requestRenderMethodID = jniEnv->GetMethodID(tangramClass, "requestRender", "()V");
     setRenderModeMethodID = jniEnv->GetMethodID(tangramClass, "setRenderMode", "(I)V");
+    sceneReadyCallbackMID = jniEnv->GetMethodID(tangramClass, "sceneReadyCallback", "(ZLcom/mapzen/tangram/SceneUpdateError;)V");
 
     jclass featurePickListenerClass = jniEnv->FindClass("com/mapzen/tangram/MapController$FeaturePickListener");
     onFeaturePickMID = jniEnv->GetMethodID(featurePickListenerClass, "onFeaturePick", "(Ljava/util/Map;FF)V");
@@ -104,8 +105,6 @@ void setupJniEnv(JNIEnv* jniEnv) {
     }
     sceneUpdateErrorClass = (jclass)jniEnv->NewGlobalRef(jniEnv->FindClass("com/mapzen/tangram/SceneUpdateError"));
     sceneUpdateErrorInitMID = jniEnv->GetMethodID(sceneUpdateErrorClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;I)V");
-    jclass sceneUpdateErrorListenerClass = jniEnv->FindClass("com/mapzen/tangram/MapController$SceneUpdateErrorListener");
-    onSceneUpdateErrorMID = jniEnv->GetMethodID(sceneUpdateErrorListenerClass, "onSceneUpdateError", "(Lcom/mapzen/tangram/SceneUpdateError;)V");
 
     if (hashmapClass) {
         jniEnv->DeleteGlobalRef(hashmapClass);
@@ -360,24 +359,6 @@ void setCurrentThreadPriority(int priority) {
     setpriority(PRIO_PROCESS, tid, priority);
 }
 
-void sceneUpdateErrorCallback(jobject updateCallbackRef, const SceneUpdateError& sceneUpdateError) {
-
-    if (!updateCallbackRef) {
-        return;
-    }
-
-    JniThreadBinding jniEnv(jvm);
-
-    jstring jUpdateStatusPath = jniEnv->NewStringUTF(sceneUpdateError.update.path.c_str());
-    jstring jUpdateStatusValue = jniEnv->NewStringUTF(sceneUpdateError.update.value.c_str());
-    jint jError = (jint)sceneUpdateError.error;
-    jobject jUpdateErrorStatus = jniEnv->NewObject(sceneUpdateErrorClass, sceneUpdateErrorInitMID,
-                                                   jUpdateStatusPath, jUpdateStatusValue, jError);
-
-    jniEnv->CallVoidMethod(updateCallbackRef, onSceneUpdateErrorMID, jUpdateErrorStatus);
-    jniEnv->DeleteGlobalRef(updateCallbackRef);
-}
-
 void labelPickCallback(jobject listener, const Tangram::LabelPickResult* labelPickResult) {
 
     JniThreadBinding jniEnv(jvm);
@@ -473,5 +454,44 @@ void initGLExtensions() {
 
     glExtensionsLoaded = true;
 }
+    
+void AndroidPlatform::sceneReadyCallback(bool success, const SceneError& sceneError) {
+
+    JniThreadBinding jniEnv(jvm);
+
+    jobject jUpdateErrorStatus = 0;
+
+    if (!success) {
+        jstring jUpdateStatusPath = jniEnv->NewStringUTF(sceneError.update.path.c_str());
+        jstring jUpdateStatusValue = jniEnv->NewStringUTF(sceneError.update.value.c_str());
+        jint jError = (jint) sceneError.error;
+        jobject jUpdateErrorStatus = jniEnv->NewObject(sceneUpdateErrorClass,
+                                                       sceneUpdateErrorInitMID,
+                                                       jUpdateStatusPath, jUpdateStatusValue,
+                                                       jError);
+    }
+
+    jniEnv->CallVoidMethod(m_tangramInstance, sceneReadyCallbackMID, success, jUpdateErrorStatus);
+}
+
+void loadScene(Map& map, const char* cPath, const std::vector<SceneUpdate>& updates) {
+
+    map.loadScene(resolveScenePath(cPath).c_str(), false,
+                   [&](bool success, const Tangram::SceneError& error){
+                       auto platform = static_cast<AndroidPlatform&>(*map.getPlatform());
+                       platform.sceneReadyCallback(success, error);
+                   },
+                   updates);
+}
+
+void applySceneUpdates(Map& map) {
+
+    map.applySceneUpdates(
+            [&](bool success, const Tangram::SceneError& error) {
+                auto platform = static_cast<AndroidPlatform&>(*map.getPlatform());
+                platform.sceneReadyCallback(success, error);
+            });
+}
+
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -474,24 +474,4 @@ void AndroidPlatform::sceneReadyCallback(bool success, const SceneError& sceneEr
     jniEnv->CallVoidMethod(m_tangramInstance, sceneReadyCallbackMID, success, jUpdateErrorStatus);
 }
 
-void loadScene(Map& map, const char* cPath, const std::vector<SceneUpdate>& updates) {
-
-    map.loadScene(resolveScenePath(cPath).c_str(), false,
-                   [&](bool success, const Tangram::SceneError& error){
-                       auto platform = static_cast<AndroidPlatform&>(*map.getPlatform());
-                       platform.sceneReadyCallback(success, error);
-                   },
-                   updates);
-}
-
-void applySceneUpdates(Map& map) {
-
-    map.applySceneUpdates(
-            [&](bool success, const Tangram::SceneError& error) {
-                auto platform = static_cast<AndroidPlatform&>(*map.getPlatform());
-                platform.sceneReadyCallback(success, error);
-            });
-}
-
-
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -81,7 +81,7 @@ void setupJniEnv(JNIEnv* jniEnv) {
     getFontFallbackFilePath = jniEnv->GetMethodID(tangramClass, "getFontFallbackFilePath", "(II)Ljava/lang/String;");
     requestRenderMethodID = jniEnv->GetMethodID(tangramClass, "requestRender", "()V");
     setRenderModeMethodID = jniEnv->GetMethodID(tangramClass, "setRenderMode", "(I)V");
-    sceneReadyCallbackMID = jniEnv->GetMethodID(tangramClass, "sceneReadyCallback", "(ZLcom/mapzen/tangram/SceneUpdateError;)V");
+    sceneReadyCallbackMID = jniEnv->GetMethodID(tangramClass, "sceneReadyCallback", "(IZLcom/mapzen/tangram/SceneUpdateError;)V");
 
     jclass featurePickListenerClass = jniEnv->FindClass("com/mapzen/tangram/MapController$FeaturePickListener");
     onFeaturePickMID = jniEnv->GetMethodID(featurePickListenerClass, "onFeaturePick", "(Ljava/util/Map;FF)V");
@@ -455,7 +455,7 @@ void initGLExtensions() {
     glExtensionsLoaded = true;
 }
     
-void AndroidPlatform::sceneReadyCallback(bool success, const SceneError& sceneError) {
+void AndroidPlatform::sceneReadyCallback(SceneID id, bool success, const SceneError& sceneError) {
 
     JniThreadBinding jniEnv(jvm);
 
@@ -471,7 +471,7 @@ void AndroidPlatform::sceneReadyCallback(bool success, const SceneError& sceneEr
                                                        jError);
     }
 
-    jniEnv->CallVoidMethod(m_tangramInstance, sceneReadyCallbackMID, success, jUpdateErrorStatus);
+    jniEnv->CallVoidMethod(m_tangramInstance, sceneReadyCallbackMID, id, success, jUpdateErrorStatus);
 }
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -11,7 +11,7 @@ void setupJniEnv(JNIEnv* _jniEnv);
 void onUrlSuccess(JNIEnv* jniEnv, jbyteArray jFetchedBytes, jlong jCallbackPtr);
 void onUrlFailure(JNIEnv* jniEnv, jlong jCallbackPtr);
 
-std::string resolveScenePath(const char* path);
+//std::string resolveScenePath(const char* path);
 
 std::string stringFromJString(JNIEnv* jniEnv, jstring string);
 
@@ -20,12 +20,16 @@ namespace Tangram {
 struct LabelPickResult;
 struct FeaturePickResult;
 struct MarkerPickResult;
-struct SceneUpdateError;
+class Map;
+struct SceneUpdate;
+struct SceneError;
 
 void featurePickCallback(jobject listener, const Tangram::FeaturePickResult* featurePickResult);
 void markerPickCallback(jobject listener, jobject tangramInstance, const Tangram::MarkerPickResult* markerPickResult);
 void labelPickCallback(jobject listener, const Tangram::LabelPickResult* labelPickResult);
-void sceneUpdateErrorCallback(jobject updateStatusCallbackRef, const SceneUpdateError& sceneUpdateErrorStatus);
+
+void loadScene(Map& map, const char* cPath, const std::vector<SceneUpdate>& updates);
+void applySceneUpdates(Map& map);
 
 class AndroidPlatform : public Platform {
 
@@ -41,6 +45,7 @@ public:
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     bool startUrlRequest(const std::string& _url, UrlCallback _callback) override;
     void cancelUrlRequest(const std::string& _url) override;
+    void sceneReadyCallback(bool success, const SceneError& error);
 
 private:
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -11,9 +11,8 @@ void setupJniEnv(JNIEnv* _jniEnv);
 void onUrlSuccess(JNIEnv* jniEnv, jbyteArray jFetchedBytes, jlong jCallbackPtr);
 void onUrlFailure(JNIEnv* jniEnv, jlong jCallbackPtr);
 
-//std::string resolveScenePath(const char* path);
-
 std::string stringFromJString(JNIEnv* jniEnv, jstring string);
+std::string resolveScenePath(const char* path);
 
 namespace Tangram {
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -22,6 +22,7 @@ struct MarkerPickResult;
 class Map;
 struct SceneUpdate;
 struct SceneError;
+using SceneID = int32_t;
 
 void featurePickCallback(jobject listener, const Tangram::FeaturePickResult* featurePickResult);
 void markerPickCallback(jobject listener, jobject tangramInstance, const Tangram::MarkerPickResult* markerPickResult);
@@ -44,7 +45,7 @@ public:
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     bool startUrlRequest(const std::string& _url, UrlCallback _callback) override;
     void cancelUrlRequest(const std::string& _url) override;
-    void sceneReadyCallback(bool success, const SceneError& error);
+    void sceneReadyCallback(SceneID id, bool success, const SceneError& error);
 
 private:
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -28,8 +28,6 @@ void featurePickCallback(jobject listener, const Tangram::FeaturePickResult* fea
 void markerPickCallback(jobject listener, jobject tangramInstance, const Tangram::MarkerPickResult* markerPickResult);
 void labelPickCallback(jobject listener, const Tangram::LabelPickResult* labelPickResult);
 
-void loadScene(Map& map, const char* cPath, const std::vector<SceneUpdate>& updates);
-void applySceneUpdates(Map& map);
 
 class AndroidPlatform : public Platform {
 
@@ -45,7 +43,7 @@ public:
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     bool startUrlRequest(const std::string& _url, UrlCallback _callback) override;
     void cancelUrlRequest(const std::string& _url) override;
-    void sceneReadyCallback(SceneID id, bool success, const SceneError& error);
+    void sceneReadyCallback(SceneID id, const SceneError* error);
 
 private:
 

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -116,7 +116,7 @@ extern "C" {
         static_cast<Tangram::AndroidPlatform&>(*platform).dispose(jniEnv);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jobject updateErrorCallback, jstring path, jobjectArray updateStrings) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path, jobjectArray updateStrings) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         const char* cPath = jniEnv->GetStringUTFChars(path, NULL);
@@ -131,10 +131,8 @@ extern "C" {
             jniEnv->DeleteLocalRef(value);
         }
 
-        auto updateErrorCallbackRef = jniEnv->NewGlobalRef(updateErrorCallback);
-        map->loadScene(resolveScenePath(cPath).c_str(), false, sceneUpdates, [updateErrorCallbackRef](auto sceneUpdateErrorStatus) {
-            Tangram::sceneUpdateErrorCallback(updateErrorCallbackRef, sceneUpdateErrorStatus);
-        });
+        Tangram::loadScene(*map, cPath, sceneUpdates);
+
         jniEnv->ReleaseStringUTFChars(path, cPath);
     }
 
@@ -521,13 +519,11 @@ extern "C" {
         map->queueSceneUpdate(sceneUpdates);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeApplySceneUpdates(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jobject updateErrorCallback) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeApplySceneUpdates(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto updateErrorCallbackRef = jniEnv->NewGlobalRef(updateErrorCallback);
-        map->applySceneUpdates([updateErrorCallbackRef](auto sceneUpdateErrorStatus) {
-            Tangram::sceneUpdateErrorCallback(updateErrorCallbackRef, sceneUpdateErrorStatus);
-        });
+
+        Tangram::applySceneUpdates(*map);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeOnLowMemory(JNIEnv* jnienv, jobject obj, jlong mapPtr) {

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -137,7 +137,7 @@ extern "C" {
             jniEnv->DeleteLocalRef(value);
         }
 
-        jint sceneId = map->loadScene(resolveScenePath(cPath).c_str(), false, sceneUpdates);
+        jint sceneId = map->loadSceneAsync(resolveScenePath(cPath).c_str(), false, sceneUpdates);
 
         jniEnv->ReleaseStringUTFChars(path, cPath);
 

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -498,18 +498,9 @@ extern "C" {
         jniEnv->ReleaseIntArrayElements(buffer, ptr, JNI_ABORT);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeQueueSceneUpdate(JNIEnv* jnienv, jobject obj, jlong mapPtr, jstring path, jstring value) {
+    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeUpdateScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jobjectArray updateStrings) {
         assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        const char* cPath = jnienv->GetStringUTFChars(path, NULL);
-        const char* cValue = jnienv->GetStringUTFChars(value, NULL);
-        map->queueSceneUpdate(cPath, cValue);
-        jnienv->ReleaseStringUTFChars(path, cPath);
-        jnienv->ReleaseStringUTFChars(value, cValue);
-    }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeQueueSceneUpdates(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jobjectArray updateStrings) {
-        assert(mapPtr > 0);
         size_t nUpdateStrings = (updateStrings == NULL)? 0 : jniEnv->GetArrayLength(updateStrings);
 
         std::vector<Tangram::SceneUpdate> sceneUpdates;
@@ -521,17 +512,12 @@ extern "C" {
             jniEnv->DeleteLocalRef(value);
         }
 
-        if (sceneUpdates.empty()) { return; }
+        // Already checked on the java side
+        if (sceneUpdates.empty()) { return -1; }
 
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        map->queueSceneUpdate(sceneUpdates);
-    }
 
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeApplySceneUpdates(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-
-        return map->applySceneUpdates();
+        return map->updateSceneAsync(sceneUpdates);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeOnLowMemory(JNIEnv* jnienv, jobject obj, jlong mapPtr) {

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -104,8 +104,8 @@ extern "C" {
         auto platform = std::make_shared<Tangram::AndroidPlatform>(jniEnv, assetManager, tangramInstance);
         auto map = new Tangram::Map(platform);
 
-        map->setSceneReadyListener([platform](Tangram::SceneID id, bool success, const Tangram::SceneError& error) {
-                platform->sceneReadyCallback(id, success, error);
+        map->setSceneReadyListener([platform](Tangram::SceneID id, const Tangram::SceneError* error) {
+                platform->sceneReadyCallback(id, error);
             });
         return reinterpret_cast<jlong>(map);
     }

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -512,9 +512,6 @@ extern "C" {
             jniEnv->DeleteLocalRef(value);
         }
 
-        // Already checked on the java side
-        if (sceneUpdates.empty()) { return -1; }
-
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
 
         return map->updateSceneAsync(sceneUpdates);

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -137,6 +137,28 @@ extern "C" {
             jniEnv->DeleteLocalRef(value);
         }
 
+        jint sceneId = map->loadScene(resolveScenePath(cPath).c_str(), false, sceneUpdates);
+
+        jniEnv->ReleaseStringUTFChars(path, cPath);
+
+        return sceneId;
+    }
+
+    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeLoadSceneAsync(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path, jobjectArray updateStrings) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        const char* cPath = jniEnv->GetStringUTFChars(path, NULL);
+        size_t nUpdateStrings = (updateStrings == NULL) ? 0 : jniEnv->GetArrayLength(updateStrings);
+
+        std::vector<Tangram::SceneUpdate> sceneUpdates;
+        for (size_t i = 0; i < nUpdateStrings;) {
+            jstring path = (jstring) (jniEnv->GetObjectArrayElement(updateStrings, i++));
+            jstring value = (jstring) (jniEnv->GetObjectArrayElement(updateStrings, i++));
+            sceneUpdates.emplace_back(stringFromJString(jniEnv, path), stringFromJString(jniEnv, value));
+            jniEnv->DeleteLocalRef(path);
+            jniEnv->DeleteLocalRef(value);
+        }
+
         jint sceneId = map->loadSceneAsync(resolveScenePath(cPath).c_str(), false, sceneUpdates);
 
         jniEnv->ReleaseStringUTFChars(path, cPath);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -130,21 +130,6 @@ public class MapController implements Renderer {
     }
 
     /**
-     * @deprecated
-     * Interface for a callback to received additional error information in a {@link SceneUpdateError}
-     * Triggered after a call of {@link #applySceneUpdates()} or {@link #loadSceneFile(String, List<SceneUpdate>)}
-     * Listener should be set with {@link #setSceneUpdateErrorListener(SceneUpdateErrorListener)}
-     * The callback will be run on the main (UI) thread.
-     */
-    public interface SceneUpdateErrorListener {
-        /**
-         * Receive error status when a scene update failed
-         * @param sceneUpdateError The  {@link SceneUpdateError} holding error informations
-         */
-        void onSceneUpdateError(SceneUpdateError sceneUpdateError);
-    }
-
-    /**
      * Interface for listening to scene load status information.
      * Triggered after a call of {@link #applySceneUpdates()} or {@link #loadSceneFile(String, List<SceneUpdate>)}
      * Listener should be set with {@link #setSceneLoadListener(SceneLoadListener)}
@@ -790,29 +775,6 @@ public class MapController implements Renderer {
     }
 
     /**
-     * @deprecated use setSceneLoadListener instead
-     * Set a listener for scene update error statuses
-     * @param listener The {@link SceneUpdateErrorListener} to call after scene update have failed
-     */
-    public void setSceneUpdateErrorListener(final SceneUpdateErrorListener listener) {
-        if (listener == null) {
-            sceneUpdateErrorListener = null;
-        } else {
-            sceneUpdateErrorListener = new SceneUpdateErrorListener() {
-                @Override
-                public void onSceneUpdateError(final SceneUpdateError sceneUpdateError) {
-                    uiThreadHandler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            listener.onSceneUpdateError(sceneUpdateError);
-                        }
-                    });
-                }
-            };
-        }
-    }
-
-    /**
      * Set a listener for label pick events
      * @param listener The {@link LabelPickListener} to call
      */
@@ -1246,7 +1208,6 @@ public class MapController implements Renderer {
     private HttpHandler httpHandler;
     private FeaturePickListener featurePickListener;
     private SceneLoadListener sceneLoadListener;
-    private SceneUpdateErrorListener sceneUpdateErrorListener;
     private LabelPickListener labelPickListener;
     private MarkerPickListener markerPickListener;
     private ViewCompleteListener viewCompleteListener;
@@ -1343,10 +1304,6 @@ public class MapController implements Renderer {
 
     // Called from JNI on worker or render-thread.
     void sceneReadyCallback(final int sceneId, final boolean success, final SceneUpdateError error) {
-        if (!success && sceneUpdateErrorListener != null) {
-            // TODO run on main thread
-            sceneUpdateErrorListener.onSceneUpdateError(error);
-        }
 
         final SceneLoadListener cb = sceneLoadListener;
         if (cb != null) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -272,9 +272,6 @@ public class MapController implements Renderer {
         });
     }
 
-    static MapController getInstance(GLSurfaceView view) {
-        return new MapController(view);
-    }
 
     /**
      * Load a new scene file.

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -762,21 +762,17 @@ public class MapController implements Renderer {
      * @param listener The {@link FeaturePickListener} to call
      */
     public void setFeaturePickListener(final FeaturePickListener listener) {
-        if (listener == null) {
-            featurePickListener = null;
-        } else {
-            featurePickListener = new FeaturePickListener() {
-                @Override
-                public void onFeaturePick(final Map<String, String> properties, final float positionX, final float positionY) {
-                    uiThreadHandler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            listener.onFeaturePick(properties, positionX, positionY);
-                        }
-                    });
-                }
-            };
-        }
+        featurePickListener = (listener == null) ? null : new FeaturePickListener() {
+            @Override
+            public void onFeaturePick(final Map<String, String> properties, final float positionX, final float positionY) {
+                uiThreadHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        listener.onFeaturePick(properties, positionX, positionY);
+                    }
+                });
+            }
+        };
     }
 
     /**
@@ -792,21 +788,17 @@ public class MapController implements Renderer {
      * @param listener The {@link LabelPickListener} to call
      */
     public void setLabelPickListener(final LabelPickListener listener) {
-        if (listener == null) {
-            labelPickListener = null;
-        } else {
-            labelPickListener = new LabelPickListener() {
-                @Override
-                public void onLabelPick(final LabelPickResult labelPickResult, final float positionX, final float positionY) {
-                    uiThreadHandler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            listener.onLabelPick(labelPickResult, positionX, positionY);
-                        }
-                    });
-                }
-            };
-        }
+        labelPickListener = (listener == null) ? null : new LabelPickListener() {
+            @Override
+            public void onLabelPick(final LabelPickResult labelPickResult, final float positionX, final float positionY) {
+                uiThreadHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        listener.onLabelPick(labelPickResult, positionX, positionY);
+                    }
+                });
+            }
+        };
     }
 
     /**
@@ -814,21 +806,17 @@ public class MapController implements Renderer {
      * @param listener The {@link MarkerPickListener} to call
      */
     public void setMarkerPickListener(final MarkerPickListener listener) {
-        if (listener == null) {
-            markerPickListener = null;
-        } else {
-            markerPickListener = new MarkerPickListener() {
-                @Override
-                public void onMarkerPick(final MarkerPickResult markerPickResult, final float positionX, final float positionY) {
-                    uiThreadHandler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            listener.onMarkerPick(markerPickResult, positionX, positionY);
-                        }
-                    });
-                }
-            };
-        }
+        markerPickListener = (listener == null) ? null : new MarkerPickListener() {
+            @Override
+            public void onMarkerPick(final MarkerPickResult markerPickResult, final float positionX, final float positionY) {
+                uiThreadHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        listener.onMarkerPick(markerPickResult, positionX, positionY);
+                    }
+                });
+            }
+        };
     }
 
     /**
@@ -917,11 +905,7 @@ public class MapController implements Renderer {
      * @param listener The {@link ViewCompleteListener} to call when the view is complete
      */
     public void setViewCompleteListener(final ViewCompleteListener listener) {
-        if (listener == null) {
-            viewCompleteListener = null;
-            return;
-        }
-        viewCompleteListener = new ViewCompleteListener() {
+        viewCompleteListener = (listener == null) ? null : new ViewCompleteListener() {
             @Override
             public void onViewComplete() {
                 uiThreadHandler.post(new Runnable() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -55,6 +55,7 @@ public class MapController implements Renderer {
         SCENE_UPDATE_PATH_NOT_FOUND,
         SCENE_UPDATE_PATH_YAML_SYNTAX_ERROR,
         SCENE_UPDATE_VALUE_YAML_SYNTAX_ERROR,
+        NO_VALID_SCENE,
     }
 
     protected static EaseType DEFAULT_EASE_TYPE = EaseType.CUBIC;
@@ -137,17 +138,11 @@ public class MapController implements Renderer {
      */
     public interface SceneLoadListener {
         /**
-         * Received when a scene load succeeded.
+         * Received when a scene load finished. The scene load or update failed when sceneError is not null.
          * @param sceneId returned by {@link #updateScene(List<SceneUpdate>)} or {@link #loadSceneFile(String, List<SceneUpdate>)}
+         * @param sceneError The {@link SceneError} holding error information
          */
-        void onSceneReady(int sceneId);
-
-        /**
-         * Receive error status when a scene load failed
-         * @param sceneId returned by {@link #updateScene(List<SceneUpdate>)} or {@link #loadSceneFile(String, List<SceneUpdate>)}
-         * @param sceneUpdateError The  {@link SceneUpdateError} holding error informations
-         */
-        void onSceneError(int sceneId, SceneUpdateError sceneUpdateError);
+        void onSceneReady(int sceneId, SceneError sceneError);
     }
 
     /**
@@ -1279,18 +1274,14 @@ public class MapController implements Renderer {
     }
 
     // Called from JNI on worker or render-thread.
-    void sceneReadyCallback(final int sceneId, final boolean success, final SceneUpdateError error) {
+    void sceneReadyCallback(final int sceneId, final SceneError error) {
 
         final SceneLoadListener cb = sceneLoadListener;
         if (cb != null) {
             uiThreadHandler.post(new Runnable() {
                 @Override
                 public void run() {
-                    if (success) {
-                        cb.onSceneReady(sceneId);
-                    } else {
-                        cb.onSceneError(sceneId, error);
-                    }
+                    cb.onSceneReady(sceneId, error);
                 }
             });
         }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -18,93 +18,35 @@ public class MapView extends FrameLayout {
 
     protected GLSurfaceView glSurfaceView;
     protected MapController mapController;
-    protected AsyncTask<Void, Void, Boolean> getMapTask;
 
     public MapView(Context context) {
-
         super(context);
-
         configureGLSurfaceView();
-
     }
 
     public MapView(Context context, AttributeSet attrs) {
-
         super(context, attrs);
-
         configureGLSurfaceView();
-
     }
 
     /**
-     * Interface for receiving a {@code MapController} once it is ready to be used
-     */
-    public interface OnMapReadyCallback {
-
-        /**
-         * Called when the map is ready to be used
-         * @param mapController A non-null {@code MapController} instance for this {@code MapView}
-         */
-        void onMapReady(MapController mapController);
-
-    }
-
-    /**
-     * Construct a {@code MapController} asynchronously; may only be called from the UI thread
-     * @param callback The object to receive the resulting MapController in a callback;
+     * Construct a {@code MapController}; may only be called from the UI thread
+     * @param listener The listener to receive to receive scene load events;
      * the callback will be made on the UI thread
-     * @param sceneFilePath Location of the YAML scene file within the asset bundle
      */
-    public void getMapAsync(@NonNull final OnMapReadyCallback callback,
-                            @NonNull final String sceneFilePath) {
+    public MapController getMap(MapController.SceneLoadListener listener) {
+        if (mapController != null) {
+            return mapController;
+        }
+        mapController = getMapInstance();
+        mapController.setSceneLoadListener(listener);
+        mapController.init();
 
-        getMapAsync(callback, sceneFilePath, null);
-    }
-
-    /**
-     * Construct a {@code MapController} asynchronously; may only be called from the UI thread
-     * @param callback The object to receive the resulting MapController in a callback;
-     * the callback will be made on the UI thread
-     * @param sceneFilePath Location of the YAML scene file within the asset bundle
-     * @param sceneUpdates List of SceneUpdate to be applied when loading this scene
-     */
-    public void getMapAsync(@NonNull final OnMapReadyCallback callback,
-                            @NonNull final String sceneFilePath,
-                            final List<SceneUpdate> sceneUpdates) {
-
-        disposeTask();
-
-        final MapController mapInstance = getMapInstance();
-
-        getMapTask = new AsyncTask<Void, Void, Boolean>() {
-
-            @Override
-            @SuppressWarnings("WrongThread")
-            protected Boolean doInBackground(Void... params) {
-                mapInstance.init();
-                mapInstance.loadSceneFile(sceneFilePath, sceneUpdates);
-                return true;
-            }
-
-            @Override
-            protected void onPostExecute(Boolean ok) {
-                addView(glSurfaceView);
-                disposeMap();
-                mapController = mapInstance;
-                callback.onMapReady(mapController);
-            }
-
-            @Override
-            protected void onCancelled(Boolean ok) {
-                mapInstance.dispose();
-            }
-
-        }.execute();
-
+        return mapController;
     }
 
     protected MapController getMapInstance() {
-        return MapController.getInstance(glSurfaceView);
+        return new MapController(glSurfaceView);
     }
 
     protected void configureGLSurfaceView() {
@@ -113,17 +55,7 @@ public class MapView extends FrameLayout {
         glSurfaceView.setEGLContextClientVersion(2);
         glSurfaceView.setPreserveEGLContextOnPause(true);
         glSurfaceView.setEGLConfigChooser(new ConfigChooser(8, 8, 8, 0, 16, 0));
-
-    }
-
-    protected void disposeTask() {
-
-        if (getMapTask != null) {
-            // MapController is being initialized, so we'll dispose it in the onCancelled callback.
-            getMapTask.cancel(true);
-        }
-        getMapTask = null;
-
+        addView(glSurfaceView);
     }
 
     protected void disposeMap() {
@@ -162,7 +94,6 @@ public class MapView extends FrameLayout {
      */
     public void onDestroy() {
 
-        disposeTask();
         disposeMap();
 
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/SceneError.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/SceneError.java
@@ -3,16 +3,16 @@ package com.mapzen.tangram;
 import com.mapzen.tangram.MapController.Error;
 
 /**
- * {@code SceneUpdateError} Holds an error status and its associated scene updated
+ * {@code SceneError} Holds an error status and its associated scene updated
  */
 
-public class SceneUpdateError {
+public class SceneError {
 
 
     private SceneUpdate sceneUpdate;
     private Error error;
 
-    private SceneUpdateError(String sceneUpdatePath, String sceneUpdateValue, int error) {
+    private SceneError(String sceneUpdatePath, String sceneUpdateValue, int error) {
         this.sceneUpdate = new SceneUpdate(sceneUpdatePath, sceneUpdateValue);
         this.error = Error.values()[error];
     }

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -56,9 +56,9 @@ bool keepRunning = true;
 
 void loadSceneFile() {
     if (mapzenApiKey.empty()) {
-        map->loadSceneAsync(sceneFile.c_str(), true, nullptr, {});
+        map->loadSceneAsync(sceneFile.c_str(), true, {});
     } else {
-        map->loadSceneAsync(sceneFile.c_str(), true, nullptr,
+        map->loadSceneAsync(sceneFile.c_str(), true,
                             {SceneUpdate("global.sdk_mapzen_api_key", mapzenApiKey)});
     }
 }

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -56,9 +56,9 @@ bool keepRunning = true;
 
 void loadSceneFile() {
     if (mapzenApiKey.empty()) {
-        map->loadSceneAsync(sceneFile.c_str(), true, {}, nullptr, {});
+        map->loadSceneAsync(sceneFile.c_str(), true, nullptr, {});
     } else {
-        map->loadSceneAsync(sceneFile.c_str(), true, {}, nullptr,
+        map->loadSceneAsync(sceneFile.c_str(), true, nullptr,
                             {SceneUpdate("global.sdk_mapzen_api_key", mapzenApiKey)});
     }
 }

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -378,24 +378,25 @@ void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods
                 map->setPixelScale(pixel_scale);
                 break;
             case GLFW_KEY_P:
-                map->queueSceneUpdate("cameras", "{ main_camera: { type: perspective } }");
-                map->applySceneUpdates();
+                map->updateSceneAsync({SceneUpdate{"cameras", "{ main_camera: { type: perspective } }"}});
                 break;
             case GLFW_KEY_I:
-                map->queueSceneUpdate("cameras", "{ main_camera: { type: isometric } }");
-                map->applySceneUpdates();
+                map->updateSceneAsync({SceneUpdate{"cameras", "{ main_camera: { type: isometric } }"}});
                 break;
             case GLFW_KEY_G:
                 static bool geoJSON = false;
                 if (!geoJSON) {
-                    map->queueSceneUpdate("sources.osm.type", "GeoJSON");
-                    map->queueSceneUpdate("sources.osm.url", "https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json");
+                    map->updateSceneAsync({
+                            SceneUpdate{"sources.osm.type", "GeoJSON"},
+                            SceneUpdate{"sources.osm.url", "https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json"}
+                        });
                 } else {
-                    map->queueSceneUpdate("sources.osm.type", "MVT");
-                    map->queueSceneUpdate("sources.osm.url", "https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.mvt");
+                    map->updateSceneAsync({
+                            SceneUpdate{"sources.osm.type", "MVT"},
+                            SceneUpdate{"sources.osm.url", "https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.mvt"}
+                        });
                 }
                 geoJSON = !geoJSON;
-                map->applySceneUpdates();
                 break;
             case GLFW_KEY_ESCAPE:
                 glfwSetWindowShouldClose(window, true);

--- a/platforms/ios/demo/src/MapViewController.h
+++ b/platforms/ios/demo/src/MapViewController.h
@@ -10,7 +10,7 @@
 
 @interface MapViewControllerDelegate : NSObject <TGMapViewDelegate>
 
-- (void)mapView:(TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nonnull NSError *)sceneError;
+- (void)mapView:(TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nullable NSError *)sceneError;
 - (void)mapViewDidCompleteLoading:(TGMapViewController *)mapView;
 - (void)mapView:(TGMapViewController *)mapView didSelectFeature:(NSDictionary *)feature atScreenPosition:(CGPoint)position;
 - (void)mapView:(TGMapViewController *)mapView didSelectLabel:(TGLabelPickResult *)labelPickResult atScreenPosition:(CGPoint)position;

--- a/platforms/ios/demo/src/MapViewController.h
+++ b/platforms/ios/demo/src/MapViewController.h
@@ -10,7 +10,7 @@
 
 @interface MapViewControllerDelegate : NSObject <TGMapViewDelegate>
 
-- (void)mapView:(TGMapViewController *)mapView didSceneReady:(int)sceneID WithError:(nonnull NSError *)sceneError;
+- (void)mapView:(TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nonnull NSError *)sceneError;
 - (void)mapViewDidCompleteLoading:(TGMapViewController *)mapView;
 - (void)mapView:(TGMapViewController *)mapView didSelectFeature:(NSDictionary *)feature atScreenPosition:(CGPoint)position;
 - (void)mapView:(TGMapViewController *)mapView didSelectLabel:(TGLabelPickResult *)labelPickResult atScreenPosition:(CGPoint)position;

--- a/platforms/ios/demo/src/MapViewController.h
+++ b/platforms/ios/demo/src/MapViewController.h
@@ -10,13 +10,12 @@
 
 @interface MapViewControllerDelegate : NSObject <TGMapViewDelegate>
 
-- (void)mapView:(TGMapViewController *)mapView didLoadSceneAsync:(NSString *)scene;
+- (void)mapView:(TGMapViewController *)mapView didSceneReady:(int)sceneID WithError:(nonnull NSError *)sceneError;
 - (void)mapViewDidCompleteLoading:(TGMapViewController *)mapView;
 - (void)mapView:(TGMapViewController *)mapView didSelectFeature:(NSDictionary *)feature atScreenPosition:(CGPoint)position;
 - (void)mapView:(TGMapViewController *)mapView didSelectLabel:(TGLabelPickResult *)labelPickResult atScreenPosition:(CGPoint)position;
 - (void)mapView:(TGMapViewController *)mapView didSelectMarker:(TGMarkerPickResult *)markerPickResult atScreenPosition:(TGGeoPoint)position;
 - (void)mapView:(TGMapViewController *)view didCaptureScreenshot:(UIImage *)screenshot;
-- (void)mapView:(TGMapViewController *)mapView didFailSceneUpdateWithError:(NSError *)sceneUpdateError;
 
 @end
 

--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -34,10 +34,8 @@
     // [mapView captureScreenshot:YES];
 }
 
-- (void)mapView:(TGMapViewController *)mapView didLoadSceneAsync:(NSString *)scene
+- (void)mapViewDidSceneLoad:(TGMapViewController *)mapView
 {
-    NSLog(@"Did load scene async %@", scene);
-
     TGGeoPoint newYork;
     newYork.longitude = -74.00976419448854;
     newYork.latitude = 40.70532700869127;
@@ -52,6 +50,11 @@
     // Add a client data source, named 'mz_route_line_transit'
     MapViewController* vc = (MapViewController *)mapView;
     vc.mapData = [mapView addDataLayer:@"mz_route_line_transit"];
+}
+
+- (void)mapView:(TGMapViewController *)mapView didLoadSceneAsync:(NSString *)scene
+{
+    // Deprecate!!
 }
 
 - (void)mapView:(TGMapViewController *)mapView didSelectMarker:(TGMarkerPickResult *)markerPickResult atScreenPosition:(TGGeoPoint)position;

--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -23,19 +23,20 @@
     NSLog(@"Did capture screenshot");
 }
 
-- (void)mapView:(TGMapViewController *)mapView didFailSceneUpdateWithError:(NSError *)sceneUpdateError;
-{
-    NSLog(@"Scene update error for update with error %@", sceneUpdateError);
-}
-
 - (void)mapViewDidCompleteLoading:(TGMapViewController *)mapView
 {
     NSLog(@"Did complete view");
     // [mapView captureScreenshot:YES];
 }
 
-- (void)mapViewDidSceneLoad:(TGMapViewController *)mapView
+- (void)mapView:(TGMapViewController *)mapView didSceneReady:(int)sceneID Success:(bool)success WithError:(nonnull NSError *)sceneError
 {
+    if (!success) { return; }
+    if (!sceneError) {
+        NSLog(@"Scene Ready with error %@", sceneError);
+        return;
+    }
+
     TGGeoPoint newYork;
     newYork.longitude = -74.00976419448854;
     newYork.latitude = 40.70532700869127;
@@ -50,11 +51,6 @@
     // Add a client data source, named 'mz_route_line_transit'
     MapViewController* vc = (MapViewController *)mapView;
     vc.mapData = [mapView addDataLayer:@"mz_route_line_transit"];
-}
-
-- (void)mapView:(TGMapViewController *)mapView didLoadSceneAsync:(NSString *)scene
-{
-    // Deprecate!!
 }
 
 - (void)mapView:(TGMapViewController *)mapView didSelectMarker:(TGMarkerPickResult *)markerPickResult atScreenPosition:(TGGeoPoint)position;

--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -29,7 +29,7 @@
     // [mapView captureScreenshot:YES];
 }
 
-- (void)mapView:(TGMapViewController *)mapView didSceneReady:(int)sceneID WithError:(nonnull NSError *)sceneError
+- (void)mapView:(TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nonnull NSError *)sceneError
 {
     if (sceneError) {
         NSLog(@"Scene Ready with error %@", sceneError);

--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -29,10 +29,9 @@
     // [mapView captureScreenshot:YES];
 }
 
-- (void)mapView:(TGMapViewController *)mapView didSceneReady:(int)sceneID Success:(bool)success WithError:(nonnull NSError *)sceneError
+- (void)mapView:(TGMapViewController *)mapView didSceneReady:(int)sceneID WithError:(nonnull NSError *)sceneError
 {
-    if (!success) { return; }
-    if (!sceneError) {
+    if (sceneError) {
         NSLog(@"Scene Ready with error %@", sceneError);
         return;
     }

--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -29,7 +29,7 @@
     // [mapView captureScreenshot:YES];
 }
 
-- (void)mapView:(TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nonnull NSError *)sceneError
+- (void)mapView:(TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nullable NSError *)sceneError
 {
     if (sceneError) {
         NSLog(@"Scene Ready with error %@", sceneError);

--- a/platforms/ios/src/TangramMap/TGHelpers.h
+++ b/platforms/ios/src/TangramMap/TGHelpers.h
@@ -12,8 +12,8 @@
 @interface TGHelpers : NSObject
 
 + (Tangram::EaseType)convertEaseTypeFrom:(TGEaseType)ease;
-+ (TGError)convertSceneUpdateErrorTypeFrom:(Tangram::Error)error;
-+ (NSError *)errorFromSceneUpdateError:(Tangram::SceneUpdateError)updateError;
++ (TGError)convertTGErrorTypeFrom:(Tangram::Error)error;
++ (NSError *)errorFromSceneError:(Tangram::SceneError)updateError;
 
 @end
 

--- a/platforms/ios/src/TangramMap/TGHelpers.mm
+++ b/platforms/ios/src/TangramMap/TGHelpers.mm
@@ -36,10 +36,12 @@
             return TGErrorSceneUpdatePathNotFound;
         case Tangram::Error::scene_update_value_yaml_syntax_error:
             return TGErrorSceneUpdateValueYAMLSyntaxError;
+        case Tangram::Error::none:
+            return TGErrorNone;
     }
 }
 
-+ (NSError *)errorFromSceneUpdateError:(Tangram::SceneUpdateError)updateError
++ (NSError *)errorFromSceneError:(Tangram::SceneError)updateError
 {
     NSString* path = [NSString stringWithUTF8String:updateError.update.path.c_str()];
     NSString* value = [NSString stringWithUTF8String:updateError.update.value.c_str()];

--- a/platforms/ios/src/TangramMap/TGHelpers.mm
+++ b/platforms/ios/src/TangramMap/TGHelpers.mm
@@ -49,8 +49,13 @@
     NSString* value = [NSString stringWithUTF8String:updateError.update.value.c_str()];
     TGSceneUpdate* udpate = [[TGSceneUpdate alloc] initWithPath:path value:value];
 
-    NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] init];
-    [userInfo setObject:udpate forKey:@"TGUpdate"];
+    NSDictionary *userInfo = @{
+        NSLocalizedDescriptionKey: NSLocalizedString(@"An error occured during Scene Update.", nil),
+        NSLocalizedFailureReasonErrorKey: NSLocalizedString(
+            @"Possible bad yaml reference in the SceneUpdate object or within the scene", nil),
+        NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(
+            @"Try checking SceneUpdate path and value parameters, and making sure they conform to be valid yaml objects", nil),
+    };
 
     NSError* error = [NSError errorWithDomain:TGErrorDomain
                                          code:(NSInteger)updateError.error

--- a/platforms/ios/src/TangramMap/TGHelpers.mm
+++ b/platforms/ios/src/TangramMap/TGHelpers.mm
@@ -36,6 +36,8 @@
             return TGErrorSceneUpdatePathNotFound;
         case Tangram::Error::scene_update_value_yaml_syntax_error:
             return TGErrorSceneUpdateValueYAMLSyntaxError;
+        case Tangram::Error::no_valid_scene:
+            return TGErrorNoValidScene;
         case Tangram::Error::none:
             return TGErrorNone;
     }

--- a/platforms/ios/src/TangramMap/TGHelpers.mm
+++ b/platforms/ios/src/TangramMap/TGHelpers.mm
@@ -47,10 +47,11 @@
 {
     NSString* path = [NSString stringWithUTF8String:updateError.update.path.c_str()];
     NSString* value = [NSString stringWithUTF8String:updateError.update.value.c_str()];
-    TGSceneUpdate* udpate = [[TGSceneUpdate alloc] initWithPath:path value:value];
+    TGSceneUpdate* update = [[TGSceneUpdate alloc] initWithPath:path value:value];
 
     NSDictionary *userInfo = @{
-        NSLocalizedDescriptionKey: NSLocalizedString(@"An error occured during Scene Update.", nil),
+        NSLocalizedDescriptionKey: NSLocalizedString((
+            [NSString stringWithFormat:@"An error occured during Scene Update -> (%@: %@)", update.path, update.value]), nil),
         NSLocalizedFailureReasonErrorKey: NSLocalizedString(
             @"Possible bad yaml reference in the SceneUpdate object or within the scene", nil),
         NSLocalizedRecoverySuggestionErrorKey: NSLocalizedString(

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clearDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource;
 
+- (Tangram::SceneReadyCallback)setSceneReadyListener;
+
 NS_ASSUME_NONNULL_END
 
 @property (assign, nonatomic, nullable) Tangram::Map* map;

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -219,6 +219,7 @@ NS_ASSUME_NONNULL_END
 
  @param mapView a pointer to the map view
  @param scene the path to the scene that has been loaded
+ TODO: deprecate for didSceneLoad
  */
 - (void)mapView:(nonnull TGMapViewController *)mapView didLoadSceneAsync:(nonnull NSString *)scene;
 /**
@@ -268,13 +269,18 @@ NS_ASSUME_NONNULL_END
 
 /**
  Called whenever scene updates have been applied to the scene file.
- The list of scene update statuses will be emtpy if all updates have been applied successfully.
+ The list of scene update statuses will be empty if all updates have been applied successfully.
  Called whenever scene updates have failed to apply to the scene file.
 
  @param mapView a pointer to the map view
  @param sceneUpdateError a NSError containing information about the scene update that failed
+ TODO: Mark this as deprecated
  */
 - (void)mapView:(nonnull TGMapViewController *)mapView didFailSceneUpdateWithError:(nonnull NSError *)sceneUpdateError;
+
+// TODO: Documentation
+- (void)mapView:(nonnull TGMapViewController *)mapView didSceneLoadWithError:(nonnull NSError *)sceneError;
+- (void)mapViewDidSceneLoad:(nonnull TGMapViewController *)mapView;
 
 @end
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -213,15 +213,7 @@ NS_ASSUME_NONNULL_END
  */
 @protocol TGMapViewDelegate <NSObject>
 @optional
-/**
- Called after a `-[TGMapViewController loadSceneFileAsync:]` or
- `-[TGMapViewController loadSceneFileAsync:sceneUpdates:]` is completed.
 
- @param mapView a pointer to the map view
- @param scene the path to the scene that has been loaded
- TODO: deprecate for didSceneLoad
- */
-- (void)mapView:(nonnull TGMapViewController *)mapView didLoadSceneAsync:(nonnull NSString *)scene;
 /**
  Always called after the method `-[TGMapViewController pickFeatureAt:]` is called on the map view.
 
@@ -267,20 +259,20 @@ NS_ASSUME_NONNULL_END
  */
 - (void)mapView:(nonnull TGMapViewController *)view didCaptureScreenshot:(nonnull UIImage *)screenshot;
 
+// TODO: Update Documentation
 /**
- Called whenever scene updates have been applied to the scene file.
- The list of scene update statuses will be empty if all updates have been applied successfully.
- Called whenever scene updates have failed to apply to the scene file.
+ If set by the user, this is called after a
+ `-[TGMapViewController loadSceneFile]` or
+ `-[TGMapViewController loadSceneFileAsync:]` or
+ `-[TGMapViewController loadSceneFileAsync:sceneUpdates:]` or
+ `-[TGMapViewController applySceneUpdate]` is completed.
 
  @param mapView a pointer to the map view
- @param sceneUpdateError a NSError containing information about the scene update that failed
- TODO: Mark this as deprecated
+ @param sceneID sceneID corresponding to which this callback will be called 
+ @param success whether the scene load or update succeed or not. To be used by the user to perform success/fail behavior
+ @param sceneError any errors during scene load or update
  */
-- (void)mapView:(nonnull TGMapViewController *)mapView didFailSceneUpdateWithError:(nonnull NSError *)sceneUpdateError;
-
-// TODO: Documentation
-- (void)mapView:(nonnull TGMapViewController *)mapView didSceneLoadWithError:(nonnull NSError *)sceneError;
-- (void)mapViewDidSceneLoad:(nonnull TGMapViewController *)mapView;
+- (void)mapView:(nonnull TGMapViewController *)mapView didSceneReady:(int)sceneID Success:(bool)success WithError:(nonnull NSError *)sceneError;
 
 @end
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -270,7 +270,7 @@ NS_ASSUME_NONNULL_END
  @param sceneID sceneID corresponding to which this callback will be called 
  @param sceneError any errors during scene load or update
  */
-- (void)mapView:(nonnull TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nonnull NSError *)sceneError;
+- (void)mapView:(nonnull TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nullable NSError *)sceneError;
 
 @end
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -538,7 +538,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return the integer (SceneID) associated with this scene update or -1 if scene can not be updated.
  */
-- (int)updateScene:(NSArray<TGSceneUpdate *> *)sceneUpdates;
+- (int)updateSceneAsync:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 
 #pragma mark Feature picking interface
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -259,7 +259,6 @@ NS_ASSUME_NONNULL_END
  */
 - (void)mapView:(nonnull TGMapViewController *)view didCaptureScreenshot:(nonnull UIImage *)screenshot;
 
-// TODO: Update Documentation
 /**
  If set by the user, this is called after a
  `-[TGMapViewController loadSceneFile]` or
@@ -271,7 +270,7 @@ NS_ASSUME_NONNULL_END
  @param sceneID sceneID corresponding to which this callback will be called 
  @param sceneError any errors during scene load or update
  */
-- (void)mapView:(nonnull TGMapViewController *)mapView didSceneReady:(int)sceneID WithError:(nonnull NSError *)sceneError;
+- (void)mapView:(nonnull TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nonnull NSError *)sceneError;
 
 @end
 
@@ -492,7 +491,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param path the scene path URL
 
- @return the integer (SceneID) associated with this scene load.
+ @return the integer (SceneID) associated with this scene load or -1 if scene can not be loaded. 
  */
 - (int)loadSceneFile:(NSString *)path;
 
@@ -504,17 +503,17 @@ NS_ASSUME_NONNULL_BEGIN
  @param path the scene path URL
  @param sceneUpdates a list of `TGSceneUpdate` to apply to the scene
 
- @return the integer (SceneID) associated with this scene load.
+ @return the integer (SceneID) associated with this scene load or -1 if scene can not be loaded.
  */
 - (int)loadSceneFile:(NSString *)path sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 
 /**
- Loads a scene file asynchronously, may call `-[TGMapViewDelegate didSceneReady:WithError:]`
+ Loads a scene file asynchronously, may call `-[TGMapViewDelegate didLoadScene:withError:]`
  if a `TGMapViewDelegate` is set to the map view.
 
  @param path the scene path URL
 
- @return the integer (SceneID) associated with this scene load.
+ @return the integer (SceneID) associated with this scene load or -1 if scene can not be loaded.
  */
 - (int)loadSceneFileAsync:(NSString *)path;
 
@@ -526,18 +525,18 @@ NS_ASSUME_NONNULL_BEGIN
  @param path the scene path URL
  @param sceneUpdates a list of `TGSceneUpdate` to apply to the scene
 
- @return the integer (SceneID) associated with this scene load.
+ @return the integer (SceneID) associated with this scene load or -1 if scene can not be loaded.
  */
 - (int)loadSceneFileAsync:(NSString *)path sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 
 /**
- Update the scene with the list of updates asyncronously, may call `-[TGMapViewDelegate didSceneReady:WithError:]`
+ Update the scene with the list of updates asyncronously, may call `-[TGMapViewDelegate didLoadScene:withError:]`
  if a `TGMapViewDelegate` is set to the map view. Also see `TGSceneUpdate` for more info.
  
  @param sceneUpdates a list of updates to apply to the scene, see `TGSceneUpdate` for more infos
  If a scene update error happens, scene udpates won't be applied.
 
- @return the integer (SceneID) associated with this scene update.
+ @return the integer (SceneID) associated with this scene update or -1 if scene can not be updated.
  */
 - (int)updateScene:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -269,10 +269,9 @@ NS_ASSUME_NONNULL_END
 
  @param mapView a pointer to the map view
  @param sceneID sceneID corresponding to which this callback will be called 
- @param success whether the scene load or update succeed or not. To be used by the user to perform success/fail behavior
  @param sceneError any errors during scene load or update
  */
-- (void)mapView:(nonnull TGMapViewController *)mapView didSceneReady:(int)sceneID Success:(bool)success WithError:(nonnull NSError *)sceneError;
+- (void)mapView:(nonnull TGMapViewController *)mapView didSceneReady:(int)sceneID WithError:(nonnull NSError *)sceneError;
 
 @end
 
@@ -492,8 +491,10 @@ NS_ASSUME_NONNULL_BEGIN
  Tangram will automatically load that remote scene file.
 
  @param path the scene path URL
+
+ @return the integer (SceneID) associated with this scene load.
  */
-- (void)loadSceneFile:(NSString *)path;
+- (int)loadSceneFile:(NSString *)path;
 
 /**
  Loads a scene file (similar to `-loadSceneFile:`), with a list of
@@ -502,16 +503,20 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param path the scene path URL
  @param sceneUpdates a list of `TGSceneUpdate` to apply to the scene
+
+ @return the integer (SceneID) associated with this scene load.
  */
-- (void)loadSceneFile:(NSString *)path sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
+- (int)loadSceneFile:(NSString *)path sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 
 /**
- Loads a scene file asynchronously, may call `-[TGMapViewDelegate mapView:didLoadSceneAsync:]`
+ Loads a scene file asynchronously, may call `-[TGMapViewDelegate didSceneReady:WithError:]`
  if a `TGMapViewDelegate` is set to the map view.
 
  @param path the scene path URL
+
+ @return the integer (SceneID) associated with this scene load.
  */
-- (void)loadSceneFileAsync:(NSString *)path;
+- (int)loadSceneFileAsync:(NSString *)path;
 
 /**
  Loads a scene asynchronously (similar to `-loadSceneFileAsync:`), with a
@@ -520,36 +525,21 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param path the scene path URL
  @param sceneUpdates a list of `TGSceneUpdate` to apply to the scene
+
+ @return the integer (SceneID) associated with this scene load.
  */
-- (void)loadSceneFileAsync:(NSString *)path sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
+- (int)loadSceneFileAsync:(NSString *)path sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 
 /**
- Queue a scene update.
-
- The path is a series of yaml keys separated by a '.' and the value is a string
- of yaml to replace the current value at the given path in the scene.
-
- @param componentPath the path of the scene component to update
- @value the value to assign to the YAML component selected with `componentPath`
-
- @note Scene updates must be applied with `-applySceneUpdates:`
- */
-- (void)queueSceneUpdate:(NSString*)componentPath withValue:(NSString*)value;
-
-/**
- Queue a list of scene updates.
-
+ Update the scene with the list of updates asyncronously, may call `-[TGMapViewDelegate didSceneReady:WithError:]`
+ if a `TGMapViewDelegate` is set to the map view. Also see `TGSceneUpdate` for more info.
+ 
  @param sceneUpdates a list of updates to apply to the scene, see `TGSceneUpdate` for more infos
-
- @note Scene updates must be applied with `-applySceneUpdates:`
- */
-- (void)queueSceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
-
-/**
- Apply scene updates queued with `-queueSceneUpdate*` methods.
  If a scene update error happens, scene udpates won't be applied.
+
+ @return the integer (SceneID) associated with this scene update.
  */
-- (void)applySceneUpdates;
+- (int)updateScene:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 
 #pragma mark Feature picking interface
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -154,13 +154,13 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
     self.scenePath = path;
 
     auto updateCallbackStatus = [=](int sceneID, auto sceneError) {
-        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didSceneReady:WithError:)]) { return; }
+        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didLoadScene:withError:)]) { return; }
 
         NSError* error = nil;
         if (sceneError) {
             error = [TGHelpers errorFromSceneError:*sceneError];
         }
-        [self.mapViewDelegate mapView:self didSceneReady:sceneID WithError:error];
+        [self.mapViewDelegate mapView:self didLoadScene:sceneID withError:error];
     };
 
     self.map->setSceneReadyListener(updateCallbackStatus);
@@ -179,7 +179,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
     self.scenePath = path;
 
     Tangram::SceneReadyCallback onReadyCallback = [=](int sceneID, auto sceneError) {
-        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didSceneReady:WithError:)]) { return; }
+        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didLoadScene:withError:)]) { return; }
 
         [self.markersById removeAllObjects];
 
@@ -187,7 +187,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
         if (sceneError) {
             error = [TGHelpers errorFromSceneError:*sceneError];
         }
-        [self.mapViewDelegate mapView:self didSceneReady:sceneID WithError:error];
+        [self.mapViewDelegate mapView:self didLoadScene:sceneID withError:error];
         self.renderRequested = YES;
     };
 
@@ -220,7 +220,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
     }
 
     auto updateCallbackStatus = [=](int sceneID, auto sceneError) {
-        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didSceneReady:WithError:)]) { return; }
+        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didLoadScene:withError:)]) { return; }
 
         [self.markersById removeAllObjects];
 
@@ -228,7 +228,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
         if (sceneError) {
             error = [TGHelpers errorFromSceneError:*sceneError];
         }
-        [self.mapViewDelegate mapView:self didSceneReady:sceneID WithError:error];
+        [self.mapViewDelegate mapView:self didLoadScene:sceneID withError:error];
         self.renderRequested = YES;
     };
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -205,7 +205,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 
 #pragma mark Scene updates
 
-- (int)updateScene:(NSArray<TGSceneUpdate *> *)sceneUpdates
+- (int)updateSceneAsync:(NSArray<TGSceneUpdate *> *)sceneUpdates
 {
     if (!self.map) { return -1; }
 

--- a/platforms/ios/src/TangramMap/TGTypes.h
+++ b/platforms/ios/src/TangramMap/TGTypes.h
@@ -41,6 +41,8 @@ typedef NS_ENUM(NSInteger, TGCameraType) {
 
 /// Description of error status from Tangram
 typedef NS_ENUM(NSInteger, TGError) {
+    /// No Error
+    TGErrorNone,
     /// The path of the scene update was not found on the scene file
     TGErrorSceneUpdatePathNotFound,
     /// The YAML syntax of the scene udpate path has a syntax error

--- a/platforms/ios/src/TangramMap/TGTypes.h
+++ b/platforms/ios/src/TangramMap/TGTypes.h
@@ -49,6 +49,8 @@ typedef NS_ENUM(NSInteger, TGError) {
     TGErrorSceneUpdatePathYAMLSyntaxError,
     /// The YAML syntax of the scene update value has a syntax error
     TGErrorSceneUpdateValueYAMLSyntaxError,
+    /// No valid scene was loaded (and on tries to update the scene)
+    TGErrorNoValidScene,
     /// An error code for markers
     TGErrorMarker,
 };

--- a/platforms/rpi/src/main.cpp
+++ b/platforms/rpi/src/main.cpp
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
     }
 
     map = new Map(platform);
-    map->loadScene(options.sceneFilePath.c_str(), !options.hasLocationSet, updates, nullptr);
+    map->loadScene(options.sceneFilePath.c_str(), !options.hasLocationSet, updates);
     map->setupGL();
     map->resize(getWindowWidth(), getWindowHeight());
     map->setTilt(options.tilt);

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -220,21 +220,25 @@ TEST_CASE("Scene update statuses") {
     Scene scene(platform_mock);
     REQUIRE(loadConfig(sceneString, scene.config()));
     Node& root = scene.config();
-    std::vector<SceneUpdate> updates = {{"map.a", "{ first_value"}};
-    SceneLoader::applyUpdates(platform_mock, scene, updates, [](auto updateError) {
-        CHECK(updateError.error == Error::scene_update_value_yaml_syntax_error);
-    });
-    updates = {{"!map#0", "first_value"}};
-    SceneLoader::applyUpdates(platform_mock, scene, updates, [](auto updateError) {
-        CHECK(updateError.error == Error::scene_update_path_yaml_syntax_error);
-    });
-    updates = {{"key_not_existing", "first_value"}};
-    SceneLoader::applyUpdates(platform_mock, scene, updates, [](auto updateError) {
-        CHECK(updateError.error == Error::scene_update_path_not_found);
-    });
-    updates = {{"!map#0", "{ first_value"}};
-    SceneLoader::applyUpdates(platform_mock, scene, updates, [](auto updateError) {
-        CHECK(updateError.error == Error::scene_update_value_yaml_syntax_error);
-    });
-}
 
+    std::vector<SceneUpdate> updates = {{"map.a", "{ first_value"}};
+    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(scene.errors.front().error == Error::scene_update_value_yaml_syntax_error);
+    scene.errors.clear();
+
+    updates = {{"!map#0", "first_value"}};
+    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(scene.errors.front().error == Error::scene_update_path_yaml_syntax_error);
+    scene.errors.clear();
+
+    // Test was broken
+    // updates = {{"key_not_existing", "first_value"}};
+    // CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    // CHECK(scene.errors.front().error == Error::scene_update_path_not_found);
+    // scene.errors.clear();
+
+    updates = {{"!map#0", "{ first_value"}};
+    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(scene.errors.front().error == Error::scene_update_value_yaml_syntax_error);
+    scene.errors.clear();
+}


### PR DESCRIPTION
https://github.com/tangrams/tangram-es/issues/1525

- this PR enables to recreate markers reliably in SceneLoaderLister.onReady()
  (after applySceneUpdates)

- fix unreleased GlobalRef in case SceneUpdate succeeded, otherwise
  MapController probably never got garbage collected
- update IOS/OSX