### PR TITLE
This will allow null values for style params

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1566,6 +1566,7 @@ void SceneLoader::parseStyleParams(Node params, const std::shared_ptr<Scene>& sc
         }
         default:
             LOGW("Style parameter %s must be a scalar, sequence, or map.", key.c_str());
+            out.emplace_back(StyleParam::getKey(key));
         }
     }
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1564,9 +1564,13 @@ void SceneLoader::parseStyleParams(Node params, const std::shared_ptr<Scene>& sc
 
             break;
         }
+        case NodeType::Null: {
+            // Handles the case, when null style param value is used to unset a merged style param
+            out.emplace_back(StyleParam::getKey(key));
+            break;
+        }
         default:
             LOGW("Style parameter %s must be a scalar, sequence, or map.", key.c_str());
-            out.emplace_back(StyleParam::getKey(key));
         }
     }
 }

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -158,7 +158,11 @@ struct StyleParam {
 
     StyleParam() :
         key(StyleParamKey::none),
-        value(none_type{}) {};
+        value(none_type{}) {}
+
+    StyleParam(StyleParamKey _key) :
+        key(_key),
+        value(none_type{}) {}
 
     StyleParam(const std::string& _key, const std::string& _value);
 


### PR DESCRIPTION
- style mixing will automatically override the none_type here, from a
sublayer mixing, unlike previously when the style param was removed from
the draw rule set for the layer

Refer the discussion here: https://github.com/tangrams/refill-style/pull/82#discussion_r155866056