### PR TITLE
Fix: initiate url callback when httpHandler is not set

### DIFF
--- a/platforms/ios/src/TangramMap/TGMapViewController.h
+++ b/platforms/ios/src/TangramMap/TGMapViewController.h
@@ -370,6 +370,7 @@ NS_ASSUME_NONNULL_BEGIN
  or be notified when a network request completes).
  More informations on the default provided configuration can be found on the description
  of `TGHttpHandler`.
+ @note If a scene load is called before viewDidLoad, httpHandler will result in an error response.
  */
 @property (strong, nonatomic) TGHttpHandler* httpHandler;
 

--- a/platforms/ios/src/TangramMap/iosPlatform.mm
+++ b/platforms/ios/src/TangramMap/iosPlatform.mm
@@ -140,14 +140,19 @@ FontSourceHandle iOSPlatform::systemFont(const std::string& _name, const std::st
 UrlRequestHandle iOSPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
     __strong TGMapViewController* mapViewController = m_viewController;
 
+    UrlResponse errorResponse;
     if (!mapViewController) {
-        return false;
+        errorResponse.error = "MapViewController not initialized.";
+        _callback(errorResponse);
+        return 0;
     }
 
     TGHttpHandler* httpHandler = [mapViewController httpHandler];
 
     if (!httpHandler) {
-        return false;
+        errorResponse.error = "HttpHandler not set in MapViewController";
+        _callback(errorResponse);
+        return 0;
     }
 
     TGDownloadCompletionHandler handler = ^void (NSData* data, NSURLResponse* response, NSError* error) {


### PR DESCRIPTION
Fixes #1740 

I went with giving an error response when `httpHandler` is not set for a `mapViewController` (could happen in scenarios where scene load happens before `viewDidLoad` is called by the ios view hiearchy).

The other proposed solution of creating a stock httpHandler if its not initialized may run into other issues as sceneLoad is (could be) dependent on other configurations which should be set in `viewDidLoad` or before scene loading should begin.