### PR TITLE
Load scene from string

### DIFF
--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -106,11 +106,19 @@ public:
                            bool _useScenePosition = false,
                            const std::vector<SceneUpdate>& _sceneUpdates = {});
 
+    // Load the scene provided an explicit yaml scene string
+    SceneID loadSceneYaml(const std::string& _yaml, const std::string& _resourceRoot,
+                          bool _useScenePosition = false,
+                          const std::vector<SceneUpdate>& _sceneUpdates = {});
+
     SceneID loadSceneYamlAsync(const std::string& _yaml, const std::string& _resourceRoot,
                                bool _useScenePosition = false,
                                const std::vector<SceneUpdate>& _sceneUpdates = {});
 
     // Load the scene at the given absolute file path synchronously
+    SceneID loadScene(std::shared_ptr<Scene> _scene,
+                      const std::vector<SceneUpdate>& _sceneUpdates = {});
+
     SceneID loadScene(const std::string& _scenePath,
                       bool _useScenePosition = false,
                       const std::vector<SceneUpdate>& sceneUpdates = {});

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -13,6 +13,7 @@ namespace Tangram {
 
 class Platform;
 class TileSource;
+class Scene;
 
 enum LabelType {
     icon,
@@ -98,12 +99,19 @@ public:
     ~Map();
 
     // Load the scene at the given absolute file path asynchronously.
-    SceneID loadSceneAsync(const char* _scenePath,
+    SceneID loadSceneAsync(std::shared_ptr<Scene> _scene,
+                           const std::vector<SceneUpdate>& _sceneUpdates = {});
+
+    SceneID loadSceneAsync(const std::string& _scenePath,
                            bool _useScenePosition = false,
-                           const std::vector<SceneUpdate>& sceneUpdates = {});
+                           const std::vector<SceneUpdate>& _sceneUpdates = {});
+
+    SceneID loadSceneYamlAsync(const std::string& _yaml, const std::string& _resourceRoot,
+                               bool _useScenePosition = false,
+                               const std::vector<SceneUpdate>& _sceneUpdates = {});
 
     // Load the scene at the given absolute file path synchronously
-    SceneID loadScene(const char* _scenePath,
+    SceneID loadScene(const std::string& _scenePath,
                       bool _useScenePosition = false,
                       const std::vector<SceneUpdate>& sceneUpdates = {});
 

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -99,9 +99,6 @@ public:
     ~Map();
 
     // Load the scene at the given absolute file path asynchronously.
-    SceneID loadSceneAsync(std::shared_ptr<Scene> _scene,
-                           const std::vector<SceneUpdate>& _sceneUpdates = {});
-
     SceneID loadSceneAsync(const std::string& _scenePath,
                            bool _useScenePosition = false,
                            const std::vector<SceneUpdate>& _sceneUpdates = {});
@@ -116,9 +113,6 @@ public:
                                const std::vector<SceneUpdate>& _sceneUpdates = {});
 
     // Load the scene at the given absolute file path synchronously
-    SceneID loadScene(std::shared_ptr<Scene> _scene,
-                      const std::vector<SceneUpdate>& _sceneUpdates = {});
-
     SceneID loadScene(const std::string& _scenePath,
                       bool _useScenePosition = false,
                       const std::vector<SceneUpdate>& sceneUpdates = {});
@@ -362,6 +356,12 @@ private:
 protected:
 
     std::shared_ptr<Platform> platform;
+
+    SceneID loadSceneAsync(std::shared_ptr<Scene> _scene,
+                       const std::vector<SceneUpdate>& _sceneUpdates = {});
+
+    SceneID loadScene(std::shared_ptr<Scene> _scene,
+                  const std::vector<SceneUpdate>& _sceneUpdates = {});
 
 };
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -180,17 +180,13 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
 
 // NB: Not thread-safe. Must be called on the main/render thread!
 // (Or externally synchronized with main/render thread)
-SceneID Map::loadScene(const std::string& _scenePath, bool _useScenePosition,
+SceneID Map::loadScene(std::shared_ptr<Scene> scene,
                        const std::vector<SceneUpdate>& _sceneUpdates) {
-
-    LOG("Loading scene file: %s", _scenePath.c_str());
 
     {
         std::lock_guard<std::mutex> lock(impl->sceneMutex);
         impl->lastValidScene.reset();
     }
-    auto scene = std::make_shared<Scene>(platform, _scenePath);
-    scene->useScenePosition = _useScenePosition;
 
     if (SceneLoader::loadScene(platform, scene, _sceneUpdates)) {
         impl->setScene(scene);
@@ -209,6 +205,24 @@ SceneID Map::loadScene(const std::string& _scenePath, bool _useScenePosition,
         }
     }
     return scene->id;
+}
+
+SceneID Map::loadScene(const std::string& _scenePath, bool _useScenePosition,
+                       const std::vector<SceneUpdate>& _sceneUpdates) {
+
+    LOG("Loading scene file: %s", _scenePath.c_str());
+    auto scene = std::make_shared<Scene>(platform, _scenePath);
+    scene->useScenePosition = _useScenePosition;
+    return loadScene(scene, _sceneUpdates);
+}
+
+SceneID Map::loadSceneYaml(const std::string& _yaml, const std::string& _resourceRoot,
+                           bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
+
+    LOG("Loading scene string");
+    auto scene = std::make_shared<Scene>(platform, _yaml, _resourceRoot);
+    scene->useScenePosition = _useScenePosition;
+    return loadScene(scene, _sceneUpdates);
 }
 
 SceneID Map::loadSceneAsync(const std::string& _scenePath, bool _useScenePosition,

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -29,7 +29,7 @@ public:
 
     void resolveSceneUrls(const std::shared_ptr<Platform>& platform, Scene& scene, Node& root, const Url& base);
 
-// protected for testing purposes, else could be private
+    // protected for testing purposes, else could be private
 protected:
     // Overriden in unit testing
     virtual std::string getSceneString(const std::shared_ptr<Platform>& platform,
@@ -49,7 +49,6 @@ protected:
 
     void mergeMapFields(Node& target, const Node& import);
 
-private:
     // import scene to respective root nodes
     std::unordered_map<Url, Node> m_scenes;
 

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -33,19 +33,19 @@ public:
 protected:
     // Overriden in unit testing
     virtual std::string getSceneString(const std::shared_ptr<Platform>& platform,
-            const Url& scenePath, const std::shared_ptr<Asset>& asset = nullptr);
+                                       const Url& scenePath, const std::shared_ptr<Asset>& asset = nullptr);
 
     void processScene(const std::shared_ptr<Platform>& platform, std::shared_ptr<Scene>& scene,
-            const Url& scenePath, const std::string& sceneString);
+                      const Url& scenePath, const std::string& sceneString);
 
     // Get the sequence of scene names that are designated to be imported into the
     // input scene node by its 'import' fields.
     std::vector<Url> getResolvedImportUrls(const std::shared_ptr<Platform>& platform,
-            std::shared_ptr<Scene>& scene, const Node& sceneNode, const Url& base);
+                                           std::shared_ptr<Scene>& scene, const Node& sceneNode, const Url& base);
 
     // loads all the imported scenes and the master scene and returns a unified YAML root node.
     void importScenesRecursive(const std::shared_ptr<Platform>& platform, std::shared_ptr<Scene>& scene,
-            Node& root, const Url& scenePath, std::vector<Url>& sceneStack);
+                               Node& root, const Url& scenePath, std::vector<Url>& sceneStack);
 
     void mergeMapFields(Node& target, const Node& import);
 
@@ -54,10 +54,6 @@ private:
     std::unordered_map<Url, Node> m_scenes;
 
     std::vector<Url> m_sceneQueue;
-
-    static std::atomic_uint progressCounter;
-    std::mutex sceneMutex;
-    std::condition_variable m_condition;
 
     const unsigned int MAX_SCENE_DOWNLOAD = 4;
 };

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -29,7 +29,6 @@ Scene::Scene() : id(s_serial++) {}
 
 Scene::Scene(std::shared_ptr<const Platform> _platform, const std::string& _path)
     : id(s_serial++),
-      m_path(_path),
       m_fontContext(std::make_shared<FontContext>(_platform)),
       m_featureSelection(std::make_unique<FeatureSelection>()) {
 
@@ -60,6 +59,19 @@ Scene::Scene(std::shared_ptr<const Platform> _platform, const std::string& _path
     m_mapProjection.reset(new MercatorProjection());
 }
 
+Scene::Scene(std::shared_ptr<const Platform> _platform, const std::string& _yaml, const std::string& _resourceRoot)
+    : id(s_serial++),
+      m_fontContext(std::make_shared<FontContext>(_platform)),
+      m_featureSelection(std::make_unique<FeatureSelection>()) {
+
+    m_resourceRoot = _resourceRoot;
+    m_yaml = _yaml;
+
+    m_fontContext->setSceneResourceRoot(m_resourceRoot);
+
+    m_mapProjection.reset(new MercatorProjection());
+}
+
 void Scene::copyConfig(const Scene& _other) {
 
     m_featureSelection.reset(new FeatureSelection());
@@ -68,6 +80,7 @@ void Scene::copyConfig(const Scene& _other) {
     m_fontContext = _other.m_fontContext;
 
     m_path = _other.m_path;
+    m_yaml = _other.m_yaml;
     m_resourceRoot = _other.m_resourceRoot;
 
     m_globalRefs = _other.m_globalRefs;

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -69,6 +69,7 @@ public:
 
     Scene();
     Scene(std::shared_ptr<const Platform> _platform, const std::string& _path = "");
+    Scene(std::shared_ptr<const Platform> _platform, const std::string& _yaml, const std::string& _resourceRoot);
     Scene(const Scene& _other) = delete;
 
     ~Scene();
@@ -96,6 +97,7 @@ public:
     Style* findStyle(const std::string& _name);
 
     const auto& path() const { return m_path; }
+    const auto& yaml() { return m_yaml; }
     const auto& resourceRoot() const { return m_resourceRoot; }
     const auto& config() const { return m_config; }
     const auto& tileSources() const { return m_tileSources; };
@@ -151,6 +153,8 @@ private:
 
     // The file path from which this scene was loaded
     std::string m_path;
+
+    std::string m_yaml;
 
     std::string m_resourceRoot;
 

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -172,6 +172,21 @@ extern "C" {
         const char* cResourceRoot = jniEnv->GetStringUTFChars(resourceRoot, NULL);
 
         auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
+        jint sceneId = map->loadSceneYaml(cYaml, resolveScenePath(cResourceRoot), false, sceneUpdates);
+
+        jniEnv->ReleaseStringUTFChars(yaml, cYaml);
+        jniEnv->ReleaseStringUTFChars(resourceRoot, cResourceRoot);
+
+        return sceneId;
+    }
+
+    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeLoadSceneYamlAsync(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml, jstring resourceRoot, jobjectArray updateStrings) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        const char* cYaml = jniEnv->GetStringUTFChars(yaml, NULL);
+        const char* cResourceRoot = jniEnv->GetStringUTFChars(resourceRoot, NULL);
+
+        auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
         jint sceneId = map->loadSceneYamlAsync(cYaml, resolveScenePath(cResourceRoot), false, sceneUpdates);
 
         jniEnv->ReleaseStringUTFChars(yaml, cYaml);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -331,7 +331,7 @@ public class MapController implements Renderer {
     }
 
     /**
-     * Load a new scene file asynchronously.
+     * Load a new scene synchronously, provided an explicit yaml scene string to load
      * If scene updates triggers an error, they won't be applied.
      * Use {@link #setSceneLoadListener(SceneLoadListener)} for notification when the new scene is
      * ready.
@@ -344,6 +344,25 @@ public class MapController implements Renderer {
         String[] updateStrings = bundleSceneUpdates(sceneUpdates);
         checkPointer(mapPointer);
         int sceneId = nativeLoadSceneYaml(mapPointer, yaml, resourceRoot, updateStrings);
+        removeAllMarkers();
+        requestRender();
+        return sceneId;
+    }
+
+    /**
+     * Load a new scene asynchronously, provided an explicit yaml scene string to load
+     * If scene updates triggers an error, they won't be applied.
+     * Use {@link #setSceneLoadListener(SceneLoadListener)} for notification when the new scene is
+     * ready.
+     * @param yaml YAML scene String
+     * @param resourceRoot base path to resolve relative URLs
+     * @param sceneUpdates List of {@code SceneUpdate}
+     * @return Scene ID An identifier for the scene being loaded, the same value will be passed to
+     */
+    public int loadSceneYamlAsync(String yaml, String resourceRoot, List<SceneUpdate> sceneUpdates) {
+        String[] updateStrings = bundleSceneUpdates(sceneUpdates);
+        checkPointer(mapPointer);
+        int sceneId = nativeLoadSceneYamlAsync(mapPointer, yaml, resourceRoot, updateStrings);
         removeAllMarkers();
         requestRender();
         return sceneId;
@@ -1141,6 +1160,7 @@ public class MapController implements Renderer {
     private synchronized native int nativeLoadScene(long mapPtr, String path, String[] updateStrings);
     private synchronized native int nativeLoadSceneAsync(long mapPtr, String path, String[] updateStrings);
     private synchronized native int nativeLoadSceneYaml(long mapPtr, String yaml, String resourceRoot, String[] updateStrings);
+    private synchronized native int nativeLoadSceneYamlAsync(long mapPtr, String yaml, String resourceRoot, String[] updateStrings);
     private synchronized native void nativeSetupGL(long mapPtr);
     private synchronized native void nativeResize(long mapPtr, int width, int height);
     private synchronized native boolean nativeUpdate(long mapPtr, float dt);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -304,7 +304,6 @@ public class MapController implements Renderer {
      */
     public int loadSceneFile(String path, List<SceneUpdate> sceneUpdates) {
         String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        scenePath = path;
         checkPointer(mapPointer);
         int sceneId = nativeLoadScene(mapPointer, path, updateStrings);
         removeAllMarkers();
@@ -324,9 +323,27 @@ public class MapController implements Renderer {
      */
     public int loadSceneFileAsync(String path, List<SceneUpdate> sceneUpdates) {
         String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        scenePath = path;
         checkPointer(mapPointer);
         int sceneId = nativeLoadSceneAsync(mapPointer, path, updateStrings);
+        removeAllMarkers();
+        requestRender();
+        return sceneId;
+    }
+
+    /**
+     * Load a new scene file asynchronously.
+     * If scene updates triggers an error, they won't be applied.
+     * Use {@link #setSceneLoadListener(SceneLoadListener)} for notification when the new scene is
+     * ready.
+     * @param yaml YAML scene String
+     * @param resourceRoot base path to resolve relative URLs
+     * @param sceneUpdates List of {@code SceneUpdate}
+     * @return Scene ID An identifier for the scene being loaded, the same value will be passed to
+     */
+    public int loadSceneYaml(String yaml, String resourceRoot, List<SceneUpdate> sceneUpdates) {
+        String[] updateStrings = bundleSceneUpdates(sceneUpdates);
+        checkPointer(mapPointer);
+        int sceneId = nativeLoadSceneYaml(mapPointer, yaml, resourceRoot, updateStrings);
         removeAllMarkers();
         requestRender();
         return sceneId;
@@ -1123,6 +1140,7 @@ public class MapController implements Renderer {
     private synchronized native void nativeDispose(long mapPtr);
     private synchronized native int nativeLoadScene(long mapPtr, String path, String[] updateStrings);
     private synchronized native int nativeLoadSceneAsync(long mapPtr, String path, String[] updateStrings);
+    private synchronized native int nativeLoadSceneYaml(long mapPtr, String yaml, String resourceRoot, String[] updateStrings);
     private synchronized native void nativeSetupGL(long mapPtr);
     private synchronized native void nativeResize(long mapPtr, int width, int height);
     private synchronized native boolean nativeUpdate(long mapPtr, float dt);
@@ -1188,7 +1206,6 @@ public class MapController implements Renderer {
     // Private members
     // ===============
 
-    private String scenePath;
     private long mapPointer;
     private long time = System.nanoTime();
     private GLSurfaceView mapView;

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -383,6 +383,9 @@ void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods
             case GLFW_KEY_I:
                 map->updateSceneAsync({SceneUpdate{"cameras", "{ main_camera: { type: isometric } }"}});
                 break;
+            case GLFW_KEY_M:
+                map->loadSceneYamlAsync("{ scene: { background: { color: red } } }", std::string(""));
+                break;
             case GLFW_KEY_G:
                 static bool geoJSON = false;
                 if (!geoJSON) {

--- a/platforms/common/glfwApp.h
+++ b/platforms/common/glfwApp.h
@@ -8,7 +8,9 @@ namespace Tangram {
 
 namespace GlfwApp {
 
-void create(std::shared_ptr<Platform> platform, std::string sceneFile, int width, int height);
+void create(std::shared_ptr<Platform> platform, int width, int height);
+void setScene(const std::string& _path, const std::string& _yaml);
+void parseArgs(int argc, char* argv[]);
 void run();
 void stop(int);
 void destroy();

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -22,8 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (Tangram::SceneReadyCallback)sceneReadyListener;
 
-- (std::vector<Tangram::SceneUpdate>)unpackSceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
-
 NS_ASSUME_NONNULL_END
 
 @property (assign, nonatomic, nullable) Tangram::Map* map;

--- a/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController+Internal.h
@@ -20,7 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clearDataSource:(std::shared_ptr<Tangram::TileSource>)tileSource;
 
-- (Tangram::SceneReadyCallback)setSceneReadyListener;
+- (Tangram::SceneReadyCallback)sceneReadyListener;
+
+- (std::vector<Tangram::SceneUpdate>)unpackSceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 
 NS_ASSUME_NONNULL_END
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -264,8 +264,8 @@ NS_ASSUME_NONNULL_END
  `-[TGMapViewController loadSceneFile]` or
  `-[TGMapViewController loadSceneFileAsync:]` or
  `-[TGMapViewController loadSceneFileAsync:sceneUpdates:]` or
- `-[TGMapViewController loadSceneFileYaml:sceneUpdates:]` or
- `-[TGMapViewController loadSceneFileYamlAsync:sceneUpdates:]` or
+ `-[TGMapViewController loadSceneFileYaml:resourceRoot:sceneUpdates:]` or
+ `-[TGMapViewController loadSceneFileYamlAsync:resourceRoot:sceneUpdates:]` or
  `-[TGMapViewController applySceneUpdate]` is completed.
 
  @param mapView a pointer to the map view
@@ -533,7 +533,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Loads a scene synchronously using an explicitly specified yaml string, with a list of updates
- to be applied to be applied to the scene.
+ to be applied to the scene.
  If a scene update error happens, scene updates won't be applied.
 
  @param yaml Yaml scene string
@@ -546,7 +546,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Loads a scene asynchronously using an explicitly specified yaml string, with a list of updates
- to be applied to be applied to the scene.
+ to be applied to the scene.
  If a scene update error happens, scene updates won't be applied.
 
  @param yaml Yaml scene string

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -264,6 +264,8 @@ NS_ASSUME_NONNULL_END
  `-[TGMapViewController loadSceneFile]` or
  `-[TGMapViewController loadSceneFileAsync:]` or
  `-[TGMapViewController loadSceneFileAsync:sceneUpdates:]` or
+ `-[TGMapViewController loadSceneFileYaml:sceneUpdates:]` or
+ `-[TGMapViewController loadSceneFileYamlAsync:sceneUpdates:]` or
  `-[TGMapViewController applySceneUpdate]` is completed.
 
  @param mapView a pointer to the map view
@@ -528,6 +530,32 @@ NS_ASSUME_NONNULL_BEGIN
  @return the integer (SceneID) associated with this scene load or -1 if scene can not be loaded.
  */
 - (int)loadSceneFileAsync:(NSString *)path sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
+
+/**
+ Loads a scene synchronously using an explicitly specified yaml string, with a list of updates
+ to be applied to be applied to the scene.
+ If a scene update error happens, scene updates won't be applied.
+
+ @param yaml Yaml scene string
+ @param resourceRoot Base path to resolve relative urls within the yaml scene string
+ @param sceneUpdates a list of `TGSceneUpdate` to apply to the scene
+
+ @return the integer (SceneID) associated with this scene load or -1 if scene can not be loaded.
+*/
+- (int)loadSceneYaml:(NSString *)yaml resourceRoot:(NSString *)resourceRoot sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
+
+/**
+ Loads a scene asynchronously using an explicitly specified yaml string, with a list of updates
+ to be applied to be applied to the scene.
+ If a scene update error happens, scene updates won't be applied.
+
+ @param yaml Yaml scene string
+ @param resourceRoot Base path to resolve relative urls within the yaml scene string
+ @param sceneUpdates a list of `TGSceneUpdate` to apply to the scene
+
+ @return the integer (SceneID) associated with this scene load or -1 if scene can not be loaded.
+*/
+- (int)loadSceneYamlAsync:(NSString *)yaml resourceRoot:(NSString *)resourceRoot sceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates;
 
 /**
  Update the scene with the list of updates asyncronously, may call `-[TGMapViewDelegate didLoadScene:withError:]`

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -128,7 +128,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 
 #pragma mark Scene loading interface
 
-- (std::vector<Tangram::SceneUpdate>)unpackSceneUpdates:(NSArray<TGSceneUpdate *> *)sceneUpdates
+std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *sceneUpdates)
 {
     std::vector<Tangram::SceneUpdate> updates;
     if (sceneUpdates) {
@@ -168,7 +168,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 {
     if (!self.map) { return -1; }
 
-    auto updates = [self unpackSceneUpdates:sceneUpdates];
+    auto updates = unpackSceneUpdates(sceneUpdates);
 
     self.map->setSceneReadyListener([self sceneReadyListener]);
     return self.map->loadScene([path UTF8String], false, updates);
@@ -178,7 +178,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 {
     if (!self.map) { return -1; }
 
-    auto updates = [self unpackSceneUpdates:sceneUpdates];
+    auto updates = unpackSceneUpdates(sceneUpdates);
 
     self.map->setSceneReadyListener([self sceneReadyListener]);
     return self.map->loadSceneAsync([path UTF8String], false, updates);
@@ -188,7 +188,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 {
     if (!self.map) { return -1; }
 
-    auto updates = [self unpackSceneUpdates:sceneUpdates];
+    auto updates = unpackSceneUpdates(sceneUpdates);
 
     self.map->setSceneReadyListener([self sceneReadyListener]);
     return self.map->loadSceneYaml([yaml UTF8String], [resourceRoot UTF8String], false, updates);
@@ -198,7 +198,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
 {
     if (!self.map) { return -1; }
 
-    auto updates = [self unpackSceneUpdates:sceneUpdates];
+    auto updates = unpackSceneUpdates(sceneUpdates);
 
     self.map->setSceneReadyListener([self sceneReadyListener]);
     return self.map->loadSceneYamlAsync([yaml UTF8String], [resourceRoot UTF8String], false, updates);
@@ -214,7 +214,7 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
         return -1;
     }
 
-    auto updates = [self unpackSceneUpdates:sceneUpdates];
+    auto updates = unpackSceneUpdates(sceneUpdates);
 
     self.map->setSceneReadyListener([self sceneReadyListener]);
     return self.map->updateSceneAsync(updates);

--- a/platforms/linux/src/main.cpp
+++ b/platforms/linux/src/main.cpp
@@ -12,19 +12,10 @@ int main(int argc, char* argv[]) {
 
     auto platform = std::make_shared<LinuxPlatform>();
 
-    std::string sceneFile = "scene.yaml";
-    // Load file from command line, if given.
-    int argi = 0;
-    while (++argi < argc) {
-        if (strcmp(argv[argi - 1], "-f") == 0) {
-            sceneFile = std::string(argv[argi]);
-            LOG("File from command line: %s\n", argv[argi]);
-            break;
-        }
-    }
-
     // Create the windowed app.
-    GlfwApp::create(platform, sceneFile, 1024, 768);
+    GlfwApp::create(platform, 1024, 768);
+
+    GlfwApp::parseArgs(argc, argv);
 
     // Give it a chance to shutdown cleanly on CTRL-C
     signal(SIGINT, &GlfwApp::stop);

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -12,19 +12,10 @@ int main(int argc, char* argv[]) {
 
     auto platform = std::make_shared<OSXPlatform>();
 
-    std::string sceneFile = "scene.yaml";
-    // Load file from command line, if given.
-    int argi = 0;
-    while (++argi < argc) {
-        if (strcmp(argv[argi - 1], "-f") == 0) {
-            sceneFile = std::string(argv[argi]);
-            LOG("File from command line: %s\n", argv[argi]);
-            break;
-        }
-    }
-
     // Create the windowed app.
-    GlfwApp::create(platform, sceneFile, 1024, 768);
+    GlfwApp::create(platform, 1024, 768);
+
+    GlfwApp::parseArgs(argc, argv);
 
     // Give it a chance to shutdown cleanly on CTRL-C
     signal(SIGINT, &GlfwApp::stop);


### PR DESCRIPTION
Scene strings can now be tested like this:
```
 ./tangram -s "{ import: [ refill-style.yaml, themes/color-blue.yaml] }" /home/jeff/work/tangram-es/styles/refill/
```

Added ios interfaces.