### PR TITLE
fix: use GetStringUTFLength when converting Java UTF16 to UTF8 C-strings

### DIFF
--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -141,7 +141,7 @@ void onUrlFailure(JNIEnv* _jniEnv, jlong _jCallbackPtr) {
 }
 
 std::string stringFromJString(JNIEnv* jniEnv, jstring string) {
-    size_t length = jniEnv->GetStringLength(string);
+    size_t length = jniEnv->GetStringUTFLength(string);
     std::string out(length, 0);
     jniEnv->GetStringUTFRegion(string, 0, length, &out[0]);
     return out;


### PR DESCRIPTION
Internal PR to resolve CI for #1600 

Thanks @cleeus for catching this issue.