### PR TITLE
Naming convention for debug version of iOS snapshots

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,8 +29,8 @@ deployment:
       # Add the license file.
       - zip ${CIRCLE_ARTIFACTS}/pod.zip LICENSE
       # Upload the Cocoapods archive to S3.
-      - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-snapshots/tangram-snapshot-${CIRCLE_BUILD_NUM}.zip
-      - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-latest.zip
+      - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-snapshots/tangram-snapshot-debug-${CIRCLE_BUILD_NUM}.zip
+      - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-latest-debug.zip
   releases:
     # For any tag of the form 1, 1.2, 1.2.3, etc. we will deploy a release build.
     tag: /[0-9]+(\.[0-9]+)*/

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -2,6 +2,7 @@ iOS
 ===
 
 The recommended way to use tangram-es in an iOS project is to add it as a CocoaPods dependency. The library is hosted in CocoaPods under the pod name 'Tangram-es'. To find the latest version, check CocoaPods: https://cocoapods.org/pods/Tangram-es.
+For convenience, we also provide Debug snapshots and Releases at [ios.mapzen.com](http://ios.mapzen.com/).
 
 ## Setup ##
 
@@ -35,6 +36,8 @@ make ios MAPZEN_API_KEY=mapzen-xxxx
 ```
 
 You can optionally append `DEBUG=1` or `RELEASE=1` to choose the build type.
+
+> Note: DEBUG version of the framework does not have bitcode enabled. If you need bitcode, make sure to get RELEASE version of the framework.
 
 This will generate an Xcode project that you can use to deploy on device or simulator:
 


### PR DESCRIPTION
Make sure to reflect the build type of available s3 frameworks in the naming of available frameworks on ios.mapzen.com.