### PR TITLE
Update android builds

### DIFF
--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -27,7 +27,7 @@ That's it! If you want to build tangram-es for Android from scratch, continue re
 
 ## Setup ##
 
-To build for Android you'll need [Android Studio](https://developer.android.com/studio/index.html) version 2.2 or newer on Mac OS X, Ubuntu, or Windows 10. Using the Android Studio SDK Manager, install or update the 'CMake', 'LLDB', and 'NDK' packages from the 'SDK Tools' tab.
+To build for Android you'll need [Android Studio](https://developer.android.com/studio/index.html) version 3.0 or newer on Mac OS X, Ubuntu, or Windows 10. Using the Android Studio SDK Manager, install or update the 'CMake', 'LLDB', and 'NDK' packages from the 'SDK Tools' tab.
 
 The demo application uses the Mapzen vector tile service, so you will need a Mapzen API key to build and run the demo. 
 

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -3,9 +3,10 @@ allprojects {
     repositories {
       mavenCentral()
       jcenter()
+      google()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:2.3.3'
+      classpath 'com.android.tools.build:gradle:3.0.1'
       classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
   }
@@ -14,6 +15,7 @@ allprojects {
     repositories {
       mavenCentral()
       jcenter()
+      google()
     }
   }
 }

--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 26
-  buildToolsVersion '25.0.3'
+  buildToolsVersion '26.0.2'
 
   def apiKey = project.hasProperty('mapzenApiKey') ? mapzenApiKey : System.getenv('MAPZEN_API_KEY')
 

--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -10,6 +10,8 @@ android {
     minSdkVersion 15
     targetSdkVersion 26
     buildConfigField 'String', 'MAPZEN_API_KEY', '"' + apiKey + '"'
+    // provide dimension strategy for tangram library's dim
+    missingDimensionStrategy 'tangramAbi', 'slim'
   }
 
   sourceSets.main {
@@ -27,9 +29,10 @@ android {
       minifyEnabled true
     }
   }
+
 }
 
 dependencies {
-  compile project(path: ':tangram')
-  compile 'com.android.support:design:25.3.1'
+  implementation project(path: ':tangram')
+  implementation 'com.android.support:design:25.3.1'
 }

--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -9,8 +9,6 @@ android {
     minSdkVersion 15
     targetSdkVersion 26
     buildConfigField 'String', 'MAPZEN_API_KEY', '"' + apiKey + '"'
-    // provide dimension strategy for tangram library's dim
-    missingDimensionStrategy 'tangramAbi', 'slim'
   }
 
   sourceSets.main {

--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 26
-  buildToolsVersion '26.0.2'
 
   def apiKey = project.hasProperty('mapzenApiKey') ? mapzenApiKey : System.getenv('MAPZEN_API_KEY')
 

--- a/platforms/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platforms/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -8,7 +8,7 @@ apply from: 'versioning.gradle'
 
 android {
   compileSdkVersion 26
-  buildToolsVersion '25.0.3'
+  buildToolsVersion '26.0.2'
 
   defaultConfig {
     minSdkVersion 15

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -45,6 +45,8 @@ android {
     }
   }
 
+  flavorDimensions "tangramAbi"
+
   buildTypes {
     debug {
       externalNativeBuild {
@@ -74,8 +76,8 @@ android {
 }
 
 dependencies {
-  compile 'com.squareup.okhttp3:okhttp:3.5.0'
-  compile 'com.android.support:support-annotations:25.3.1'
+  api 'com.squareup.okhttp3:okhttp:3.5.0'
+  api 'com.android.support:support-annotations:25.3.1'
 }
 
 apply from: file('gradle-mvn-push.gradle')

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -33,7 +33,7 @@ android {
                  '-Wmissing-field-initializers',
                  '-Wno-format-pedantic'
 
-        abiFilters 'armeabi-v7a'
+        abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'
       }
     }
   }
@@ -57,20 +57,6 @@ android {
         cmake.cppFlags'-g0'
       }
     }
-  }
-  productFlavors {
-    slim {
-      // Default configuration
-    }
-    full {
-      externalNativeBuild.cmake.abiFilters 'x86', 'arm64-v8a'
-    }
-  }
-
-  if (project.hasProperty('doFullRelease')) {
-    defaultPublishConfig 'fullRelease'
-  } else {
-    defaultPublishConfig 'slimDebug'
   }
 }
 

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -8,7 +8,6 @@ apply from: 'versioning.gradle'
 
 android {
   compileSdkVersion 26
-  buildToolsVersion '26.0.2'
 
   defaultConfig {
     minSdkVersion 15

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -76,7 +76,7 @@ android {
 
 dependencies {
   api 'com.squareup.okhttp3:okhttp:3.5.0'
-  api 'com.android.support:support-annotations:25.3.1'
+  implementation 'com.android.support:support-annotations:25.3.1'
 }
 
 apply from: file('gradle-mvn-push.gradle')


### PR DESCRIPTION
- Updates gradle configs to use new dependency configuration
 - Uses gradle 3.0.1
 - needs android studio 3.0 (Updated readme)
- Updates build tools to 26.0.2

Followed migration instructions from: https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html

Closes #1732 