### PR TITLE
Use sprite texture density aptly

### DIFF
--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -21,17 +21,19 @@
 
 namespace Tangram {
 
-Texture::Texture(unsigned int _width, unsigned int _height, TextureOptions _options, bool _generateMipmaps)
+Texture::Texture(unsigned int _width, unsigned int _height, TextureOptions _options,
+        bool _generateMipmaps, float _density)
     : m_options(_options), m_generateMipmaps(_generateMipmaps) {
 
+    m_invDensity = 1.f/_density;
     m_glHandle = 0;
     m_shouldResize = false;
     m_target = GL_TEXTURE_2D;
     resize(_width, _height);
 }
 
-Texture::Texture(const std::vector<char>& _data, TextureOptions options, bool generateMipmaps)
-    : Texture(0u, 0u, options, generateMipmaps) {
+Texture::Texture(const std::vector<char>& _data, TextureOptions options, bool generateMipmaps, float density)
+    : Texture(0u, 0u, options, generateMipmaps, density) {
 
     loadImageFromMemory(_data);
 }

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -38,13 +38,11 @@ class Texture {
 
 public:
 
-    Texture(unsigned int _width, unsigned int _height,
-            TextureOptions _options = DEFAULT_TEXTURE_OPTION,
-            bool _generateMipmaps = false);
+    Texture(unsigned int _width, unsigned int _height, TextureOptions _options = DEFAULT_TEXTURE_OPTION,
+            bool _generateMipmaps = false, float _density = 1.f);
 
-    Texture(const std::vector<char>& _data,
-            TextureOptions _options = DEFAULT_TEXTURE_OPTION,
-            bool _generateMipmaps = false);
+    Texture(const std::vector<char>& _data, TextureOptions _options = DEFAULT_TEXTURE_OPTION,
+            bool _generateMipmaps = false, float _density = 1.f);
 
     Texture(Texture&& _other);
     Texture& operator=(Texture&& _other);
@@ -98,6 +96,8 @@ public:
 
     auto& spriteAtlas() { return m_spriteAtlas; }
 
+    float invDensity() const { return m_invDensity; }
+
 protected:
 
     void generate(RenderState& rs, GLuint _textureUnit);
@@ -124,6 +124,8 @@ protected:
 private:
 
     bool m_generateMipmaps;
+    // used to determine css size by using as a multiplier with the defined texture size/sprite size
+    float m_invDensity = 1.f;
 
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -674,11 +674,11 @@ void SceneLoader::loadTexture(const std::shared_ptr<Platform>& platform, const s
             const std::string& spriteName = it->first.Scalar();
 
             if (sprite) {
-                glm::vec4 desc = parseVec<glm::vec4>(sprite) * density;
+                glm::vec4 desc = parseVec<glm::vec4>(sprite);
                 glm::vec2 pos = glm::vec2(desc.x, desc.y);
                 glm::vec2 size = glm::vec2(desc.z, desc.w);
 
-                atlas->addSpriteNode(spriteName, pos, size);
+                atlas->addSpriteNode(spriteName, pos, size, density);
             }
         }
         atlas->updateSpriteNodes({texture->getWidth(), texture->getHeight()});

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -554,7 +554,8 @@ bool SceneLoader::extractTexFiltering(Node& filtering, TextureFiltering& filter)
 std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platform>& platform,
                                                    const std::string& name, const std::string& urlString,
                                                    const TextureOptions& options, bool generateMipmaps,
-                                                   const std::shared_ptr<Scene>& scene) {
+                                                   const std::shared_ptr<Scene>& scene,
+                                                   float density) {
 
     std::shared_ptr<Texture> texture;
 
@@ -575,7 +576,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platfor
             LOGE("Can't decode Base64 texture");
             return nullptr;
         }
-        texture = std::make_shared<Texture>(0, 0, options, generateMipmaps);
+        texture = std::make_shared<Texture>(0, 0, options, generateMipmaps, density);
 
         std::vector<char> textureData;
         auto cdata = reinterpret_cast<char*>(blob.data());
@@ -584,7 +585,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platfor
             LOGE("Invalid Base64 texture");
         }
     } else {
-        texture = std::make_shared<Texture>(std::vector<char>(), options, generateMipmaps);
+        texture = std::make_shared<Texture>(std::vector<char>(), options, generateMipmaps, density);
 
         scene->pendingTextures++;
         scene->startUrlRequest(platform, url, [&, url, scene, texture](UrlResponse response) {
@@ -657,16 +658,16 @@ void SceneLoader::loadTexture(const std::shared_ptr<Platform>& platform, const s
         }
     }
 
-    auto texture = fetchTexture(platform, name, url, options, generateMipmaps, scene);
+    float density = 1.f;
+    if (Node d = textureConfig["density"]) {
+        double val;
+        if (getDouble(d, val)) { density = val; }
+    }
+
+    auto texture = fetchTexture(platform, name, url, options, generateMipmaps, scene, density);
 
     if (Node sprites = textureConfig["sprites"]) {
         auto atlas = std::make_unique<SpriteAtlas>();
-
-        float density = 1.f;
-        if (Node d = textureConfig["density"]) {
-            double val;
-            if (getDouble(d, val)) { density = val; }
-        }
 
         for (auto it = sprites.begin(); it != sprites.end(); ++it) {
 
@@ -678,7 +679,7 @@ void SceneLoader::loadTexture(const std::shared_ptr<Platform>& platform, const s
                 glm::vec2 pos = glm::vec2(desc.x, desc.y);
                 glm::vec2 size = glm::vec2(desc.z, desc.w);
 
-                atlas->addSpriteNode(spriteName, pos, size, density);
+                atlas->addSpriteNode(spriteName, pos, size);
             }
         }
         atlas->updateSpriteNodes({texture->getWidth(), texture->getHeight()});

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -70,7 +70,7 @@ struct SceneLoader {
     /* loads a texture with default texture properties */
     static std::shared_ptr<Texture> getOrLoadTexture(const std::shared_ptr<Platform>& platform, const std::string& url, const std::shared_ptr<Scene>& scene);
     static std::shared_ptr<Texture> fetchTexture(const std::shared_ptr<Platform>& platform, const std::string& name, const std::string& url,
-            const TextureOptions& options, bool generateMipmaps, const std::shared_ptr<Scene>& scene);
+            const TextureOptions& options, bool generateMipmaps, const std::shared_ptr<Scene>& scene, float density = 1.f);
     static bool extractTexFiltering(Node& filtering, TextureFiltering& filter);
 
     static MaterialTexture loadMaterialTexture(const std::shared_ptr<Platform>& platform, Node matCompNode,

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -4,8 +4,8 @@ namespace Tangram {
 
 SpriteAtlas::SpriteAtlas() {}
 
-void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size, uint8_t _density) {
-    m_spritesNodes[_name] = SpriteNode { {}, {}, _size, _origin, 1.f/_density};
+void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size) {
+    m_spritesNodes[_name] = SpriteNode { {}, {}, _size, _origin};
 }
 
 bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) const {

--- a/core/src/scene/spriteAtlas.cpp
+++ b/core/src/scene/spriteAtlas.cpp
@@ -4,8 +4,8 @@ namespace Tangram {
 
 SpriteAtlas::SpriteAtlas() {}
 
-void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size) {
-    m_spritesNodes[_name] = SpriteNode { {}, {}, _size, _origin };
+void SpriteAtlas::addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size, uint8_t _density) {
+    m_spritesNodes[_name] = SpriteNode { {}, {}, _size, _origin, 1.f/_density};
 }
 
 bool SpriteAtlas::getSpriteNode(const std::string& _name, SpriteNode& _node) const {

--- a/core/src/scene/spriteAtlas.h
+++ b/core/src/scene/spriteAtlas.h
@@ -13,7 +13,6 @@ struct SpriteNode {
     glm::vec2 m_uvTR;
     glm::vec2 m_size;
     glm::vec2 m_origin;
-    float m_invDensity; // used to determine css size by using as a multiplier with the defined sprite size
 };
 
 class SpriteAtlas {
@@ -21,10 +20,8 @@ class SpriteAtlas {
 public:
     SpriteAtlas();
 
-    /* Creates a sprite node in the atlas located at _origin in the texture by a size in pixels _size
-     * and having default pixel density as _density
-     */
-    void addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size, uint8_t _density);
+    /* Creates a sprite node in the atlas located at _origin in the texture by a size in pixels _size */
+    void addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size);
     bool getSpriteNode(const std::string& _name, SpriteNode& _node) const;
     void updateSpriteNodes(const glm::vec2&  _textureSize);
 

--- a/core/src/scene/spriteAtlas.h
+++ b/core/src/scene/spriteAtlas.h
@@ -13,6 +13,7 @@ struct SpriteNode {
     glm::vec2 m_uvTR;
     glm::vec2 m_size;
     glm::vec2 m_origin;
+    float m_invDensity; // used to determine css size by using as a multiplier with the defined sprite size
 };
 
 class SpriteAtlas {
@@ -20,8 +21,10 @@ class SpriteAtlas {
 public:
     SpriteAtlas();
 
-    /* Creates a sprite node in the atlas located at _origin in the texture by a size in pixels _size */
-    void addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size);
+    /* Creates a sprite node in the atlas located at _origin in the texture by a size in pixels _size
+     * and having default pixel density as _density
+     */
+    void addSpriteNode(const std::string& _name, glm::vec2 _origin, glm::vec2 _size, uint8_t _density);
     bool getSpriteNode(const std::string& _name, SpriteNode& _node) const;
     void updateSpriteNodes(const glm::vec2&  _textureSize);
 

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -339,7 +339,8 @@ bool PointStyleBuilder::getUVQuad(Parameters& _params, glm::vec4& _quad, Texture
             }
 
             if (std::isnan(_params.size.x)) {
-                _params.size = spriteNode.m_size;
+                // determine the css size of the sprite if size is not determined from style draw rule
+                _params.size = spriteNode.m_size * spriteNode.m_invDensity;
             }
 
             _quad.x = spriteNode.m_uvBL.x;

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -340,7 +340,7 @@ bool PointStyleBuilder::getUVQuad(Parameters& _params, glm::vec4& _quad, Texture
 
             if (std::isnan(_params.size.x)) {
                 // determine the css size of the sprite if size is not determined from style draw rule
-                _params.size = spriteNode.m_size * spriteNode.m_invDensity;
+                _params.size = spriteNode.m_size * texture->invDensity();
             }
 
             _quad.x = spriteNode.m_uvBL.x;
@@ -349,7 +349,7 @@ bool PointStyleBuilder::getUVQuad(Parameters& _params, glm::vec4& _quad, Texture
             _quad.w = spriteNode.m_uvTR.y;
         } else {
             if (std::isnan(_params.size.x)) {
-                _params.size = glm::vec2{texture->getWidth(), texture->getHeight()};
+                _params.size = glm::vec2{texture->getWidth(), texture->getHeight()} * texture->invDensity();
             }
         }
         _params.size *= m_style.pixelScale();


### PR DESCRIPTION
Fixes the usage of the texture density property.

Based on the description https://github.com/tangrams/tangram/pull/234, and discussion with the JS and cartography crew, density defines divisor which is used to get the size of the sprites in css pixel units. The below implementation reflects this change and matches the behavior with the JS implementation.