### PR TITLE
Fix: Error on when path for scene update is malformed or incorrect

### DIFF
--- a/core/src/util/yamlHelper.h
+++ b/core/src/util/yamlHelper.h
@@ -18,7 +18,9 @@ struct YamlPath {
     YamlPath(const std::string& path);
     YamlPath add(int index);
     YamlPath add(const std::string& key);
-    YAML::Node get(YAML::Node root);
+    // returns true and sets n to a valid node with r as the root node.
+    // returns false when path is malformed and sets n to empty node.
+    bool get(YAML::Node r, YAML::Node& n);
     std::string codedPath;
 };
 

--- a/core/src/util/yamlHelper.h
+++ b/core/src/util/yamlHelper.h
@@ -18,9 +18,10 @@ struct YamlPath {
     YamlPath(const std::string& path);
     YamlPath add(int index);
     YamlPath add(const std::string& key);
-    // returns true and sets n to a valid node with r as the root node.
-    // returns false when path is malformed and sets n to empty node.
-    bool get(YAML::Node r, YAML::Node& n);
+    // Follow this path from a root node and set 'out' to the result.
+    // Returns true if the path exists up to the final token (i.e. the output
+    // may be a new node), otherwise returns false and leaves 'out' unchanged.
+    bool get(YAML::Node root, YAML::Node& out);
     std::string codedPath;
 };
 

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -226,16 +226,23 @@ TEST_CASE("Scene update statuses") {
     CHECK(scene.errors.front().error == Error::scene_update_value_yaml_syntax_error);
     scene.errors.clear();
 
-    updates = {{"!map#0", "first_value"}};
+    updates = {{"someKey.somePath", "someValue"}};
     CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
-    CHECK(scene.errors.front().error == Error::scene_update_path_yaml_syntax_error);
+    CHECK(scene.errors.front().error == Error::scene_update_path_not_found);
     scene.errors.clear();
 
-    // Test was broken
-    // updates = {{"key_not_existing", "first_value"}};
-    // CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
-    // CHECK(scene.errors.front().error == Error::scene_update_path_not_found);
-    // scene.errors.clear();
+    updates = {{"map.a.map_a_value", "someValue"}};
+    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(scene.errors.front().error == Error::scene_update_path_not_found);
+    scene.errors.clear();
+
+    updates = {{"!map#0", "first_value"}};
+    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(scene.errors.front().error == Error::scene_update_path_not_found);
+    scene.errors.clear();
+
+    updates = {{"key_not_existing", "first_value"}};
+    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == true);
 
     updates = {{"!map#0", "{ first_value"}};
     CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);


### PR DESCRIPTION
A node path in a yaml tree is "invalid" when it is either malformed (missing apt delimiter) or has missing missing nodes in between a path.

A path is however still "valid" if the last node in the path is missing, at which point during a scene update will get added to the scene config.