### PR TITLE
Cancelled URL requests produce debug (not error) messages

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1319,7 +1319,11 @@ public class MapController implements Renderer {
         httpHandler.onRequest(url, new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
-                android.util.Log.e("Tangram", "Failed url request: " + url + " " + e.toString());
+                if (call.isCanceled()) {
+                    android.util.Log.d("Tangram", "Canceled URL request: " + url);
+                } else {
+                    android.util.Log.e("Tangram", "Failed URL request: " + url + " " + e.toString());
+                }
                 nativeOnUrlFailure(callbackPtr);
             }
 

--- a/platforms/ios/src/TangramMap/iosPlatform.mm
+++ b/platforms/ios/src/TangramMap/iosPlatform.mm
@@ -228,7 +228,12 @@ bool iOSPlatform::startUrlRequest(const std::string& _url, UrlCallback _callback
 
         if (error != nil) {
 
-            LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
+            if (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled) {
+                LOGD("Request cancelled: %s", [response.URL.absoluteString UTF8String]);
+            } else {
+                LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
+            }
+
 
         } else if (statusCode < 200 || statusCode >= 300) {
 


### PR DESCRIPTION
Resolves https://github.com/tangrams/tangram-es/issues/1610

The iOS and Android code for this is almost identical! Curiously though, NSURLSession uses the British "cancelled" and OkHTTP uses the US "canceled". I've made the log messages consistent with each.