### PR TITLE
Clarify android MapView.onDestroy documentation

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -91,6 +91,7 @@ public class MapView extends FrameLayout {
 
     /**
      * You must call this method from the parent Activity/Fragment's corresponding method.
+     * Any access to MapView.mapController is illegal after this call.
      */
     public void onDestroy() {
 


### PR DESCRIPTION
to include an explicit mention of illegal access to MapView.mapController after onDestroy call.

Closes #1680 