### PR TITLE
Cancelled URL request errors are correctly silenced on iOS and OSX

### DIFF
--- a/platforms/ios/src/TangramMap/iosPlatform.mm
+++ b/platforms/ios/src/TangramMap/iosPlatform.mm
@@ -228,12 +228,11 @@ bool iOSPlatform::startUrlRequest(const std::string& _url, UrlCallback _callback
 
         if (error != nil) {
 
-            if (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled) {
+            if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) {
                 LOGD("Request cancelled: %s", [response.URL.absoluteString UTF8String]);
             } else {
                 LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
             }
-
 
         } else if (statusCode < 200 || statusCode >= 300) {
 

--- a/platforms/osx/src/osxPlatform.mm
+++ b/platforms/osx/src/osxPlatform.mm
@@ -127,7 +127,11 @@ bool OSXPlatform::startUrlRequest(const std::string& _url, UrlCallback _callback
 
         if (error != nil) {
 
-            LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
+            if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) {
+                LOGD("Request cancelled: %s", [response.URL.absoluteString UTF8String]);
+            } else {
+                LOGE("Response \"%s\" with error \"%s\".", response, [error.localizedDescription UTF8String]);
+            }
 
         } else if (statusCode < 200 || statusCode >= 300) {
 


### PR DESCRIPTION
This fixes the implementation of #1611 and adds the same change for OSX.

NSError 'domain' is a NSString value that can't be correctly compared using ==.

