### PR TITLE
slowdown circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ deployment:
       - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-snapshots/tangram-snapshot-debug-${CIRCLE_BUILD_NUM}.zip
       - aws s3 cp ${CIRCLE_ARTIFACTS}/pod.zip s3://ios.mapzen.com/tangram-latest-debug.zip
       # Build the MacOS demo app and package it into demo.zip
-      - make osx -j MACOSX_DEPLOYMENT_TARGET=10.10.0
+      - make osx -j 2 MACOSX_DEPLOYMENT_TARGET=10.10.0
       - cd build/osx/bin && zip -r ${CIRCLE_ARTIFACTS}/demo.zip tangram.app
       # Upload the demo archive to S3.
       - aws s3 cp ${CIRCLE_ARTIFACTS}/demo.zip s3://ios.mapzen.com/tangram-osx-snapshots/tangram-snapshot-debug-${CIRCLE_BUILD_NUM}.zip


### PR DESCRIPTION
parallel osx builds have been failing randomly on circle. This should slow down the builds for good!

Number of threads is debatable!

As an example: https://circleci.com/gh/tangrams/tangram-es/2340