### PR TITLE
Fix #1723

### DIFF
--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -130,7 +130,7 @@ void TileManager::updateTileSets(const View& _view) {
     m_tilesInProgress = 0;
     m_tileSetChanged = false;
 
-    if (_view.changedOnLastUpdate() && !getDebugFlag(DebugFlags::freeze_tiles)) {
+    if (!getDebugFlag(DebugFlags::freeze_tiles)) {
 
         for (auto& tileSet : m_tileSets) {
             tileSet.visibleTiles.clear();


### PR DESCRIPTION
Remove this small optimization which lead to not create the set of visible tiles for new ClientDataSources until the view has changed.

https://github.com/tangrams/tangram-es/issues/1723