### PR TITLE
Support iOS builds with Xcode 9 and iOS 11 SDK

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 8.1
+    version: 9.0
   environment:
     # Dummy values, Circle won't run without a project and scheme.
     XCODE_PROJECT: build/tangram.xcodeproj

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
     XCODE_SCHEME: phony
 dependencies:
   pre:
-    - brew install awscli
+    - brew install awscli cmake
     - gem install jazzy
 checkout:
   post:

--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -2,6 +2,8 @@ include(${CMAKE_SOURCE_DIR}/toolchains/iOS.toolchain.cmake)
 
 set(FRAMEWORK_VERSION "0.8.2-dev")
 
+set(IOS_TARGET_VERSION "10.0")
+
 message(STATUS "Build for iOS archs " ${IOS_ARCH})
 
 set(FRAMEWORK_NAME TangramMap)
@@ -14,6 +16,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}
     -std=c++14
     -stdlib=libc++
     -w
+    -miphoneos-version-min=${IOS_TARGET_VERSION}
     -isysroot ${CMAKE_IOS_SDK_ROOT}")
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
@@ -22,6 +25,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}
     -fobjc-abi-version=2
     -fobjc-arc
     -w
+    -miphoneos-version-min=${IOS_TARGET_VERSION}
     -isysroot ${CMAKE_IOS_SDK_ROOT}")
 
 if(${IOS_PLATFORM} STREQUAL "SIMULATOR")
@@ -135,6 +139,7 @@ set_xcode_property(${FRAMEWORK_NAME} VALID_ARCHS "${IOS_ARCH}")
 set_xcode_property(${FRAMEWORK_NAME} ARCHS "${IOS_ARCH}")
 set_xcode_property(${FRAMEWORK_NAME} DEFINES_MODULE "YES")
 set_xcode_property(${FRAMEWORK_NAME} CURRENT_PROJECT_VERSION "${FRAMEWORK_VERSION}")
+set_xcode_property(${FRAMEWORK_NAME} IPHONEOS_DEPLOYMENT_TARGET "${IOS_TARGET_VERSION}")
 
 # Set RPATH to be within the application /Frameworks directory
 set_xcode_property(${FRAMEWORK_NAME} LD_DYLIB_INSTALL_NAME "@rpath/${FRAMEWORK_NAME}.framework/${FRAMEWORK_NAME}")

--- a/toolchains/iOS.framework.cmake
+++ b/toolchains/iOS.framework.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_SOURCE_DIR}/toolchains/iOS.toolchain.cmake)
 
 set(FRAMEWORK_VERSION "0.8.2-dev")
 
-set(IOS_TARGET_VERSION "10.0")
+set(IOS_TARGET_VERSION "9.3")
 
 message(STATUS "Build for iOS archs " ${IOS_ARCH})
 


### PR DESCRIPTION
Currently Tangram ES cannot make iOS builds using Xcode 9 for two reasons:
 - iOS 11 doesn't support 32-bit architectures and Xcode 9 compiles with `-miphoneos-version-min=11.0` by default, so linking fails for 32-bit builds.
 - The version of SQLite3 shipped with iOS 11 creates a build error for the version of SQLiteCpp currently used in Tangram ES (more info: https://github.com/SRombauts/SQLiteCpp/commit/1a2c7cbba707ea31affa056925a013b1041738cb).

This PR addresses both of those issues and updates our CircleCI configuration to use Xcode9 for iOS builds.

I've set the target iOS version to 10.0 for now, this is easily adjustable if we find a reason to change it.

I believe that fixing the issue with SQLiteCpp means that it is no longer compatible with versions of SQlite3 below 3.19 - which implies that the iOS 11 SDK will required to build Tangram ES.