### PR TITLE
Fix iOS memory leak

### DIFF
--- a/platforms/ios/demo/src/MapViewController.h
+++ b/platforms/ios/demo/src/MapViewController.h
@@ -10,19 +10,19 @@
 
 @interface MapViewControllerDelegate : NSObject <TGMapViewDelegate>
 
-- (void)mapView:(TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nullable NSError *)sceneError;
-- (void)mapViewDidCompleteLoading:(TGMapViewController *)mapView;
-- (void)mapView:(TGMapViewController *)mapView didSelectFeature:(NSDictionary *)feature atScreenPosition:(CGPoint)position;
-- (void)mapView:(TGMapViewController *)mapView didSelectLabel:(TGLabelPickResult *)labelPickResult atScreenPosition:(CGPoint)position;
-- (void)mapView:(TGMapViewController *)mapView didSelectMarker:(TGMarkerPickResult *)markerPickResult atScreenPosition:(TGGeoPoint)position;
-- (void)mapView:(TGMapViewController *)view didCaptureScreenshot:(UIImage *)screenshot;
+- (void)mapView:(nonnull TGMapViewController *)mapView didLoadScene:(int)sceneID withError:(nullable NSError *)sceneError;
+- (void)mapViewDidCompleteLoading:(nonnull TGMapViewController *)mapView;
+- (void)mapView:(nonnull TGMapViewController *)mapView didSelectFeature:(nullable NSDictionary *)feature atScreenPosition:(CGPoint)position;
+- (void)mapView:(nonnull TGMapViewController *)mapView didSelectLabel:(nullable TGLabelPickResult *)labelPickResult atScreenPosition:(CGPoint)position;
+- (void)mapView:(nonnull TGMapViewController *)mapView didSelectMarker:(nullable TGMarkerPickResult *)markerPickResult atScreenPosition:(TGGeoPoint)position;
+- (void)mapView:(nonnull TGMapViewController *)view didCaptureScreenshot:(nonnull UIImage *)screenshot;
 
 @end
 
 @interface MapViewControllerRecognizerDelegate : NSObject <TGRecognizerDelegate>
 
-- (void)mapView:(TGMapViewController *)view recognizer:(UIGestureRecognizer *)recognizer didRecognizeSingleTapGesture:(CGPoint)location;
-- (void)mapView:(TGMapViewController *)view recognizer:(UIGestureRecognizer *)recognizer didRecognizeLongPressGesture:(CGPoint)location;
+- (void)mapView:(nonnull TGMapViewController *)view recognizer:(nonnull UIGestureRecognizer *)recognizer didRecognizeSingleTapGesture:(CGPoint)location;
+- (void)mapView:(nonnull TGMapViewController *)view recognizer:(nonnull UIGestureRecognizer *)recognizer didRecognizeLongPressGesture:(CGPoint)location;
 
 @end
 

--- a/platforms/ios/src/TangramMap/TGMapData+Internal.h
+++ b/platforms/ios/src/TangramMap/TGMapData+Internal.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-- (instancetype)initWithMapView:(TGMapViewController *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::TileSource>)source;
+- (instancetype)initWithMapView:(__weak TGMapViewController *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::TileSource>)source;
 
 NS_ASSUME_NONNULL_END
 

--- a/platforms/ios/src/TangramMap/TGMapData.h
+++ b/platforms/ios/src/TangramMap/TGMapData.h
@@ -109,6 +109,6 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 /// The map view this data source is on
-@property (readonly, nonatomic) TGMapViewController* _Nullable map;
+@property (readonly, weak, nonatomic) TGMapViewController* _Nullable map;
 
 @end

--- a/platforms/ios/src/TangramMap/TGMapData.mm
+++ b/platforms/ios/src/TangramMap/TGMapData.mm
@@ -32,7 +32,7 @@ static inline void tangramProperties(TGFeatureProperties* properties, Tangram::P
 
 @implementation TGMapData
 
-- (instancetype)initWithMapView:(TGMapViewController *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::ClientGeoJsonSource>)source
+- (instancetype)initWithMapView:(__weak TGMapViewController *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::ClientGeoJsonSource>)source
 {
     self = [super init];
 

--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -545,7 +545,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  If an error occurs while applying updates the new scene will not be applied.
  See `TGSceneUpdate` for details.
- 
+
  @param yaml YAML scene string.
  @param url The base URL used to resolve relative URLs in the scene.
  @param updates A list of `TGSceneUpdate` to apply to the scene.

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -105,7 +105,8 @@ __CG_STATIC_ASSERT(sizeof(TGGeoPoint) == sizeof(Tangram::LngLat));
                     dataLayerName, "", generateCentroid);
     self.map->addTileSource(source);
 
-    TGMapData* clientData = [[TGMapData alloc] initWithMapView:self name:name source:source];
+    __weak TGMapViewController* weakSelf = self;
+    TGMapData* clientData = [[TGMapData alloc] initWithMapView:weakSelf name:name source:source];
     self.dataLayersByName[name] = clientData;
 
     return clientData;
@@ -140,17 +141,18 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 }
 
 - (Tangram::SceneReadyCallback)sceneReadyListener {
-    return [=](int sceneID, auto sceneError) {
-        [self.markersById removeAllObjects];
-        [self renderOnce];
+    __weak TGMapViewController* weakSelf = self;
+    return [weakSelf](int sceneID, auto sceneError) {
+        [weakSelf.markersById removeAllObjects];
+        [weakSelf renderOnce];
 
-        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didLoadScene:withError:)]) { return; }
+        if (!weakSelf.mapViewDelegate || ![weakSelf.mapViewDelegate respondsToSelector:@selector(mapView:didLoadScene:withError:)]) { return; }
 
         NSError* error = nil;
         if (sceneError) {
             error = [TGHelpers errorFromSceneError:*sceneError];
         }
-        [self.mapViewDelegate mapView:self didLoadScene:sceneID withError:error];
+        [weakSelf.mapViewDelegate mapView:weakSelf didLoadScene:sceneID withError:error];
     };
 }
 
@@ -275,23 +277,24 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
     screenPosition.x *= self.contentScaleFactor;
     screenPosition.y *= self.contentScaleFactor;
 
-    self.map->pickFeatureAt(screenPosition.x, screenPosition.y, [=](const Tangram::FeaturePickResult* featureResult) {
-        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didSelectFeature:atScreenPosition:)]) {
+    __weak TGMapViewController* weakSelf = self;
+    self.map->pickFeatureAt(screenPosition.x, screenPosition.y, [weakSelf](const Tangram::FeaturePickResult* featureResult) {
+        if (!weakSelf.mapViewDelegate || ![weakSelf.mapViewDelegate respondsToSelector:@selector(mapView:didSelectFeature:atScreenPosition:)]) {
             return;
         }
 
         CGPoint position = CGPointMake(0.0, 0.0);
 
         if (!featureResult) {
-            [self.mapViewDelegate mapView:self didSelectFeature:nil atScreenPosition:position];
+            [weakSelf.mapViewDelegate mapView:weakSelf didSelectFeature:nil atScreenPosition:position];
             return;
         }
 
         NSMutableDictionary* featureProperties = [[NSMutableDictionary alloc] init];
 
         const auto& properties = featureResult->properties;
-        position = CGPointMake(featureResult->position[0] / self.contentScaleFactor,
-                               featureResult->position[1] / self.contentScaleFactor);
+        position = CGPointMake(featureResult->position[0] / weakSelf.contentScaleFactor,
+                               featureResult->position[1] / weakSelf.contentScaleFactor);
 
         for (const auto& item : properties->items()) {
             NSString* key = [NSString stringWithUTF8String:item.key.c_str()];
@@ -299,7 +302,7 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
             featureProperties[key] = value;
         }
 
-        [self.mapViewDelegate mapView:self didSelectFeature:featureProperties atScreenPosition:position];
+        [weakSelf.mapViewDelegate mapView:weakSelf didSelectFeature:featureProperties atScreenPosition:position];
     });
 }
 
@@ -310,34 +313,35 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
     screenPosition.x *= self.contentScaleFactor;
     screenPosition.y *= self.contentScaleFactor;
 
-    self.map->pickMarkerAt(screenPosition.x, screenPosition.y, [=](const Tangram::MarkerPickResult* markerPickResult) {
-        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didSelectMarker:atScreenPosition:)]) {
+    __weak TGMapViewController* weakSelf = self;
+    self.map->pickMarkerAt(screenPosition.x, screenPosition.y, [weakSelf](const Tangram::MarkerPickResult* markerPickResult) {
+        if (!weakSelf.mapViewDelegate || ![weakSelf.mapViewDelegate respondsToSelector:@selector(mapView:didSelectMarker:atScreenPosition:)]) {
             return;
         }
 
         CGPoint position = CGPointMake(0.0, 0.0);
 
         if (!markerPickResult) {
-            [self.mapViewDelegate mapView:self didSelectMarker:nil atScreenPosition:position];
+            [weakSelf.mapViewDelegate mapView:weakSelf didSelectMarker:nil atScreenPosition:position];
             return;
         }
 
         NSString* key = [NSString stringWithFormat:@"%d", (NSUInteger)markerPickResult->id];
-        TGMarker* marker = [self.markersById objectForKey:key];
+        TGMarker* marker = [weakSelf.markersById objectForKey:key];
 
         if (!marker) {
-            [self.mapViewDelegate mapView:self didSelectMarker:nil atScreenPosition:position];
+            [weakSelf.mapViewDelegate mapView:weakSelf didSelectMarker:nil atScreenPosition:position];
             return;
         }
 
-        position = CGPointMake(markerPickResult->position[0] / self.contentScaleFactor,
-                               markerPickResult->position[1] / self.contentScaleFactor);
+        position = CGPointMake(markerPickResult->position[0] / weakSelf.contentScaleFactor,
+                               markerPickResult->position[1] / weakSelf.contentScaleFactor);
 
         TGGeoPoint coordinates = TGGeoPointMake(markerPickResult->coordinates.longitude,
                                                 markerPickResult->coordinates.latitude);
 
         TGMarkerPickResult* result = [[TGMarkerPickResult alloc] initWithCoordinates:coordinates marker:marker];
-        [self.mapViewDelegate mapView:self didSelectMarker:result atScreenPosition:position];
+        [weakSelf.mapViewDelegate mapView:weakSelf didSelectMarker:result atScreenPosition:position];
     });
 }
 
@@ -348,15 +352,16 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
     screenPosition.x *= self.contentScaleFactor;
     screenPosition.y *= self.contentScaleFactor;
 
-    self.map->pickLabelAt(screenPosition.x, screenPosition.y, [=](const Tangram::LabelPickResult* labelPickResult) {
-        if (!self.mapViewDelegate || ![self.mapViewDelegate respondsToSelector:@selector(mapView:didSelectLabel:atScreenPosition:)]) {
+    __weak TGMapViewController* weakSelf = self;
+    self.map->pickLabelAt(screenPosition.x, screenPosition.y, [weakSelf](const Tangram::LabelPickResult* labelPickResult) {
+        if (!weakSelf.mapViewDelegate || ![weakSelf.mapViewDelegate respondsToSelector:@selector(mapView:didSelectLabel:atScreenPosition:)]) {
             return;
         }
 
         CGPoint position = CGPointMake(0.0, 0.0);
 
         if (!labelPickResult) {
-            [self.mapViewDelegate mapView:self didSelectLabel:nil atScreenPosition:position];
+            [weakSelf.mapViewDelegate mapView:weakSelf didSelectLabel:nil atScreenPosition:position];
             return;
         }
 
@@ -364,8 +369,8 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 
         const auto& touchItem = labelPickResult->touchItem;
         const auto& properties = touchItem.properties;
-        position = CGPointMake(touchItem.position[0] / self.contentScaleFactor,
-                               touchItem.position[1] / self.contentScaleFactor);
+        position = CGPointMake(touchItem.position[0] / weakSelf.contentScaleFactor,
+                               touchItem.position[1] / weakSelf.contentScaleFactor);
 
         for (const auto& item : properties->items()) {
             NSString* key = [NSString stringWithUTF8String:item.key.c_str()];
@@ -377,7 +382,7 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
         TGLabelPickResult* tgLabelPickResult = [[TGLabelPickResult alloc] initWithCoordinates:coordinates
                                                                                          type:(TGLabelType)labelPickResult->type
                                                                                    properties:featureProperties];
-        [self.mapViewDelegate mapView:self didSelectLabel:tgLabelPickResult atScreenPosition:position];
+        [weakSelf.mapViewDelegate mapView:weakSelf didSelectLabel:tgLabelPickResult atScreenPosition:position];
     });
 }
 
@@ -822,7 +827,8 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self != nil) {
-        std::shared_ptr<Tangram::Platform> platform(new Tangram::iOSPlatform(self));
+        __weak TGMapViewController* weakSelf = self;
+        std::shared_ptr<Tangram::Platform> platform(new Tangram::iOSPlatform(weakSelf));
         self.map = new Tangram::Map(platform);
     }
     return self;
@@ -832,7 +838,8 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 {
     self = [super initWithCoder:aDecoder];
     if (self != nil) {
-        std::shared_ptr<Tangram::Platform> platform(new Tangram::iOSPlatform(self));
+        __weak TGMapViewController* weakSelf = self;
+        std::shared_ptr<Tangram::Platform> platform(new Tangram::iOSPlatform(weakSelf));
         self.map = new Tangram::Map(platform);
     }
     return self;

--- a/platforms/ios/src/TangramMap/TGMapViewController.mm
+++ b/platforms/ios/src/TangramMap/TGMapViewController.mm
@@ -875,11 +875,14 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 
     [self setupGestureRecognizers];
     [self setupGL];
-
 }
 
 - (void)dealloc
 {
+    if (self.map) {
+        delete self.map;
+    }
+
     if ([EAGLContext currentContext] == self.context) {
         [EAGLContext setCurrentContext:nil];
     }
@@ -913,14 +916,6 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
         [backgroundColor getRed:&red green:&green blue:&blue alpha:&alpha];
         self.map->setDefaultBackgroundColor(red, green, blue);
     }
-}
-
-- (void)tearDownGL
-{
-    if (!self.map) { return; }
-
-    delete self.map;
-    self.map = nullptr;
 }
 
 -(void)viewWillLayoutSubviews {

--- a/platforms/ios/src/TangramMap/iosPlatform.h
+++ b/platforms/ios/src/TangramMap/iosPlatform.h
@@ -14,7 +14,7 @@ class iOSPlatform : public Platform {
 
 public:
 
-    iOSPlatform(TGMapViewController* _viewController);
+    iOSPlatform(__weak TGMapViewController* _viewController);
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
     std::string resolveAssetPath(const std::string& _path) const override;
@@ -28,7 +28,7 @@ public:
 
 private:
 
-    TGMapViewController* m_viewController;
+    __weak TGMapViewController* m_viewController;
     NSURL* m_resourceRoot;
 
 };

--- a/platforms/ios/src/TangramMap/iosPlatform.mm
+++ b/platforms/ios/src/TangramMap/iosPlatform.mm
@@ -49,7 +49,7 @@ void initGLExtensions() {
     // No-op
 }
 
-iOSPlatform::iOSPlatform(TGMapViewController* _viewController) :
+iOSPlatform::iOSPlatform(__weak TGMapViewController* _viewController) :
     Platform(),
     m_viewController(_viewController)
 {

--- a/platforms/ios/src/TangramMap/iosPlatform.mm
+++ b/platforms/ios/src/TangramMap/iosPlatform.mm
@@ -57,7 +57,13 @@ iOSPlatform::iOSPlatform(__weak TGMapViewController* _viewController) :
 }
 
 void iOSPlatform::requestRender() const {
-    [m_viewController renderOnce];
+    __strong TGMapViewController* mapViewController = m_viewController;
+
+    if (!mapViewController) {
+        return;
+    }
+
+    [mapViewController renderOnce];
 }
 
 void iOSPlatform::setResourceRoot(NSURL* _resourceRoot) {
@@ -66,7 +72,13 @@ void iOSPlatform::setResourceRoot(NSURL* _resourceRoot) {
 
 void iOSPlatform::setContinuousRendering(bool _isContinuous) {
     Platform::setContinuousRendering(_isContinuous);
-    [m_viewController setContinuous:_isContinuous];
+    __strong TGMapViewController* mapViewController = m_viewController;
+
+    if (!mapViewController) {
+        return;
+    }
+
+    [mapViewController setContinuous:_isContinuous];
 }
 
 std::string iOSPlatform::resolveAssetPath(const std::string& _path) const {
@@ -176,7 +188,13 @@ FontSourceHandle iOSPlatform::systemFont(const std::string& _name, const std::st
 }
 
 bool iOSPlatform::startUrlRequest(const std::string& _url, UrlCallback _callback) {
-    TGHttpHandler* httpHandler = [m_viewController httpHandler];
+    __strong TGMapViewController* mapViewController = m_viewController;
+
+    if (!mapViewController) {
+        return false;
+    }
+
+    TGHttpHandler* httpHandler = [mapViewController httpHandler];
 
     if (!httpHandler) {
         return false;
@@ -223,9 +241,17 @@ bool iOSPlatform::startUrlRequest(const std::string& _url, UrlCallback _callback
 }
 
 void iOSPlatform::cancelUrlRequest(const std::string& _url) {
-    TGHttpHandler* httpHandler = [m_viewController httpHandler];
+    __strong TGMapViewController* mapViewController = m_viewController;
 
-    if (!httpHandler) { return; }
+    if (!mapViewController) {
+        return;
+    }
+
+    TGHttpHandler* httpHandler = [mapViewController httpHandler];
+
+    if (!httpHandler) {
+        return;
+    }
 
     NSString* url = [NSString stringWithUTF8String:_url.c_str()];
     [httpHandler cancelDownloadRequestAsync:url];


### PR DESCRIPTION
- Add content of incorrectly removed `tearDownGL` method call
- Use weak references for `TGMapViewController`

Fixes #1690