### PR TITLE
SceneLoader cleanups

### DIFF
--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -148,10 +148,6 @@ public:
     float pixelScale() { return m_pixelScale; }
     void setPixelScale(float _scale);
 
-    // Should be locked when the texture collection is being accessed by
-    // multiple threads.
-    std::mutex textureMutex;
-
     std::atomic_ushort pendingTextures{0};
     std::atomic_ushort pendingFonts{0};
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -68,7 +68,7 @@ struct SceneLoader {
     static Filter generatePredicate(Node filter, std::string _key);
     static bool getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea);
     /* loads a texture with default texture properties */
-    static bool loadTexture(const std::shared_ptr<Platform>& platform, const std::string& url, const std::shared_ptr<Scene>& scene);
+    static std::shared_ptr<Texture> loadTexture(const std::shared_ptr<Platform>& platform, const std::string& url, const std::shared_ptr<Scene>& scene);
     static std::shared_ptr<Texture> fetchTexture(const std::shared_ptr<Platform>& platform, const std::string& name, const std::string& url,
             const TextureOptions& options, bool generateMipmaps, const std::shared_ptr<Scene>& scene);
     static bool extractTexFiltering(Node& filtering, TextureFiltering& filter);


### PR DESCRIPTION
- remove Scene::textureMutex, Textures are only added on the scene-load tread
- remove unnecessary checks: 'scene' must be valid on scene-load thread