### PR TITLE
Fix iOS Headers and add custom URL Configuration initializer

### DIFF
--- a/platforms/ios/src/TangramMap/TGHttpHandler.h
+++ b/platforms/ios/src/TangramMap/TGHttpHandler.h
@@ -43,6 +43,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)init;
 
+
+/**
+ Initializes a http handler with the custom configuration.
+
+ @param configuration custom NSURLConfiguration object
+ @return an initialized http handler
+ */
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration;
+
 /**
  Initializes a http handler with a user defined configuration.
 

--- a/platforms/ios/src/TangramMap/TGHttpHandler.mm
+++ b/platforms/ios/src/TangramMap/TGHttpHandler.mm
@@ -34,6 +34,18 @@
     return self;
 }
 
+
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration
+{
+    self = [super init];
+
+    if (self) {
+        [self initialSetupWithConfiguration:configuration];
+    }
+
+    return self;
+}
+
 - (instancetype)initWithCachePath:(NSString*)cachePath cacheMemoryCapacity:(NSUInteger)memoryCapacity cacheDiskCapacity:(NSUInteger)diskCapacity
 {
     self = [super init];
@@ -74,8 +86,7 @@
 - (void)setAdditionalHTTPHeaders:(NSMutableDictionary *)HTTPAdditionalHeaders {
     _HTTPAdditionalHeaders = HTTPAdditionalHeaders;
     self.configuration.HTTPAdditionalHeaders = HTTPAdditionalHeaders;
-    //Probably unnecessary, but for safety sake
-    self.session.configuration.HTTPAdditionalHeaders = HTTPAdditionalHeaders;
+    self.session = [NSURLSession sessionWithConfiguration:self.configuration];
 }
 
 - (void)setCachePath:(NSString*)cachePath cacheMemoryCapacity:(NSUInteger)memoryCapacity cacheDiskCapacity:(NSUInteger)diskCapacity

--- a/platforms/ios/src/TangramMap/TGHttpHandler.mm
+++ b/platforms/ios/src/TangramMap/TGHttpHandler.mm
@@ -97,6 +97,7 @@
 
     self.configuration.URLCache = tileCache;
     self.configuration.requestCachePolicy = NSURLRequestUseProtocolCachePolicy;
+    self.session = [NSURLSession sessionWithConfiguration:self.configuration];
 }
 
 #pragma mark - Instance Methods


### PR DESCRIPTION
The iOS Header implementation is currently non-functional as NSURLSession
makes a copy of the configuration (as documented). Fix for this is to
reset the URL session when new headers are installed. An alternative
instead of setting headers is to pass in a configuration at creation time.