### PR TITLE
Fix text_source left/right with js function

### DIFF
--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -357,6 +357,8 @@ void StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
 
         switch (_key) {
             case StyleParamKey::text_source:
+            case StyleParamKey::text_source_left:
+            case StyleParamKey::text_source_right:
                 _val = value;
                 break;
             default:


### PR DESCRIPTION
- directly assign the value of the function evaluation