### PR TITLE
Allow scene inputs to be parsed as file paths in OSX demo

### DIFF
--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -74,11 +74,7 @@ void parseArgs(int argc, char* argv[]) {
     int argi = 0;
     while (++argi < argc) {
         if (strcmp(argv[argi - 1], "-f") == 0) {
-            Url url(argv[argi]);
-            if (!url.hasScheme()) {
-                url = url.resolved(Url("file://"));
-            }
-            sceneFile = url.string();
+            sceneFile = std::string(argv[argi]);
             LOG("File from command line: %s\n", argv[argi]);
             break;
         }

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -174,8 +174,17 @@ int main(int argc, char* argv[]) {
     NSString* sceneInputString = [NSString stringWithUTF8String:GlfwApp::sceneFile.c_str()];
     NSURL* resourceDirectoryUrl = [[NSBundle mainBundle] resourceURL];
     NSURL* sceneFileUrl = [NSURL URLWithString:sceneInputString relativeToURL:resourceDirectoryUrl];
-    
-    GlfwApp::sceneFile = std::string([[sceneFileUrl absoluteString] UTF8String]);
+    if (sceneFileUrl == nil) {
+        // Parsing input as a URL failed, try as a file path next.
+        sceneFileUrl = [NSURL fileURLWithPath:sceneInputString relativeToURL:resourceDirectoryUrl];
+    }
+
+    if (sceneFileUrl != nil) {
+        GlfwApp::sceneFile = std::string([[sceneFileUrl absoluteString] UTF8String]);
+    } else {
+        LOGE("Scene input could not be resolved to a valid URL: %s", [sceneInputString UTF8String]);
+    }
+
 
     // Give it a chance to shutdown cleanly on CTRL-C
     signal(SIGINT, &GlfwApp::stop);


### PR DESCRIPTION
This resolves an issue (sometimes a crash) where valid file paths are not legal as general URLs according to NSURL, e.g. paths containing spaces.

Resolves #1536 