### PR TITLE
Android tools update

### DIFF
--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -5,7 +5,7 @@ allprojects {
       jcenter()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:2.2.3'
+      classpath 'com.android.tools.build:gradle:2.3.3'
       classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
   }

--- a/platforms/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platforms/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 14 20:10:31 EDT 2016
+#Wed Aug 02 15:25:27 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -7,12 +7,12 @@ version = VERSION_NAME
 apply from: 'versioning.gradle'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion '25.0.2'
+  compileSdkVersion 26
+  buildToolsVersion '25.0.3'
 
   defaultConfig {
     minSdkVersion 15
-    targetSdkVersion 25
+    targetSdkVersion 26
     versionCode buildVersionCode()
     versionName VERSION_NAME
     externalNativeBuild {

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -74,7 +74,7 @@ android {
 dependencies {
   compile 'com.squareup.okhttp3:okhttp:3.5.0'
   compile 'xmlpull:xmlpull:1.1.3.1'
-  compile 'com.android.support:support-annotations:25.0.0'
+  compile 'com.android.support:support-annotations:25.3.1'
 }
 
 apply from: file('gradle-mvn-push.gradle')


### PR DESCRIPTION
 **Updates the Gradle wrapper version from 2.14.1 to 3.3 and the Gradle Android build plugin version from 2.2.3 to 2.3.3**

This enables "instant run", which re-deploys apps super fast after small changes, and makes C++ build output visible in the Android Studio console. It also prevents the native debugger from stopping at breakpoints on some machines (read: Varun's), while still working correctly on other machines (read: mine). More data points here will be useful.

**Updates the target Android SDK to 26**

O! O! Android O!

**Update support-annotations dependency version from 25.0.0 to 25.3.1**

Seems like good hygiene.