### PR TITLE
Enable 'tms' flag for data sources

### DIFF
--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -10,10 +10,11 @@
 namespace Tangram {
 
 NetworkDataSource::NetworkDataSource(std::shared_ptr<Platform> _platform, const std::string& _urlTemplate,
-        std::vector<std::string>&& _urlSubdomains) :
+        std::vector<std::string>&& _urlSubdomains, bool isTms) :
     m_platform(_platform),
     m_urlTemplate(_urlTemplate),
     m_urlSubdomains(std::move(_urlSubdomains)),
+    m_isTms(isTms),
     m_maxDownloads(MAX_DOWNLOADS) {}
 
 std::string NetworkDataSource::constructURL(const TileID& _tileCoord, size_t _subdomainIndex) const {
@@ -25,7 +26,13 @@ std::string NetworkDataSource::constructURL(const TileID& _tileCoord, size_t _su
     }
     size_t yPos = url.find("{y}");
     if (yPos != std::string::npos) {
-        url.replace(yPos, 3, std::to_string(_tileCoord.y));
+        int y = _tileCoord.y;
+        int z = _tileCoord.z;
+        if (m_isTms) {
+            // Convert XYZ to TMS
+            y = (1 << z) - 1 - _tileCoord.y;
+        }
+        url.replace(yPos, 3, std::to_string(y));
     }
     size_t zPos = url.find("{z}");
     if (zPos != std::string::npos) {

--- a/core/src/data/networkDataSource.h
+++ b/core/src/data/networkDataSource.h
@@ -10,7 +10,7 @@ class NetworkDataSource : public TileSource::DataSource {
 public:
 
     NetworkDataSource(std::shared_ptr<Platform> _platform, const std::string& _urlTemplate,
-            std::vector<std::string>&& _urlSubdomains);
+            std::vector<std::string>&& _urlSubdomains, bool isTms);
 
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
@@ -28,6 +28,7 @@ private:
     std::string m_urlTemplate;
     std::vector<std::string> m_urlSubdomains;
     size_t m_urlSubdomainIndex = 0;
+    bool m_isTms = false;
 
     std::vector<TileID> m_pending;
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1066,6 +1066,11 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
         isMBTilesFile = urlLength > extLength && (url.compare(urlLength - extLength, extLength, extStr) == 0);
     }
 
+    bool isTms = false;
+    if (auto tmsNode = source["tms"]) {
+        getBool(tmsNode, isTms);
+    }
+
     auto rawSources = std::make_unique<MemoryCacheDataSource>();
     rawSources->setCacheSize(CACHE_SIZE);
 
@@ -1075,7 +1080,7 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
         // Create an MBTiles data source from the file at the url and add it to the source chain.
         rawSources->setNext(std::make_unique<MBTilesDataSource>(platform, name, url, ""));
     } else if (tiled) {
-        rawSources->setNext(std::make_unique<NetworkDataSource>(platform, url, std::move(subdomains)));
+        rawSources->setNext(std::make_unique<NetworkDataSource>(platform, url, std::move(subdomains), isTms));
     }
 
     std::shared_ptr<TileSource> sourcePtr;


### PR DESCRIPTION
Follows the behavior described in https://github.com/tangrams/tangram/issues/359

A simple change, but I haven't yet found a data source to test it with (the one used in the issue above appears dead now).

Resolves #971 