### PR TITLE
Add a default fps to the iOS view

### DIFF
--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -307,6 +307,8 @@ NS_ASSUME_NONNULL_BEGIN
  system_ (based on a `UIKit` coordinate system); which is independent of the phone pixel density. Refer the
  <a href="https://developer.apple.com/library/content/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/GraphicsDrawingOverview/GraphicsDrawingOverview.html">Apple documentation</a>
  _Coordinate Systems and Drawing in iOS_ for more informations.
+ The `preferredFramesPerSecond` is set by default to 60, make sure that this value fits the need of
+ your application.
 
  */
 @interface TGMapViewController : GLKViewController <UIGestureRecognizerDelegate>

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -915,6 +915,9 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 
     // Query background color set in UI designer
     GLKView* view = (GLKView *)self.view;
+
+    self.preferredFramesPerSecond = 60;
+
     UIColor* backgroundColor = view.backgroundColor;
 
     if (backgroundColor != nil) {


### PR DESCRIPTION
`preferredFramesPerSecond` will now be set by default to 60 on the framework map view.