### PR TITLE
fixes an issue with zipped import asset with parent yaml

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -189,7 +189,8 @@ void Scene::createSceneAsset(const std::shared_ptr<Platform>& platform, const Ur
             // Data to be fetched later (and zipHandle created) in network callback
             asset = std::make_shared<ZippedAsset>(resolvedStr);
 
-        } else if (relativeUrl.isAbsolute() || base.isEmpty()) {
+        } else if (relativeUrl.isAbsolute() || base.isEmpty() || !m_assets[baseStr]->zipHandle()) {
+            // load zip asset from File if its absolute or no base or base is not a zip asset
             asset = std::make_shared<ZippedAsset>(resolvedStr, nullptr, platform->bytesFromFile(resolvedStr.c_str()));
         } else {
             auto parentAsset = static_cast<ZippedAsset*>(m_assets[baseStr].get());


### PR DESCRIPTION
It looks like there was an incorrect assumption that an imported "relative path" of a zipped bundled must have a parent which itself is a zipped bundle, so incorrect code path was being taken.

Example scene file which will segfault without this fix:

```
import:
   - refill-style.zip
```