### PR TITLE
Include all shaped glyph from the last cluster

### DIFF
--- a/core/src/text/textUtil.cpp
+++ b/core/src/text/textUtil.cpp
@@ -24,8 +24,6 @@ float TextWrapper::getShapeRangeWidth(const alfons::LineLayout& _line) {
         lineWidth += _line.advance(shape);
 
         if (shape.mustBreak) {
-            lastShape = shapeCount;
-            lastChar = charCount;
             lastWidth = lineWidth;
 
             // Append shapes of current glyph cluster
@@ -34,6 +32,9 @@ float TextWrapper::getShapeRangeWidth(const alfons::LineLayout& _line) {
                 lineWidth += _line.advance(*it);
                 shapeCount++;
             }
+
+            lastChar = charCount;
+            lastShape = shapeCount;
 
             auto& endShape = _line.shapes()[lastShape-1];
 


### PR DESCRIPTION
previously the `lastShape` was not updated to include the shape of the last cluster (which is set to
must break in alfons) and hence last shape of the last cluster were not drawn.

Old behavior (Refer to continents names ending in vowels for example):
![screen shot 2017-09-05 at 4 06 49 pm](https://user-images.githubusercontent.com/360641/30087226-561ebb8c-9254-11e7-89f6-8b61286e1a8c.png)

Fixed behavior:
![screen shot 2017-09-05 at 4 06 04 pm](https://user-images.githubusercontent.com/360641/30087237-6162ed9c-9254-11e7-947a-3096720e3b78.png)



This fixes a regression, which was previously reported and fixed (partially) in #1293 and #1294 respectively.