### PR TITLE
Fix: text style should only draw when a `font` draw rule is found

### DIFF
--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -46,6 +46,14 @@ DrawRule::DrawRule(const DrawRuleData& _ruleData, const std::string& _layerName,
     }
 }
 
+bool DrawRule::hasParameterSet(StyleParamKey _key) const {
+    if (auto& param = findParameter(_key)) {
+        auto key = static_cast<uint8_t>(param.key);
+        return active[key];
+    }
+    return false;
+}
+
 void DrawRule::merge(const DrawRuleData& _ruleData, const SceneLayer& _layer) {
 
     evalConflict(*this, _ruleData, _layer);

--- a/core/src/scene/drawRule.h
+++ b/core/src/scene/drawRule.h
@@ -93,6 +93,8 @@ struct DrawRule {
 
     size_t getParamSetHash() const;
 
+    bool hasParameterSet(StyleParamKey _key) const;
+
     const StyleParam& findParameter(StyleParamKey _key) const;
 
     template<typename T>

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -551,6 +551,19 @@ void TextStyleBuilder::addLineTextLabels(const Feature& _feat, const TextStyle::
     }
 }
 
+bool TextStyleBuilder::checkRule(const DrawRule& _rule) const {
+    if (_rule.hasParameterSet(StyleParamKey::text_font_family) ||
+        _rule.hasParameterSet(StyleParamKey::text_font_fill) ||
+        _rule.hasParameterSet(StyleParamKey::text_font_size) ||
+        _rule.hasParameterSet(StyleParamKey::text_font_stroke_color) ||
+        _rule.hasParameterSet(StyleParamKey::text_font_stroke_width) ||
+        _rule.hasParameterSet(StyleParamKey::text_font_style) ||
+        _rule.hasParameterSet(StyleParamKey::text_font_weight)) {
+        return true;
+    }
+    return false;
+}
+
 TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
                                                   const Properties& _props,
                                                   bool _iconText) const {

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -251,6 +251,9 @@ bool TextStyleBuilder::handleBoundaryLabel(const Feature& _feat, const DrawRule&
 }
 
 bool TextStyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) {
+
+    if (!checkRule(_rule)) { return false; }
+
     TextStyle::Parameters params = applyRule(_rule, _feat.props, false);
 
     Label::Type labelType;

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -57,20 +57,7 @@ public:
     bool handleBoundaryLabel(const Feature& _feat, const DrawRule& _rule,
                              const TextStyle::Parameters& _params);
 
-    bool checkRule(const DrawRule& _rule) const override {
-        if (_rule.hasParameterSet(StyleParamKey::text_font_family) ||
-            _rule.hasParameterSet(StyleParamKey::text_font_fill) ||
-            _rule.hasParameterSet(StyleParamKey::text_font_size) ||
-            _rule.hasParameterSet(StyleParamKey::text_font_stroke_color) ||
-            _rule.hasParameterSet(StyleParamKey::text_font_stroke_width) ||
-            _rule.hasParameterSet(StyleParamKey::text_font_style) ||
-            _rule.hasParameterSet(StyleParamKey::text_font_weight)) {
-            return true;
-        }
-
-        return false;
-    }
-
+    bool checkRule(const DrawRule& _rule) const override;
     std::vector<std::unique_ptr<Label>>* labels() { return &m_labels; }
 
     void addLayoutItems(LabelCollider& _layout) override;

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -57,7 +57,19 @@ public:
     bool handleBoundaryLabel(const Feature& _feat, const DrawRule& _rule,
                              const TextStyle::Parameters& _params);
 
-    bool checkRule(const DrawRule& _rule) const override { return true; }
+    bool checkRule(const DrawRule& _rule) const override {
+        if (_rule.hasParameterSet(StyleParamKey::text_font_family) ||
+            _rule.hasParameterSet(StyleParamKey::text_font_fill) ||
+            _rule.hasParameterSet(StyleParamKey::text_font_size) ||
+            _rule.hasParameterSet(StyleParamKey::text_font_stroke_color) ||
+            _rule.hasParameterSet(StyleParamKey::text_font_stroke_width) ||
+            _rule.hasParameterSet(StyleParamKey::text_font_style) ||
+            _rule.hasParameterSet(StyleParamKey::text_font_weight)) {
+            return true;
+        }
+
+        return false;
+    }
 
     std::vector<std::unique_ptr<Label>>* labels() { return &m_labels; }
 


### PR DESCRIPTION
Documentation: https://github.com/tangrams/tangram-docs/blob/gh-pages/pages/Styles-Overview.md#text-draw-group-requirements

Fixes issue with rogue black labels in tron. (cc @nvkelso)