### PR TITLE
Fix calculation of View::pixelsPerMeter()

### DIFF
--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -226,7 +226,7 @@ void View::update(bool _constrainToWorldBounds) {
     m_changed = false;
 
     if (_constrainToWorldBounds) {
-        m_constraint.setRadius(std::fmax(getWidth(), getHeight()) / pixelsPerMeter() / pixelScale());
+        m_constraint.setRadius(0.5 * std::fmax(getWidth(), getHeight()) / pixelsPerMeter() / pixelScale());
         m_pos.x = m_constraint.getConstrainedX(m_pos.x);
         m_pos.y = m_constraint.getConstrainedY(m_pos.y);
         m_zoom -= std::log(m_constraint.getConstrainedScale()) / std::log(2);

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -332,7 +332,7 @@ double View::screenToGroundPlaneInternal(double& _screenX, double& _screenY) con
 
 float View::pixelsPerMeter() const {
 
-    double metersPerTile = MapProjection::HALF_CIRCUMFERENCE * exp2(-m_zoom);
+    double metersPerTile = 2.0 * MapProjection::HALF_CIRCUMFERENCE * exp2(-m_zoom);
     return s_pixelsPerTile / metersPerTile;
 }
 


### PR DESCRIPTION
This is probably an *extremely* old bug that impacts shaders using the 'u_pixels_per_meter' uniform, like the "waves" shaders in refill.

Before there was noticeable crawling of the pattern:
![waves-before](https://user-images.githubusercontent.com/3371850/33787340-9eb12fe4-dc21-11e7-96ec-2344fd7c28cd.gif)

Now it's steady while panning:
![waves-after](https://user-images.githubusercontent.com/3371850/33787362-bb22248a-dc21-11e7-8bbc-3994b6c23cb1.gif)



