### PR TITLE
Wait for pending textures before creating tiles

### DIFF
--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -391,8 +391,9 @@ void Map::resize(int _newWidth, int _newHeight) {
 
 bool Map::update(float _dt) {
 
-    // Wait until font resources are fully loaded
-    if (impl->scene->pendingFonts > 0) {
+    // Wait until font and texture resources are fully loaded
+    if (impl->scene->pendingFonts > 0 ||
+        impl->scene->pendingTextures > 0) {
         platform->requestRender();
         return false;
     }

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -391,16 +391,15 @@ void Map::resize(int _newWidth, int _newHeight) {
 
 bool Map::update(float _dt) {
 
+    impl->jobQueue.runJobs();
+
     // Wait until font and texture resources are fully loaded
     if (impl->scene->pendingFonts > 0 ||
         impl->scene->pendingTextures > 0) {
-        platform->requestRender();
         return false;
     }
 
     FrameInfo::beginUpdate();
-
-    impl->jobQueue.runJobs();
 
     impl->scene->updateTime(_dt);
 


### PR DESCRIPTION
Should fix use of incomplete texture atlas and concurrent read/writes of texture data.

https://github.com/tangrams/tangram-es/issues/1706