### PR TITLE
Include new urdu font which has better typeface support for urdu language

### DIFF
--- a/platforms/common/appleAllowedFonts.mm
+++ b/platforms/common/appleAllowedFonts.mm
@@ -3,7 +3,7 @@
 bool allowedFamily(NSString* familyName) {
     const NSArray<NSString *> *allowedFamilyList = @[ @"Hebrew", @"Kohinoor", @"Gumurki", @"Thonburi", @"Tamil",
                                                     @"Gurmukhi", @"Kailasa", @"Sangam", @"PingFang", @"Geeza",
-                                                    @"Mishafi", @"Farah", @"Hiragino", @"Gothic" ];
+                                                    @"Mishafi", @"Farah", @"Hiragino", @"Gothic", @"Nastaliq" ];
 
     for (NSString* allowedFamily in allowedFamilyList) {
         if ( [familyName containsString:allowedFamily] ) { return true; }


### PR DESCRIPTION
gets bundled with system fonts in ios 11.

As an example of how it looks:
![img_243db2fb3e0b-1](https://user-images.githubusercontent.com/360641/31459656-a9f121e2-ae78-11e7-90b3-52bbb519768d.jpeg)

P.S. Read about it [here](http://www.oxgadgets.com/2017/10/meet-mudassir-azeemi-the-boy-who-brought-nastaleeq-to-ios.html) and [here](http://www.riazhaq.com/2017/09/apple-ios-11-supports-nastaliq-as.html)