### PR TITLE
Fix JobQueue thread safety

### DIFF
--- a/core/src/util/jobQueue.cpp
+++ b/core/src/util/jobQueue.cpp
@@ -13,24 +13,39 @@ void JobQueue::add(Job job) {
 
     if (!m_stopped) {
         std::lock_guard<std::mutex> lock(m_mutex);
-        m_jobs.push_back(job);
+        m_jobs.push_back(std::move(job));
     } else {
         job();
     }
 }
 
 void JobQueue::runJobs() {
+    std::vector<Job> localJobs;
 
-    for (size_t i = 0; i < m_jobs.size(); i++) {
-        Job job;
-        {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            job.swap(m_jobs[i]);
-        }
-        job();
+    {
+        //steal contents of m_jobs inside the lock
+        std::lock_guard<std::mutex> lock(m_mutex);
+        localJobs.swap(m_jobs);
+        //now the lock can be released as we won't touch m_jobs anymore
     }
-    m_jobs.clear();
 
+    //execute jobs outside of the lock
+    for (auto &jobref : localJobs) {
+        Job job = std::move(jobref);
+        job();
+        //job dtor triggers here
+    }
+
+
+    //try to give back memory to m_jobs
+    if(!localJobs.empty()){
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if(m_jobs.empty() && m_jobs.capacity() < localJobs.capacity()) {
+            //clear does not release capacity/memory
+            localJobs.clear();
+            m_jobs.swap(localJobs);
+        }
+    }
 }
 
 } //namespace Tangram

--- a/core/src/util/jobQueue.cpp
+++ b/core/src/util/jobQueue.cpp
@@ -4,9 +4,7 @@ namespace Tangram {
 
 JobQueue::~JobQueue() {
 
-    if (!m_jobs.empty()) {
-        runJobs();
-    }
+    if (!m_jobs.empty()) { runJobs(); }
 }
 
 void JobQueue::add(Job job) {
@@ -23,29 +21,29 @@ void JobQueue::runJobs() {
     std::vector<Job> localJobs;
 
     {
-        //steal contents of m_jobs inside the lock
+        // steal contents of m_jobs inside the lock
         std::lock_guard<std::mutex> lock(m_mutex);
-        localJobs.swap(m_jobs);
-        //now the lock can be released as we won't touch m_jobs anymore
+        m_jobs.swap(localJobs);
+        // now the lock can be released as we won't touch m_jobs anymore
     }
 
-    //execute jobs outside of the lock
-    for (auto &jobref : localJobs) {
+    // execute jobs outside of the lock
+    for (auto& jobref : localJobs) {
         Job job = std::move(jobref);
         job();
-        //job dtor triggers here
+        // job dtor triggers here
     }
 
 
-    //try to give back memory to m_jobs
-    if(!localJobs.empty()){
+    // try to give back memory to m_jobs
+    if (!localJobs.empty()) {
         std::lock_guard<std::mutex> lock(m_mutex);
-        if(m_jobs.empty() && m_jobs.capacity() < localJobs.capacity()) {
-            //clear does not release capacity/memory
+        if (m_jobs.empty() && m_jobs.capacity() < localJobs.capacity()) {
+            // clear does not release capacity/memory
             localJobs.clear();
             m_jobs.swap(localJobs);
         }
     }
 }
 
-} //namespace Tangram
+} // namespace Tangram

--- a/core/src/util/jobQueue.h
+++ b/core/src/util/jobQueue.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <mutex>
 #include <vector>
+#include <atomic>
 
 namespace Tangram {
 
@@ -33,7 +34,7 @@ private:
 
     std::vector<Job> m_jobs;
     std::mutex m_mutex;
-    bool m_stopped = false;
+    std::atomic<bool> m_stopped{false};
 };
 
 }

--- a/tests/unit/jobQueueTests.cpp
+++ b/tests/unit/jobQueueTests.cpp
@@ -1,0 +1,62 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "util/jobQueue.h"
+
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <vector>
+#include <memory>
+
+using namespace Tangram;
+
+
+class Barrier {
+private:
+    std::mutex m_mutex;
+    std::condition_variable m_cond;
+    std::size_t m_count;
+public:
+    explicit Barrier(std::size_t count) : m_count(count) { }
+    void wait() {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        if (--m_count == 0) {
+            m_cond.notify_all();
+        } else {
+            m_cond.wait(lock, [this] { return m_count == 0; });
+        }
+    }
+};
+
+
+TEST_CASE("stress test JobQueue", "[JobQueue]") {
+
+    JobQueue jobQueue;
+
+    const size_t numThreads = 16;
+    Barrier allThreadsGoBarrier(numThreads);
+
+    std::vector<std::unique_ptr<std::thread>> threads;
+
+    for(size_t i=0; i<numThreads; i++) {
+        threads.emplace_back(std::make_unique<std::thread>([&]{
+            allThreadsGoBarrier.wait();
+
+            for(int k=0; k<100; k++) {
+                for(int i=0; i<100; i++) {
+                    jobQueue.add([]{});
+                    if(i%3 == 0) {
+                        std::this_thread::yield();
+                    }
+                }
+                jobQueue.runJobs();
+            }
+        }));
+    }
+
+    for(auto &thread: threads) {
+        thread->join();
+    }
+}
+


### PR DESCRIPTION
The implementation of JobQueue does not hold up to the thread safety promises in the header comments. I wrote a simple test case that stresses JobQueue a bit and easily crashes. The fixed JobQueue swaps out the m_jobs vector inside a lock and then processes the jobs.