### PR TITLE
Fix API key injection in desktop and RPi demos

### DIFF
--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -29,6 +29,8 @@ std::string sceneFile;
 std::string markerStylingPath = "layers.touch.point.draw.icons";
 std::string polylineStyle = "{ style: lines, interactive: true, color: red, width: 20px, order: 5000 }";
 
+std::string mapzenApiKey;
+
 GLFWwindow* main_window = nullptr;
 Tangram::Map* map = nullptr;
 int width = 800;
@@ -64,16 +66,20 @@ void create(std::shared_ptr<Platform> p, std::string f, int w, int h) {
         return;
     }
 
-#ifndef MAPZEN_API_KEY
-    LOG("Environment variable MAPZEN_API_KEY not set. Kindly set this environment variable and relaunch.");
-    exit(1);
-#endif
+    char* mapzenApiKeyEnvVar = getenv("MAPZEN_API_KEY");
+    if (mapzenApiKeyEnvVar && strlen(mapzenApiKeyEnvVar) > 0) {
+        mapzenApiKey = mapzenApiKeyEnvVar;
+    } else {
+        LOGW("No API key found!\n\nMapzen data sources require an API key. "
+             "Sign up for a free key at http://mapzen.com/developers and then set it from the command line with: "
+             "\n\n\texport MAPZEN_API_KEY=YOUR_KEY_HERE\n");
+    }
 
     // Setup tangram
     if (!map) {
         map = new Tangram::Map(platform);
         map->loadSceneAsync(sceneFile.c_str(), true, {}, nullptr,
-                {SceneUpdate("global.sdk_mapzen_api_key", MAPZEN_API_KEY)});
+                {SceneUpdate("global.sdk_mapzen_api_key", mapzenApiKey)});
     }
 
     // Create a windowed mode window and its OpenGL context
@@ -406,7 +412,7 @@ void dropCallback(GLFWwindow* window, int count, const char** paths) {
 
     sceneFile = std::string(paths[0]);
     map->loadSceneAsync(sceneFile.c_str(), true, {}, nullptr,
-                        {SceneUpdate("global.sdk_mapzen_api_key", MAPZEN_API_KEY)});
+                        {SceneUpdate("global.sdk_mapzen_api_key", mapzenApiKey)});
 
 }
 

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -72,7 +72,9 @@ void create(std::shared_ptr<Platform> p, std::string f, int w, int h) {
     } else {
         LOGW("No API key found!\n\nMapzen data sources require an API key. "
              "Sign up for a free key at http://mapzen.com/developers and then set it from the command line with: "
-             "\n\n\texport MAPZEN_API_KEY=YOUR_KEY_HERE\n");
+             "\n\n\texport MAPZEN_API_KEY=YOUR_KEY_HERE"
+             "\n\nOr, if using an IDE on macOS, with: "
+             "\n\n\tlaunchctl setenv MAPZEN_API_KEY YOUR_API_KEY\n");
     }
 
     // Setup tangram

--- a/platforms/rpi/src/main.cpp
+++ b/platforms/rpi/src/main.cpp
@@ -37,6 +37,8 @@ unsigned long long timePrev, timeStart;
 Map* map = nullptr;
 std::shared_ptr<LinuxPlatform> platform;
 
+std::string mapzenApiKey;
+
 static bool bUpdate = true;
 
 //==============================================================================
@@ -87,11 +89,6 @@ void setup(int argc, char **argv) {
     double lon = 0.0f;
     std::string scene = "scene.yaml";
 
-#ifndef MAPZEN_API_KEY
-    LOG("Environment variable MAPZEN_API_KEY not set. Kindly set this environment variable and relaunch.");
-    exit(1);
-#endif
-
     for (int i = 1; i < argc - 1; i++) {
         std::string argName(argv[i]), argValue(argv[i + 1]);
         if (argName == "-s" || argName == "--scene") {
@@ -113,8 +110,18 @@ void setup(int argc, char **argv) {
         }
     }
 
+    // Get Mapzen API key from environment variables.
+    char* mapzenApiKeyEnvVar = getenv("MAPZEN_API_KEY");
+    if (mapzenApiKeyEnvVar && strlen(mapzenApiKeyEnvVar) > 0) {
+        mapzenApiKey = mapzenApiKeyEnvVar;
+    } else {
+        LOGW("No API key found!\n\nMapzen data sources require an API key. "
+             "Sign up for a free key at http://mapzen.com/developers and then set it from the command line with: "
+             "\n\n\texport MAPZEN_API_KEY=YOUR_KEY_HERE\n");
+    }
+
     map = new Map(platform);
-    map->loadSceneAsync(scene.c_str(), false, {}, nullptr, {SceneUpdate("global.sdk_mapzen_api_key", MAPZEN_API_KEY)});
+    map->loadSceneAsync(scene.c_str(), false, {}, nullptr, {SceneUpdate("global.sdk_mapzen_api_key", mapzenApiKey)});
     map->setupGL();
     map->resize(width, height);
     if (lon != 0.0f && lat != 0.0f) {


### PR DESCRIPTION
Desktop demo apps now check for a MAPZEN_API_KEY environment variable at run-time and apply it to the scene file. If this variable isn't found, the app continues but prints a warning with instructions to get an API key and use it with the app.