### PR TITLE
Deep copy YAML nodes when copying scene configuration

### DIFF
--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -49,7 +49,7 @@ void Scene::copyConfig(const Scene& _other) {
 
     m_featureSelection.reset(new FeatureSelection());
 
-    m_config = _other.m_config;
+    m_config = YAML::Clone(_other.m_config);
     m_fontContext = _other.m_fontContext;
 
     m_url = _other.m_url;


### PR DESCRIPTION
- this could cause the underlying scene config data could be modified by multiple threads, which
actually happens in the case of `loadSceneAsync` and `updateScene`!

Fixes #1677 