### PR TITLE
fix: preserve relative paths during Url dot-removal

### DIFF
--- a/core/src/util/url.cpp
+++ b/core/src/util/url.cpp
@@ -453,6 +453,8 @@ size_t Url::removeDotSegmentsFromRange(std::string& str, size_t start, size_t co
     size_t pos = start; // 'input' position.
     size_t out = pos; // 'output' position.
 
+    const bool had_leading_slash = count != 0 ? str[start] == '/' : true;
+
     while (pos < end) {
         if (pos + 2 < end &&
                    str[pos] == '.' &&
@@ -480,6 +482,10 @@ size_t Url::removeDotSegmentsFromRange(std::string& str, size_t start, size_t co
                    str[pos + 3] == '/') {
             pos += 3;
             out = removeLastSegmentFromRange(str, start, out);
+            if(out == 0 && !had_leading_slash) {
+                //do not introduce a leading slash (also skip the slash of this /../ segment)
+                pos++;
+            }
         } else if (pos + 3 == end &&
                    str[pos] == '/' &&
                    str[pos + 1] == '.' &&

--- a/tests/unit/urlTests.cpp
+++ b/tests/unit/urlTests.cpp
@@ -94,6 +94,27 @@ TEST_CASE("Remove dot segments from a path", "[Url]") {
     CHECK(Url::removeDotSegmentsFromString("a//b//c") == "a//b//c");
     CHECK(Url::removeDotSegmentsFromString("a./b../..c/.d") == "a./b../..c/.d");
 
+    //preserve absolute and relative urls (keep the leading / when given, don't add one)
+    CHECK(Url::removeDotSegmentsFromString("a/../b") == "b");
+    CHECK(Url::removeDotSegmentsFromString("/a/../b") == "/b");
+    CHECK(Url::removeDotSegmentsFromString("a/../") == "");
+    CHECK(Url::removeDotSegmentsFromString("/a/../") == "/");
+    CHECK(Url::removeDotSegmentsFromString("a/../../") == "");
+    CHECK(Url::removeDotSegmentsFromString("/a/../../") == "/");
+    CHECK(Url::removeDotSegmentsFromString("a/b/../c") == "a/c");
+    CHECK(Url::removeDotSegmentsFromString("/a/b/../c") == "/a/c");
+    CHECK(Url::removeDotSegmentsFromString("a/b/../") == "a/");
+    CHECK(Url::removeDotSegmentsFromString("/a/b/../") == "/a/");
+    CHECK(Url::removeDotSegmentsFromString("a/b/../c/d") == "a/c/d");
+    CHECK(Url::removeDotSegmentsFromString("/a/b/../c/d") == "/a/c/d");
+    CHECK(Url::removeDotSegmentsFromString("a/b/../../c") == "c");
+    CHECK(Url::removeDotSegmentsFromString("/a/b/../../c") == "/c");
+    CHECK(Url::removeDotSegmentsFromString("a/b/../../../c") == "c");
+    CHECK(Url::removeDotSegmentsFromString("/a/b/../../../c") == "/c");
+    CHECK(Url::removeDotSegmentsFromString("./a/b/../../c") == "c");
+    CHECK(Url::removeDotSegmentsFromString("/./a/b/../../c") == "/c");
+    CHECK(Url::removeDotSegmentsFromString("/../a") == "/a");
+
 }
 
 TEST_CASE("Produce a 'standardized' URL", "[Url]") {


### PR DESCRIPTION
Hi all,

I hit an issue when working with scene imports from local paths. Given a filesystem of:
* scene.yaml with import: foo/bar.yaml
* foo/bar.yaml with import ../bar/baz.yaml
* bar/baz.yaml

The relative url in "import: ../bar/baz.yaml" will be transformed to "/bar/baz.yaml" during dot removal. This of course is an absolute path that probably doesn't exist.
