### PR TITLE
Remove 'armeabi' and 'arm64-v8a' architectures from Android builds

### DIFF
--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -62,7 +62,7 @@ android {
       // Default configuration
     }
     full {
-      externalNativeBuild.cmake.abiFilters 'armeabi', 'arm64-v8a', 'x86'
+      externalNativeBuild.cmake.abiFilters 'x86'
     }
   }
 


### PR DESCRIPTION
Significantly reduces Android library build time and output size at a negligible functional cost. Full release AAR size is reduced from 19.9MB to 5.7MB, a __size reduction of 71%__.

Dropped architectures:
 - __armeabi__, the ABI for ARMv6 CPUs, is no longer supported by Android as of 4.4 (according to the compatibility requirements, section 3.3.1: https://source.android.com/compatibility/4.4/android-4.4-cdd.pdf). Our minimum supported Android version is 4.0.3, so it is theoretically possible that an ARMv6 device could install our AAR and fail to load a compatible native library at runtime, but I expect this case to be vanishingly rare. We could consider increasing our minimum Android version to 4.4, but that would exclude ~7% of currently active devices (according to the Android Dashboards: https://developer.android.com/about/dashboards/index.html).
 - __arm64-v8a__, the ABI for 64-bit ARM CPUs, has backward compatibility with binaries using the 32-bit `armeabi-v7a` ABI (according to: https://en.wikipedia.org/wiki/ARM_architecture#ARMv8-A). There are possible performance benefits to running ARM64 binaries on a 64-bit ARM device and I'd like to do some benchmarks to make sure we're not making a dramatic sacrifice on 64-bit devices.

Kept architectures:
 - __armeabi-v7a__, the ABI for ARMv7 CPUs, is the target for the vast majority of active Android devices.
 - __x86__, the ABI for 32-bit x86 CPUs, is used rarely for mobile devices (mostly niche products like the ZenFone) but is immensely helpful for running in the Android emulator. The x86 emulator is at least 10x faster than the ARM emulator and is strongly recommended by Android Studio.