### PR TITLE
Fixed failing test on 32bit Linux

### DIFF
--- a/tests/unit/mercProjTests.cpp
+++ b/tests/unit/mercProjTests.cpp
@@ -15,7 +15,7 @@ TEST_CASE( "Testing some functionality for mercator projection", "[MERCATOR][PRO
     glm::dvec2 lonLat = glm::dvec2(0.0,0.0);
     glm::dvec2 worldCoord = glm::dvec2(0.0, 0.0);
     //glm::ivec3 tileCoord = glm::ivec3(2, 2, 3);
-    double epsilon = 0.000000000000000001;
+    double epsilon = 0.000000000001;
     //check if all the test tileCoordinates are loaded
     /*REQUIRE(dataSource.JsonRootSize() == 3);
     //check if all the test tiles have data in the jsonRoots data structure


### PR DESCRIPTION
Running the unit tests on a 32Bit Linux (Ubuntu 16.04 LTS) will cause the mercProjTest to fail when  checking the testLonLat.y value against the error limit epsilon after converting meters to lon/lat.

For a 32bit system, the calculation returns a extremely small value, which is bigger than the error threshold epsilon (in my case 6.12574e-17) while the 64bit system returns 0. Therefore the tests for 32bit systems fail.

The value epsilon used for the comparison of the floating point numbers is accurate to 18 decimal places. Since for the calculation with decimal degress an accuracy of 10 decimal places is sufficient to describe a dot on the μm exactly (see [Wikipedia Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees) ) I have adjusted the epsilon value to 12 decimal places. This is still accurate enough and allows to run the unit tests successfully also on 32bit systems.