### PR TITLE
Apply 'max_tilt' to isometric and flat cameras

### DIFF
--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -237,7 +237,8 @@ void View::update(bool _constrainToWorldBounds) {
         float maxPitchRadians = glm::radians(getMaxPitch());
         if (m_type != CameraType::perspective) {
             // Prevent projection plane from intersecting ground plane.
-            maxPitchRadians = atan2(m_pos.z, m_height * .5f);
+            float intersectingPitchRadians = atan2(m_pos.z, m_height * .5f);
+            maxPitchRadians = glm::min(maxPitchRadians, intersectingPitchRadians);
         }
         m_pitch = glm::clamp(m_pitch, 0.f, maxPitchRadians);
     }

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -87,7 +87,7 @@ public:
     // Set the maximum pitch angle in degrees as a series of stops over zooms.
     void setMaxPitchStops(std::shared_ptr<Stops> stops);
 
-    // Get the maximum pitch angle for the current zoom.
+    // Get the maximum pitch angle for the current zoom, in degrees.
     float getMaxPitch() const;
 
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
@@ -237,7 +237,7 @@ protected:
     float m_aspect;
     float m_pixelScale = 1.0f;
     float m_fov = 0.25 * PI;
-    float m_maxPitch = 0.5 * PI;
+    float m_maxPitch = 90.f;
 
     CameraType m_type;
 


### PR DESCRIPTION
Resolves https://github.com/tangrams/tangram-es/issues/1759

 - As noted in the issue, `m_maxPitch` was being ignored for isometric and flat cameras. Now it is used in conjunction with the ground-plane-intersection pitch.
 - The units of `m_maxPitch` were not clear and the initial value suggested that it was radians. It is in fact degrees, and the code makes that clear now. (I think that initial value is overridden in most cases.)