### PR TITLE
OSX Demo Revamp

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ deployment:
       - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-snapshots/tangram-snapshot-debug-${CIRCLE_BUILD_NUM}.zip
       - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-latest-debug.zip
       # Build the MacOS demo app and package it into demo.zip
-      - make -j osx
+      - make osx -j MACOSX_DEPLOYMENT_TARGET=10.10.0
       - cd build/osx/bin && zip -r ${CIRCLE_ARTIFACTS}/demo.zip tangram.app
       # Upload the demo archive to S3.
       - aws s3 cp ${CIRCLE_ARTIFACTS}/demo.zip s3://ios.mapzen.com/tangram-osx-snapshots/tangram-snapshot-debug-${CIRCLE_BUILD_NUM}.zip

--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,12 @@ deployment:
       # Upload the Cocoapods archive to S3.
       - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-snapshots/tangram-snapshot-debug-${CIRCLE_BUILD_NUM}.zip
       - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-latest-debug.zip
+      # Build the MacOS demo app and package it into demo.zip
+      - make -j osx
+      - cd build/osx/bin && zip -r ${CIRCLE_ARTIFACTS}/demo.zip tangram.app
+      # Upload the demo archive to S3.
+      - aws s3 cp ${CIRCLE_ARTIFACTS}/demo.zip s3://ios.mapzen.com/tangram-osx-snapshots/tangram-snapshot-debug-${CIRCLE_BUILD_NUM}.zip
+      - aws s3 cp ${CIRCLE_ARTIFACTS}/demo.zip s3://ios.mapzen.com/tangram-osx-latest-debug.zip
   releases:
     # For any tag of the form 1, 1.2.3, 1.4-beta2, etc. we will deploy a release build.
     tag: /[0-9]+(\.[0-9]+)*(-beta[0-9]*)?/

--- a/core/include/tangram/tangram.h
+++ b/core/include/tangram/tangram.h
@@ -1,0 +1,23 @@
+// Tangram ES
+// A library for rendering 3D maps from vector data using OpenGL
+//
+// Copyright (c) 2017 Mapzen (mapzen.com)
+//
+#pragma once
+
+#define TANGRAM_VERSION_MAJOR 0
+#define TANGRAM_VERSION_MINOR 8
+#define TANGRAM_VERSION_PATCH 0
+
+#include "data/clientGeoJsonSource.h"
+#include "data/properties.h"
+#include "data/propertyItem.h"
+#include "data/tileSource.h"
+#include "tile/tileID.h"
+#include "tile/tileTask.h"
+#include "util/types.h"
+#include "util/url.h"
+#include "util/variant.h"
+#include "log.h"
+#include "map.h"
+#include "platform.h"

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -3,6 +3,10 @@
 #include <GLFW/glfw3.h>
 #include <cstdlib>
 
+#ifndef BUILD_NUM_STRING
+#define BUILD_NUM_STRING ""
+#endif
+
 namespace Tangram {
 
 namespace GlfwApp {
@@ -122,12 +126,14 @@ void create(std::shared_ptr<Platform> p, int w, int h) {
         map = new Tangram::Map(platform);
     }
 
+    // Build a version string for the window title.
+    char versionString[256] = { 0 };
+    std::snprintf(versionString, sizeof(versionString), "Tangram ES %d.%d.%d " BUILD_NUM_STRING,
+        TANGRAM_VERSION_MAJOR, TANGRAM_VERSION_MINOR, TANGRAM_VERSION_PATCH);
+
     // Create a windowed mode window and its OpenGL context
     glfwWindowHint(GLFW_SAMPLES, 2);
     if (!main_window) {
-        char versionString[256] = { 0 };
-        std::snprintf(versionString, sizeof(versionString), "Tangram ES %d.%d.%d",
-            TANGRAM_VERSION_MAJOR, TANGRAM_VERSION_MINOR, TANGRAM_VERSION_PATCH);
         main_window = glfwCreateWindow(width, height, versionString, NULL, NULL);
     }
     if (!main_window) {

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -51,8 +51,6 @@ Tangram::MarkerID marker = 0;
 Tangram::MarkerID poiMarker = 0;
 Tangram::MarkerID polyline = 0;
 
-bool keepRunning = true;
-
 void loadSceneFile(bool setPosition) {
     std::vector<SceneUpdate> updates;
 
@@ -162,7 +160,7 @@ void run() {
     double lastTime = glfwGetTime();
 
     // Loop until the user closes the window
-    while (keepRunning && !glfwWindowShouldClose(main_window)) {
+    while (!glfwWindowShouldClose(main_window)) {
 
         double currentTime = glfwGetTime();
         double delta = currentTime - lastTime;
@@ -185,9 +183,9 @@ void run() {
 }
 
 void stop(int) {
-    if (keepRunning) {
+    if (!glfwWindowShouldClose(main_window)) {
         logMsg("shutdown\n");
-        keepRunning = false;
+        glfwSetWindowShouldClose(main_window, 1);
         glfwPostEmptyEvent();
     } else {
         logMsg("killed!\n");

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -1,8 +1,6 @@
 #include "glfwApp.h"
-#include "data/clientGeoJsonSource.h"
 #include "debug/textDisplay.h"
 #include <GLFW/glfw3.h>
-#include "log.h"
 #include <cstdlib>
 
 namespace Tangram {
@@ -129,7 +127,10 @@ void create(std::shared_ptr<Platform> p, int w, int h) {
     // Create a windowed mode window and its OpenGL context
     glfwWindowHint(GLFW_SAMPLES, 2);
     if (!main_window) {
-        main_window = glfwCreateWindow(width, height, "Tangram ES", NULL, NULL);
+        char versionString[256] = { 0 };
+        std::snprintf(versionString, sizeof(versionString), "Tangram ES %d.%d.%d",
+            TANGRAM_VERSION_MAJOR, TANGRAM_VERSION_MINOR, TANGRAM_VERSION_PATCH);
+        main_window = glfwCreateWindow(width, height, versionString, NULL, NULL);
     }
     if (!main_window) {
         glfwTerminate();

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -24,11 +24,11 @@ std::shared_ptr<Platform> platform;
 
 std::string sceneFile = "scene.yaml";
 std::string sceneYaml;
+std::string mapzenApiKey;
 
 std::string markerStylingPath = "layers.touch.point.draw.icons";
 std::string polylineStyle = "{ style: lines, interactive: true, color: red, width: 20px, order: 5000 }";
 
-std::string mapzenApiKey;
 
 GLFWwindow* main_window = nullptr;
 Tangram::Map* map = nullptr;
@@ -53,7 +53,7 @@ Tangram::MarkerID polyline = 0;
 
 bool keepRunning = true;
 
-void loadSceneFile(bool setPosition = false) {
+void loadSceneFile(bool setPosition) {
     std::vector<SceneUpdate> updates;
 
     if (!mapzenApiKey.empty()) {

--- a/platforms/common/glfwApp.h
+++ b/platforms/common/glfwApp.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "map.h"
-#include "platform.h"
+#include "tangram.h"
 #include <memory>
 
 namespace Tangram {

--- a/platforms/common/glfwApp.h
+++ b/platforms/common/glfwApp.h
@@ -9,10 +9,15 @@ namespace GlfwApp {
 
 void create(std::shared_ptr<Platform> platform, int width, int height);
 void setScene(const std::string& _path, const std::string& _yaml);
+void loadSceneFile(bool setPosition = false);
 void parseArgs(int argc, char* argv[]);
 void run();
 void stop(int);
 void destroy();
+
+extern std::string sceneFile;
+extern std::string sceneYaml;
+extern std::string mapzenApiKey;
 
 } // namespace GlfwApp
 

--- a/platforms/osx/Info.plist
+++ b/platforms/osx/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>tangram</string>
+	<string>Tangram ES</string>
 	<key>CFBundleExecutable</key>
 	<string>tangram</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>tangram</string>
+	<string>Tangram ES</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -6,7 +6,110 @@
 #include <signal.h>
 #include <stdlib.h>
 
+#import <AppKit/AppKit.h>
+
 using namespace Tangram;
+
+@interface TGPreferences : NSObject
++ (void)setup;
++ (void)startApiKeyInput;
++ (void)startFileOpen;
++ (void)startFileEdit;
++ (NSString*) apiKeyDefaultsName;
+@end
+
+@implementation TGPreferences
+
++ (void)setup
+{
+    // If an API key has been stored in defaults already, set it in the app.
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    NSString* storedApiKey = [defaults stringForKey:[self apiKeyDefaultsName]];
+    if (storedApiKey != nil) {
+        GlfwApp::mapzenApiKey = std::string([storedApiKey UTF8String]);
+    }
+
+    // Set up menu shortcuts.
+    NSMenu *mainMenu = [[NSApplication sharedApplication] mainMenu];
+    NSMenu *appMenu = [[mainMenu itemAtIndex:0] submenu];
+    NSMenuItem* apiKeyMenuItem = [appMenu insertItemWithTitle:@"API Key..."
+                                                       action:@selector(startApiKeyInput)
+                                                keyEquivalent:@"k"
+                                                      atIndex:1];
+    apiKeyMenuItem.target = self;
+
+    NSMenuItem* editFileMenuItem = [appMenu insertItemWithTitle:@"Edit Scene"
+                                                         action:@selector(startFileEdit)
+                                                  keyEquivalent:@"e"
+                                                        atIndex:2];
+
+    editFileMenuItem.target = self;
+
+    NSMenuItem* sceneOpenMenuItem = [appMenu insertItemWithTitle:@"Open Scene..."
+                                                           action:@selector(startFileOpen)
+                                                    keyEquivalent:@"o"
+                                                          atIndex:3];
+    sceneOpenMenuItem.target = self;
+}
+
++ (void)startApiKeyInput
+{
+    NSString* defaultsKeyString = [self apiKeyDefaultsName];
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    NSString* defaultsValueString = [defaults stringForKey:defaultsKeyString];
+
+    NSAlert* alert = [[NSAlert alloc] init];
+    [alert setMessageText:@"Set API key default"];
+
+    NSTextField *input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
+    input.translatesAutoresizingMaskIntoConstraints = YES;
+    input.editable = YES;
+    input.selectable = YES;
+    if (defaultsValueString != nil) {
+        [input setStringValue:defaultsValueString];
+        [input selectText:self];
+    }
+
+    [alert setAccessoryView:input];
+    [alert addButtonWithTitle:@"Ok"];
+    [alert addButtonWithTitle:@"Cancel"];
+    NSInteger button = [alert runModal];
+    if (button == NSAlertFirstButtonReturn) {
+        [defaults setValue:[input stringValue] forKey:defaultsKeyString];
+        GlfwApp::mapzenApiKey = std::string([[input stringValue] UTF8String]);
+        GlfwApp::loadSceneFile();
+    }
+}
+
++ (void)startFileOpen
+{
+    NSOpenPanel* openPanel = [NSOpenPanel openPanel];
+    openPanel.canChooseFiles = YES;
+    openPanel.canChooseDirectories = NO;
+    openPanel.allowsMultipleSelection = NO;
+
+    NSInteger button = [openPanel runModal];
+    if (button == NSFileHandlingPanelOKButton) {
+        NSURL* url = [openPanel URLs].firstObject;
+        LOG("Got file URL: %s", [[url absoluteString] UTF8String]);
+        GlfwApp::sceneFile = std::string([[url absoluteString] UTF8String]);
+        GlfwApp::sceneYaml.clear();
+        GlfwApp::loadSceneFile();
+    }
+}
+
++ (void)startFileEdit
+{
+    NSString* file = [NSString stringWithUTF8String:GlfwApp::sceneFile.c_str()];
+    NSURL* url = [NSURL fileURLWithPath:file];
+    [[NSWorkspace sharedWorkspace] openURL:url];
+}
+
++ (NSString*)apiKeyDefaultsName
+{
+    return @"mapzenApiKey";
+}
+@end
 
 int main(int argc, char* argv[]) {
 
@@ -14,6 +117,9 @@ int main(int argc, char* argv[]) {
 
     // Create the windowed app.
     GlfwApp::create(platform, 1024, 768);
+
+    // Menu and window changes must come after window is created.
+    [TGPreferences setup];
 
     GlfwApp::parseArgs(argc, argv);
 

--- a/toolchains/darwin.cmake
+++ b/toolchains/darwin.cmake
@@ -17,6 +17,10 @@ if(TANGRAM_APPLICATION)
   get_mapzen_api_key(MAPZEN_API_KEY)
   add_definitions(-DMAPZEN_API_KEY="${MAPZEN_API_KEY}")
 
+  if($ENV{CIRCLE_BUILD_NUM})
+    add_definitions(-DBUILD_NUM_STRING="\($ENV{CIRCLE_BUILD_NUM}\)")
+  endif()
+
   find_package(OpenGL REQUIRED)
 
   # Build GLFW.

--- a/toolchains/linux.cmake
+++ b/toolchains/linux.cmake
@@ -40,6 +40,10 @@ if(TANGRAM_APPLICATION)
   get_mapzen_api_key(MAPZEN_API_KEY)
   add_definitions(-DMAPZEN_API_KEY="${MAPZEN_API_KEY}")
 
+  if($ENV{CIRCLE_BUILD_NUM})
+    add_definitions(-DBUILD_NUM_STRING="\($ENV{CIRCLE_BUILD_NUM}\)")
+  endif()
+
   find_package(OpenGL REQUIRED)
 
   # Build GLFW.


### PR DESCRIPTION
 **Display Tangram ES version in GLFW demo title bar**

<img width="560" alt="screen shot 2017-08-09 at 11 59 58 am" src="https://user-images.githubusercontent.com/3371850/29139034-5a6f8b7c-7cfa-11e7-8fac-8081a873c2ee.png">

 **Add menu shortcuts for managing scene file and API key**

<img width="235" alt="screen shot 2017-08-09 at 11 58 28 am" src="https://user-images.githubusercontent.com/3371850/29139046-6a56d162-7cfa-11e7-97a3-dc42cbca14cc.png">

 - **API Key...** opens a dialog box that allows you to edit and save a Mapzen API key. This key is saved in user preferences and used for every version of the Tangram ES app.
 - **Edit Scene** opens the current scene file/URL using the system default application for the file type.
 - **Open Scene...** opens a file-open panel where you can pick a scene file to load.

**Add MacOS demo builds to CircleCI config**

 - Hosted on ios.mapzen.com

Resolves #1571 