### PR TITLE
path resolution for paths without file scheme

### DIFF
--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -76,6 +76,8 @@ public:
 
 protected:
 
+    // A stop gap solution to load assets having `file` scheme in the path
+    std::string removeFileScheme(const char* _path) const;
     bool bytesFromFileSystem(const char* _path, std::function<char*(size_t)> _allocator) const;
 
 private:

--- a/core/src/platform.cpp
+++ b/core/src/platform.cpp
@@ -22,6 +22,17 @@ std::string Platform::resolveAssetPath(const std::string& path) const {
     return path;
 };
 
+std::string Platform::removeFileScheme(const char *_path) const {
+    if (!_path || strlen(_path) == 0) { return ""; }
+
+    const static std::string fileScheme = "file://";
+    auto path = std::string(_path);
+    if (path.compare(0, fileScheme.length(), fileScheme) == 0) {
+        path.erase(0, fileScheme.length());
+    }
+    return path;
+}
+
 bool Platform::bytesFromFileSystem(const char* _path, std::function<char*(size_t)> _allocator) const {
     std::ifstream resource(_path, std::ifstream::ate | std::ifstream::binary);
 
@@ -41,9 +52,9 @@ bool Platform::bytesFromFileSystem(const char* _path, std::function<char*(size_t
 }
 
 std::string Platform::stringFromFile(const char* _path) const {
-    std::string out;
-    if (!_path || strlen(_path) == 0) { return out; }
 
+    auto path = removeFileScheme(_path);
+    std::string out;
     std::string data;
 
     auto allocator = [&](size_t size) {
@@ -51,14 +62,14 @@ std::string Platform::stringFromFile(const char* _path) const {
         return &data[0];
     };
 
-    bytesFromFileSystem(_path, allocator);
+    bytesFromFileSystem(path.c_str(), allocator);
 
     return data;
 }
 
 std::vector<char> Platform::bytesFromFile(const char* _path) const {
-    if (!_path || strlen(_path) == 0) { return {}; }
 
+    auto path = removeFileScheme(_path);
     std::vector<char> data;
 
     auto allocator = [&](size_t size) {
@@ -66,7 +77,7 @@ std::vector<char> Platform::bytesFromFile(const char* _path) const {
         return data.data();
     };
 
-    bytesFromFileSystem(_path, allocator);
+    bytesFromFileSystem(path.c_str(), allocator);
 
     return data;
 }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -16,6 +16,7 @@
 #include "glm/vec2.hpp"
 #include "yaml-cpp/yaml.h"
 #include "util/yamlHelper.h"
+#include "util/url.h"
 
 #include "map.h" // SceneError
 
@@ -33,7 +34,6 @@ class Style;
 class Texture;
 class TileSource;
 struct Stops;
-class Url;
 
 // Delimiter used in sceneloader for style params and layer-sublayer naming
 const std::string DELIMITER = ":";
@@ -96,7 +96,7 @@ public:
     auto& featureSelection() { return m_featureSelection; }
     Style* findStyle(const std::string& _name);
 
-    const auto& path() const { return m_path; }
+    const auto& path() const { return m_path.string(); }
     const auto& yaml() { return m_yaml; }
     const auto& resourceRoot() const { return m_resourceRoot; }
     const auto& config() const { return m_config; }
@@ -152,11 +152,11 @@ public:
 private:
 
     // The file path from which this scene was loaded
-    std::string m_path;
+    Url m_path;
 
     std::string m_yaml;
 
-    std::string m_resourceRoot;
+    Url m_resourceRoot;
 
     // The root node of the YAML scene configuration
     YAML::Node m_config;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -106,7 +106,7 @@ bool SceneLoader::applyUpdates(const std::shared_ptr<Platform>& platform, Scene&
     }
 
     Importer importer;
-    importer.resolveSceneUrls(platform, scene, root, Url(scene.path()).resolved(Url(scene.resourceRoot())));
+    importer.resolveSceneUrls(platform, scene, root, Url(scene.path()).resolved(scene.resourceRoot()));
 
     return true;
 }

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -331,7 +331,7 @@ std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, c
 
     // 1. Bundle
     // Assuming bundled ttf file follows this convention
-    std::string bundleFontPath = m_sceneResourceRoot + "fonts/" +
+    std::string bundleFontPath = m_sceneResourceRoot.string() + "fonts/" +
         FontDescription::BundleAlias(_family, _style, _weight);
 
     std::vector<char> fontData = m_platform->bytesFromFile(bundleFontPath.c_str());

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -4,6 +4,7 @@
 #include "labels/textLabel.h"
 #include "style/textStyle.h"
 #include "text/textUtil.h"
+#include "util/url.h"
 
 #include "alfons/alfons.h"
 #include "alfons/atlas.h"
@@ -16,6 +17,7 @@
 #include <mutex>
 
 namespace Tangram {
+
 
 struct FontMetrics {
     float ascender, descender, lineHeight;
@@ -115,7 +117,7 @@ public:
         std::vector<GlyphQuad>* quads;
     };
 
-    void setSceneResourceRoot(const std::string& sceneResourceRoot) { m_sceneResourceRoot = sceneResourceRoot; }
+    void setSceneResourceRoot(const Url& sceneResourceRoot) { m_sceneResourceRoot = sceneResourceRoot; }
 
     void addFont(const FontDescription& _ft, alfons::InputSource _source);
 
@@ -150,7 +152,7 @@ private:
     // textures and a MeshCallback implemented by TextStyleBuilder for adding glyph quads.
     alfons::TextBatch m_batch;
     TextWrapper m_textWrapper;
-    std::string m_sceneResourceRoot = "";
+    Url m_sceneResourceRoot = Url();
 
     std::shared_ptr<const Platform> m_platform;
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -306,32 +306,34 @@ bool AndroidPlatform::bytesFromAssetManager(const char* _path, std::function<cha
 std::string AndroidPlatform::stringFromFile(const char* _path) const {
 
     std::string data;
+    auto path = removeFileScheme(_path);
 
     auto allocator = [&](size_t size) {
         data.resize(size);
         return &data[0];
     };
 
-    if (strncmp(_path, aaPrefix, aaPrefixLen) == 0) {
-        bytesFromAssetManager(_path + aaPrefixLen, allocator);
+    if (strncmp(path.c_str(), aaPrefix, aaPrefixLen) == 0) {
+        bytesFromAssetManager(path.c_str() + aaPrefixLen, allocator);
     } else {
-        Platform::bytesFromFileSystem(_path, allocator);
+        Platform::bytesFromFileSystem(path.c_str(), allocator);
     }
     return data;
 }
 
 std::vector<char> AndroidPlatform::bytesFromFile(const char* _path) const {
     std::vector<char> data;
+    auto path = removeFileScheme(_path);
 
     auto allocator = [&](size_t size) {
         data.resize(size);
         return data.data();
     };
 
-    if (strncmp(_path, aaPrefix, aaPrefixLen) == 0) {
-        bytesFromAssetManager(_path + aaPrefixLen, allocator);
+    if (strncmp(path.c_str(), aaPrefix, aaPrefixLen) == 0) {
+        bytesFromAssetManager(path.c_str() + aaPrefixLen, allocator);
     } else {
-        Platform::bytesFromFileSystem(_path, allocator);
+        Platform::bytesFromFileSystem(path.c_str(), allocator);
     }
 
     return data;

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -117,7 +117,7 @@ TEST_CASE("Imported scenes are merged with the parent scene", "[import][core]") 
     TestImporter importer;
 
     auto scene = std::make_shared<Scene>(platform,  "a.yaml");
-    scene->resourceRoot() = "/root/";
+    scene->resourceRoot() = Url("/root/");
     auto root = importer.applySceneImports(platform, scene);
 
     CHECK(root["value"].Scalar() == "a");
@@ -130,7 +130,7 @@ TEST_CASE("Nested imports are merged recursively", "[import][core]") {
     TestImporter importer;
 
     auto scene = std::make_shared<Scene>(platform,  "c.yaml");
-    scene->resourceRoot() = "/root/";
+    scene->resourceRoot() = Url("/root/");
     auto root = importer.applySceneImports(platform, scene);
 
     CHECK(root["value"].Scalar() == "c");
@@ -145,7 +145,7 @@ TEST_CASE("Imports that would start a cycle are ignored", "[import][core]") {
 
     // If import cycles aren't checked for and stopped, this call won't return.
     auto scene = std::make_shared<Scene>(platform,  "cycle_simple.yaml");
-    scene->resourceRoot() = "/root/";
+    scene->resourceRoot() = Url("/root/");
     auto root = importer.applySceneImports(platform, scene);
 
     // Check that the scene values were applied.
@@ -159,7 +159,7 @@ TEST_CASE("Tricky import cycles are ignored", "[import][core]") {
     // The nested import should resolve to the same path as the original file,
     // and so the importer should break the cycle.
     auto scene = std::make_shared<Scene>(platform,  "cycle_tricky.yaml");
-    scene->resourceRoot() = "/root/";
+    scene->resourceRoot() = Url("/root/");
     auto root = importer.applySceneImports(platform, scene);
 
     // Check that the imported scene values were merged.
@@ -172,7 +172,7 @@ TEST_CASE("Scene URLs are resolved against their parent during import", "[import
     TestImporter importer;
 
     auto scene = std::make_shared<Scene>(platform,  "urls.yaml");
-    scene->resourceRoot() = "/root/";
+    scene->resourceRoot() = Url("/root/");
     auto root = importer.applySceneImports(platform, scene);
 
     // Check that global texture URLs are resolved correctly.
@@ -230,7 +230,7 @@ TEST_CASE("References to globals are not treated like URLs during importing", "[
     TestImporter importer;
 
     auto scene = std::make_shared<Scene>(platform,  "globals.yaml");
-    scene->resourceRoot() = "/root/";
+    scene->resourceRoot() = Url("/root/");
     auto root = importer.applySceneImports(platform, scene);
 
     // Check that font global references are preserved.
@@ -265,7 +265,7 @@ TEST_CASE("Map overwrites sequence", "[import][core]") {
     TestImporter importer(testScenes);
 
     auto scene = std::make_shared<Scene>(platform,  "base.yaml");
-    scene->resourceRoot() = "/";
+    scene->resourceRoot() = Url("/");
     auto root = importer.applySceneImports(platform, scene);
 
     CHECK(root["filter"].IsMap());
@@ -290,7 +290,7 @@ TEST_CASE("Sequence overwrites map", "[import][core]") {
     TestImporter importer(testScenes);
 
     auto scene = std::make_shared<Scene>(platform,  "base.yaml");
-    scene->resourceRoot() = "/";
+    scene->resourceRoot() = Url("/");
     auto root = importer.applySceneImports(platform, scene);
 
     CHECK(root["a"].IsSequence());
@@ -316,7 +316,7 @@ TEST_CASE("Scalar and null overwrite correctly", "[import][core]") {
     TestImporter importer(testScenes);
 
     auto scene = std::make_shared<Scene>(platform,  "base.yaml");
-    scene->resourceRoot() = "/";
+    scene->resourceRoot() = Url("/");
     auto root = importer.applySceneImports(platform, scene);
 
     CHECK(root["scalar_at_end"].Scalar() == "scalar");


### PR DESCRIPTION
- Fixes an issue for path resolution when a file resource has a url defined with no scheme.
Noticable when a remote scene import happens after a local scene import, resulting in incorrect file
resource path resolution.

Note: A complete overhaul of the asset loading functionality is happening for 0.9.0, but we need to address the bug for the next release.