### PR TITLE
Restore arm64-v8a ABI to full Android builds

### DIFF
--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -62,7 +62,7 @@ android {
       // Default configuration
     }
     full {
-      externalNativeBuild.cmake.abiFilters 'x86'
+      externalNativeBuild.cmake.abiFilters 'x86', 'arm64-v8a'
     }
   }
 


### PR DESCRIPTION
Even though the armeabi-v7a ABI is compatible with arm64 devices, omitting an arm64 native library makes it impossible to split APKs by ABI.

Resolves #1736 