### PR TITLE
Misc font handling fixes

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -710,7 +710,7 @@ void loadFontDescription(const std::shared_ptr<Platform>& platform, const Node& 
         LOGW("");
         return;
     }
-    std::string style = "normal", weight = "400", uri;
+    std::string style = "regular", weight = "400", uri;
 
     for (const auto& fontDesc : node) {
         const std::string& key = fontDesc.first.Scalar();

--- a/core/src/style/debugTextStyle.cpp
+++ b/core/src/style/debugTextStyle.cpp
@@ -55,7 +55,7 @@ std::unique_ptr<StyledMesh> DebugTextStyleBuilder::build() {
     params.text = m_tileID;
     params.fontSize = 30.f;
 
-    params.font = m_style.context()->getFont("sans-serif", "normal", "400", 32 * m_style.pixelScale());
+    params.font = m_style.context()->getFont("sans-serif", "regular", "400", 32 * m_style.pixelScale());
 
     TextStyleBuilder::LabelAttributes attrib;
     if (!prepareLabel(params, Label::Type::debug, attrib)) {

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -553,7 +553,7 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
                                                   bool _iconText) const {
 
     const static std::string defaultWeight("400");
-    const static std::string defaultStyle("normal");
+    const static std::string defaultStyle("regular");
     const static std::string defaultFamily("default");
 
     TextStyle::Parameters p;

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -316,7 +316,7 @@ std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, c
 
     // Pick the smallest font that does not scale down too much
     float fontSize = BASE_SIZE;
-    for (int i = 0; i < MAX_STEPS; i++) {
+    for (int i = 0; i < MAX_STEPS-1; i++) {
         sizeIndex = i;
 
         if (_size <= fontSize) { break; }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -9,14 +9,13 @@
 #include <memory>
 #include <regex>
 
-#define BASE_SIZE 16
-#define STEP_SIZE 12
-#define MAX_STEPS 3
 #define SDF_WIDTH 6
 
 #define MIN_LINE_WIDTH 4
 
 namespace Tangram {
+
+const std::vector<float> FontContext::s_fontRasterSizes = { 16, 28, 40 };
 
 FontContext::FontContext(std::shared_ptr<const Platform> _platform) :
     m_sdfRadius(SDF_WIDTH),
@@ -31,8 +30,8 @@ void FontContext::setPixelScale(float _scale) {
 void FontContext::loadFonts() {
     auto fallbacks = m_platform->systemFontFallbacksHandle();
 
-    for (int i = 0, size = BASE_SIZE; i < MAX_STEPS; i++, size += STEP_SIZE) {
-        m_font[i] = m_alfons.addFont("default", size);
+    for (size_t i = 0; i < s_fontRasterSizes.size(); i++) {
+        m_font[i] = m_alfons.addFont("default", s_fontRasterSizes[i]);
     }
 
     for (auto fallback : fallbacks) {
@@ -44,8 +43,8 @@ void FontContext::loadFonts() {
             source = alfons::InputSource(fallback.path);
         }
 
-        for (int i = 0, size = BASE_SIZE; i < MAX_STEPS; i++, size += STEP_SIZE) {
-            m_font[i]->addFace(m_alfons.addFontFace(source, size));
+        for (size_t i = 0; i < s_fontRasterSizes.size(); i++) {
+            m_font[i]->addFace(m_alfons.addFontFace(source, s_fontRasterSizes[i]));
         }
     }
 }
@@ -269,9 +268,9 @@ void FontContext::addFont(const FontDescription& _ft, alfons::InputSource _sourc
     // NB: Synchronize for calls from download thread
     std::lock_guard<std::mutex> lock(m_fontMutex);
 
-    for (int i = 0, size = BASE_SIZE; i < MAX_STEPS; i++, size += STEP_SIZE) {
-        auto font = m_alfons.getFont(_ft.alias, size);
-        font->addFace(m_alfons.addFontFace(_source, size));
+    for (size_t i = 0; i < s_fontRasterSizes.size(); i++) {
+        auto font = m_alfons.getFont(_ft.alias, s_fontRasterSizes[i]);
+        font->addFace(m_alfons.addFontFace(_source, s_fontRasterSizes[i]));
 
         // add fallbacks from default font
         font->addFaces(*m_font[i]);
@@ -312,15 +311,14 @@ void FontContext::ScratchBuffer::drawGlyph(const alfons::Rect& q, const alfons::
 std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, const std::string& _style,
                                                    const std::string& _weight, float _size) {
 
-    int sizeIndex = 0;
-
     // Pick the smallest font that does not scale down too much
-    float fontSize = BASE_SIZE;
-    for (int i = 0; i < MAX_STEPS-1; i++) {
-        sizeIndex = i;
+    float fontSize = s_fontRasterSizes.back();
+    size_t sizeIndex = s_fontRasterSizes.size() - 1;
 
-        if (_size <= fontSize) { break; }
-        fontSize += STEP_SIZE;
+    auto fontSizeItr = std::lower_bound(s_fontRasterSizes.begin(), s_fontRasterSizes.end(), _size);
+    if (fontSizeItr != s_fontRasterSizes.end()) {
+        fontSize = *fontSizeItr;
+        sizeIndex = fontSizeItr - s_fontRasterSizes.begin();
     }
 
     std::lock_guard<std::mutex> lock(m_fontMutex);

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -125,6 +125,8 @@ public:
 
 private:
 
+    static const std::vector<float> s_fontRasterSizes;
+
     float m_sdfRadius;
     ScratchBuffer m_scratch;
     std::vector<unsigned char> m_sdfBuffer;

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -49,13 +49,19 @@ struct FontDescription {
     }
 
     static std::string Alias(const std::string& family, const std::string& style, const std::string& weight) {
-        return family + "_" + weight + "_" + style;
+        return family + "_" + getNumericFontWeight(weight) + "_" + style;
     }
 
     static std::string BundleAlias(const std::string& family, const std::string& style, const std::string& weight) {
         // TODO: support .woff on bundle fonts
-        std::string alias = family + "-" + weight + style + ".ttf";
+        std::string alias = family + "-" + getNumericFontWeight(weight) + style + ".ttf";
         return alias;
+    }
+
+    static std::string getNumericFontWeight(const std::string& weight) {
+        if (weight == "normal") { return "400"; }
+        if (weight == "bold") { return "700"; }
+        return weight;
     }
 };
 


### PR DESCRIPTION
- match alfons default style name in ES (`normal`->`regular`)
- get font with apt font size.
We load 3 sizes for fonts, `16`,`28` and `40`. Make sure to get the font in this range.
- respect `normal` as default weight property, should map to numeric `400`. and `bold` should map to numeric `700`.