### PR TITLE
More OSX demo tweaks

### DIFF
--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -251,10 +251,15 @@ void mouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
 
     if ((time - last_time_released) < double_tap_time) {
         // Double tap recognized
-        Tangram::LngLat p;
-        map->screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
-        map->setPositionEased(p.longitude, p.latitude, 1.f);
-
+        const float duration = 0.5f;
+        Tangram::LngLat tapped, current;
+        map->screenPositionToLngLat(x, y, &tapped.longitude, &tapped.latitude);
+        map->getPosition(current.longitude, current.latitude);
+        map->setZoomEased(map->getZoom() + 1.f, duration, EaseType::quint);
+        map->setPositionEased(
+            0.5 * (tapped.longitude + current.longitude),
+            0.5 * (tapped.latitude + current.latitude),
+            duration, EaseType::quint);
     } else if ((time - last_time_pressed) < single_tap_time) {
         // Single tap recognized
         Tangram::LngLat p;

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -98,8 +98,10 @@ using namespace Tangram;
     NSInteger button = [openPanel runModal];
     if (button == NSFileHandlingPanelOKButton) {
         NSURL* url = [openPanel URLs].firstObject;
-        LOG("Got file URL: %s", [[url absoluteString] UTF8String]);
-        GlfwApp::sceneFile = std::string([[url absoluteString] UTF8String]);
+        LOG("Got URL to open: %s", [[url absoluteString] UTF8String]);
+        // TODO: When generic URL support is added to scene loading, we should
+        // use the full URL here instead of just the path.
+        GlfwApp::sceneFile = std::string([[url path] UTF8String]);
         GlfwApp::sceneYaml.clear();
         GlfwApp::loadSceneFile();
     }

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -38,7 +38,7 @@ using namespace Tangram;
                                                       atIndex:1];
     apiKeyMenuItem.target = self;
 
-    NSMenuItem* editFileMenuItem = [appMenu insertItemWithTitle:@"Edit Scene"
+    NSMenuItem* editFileMenuItem = [appMenu insertItemWithTitle:@"Open Scene with Exernal Editor"
                                                          action:@selector(startFileEdit)
                                                   keyEquivalent:@"e"
                                                         atIndex:2];
@@ -101,7 +101,7 @@ using namespace Tangram;
 + (void)startFileEdit
 {
     NSString* file = [NSString stringWithUTF8String:GlfwApp::sceneFile.c_str()];
-    NSURL* url = [NSURL fileURLWithPath:file];
+    NSURL* url = [NSURL URLWithString:file relativeToURL:[[NSBundle mainBundle] resourceURL]];
     [[NSWorkspace sharedWorkspace] openURL:url];
 }
 

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -65,21 +65,22 @@ using namespace Tangram;
     NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
     NSString* defaultsValueString = [defaults stringForKey:defaultsKeyString];
 
-    NSAlert* alert = [[NSAlert alloc] init];
-    [alert setMessageText:@"Set API key default"];
-
     NSTextField *input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
     input.translatesAutoresizingMaskIntoConstraints = YES;
     input.editable = YES;
     input.selectable = YES;
     if (defaultsValueString != nil) {
         [input setStringValue:defaultsValueString];
-        [input selectText:self];
     }
 
-    [alert setAccessoryView:input];
+    NSAlert* alert = [[NSAlert alloc] init];
+    [alert setMessageText:@"Set API key default"];
+    [alert setAccessoryView: input];
     [alert addButtonWithTitle:@"Ok"];
     [alert addButtonWithTitle:@"Cancel"];
+    [alert layout];
+    [alert.window makeFirstResponder:alert.accessoryView];
+
     NSInteger button = [alert runModal];
     if (button == NSAlertFirstButtonReturn) {
         [defaults setValue:[input stringValue] forKey:defaultsKeyString];

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -15,6 +15,7 @@ using namespace Tangram;
 + (void)startApiKeyInput;
 + (void)startFileOpen;
 + (void)startFileEdit;
++ (void)startFileReload;
 + (NSString*) apiKeyDefaultsName;
 @end
 
@@ -50,6 +51,12 @@ using namespace Tangram;
                                                     keyEquivalent:@"o"
                                                           atIndex:3];
     sceneOpenMenuItem.target = self;
+
+    NSMenuItem* sceneReloadMenuItem = [appMenu insertItemWithTitle:@"Reload Scene"
+                                                             action:@selector(startFileReload)
+                                                      keyEquivalent:@"r"
+                                                            atIndex:4];
+    sceneReloadMenuItem.target = self;
 }
 
 + (void)startApiKeyInput
@@ -103,6 +110,11 @@ using namespace Tangram;
     NSString* file = [NSString stringWithUTF8String:GlfwApp::sceneFile.c_str()];
     NSURL* url = [NSURL URLWithString:file relativeToURL:[[NSBundle mainBundle] resourceURL]];
     [[NSWorkspace sharedWorkspace] openURL:url];
+}
+
++ (void)startFileReload
+{
+    GlfwApp::loadSceneFile();
 }
 
 + (NSString*)apiKeyDefaultsName

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -34,43 +34,44 @@ using namespace Tangram;
 
     // Set up menu shortcuts.
     NSMenu *mainMenu = [[NSApplication sharedApplication] mainMenu];
+
+    // Set up Tangram ES menu.
     NSMenu *appMenu = [[mainMenu itemAtIndex:0] submenu];
-    NSMenuItem* apiKeyMenuItem = [appMenu insertItemWithTitle:@"API Key..."
-                                                       action:@selector(startApiKeyInput)
-                                                keyEquivalent:@"k"
-                                                      atIndex:1];
-    apiKeyMenuItem.target = self;
+    [appMenu insertItemWithTitle:@"API Key..."
+                          action:@selector(startApiKeyInput)
+                   keyEquivalent:@"k"
+                         atIndex:1].target = self;
 
-    NSMenuItem* editFileMenuItem = [appMenu insertItemWithTitle:@"Open Scene with Exernal Editor"
-                                                         action:@selector(startFileEdit)
-                                                  keyEquivalent:@"e"
-                                                        atIndex:2];
+    // Set up File menu.
+    NSMenuItem* fileMenuItem = [mainMenu insertItemWithTitle:@"" action:nil keyEquivalent:@"" atIndex:1];
+    NSMenu* fileMenu = [[NSMenu alloc] init];
+    [fileMenuItem setSubmenu:fileMenu];
+    [fileMenu setTitle:@"File"];
+    [fileMenu addItemWithTitle:@"Open Scene with External Editor"
+                       action:@selector(startFileEdit)
+                keyEquivalent:@"e"].target = self;
 
-    editFileMenuItem.target = self;
+    [fileMenu addItemWithTitle:@"Open Scene..."
+                       action:@selector(startFileOpen)
+                keyEquivalent:@"o"].target = self;
 
-    NSMenuItem* sceneOpenMenuItem = [appMenu insertItemWithTitle:@"Open Scene..."
-                                                           action:@selector(startFileOpen)
-                                                    keyEquivalent:@"o"
-                                                          atIndex:3];
-    sceneOpenMenuItem.target = self;
+    [fileMenu addItemWithTitle:@"Reload Scene"
+                       action:@selector(startFileReload)
+                keyEquivalent:@"r"].target = self;
 
-    NSMenuItem* sceneReloadMenuItem = [appMenu insertItemWithTitle:@"Reload Scene"
-                                                             action:@selector(startFileReload)
-                                                      keyEquivalent:@"r"
-                                                            atIndex:4];
-    sceneReloadMenuItem.target = self;
+    // Set up Edit menu.
+    NSMenuItem* editMenuItem = [mainMenu insertItemWithTitle:@"" action:nil keyEquivalent:@"" atIndex:2];
+    NSMenu* editMenu = [[NSMenu alloc] init];
+    [editMenuItem setSubmenu:editMenu];
+    [editMenu setTitle:@"Edit"];
 
-    NSMenuItem* copyMenuItem = [appMenu insertItemWithTitle:@"Copy"
-                                                     action:@selector(copyEditorTextToClipboard)
-                                              keyEquivalent:@"c"
-                                                    atIndex:5];
-    copyMenuItem.target = self;
+    [editMenu addItemWithTitle:@"Copy"
+                        action:@selector(copyEditorTextToClipboard)
+                 keyEquivalent:@"c"].target = self;
 
-    NSMenuItem* pasteMenuItem = [appMenu insertItemWithTitle:@"Paste"
-                                                      action:@selector(pasteEditorTextFromClipboard)
-                                               keyEquivalent:@"v"
-                                                     atIndex:6];
-    pasteMenuItem.target = self;
+    [editMenu addItemWithTitle:@"Paste"
+                        action:@selector(pasteEditorTextFromClipboard)
+                 keyEquivalent:@"v"].target = self;
 }
 
 + (void)startApiKeyInput


### PR DESCRIPTION
A few more conveniences for the OSX demo app
 - If the current scene file is from an HTTP URL, the **Edit Scene** menu item will open it in a browser.
 - The menu now has a **Reload Scene** item (this already worked via GLFW keyboard input, but having it in the menu is nicer UX).

TODO:
 - ~Relative resource URLs in scene files don't seem to work with the Open panel.~ _fixed_
 - ~View stdout (maybe log it to a file, then it's easy to send with a bug report)~ _won't fix here_
 - ~Open HTTP URLs (maybe support pasting URLs)~ _won't fix_
 - ~Scenes without `global.sdk_mapzen_api_key` fail to load because the scene update fails.~ _won't fix here_
 - ~Double-click should zoom the map instead of centering.~ _fixed_
 - ~Should be able to paste an API key into the alert box.~ _fixed_