### PR TITLE
Fix android with ndk15c without deprecated flags

### DIFF
--- a/core/deps/CMakeLists.txt
+++ b/core/deps/CMakeLists.txt
@@ -78,6 +78,14 @@ add_subdirectory(SQLiteCpp)
 # Extensions aren't needed for MBTiles and aren't available in older versions of sqlite3.
 target_compile_definitions(SQLiteCpp PRIVATE SQLITE_OMIT_LOAD_EXTENSION)
 
+# needed for sqlite3 to work for ndk15c+ and android api level < 21
+# refer:
+# https://github.com/android-ndk/ndk/issues/477 and
+# https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
+if (ANDROID)
+    target_compile_definitions(sqlite3 PRIVATE _FILE_OFFSET_BITS=32)
+endif()
+
 ## double-conversion ##
 #######################
 add_subdirectory(double-conversion)

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -21,8 +21,7 @@ android {
         targets 'tangram'
         arguments '-DPLATFORM_TARGET=android',
                   '-DANDROID_TOOLCHAIN=clang',
-                  '-DANDROID_STL=c++_shared',
-                  '-DANDROID_DEPRECATED_HEADERS=ON'
+                  '-DANDROID_STL=c++_shared'
         cppFlags '-std=c++14',
                  '-pedantic',
                  '-fPIC',


### PR DESCRIPTION
- With ndk15c _FILE_OFFSET_BITS=64 took affect and required the availability of certain 64 bit
functions, which are not available in api levels below 21. (We require our min api level to be 15)
- This _FILE_OFFSET_BITS was explicitly set in sqlitecpp to 64 and hence caused build failures
because of missing symbols for the 64 bit equivalent methods for `lseek`, etc.

- For our android builds to work for api level 15+ (below 21) we are required to specify
_FILE_OFFSET_BITS=32 for sqlitecpp

A detailed explaination for this issue is available here:
https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md

And I quote the main description from above:

> Android support for _FILE_OFFSET_BITS=64 (which turns off_t into off64_t and replaces each off_t function with its off64_t counterpart, such as lseek in the source becoming lseek64 at runtime) was added late. Even when it became available for the platform, it wasn‘t available from the NDK until r15. Before NDK r15, _FILE_OFFSET_BITS=64 silently did nothing: all code compiled with that was actually using a 32-bit off_t. With a new enough NDK, the situation becomes complicated. If you’re targeting an API before 21, almost all functions that take an off_t become unavailable. You‘ve asked for their 64-bit equivalents, and none of them (except lseek/lseek64) exist. As you increase your target API level, you’ll have more and more of the functions available. API 12 adds some of the <unistd.h> functions, API 21 adds mmap, and by API 24 you have everything including <stdio.h>. See the linker map for full details.

Addressed #1660 

Note: Should go in after `0.8.1` release.