### PR TITLE
Store shader uniform textures in scene config

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1582,7 +1582,8 @@ bool SceneLoader::parseStyleUniforms(const std::shared_ptr<Platform>& platform, 
             styleUniform.type = "sampler2D";
             styleUniform.value = strVal;
 
-            loadTexture(platform, strVal, scene);
+            auto texture = loadTexture(platform, strVal, scene);
+            scene->textures().emplace(strVal, texture);
         }
     } else if (value.IsSequence()) {
         int size = value.size();
@@ -1621,7 +1622,8 @@ bool SceneLoader::parseStyleUniforms(const std::shared_ptr<Platform>& platform, 
                 const std::string& textureName = strVal.Scalar();
                 textureArrayUniform.names.push_back(textureName);
 
-                loadTexture(platform, textureName, scene);
+                auto texture = loadTexture(platform, textureName, scene);
+                scene->textures().emplace(textureName, texture);
             }
 
             styleUniform.value = std::move(textureArrayUniform);


### PR DESCRIPTION
Restores correct behavior for textures specified in a shader uniform. This regression was introduced in https://github.com/tangrams/tangram-es/commit/4b4a8dbabe54c5fdcf413251d1c3bfcfba8d2738. The regression causes styles using texture uniforms to render incorrectly (notably, this impacts several styles in walkabout).