### PR TITLE
Fix ordering of color components returned from JS function as array

### DIFF
--- a/core/src/gl/framebuffer.cpp
+++ b/core/src/gl/framebuffer.cpp
@@ -20,7 +20,7 @@ FrameBuffer::FrameBuffer(int _width, int _height, bool _colorRenderBuffer) :
 
 }
 
-bool FrameBuffer::applyAsRenderTarget(RenderState& _rs, glm::vec4 _clearColor) {
+bool FrameBuffer::applyAsRenderTarget(RenderState& _rs, ColorF _clearColor) {
 
     if (!m_glFrameBufferHandle) {
         init(_rs);
@@ -35,15 +35,14 @@ bool FrameBuffer::applyAsRenderTarget(RenderState& _rs, glm::vec4 _clearColor) {
     return true;
 }
 
-void FrameBuffer::apply(RenderState& _rs, GLuint _handle, glm::vec2 _viewport, glm::vec4 _clearColor) {
+void FrameBuffer::apply(RenderState& _rs, GLuint _handle, glm::vec2 _viewport, ColorF _clearColor) {
 
     _rs.framebuffer(_handle);
     _rs.viewport(0, 0, _viewport.x, _viewport.y);
 
-    if (_clearColor == glm::vec4(0.0) && _rs.defaultOpaqueClearColor()) {
+    if (_clearColor == ColorF() && _rs.defaultOpaqueClearColor()) {
         _rs.clearDefaultOpaqueColor();
     } else {
-        _clearColor /= 255.f;
         _rs.clearColor(_clearColor.r, _clearColor.g, _clearColor.b, _clearColor.a);
     }
 

--- a/core/src/gl/framebuffer.h
+++ b/core/src/gl/framebuffer.h
@@ -6,6 +6,7 @@
 #include "glm/vec4.hpp"
 #include "gl/disposer.h"
 #include "gl.h"
+#include "util/color.h"
 
 namespace Tangram {
 
@@ -20,9 +21,9 @@ public:
 
     ~FrameBuffer();
 
-    bool applyAsRenderTarget(RenderState& _rs, glm::vec4 _clearColor = glm::vec4(0.0));
+    bool applyAsRenderTarget(RenderState& _rs, ColorF _clearColor = ColorF());
 
-    static void apply(RenderState& _rs, GLuint _handle, glm::vec2 _viewport, glm::vec4 _clearColor);
+    static void apply(RenderState& _rs, GLuint _handle, glm::vec2 _viewport, ColorF _clearColor);
 
     bool valid() const { return m_valid; }
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -523,7 +523,7 @@ void Map::render() {
     // Setup default framebuffer for a new frame
     glm::vec2 viewport(impl->view.getWidth(), impl->view.getHeight());
     FrameBuffer::apply(impl->renderState, impl->renderState.defaultFrameBuffer(),
-                       viewport, impl->scene->background().asIVec4());
+                       viewport, impl->scene->background().toColorF());
 
     if (drawSelectionBuffer) {
         impl->selectionBuffer->drawDebug(impl->renderState, viewport);

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -432,10 +432,7 @@ void StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
                     duk_pop(m_ctx);
                 }
 
-                _val = (((uint32_t)(255.0 * a) & 0xff) << 24) |
-                       (((uint32_t)(255.0 * r) & 0xff)<< 16) |
-                       (((uint32_t)(255.0 * g) & 0xff)<< 8) |
-                       (((uint32_t)(255.0 * b) & 0xff));
+                _val = Color::fromNormalized(r, g, b, a).abgr;
                 break;
             }
             default:

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -432,7 +432,7 @@ void StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
                     duk_pop(m_ctx);
                 }
 
-                _val = Color::fromNormalized(r, g, b, a).abgr;
+                _val = ColorF(r, g, b, a).toColor().abgr;
                 break;
             }
             default:

--- a/core/src/util/color.h
+++ b/core/src/util/color.h
@@ -21,6 +21,10 @@ struct Color {
         return glm::ivec4(r, g, b, a);
     }
 
+    static Color fromNormalized(double r, double g, double b, double a) {
+        return Color(255 * r, 255 * g, 255 * b, 255 * a);
+    }
+
     static Color mix(const Color& _x, const Color& _y, float _a) {
         return Color(
             _x.r * (1 - _a) + _y.r * _a,

--- a/core/src/util/color.h
+++ b/core/src/util/color.h
@@ -1,9 +1,16 @@
 #pragma once
 #include <cstdint>
-#include "glm/vec4.hpp"
 
 namespace Tangram {
 
+// We have two structs to represent color:
+struct Color;
+struct ColorF;
+
+// Color represents a 32-bit color, with 8 bits per color channel for 'r', 'g',
+// 'b', and 'a'. The color can also be accessed as a single 32-bit integer with
+// all channels packed together as 'abgr'. A Color can be converted to a ColorF
+// without losing precision.
 struct Color {
 
     union {
@@ -15,15 +22,14 @@ struct Color {
 
     Color() = default;
     Color(uint32_t _abgr) : abgr(_abgr) {}
-    Color(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a) : r(_r), g(_g), b(_b), a(_a) {}
+    Color(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a)
+        : r(_r), g(_g), b(_b), a(_a) {}
 
-    glm::ivec4 asIVec4() {
-        return glm::ivec4(r, g, b, a);
+    bool operator==(const Color& other) {
+        return abgr == other.abgr;
     }
 
-    static Color fromNormalized(double r, double g, double b, double a) {
-        return Color(255 * r, 255 * g, 255 * b, 255 * a);
-    }
+    inline ColorF toColorF();
 
     static Color mix(const Color& _x, const Color& _y, float _a) {
         return Color(
@@ -36,4 +42,39 @@ struct Color {
 
 };
 
+// ColorF represents a color with floating point channel values for 'r', 'g',
+// 'b', and 'a'. A ColorF can be converted to a Color but may lose precision.
+struct ColorF {
+
+    float r = 0, g = 0, b = 0, a = 0;
+
+    ColorF() = default;
+    ColorF(float _r, float _g, float _b, float _a)
+        : r(_r), g(_g), b(_b), a(_a) {}
+
+    bool operator==(const ColorF& other) {
+        return r == other.r && (g == other.g && (b == other.b && a == other.a));
+    }
+
+    inline Color toColor();
+
+    static ColorF mix(const ColorF& _x, const ColorF& _y, float _a) {
+        return ColorF(
+            _x.r * (1 - _a) + _y.r * _a,
+            _x.g * (1 - _a) + _y.g * _a,
+            _x.b * (1 - _a) + _y.b * _a,
+            _x.a * (1 - _a) + _y.a * _a
+        );
+    }
+
+};
+
+ColorF Color::toColorF() {
+    return ColorF(r / 255.f, g / 255.f, b / 255.f, a / 255.f);
 }
+
+Color ColorF::toColor() {
+    return Color(255 * r, 255 * g, 255 * b, 255 * a);
+}
+
+} // namespace Tangram

--- a/core/src/util/color.h
+++ b/core/src/util/color.h
@@ -13,6 +13,9 @@ struct ColorF;
 // without losing precision.
 struct Color {
 
+    // This union allows the color components to be accessed either as separate
+    // bytes or as an integer combining the four bytes. On a big-endian system
+    // the integer will combine the components in 'rgba' order instead.
     union {
         struct {
             uint8_t r, g, b, a;

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -164,7 +164,7 @@ TEST_CASE( "Test evalStyleFn - StyleParamKey::color", "[Duktape][evalStyleFn]") 
     REQUIRE(ctx.setFunctions({ R"(function () { return [1.0, 1.0, 0.0, 1.0] })"}));
     REQUIRE(ctx.evalStyle(0, StyleParamKey::color, value) == true);
     REQUIRE(value.is<uint32_t>() == true);
-    REQUIRE(value.get<uint32_t>() == 0xffffff00);
+    REQUIRE(value.get<uint32_t>() == 0xff00ffff);
 
     REQUIRE(ctx.setFunctions({ R"(function () { return [0.0, 1.0, 0.0] })"}));
     REQUIRE(ctx.evalStyle(0, StyleParamKey::color, value) == true);


### PR DESCRIPTION
The current code puts color components into the wrong parts of the resulting integer - making the final colors wrong. For example, if you set the `water` layer color to `function() { return [ 0.0, 0.25, 0.5, 1.0 ]; }` in the demo scene, you currently get:

![screen shot 2017-10-11 at 4 11 39 pm](https://user-images.githubusercontent.com/3371850/31471691-e83d40cc-ae9e-11e7-8c87-71c22a2fc86c.png)

The correct color, using the new code, is:

![screen shot 2017-10-11 at 4 10 01 pm](https://user-images.githubusercontent.com/3371850/31471656-bf71ebde-ae9e-11e7-9ee5-c8d8bfc28224.png)


The specific way that color components are converted to integers appears to match the behavior of Tangram JS by interpreting the doubles modulo 1.0, i.e. `[0., 0., 1.5, 1.]` produces the same result as `[0., 0., 0.5, 1.]`. 

Thanks to @AndreyArapov for bringing this to our attention :)