### PR TITLE
Implement % and auto sizing for point style

### DIFF
--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -95,6 +95,7 @@ public:
     size_t bufferSize();
 
     auto& spriteAtlas() { return m_spriteAtlas; }
+    const auto& spriteAtlas() const { return m_spriteAtlas; }
 
     float invDensity() const { return m_invDensity; }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1093,6 +1093,8 @@ void SceneLoader::loadSourceRasters(const std::shared_ptr<Platform>& platform, s
 }
 
 void SceneLoader::parseLightPosition(Node position, PointLight& light) {
+
+    const uint8_t allowedUnits = (Unit::pixel | Unit::meter);
     if (position.IsSequence()) {
         UnitVec<glm::vec3> lightPos;
         std::string positionSequence;
@@ -1102,7 +1104,7 @@ void SceneLoader::parseLightPosition(Node position, PointLight& light) {
             positionSequence += n.Scalar() + ",";
         }
 
-        StyleParam::parseVec3(positionSequence, {Unit::meter, Unit::pixel}, lightPos);
+        StyleParam::parseVec3(positionSequence, allowedUnits, lightPos);
         light.setPosition(lightPos);
     } else {
         LOGNode("Wrong light position parameter", position);

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -456,16 +456,18 @@ auto Stops::nearestHigherFrame(float _key) const -> std::vector<Frame>::const_it
 }
 
 void Stops::eval(const Stops& _stops, StyleParamKey _key, float _zoom, StyleParam::Value& _result) {
+
+    /* StyleParam::size stops can not have a generic evaluation, and
+     * requires more context and is handled in the pointStyleBuilder
+     */
+    if (StyleParam::isSize(_key)) { return; }
+
     if (StyleParam::isColor(_key)) {
         _result = _stops.evalColor(_zoom);
     } else if (StyleParam::isWidth(_key)) {
         _result = _stops.evalExpFloat(_zoom);
     } else if (StyleParam::isOffsets(_key)) {
         _result = _stops.evalVec2(_zoom);
-    } else if (StyleParam::isSize(_key)) {
-        // TODO: What should be done here!
-        // Size stop evaluation happens during pointStyleBuilder rule evaluation
-      //  _result = _stops.evalSize(_zoom);
     } else {
         _result = _stops.evalFloat(_zoom);
     }

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -13,8 +13,9 @@ namespace YAML {
 namespace Tangram {
 
 class MapProjection;
+struct SpriteNode;
 
-using StopValue = variant<none_type, float, Color, glm::vec2>;
+using StopValue = variant<none_type, float, Color, glm::vec2, StyleParam::SizeValue>;
 
 struct Stops {
 
@@ -24,6 +25,7 @@ struct Stops {
         Frame(float _k, float _v) : key(_k), value(_v) {}
         Frame(float _k, Color _c) : key(_k), value(_c) {}
         Frame(float _k, glm::vec2 _v) : key(_k), value(_v) {}
+        Frame(float _k, StyleParam::SizeValue sizeValue) : key(_k), value(sizeValue) {}
     };
 
     std::vector<Frame> frames;
@@ -43,7 +45,7 @@ struct Stops {
     auto evalColor(float _key) const -> uint32_t;
     auto evalVec2(float _key) const -> glm::vec2;
     auto evalExpVec2(float _key) const -> glm::vec2;
-    auto evalSize(float _key) const -> StyleParam::Value;
+    auto evalSize(float _key, const glm::vec2& cssSize, float aspectRatio, bool useCssSize) const -> glm::vec2;
     auto nearestHigherFrame(float _key) const -> std::vector<Frame>::const_iterator;
 
     static void eval(const Stops& _stops, StyleParamKey _key, float _zoom, StyleParam::Value& _result);

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -45,7 +45,7 @@ struct Stops {
     auto evalColor(float _key) const -> uint32_t;
     auto evalVec2(float _key) const -> glm::vec2;
     auto evalExpVec2(float _key) const -> glm::vec2;
-    auto evalSize(float _key, const glm::vec2& cssSize, float aspectRatio, bool useTextureInfo) const -> glm::vec2;
+    auto evalSize(float _key, const glm::vec2& cssSize) const -> glm::vec2;
     auto nearestHigherFrame(float _key) const -> std::vector<Frame>::const_iterator;
 
     static void eval(const Stops& _stops, StyleParamKey _key, float _zoom, StyleParam::Value& _result);

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -45,7 +45,7 @@ struct Stops {
     auto evalColor(float _key) const -> uint32_t;
     auto evalVec2(float _key) const -> glm::vec2;
     auto evalExpVec2(float _key) const -> glm::vec2;
-    auto evalSize(float _key, const glm::vec2& cssSize, float aspectRatio, bool useCssSize) const -> glm::vec2;
+    auto evalSize(float _key, const glm::vec2& cssSize, float aspectRatio, bool useTextureInfo) const -> glm::vec2;
     auto nearestHigherFrame(float _key) const -> std::vector<Frame>::const_iterator;
 
     static void eval(const Stops& _stops, StyleParamKey _key, float _zoom, StyleParam::Value& _result);

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -30,10 +30,10 @@ struct Stops {
 
     std::vector<Frame> frames;
     static Stops Colors(const YAML::Node& _node);
-    static Stops Widths(const YAML::Node& _node, const MapProjection& _projection, const std::vector<Unit>& _units);
+    static Stops Widths(const YAML::Node& _node, const MapProjection& _projection, uint8_t _units);
     static Stops FontSize(const YAML::Node& _node);
-    static Stops Sizes(const YAML::Node& _node, const std::vector<Unit>& _units);
-    static Stops Offsets(const YAML::Node& _node, const std::vector<Unit>& _units);
+    static Stops Sizes(const YAML::Node& _node, uint8_t _units);
+    static Stops Offsets(const YAML::Node& _node, uint8_t _units);
     static Stops Numbers(const YAML::Node& node);
 
     Stops(const std::vector<Frame>& _frames) : frames(_frames) {}

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -472,7 +472,10 @@ void StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
                 break;
             }
             case StyleParamKey::size: {
-                _val = glm::vec2(static_cast<float>(duk_get_number(m_ctx, -1)));
+                StyleParam::SizeValue vec;
+                vec.fill( {NAN, Unit::pixel} );
+                vec[0].value = static_cast<float>(duk_get_number(m_ctx, -1));
+                _val = vec;
                 break;
             }
             case StyleParamKey::order:

--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -473,8 +473,7 @@ void StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
             }
             case StyleParamKey::size: {
                 StyleParam::SizeValue vec;
-                vec.fill( {NAN, Unit::pixel} );
-                vec[0].value = static_cast<float>(duk_get_number(m_ctx, -1));
+                vec.x.value = static_cast<float>(duk_get_number(m_ctx, -1));
                 _val = vec;
                 break;
             }

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -523,8 +523,9 @@ static const std::vector<std::string> s_units = { "px", "ms", "m", "s", "%" };
 int StyleParam::parseSizeUnitPair(const std::string &_value, size_t offset,
                                   StyleParam::ValueUnitPair &_result) {
     const char* autoStr = "auto";
-    const int autoSize = 4;
-    if (_value.substr(offset, autoSize).compare(autoStr) == 0) {
+    const size_t autoSize = 4;
+
+    if (_value.size() >= (offset + autoSize) && _value.compare(offset, autoSize, autoStr) == 0) {
         _result.unit = Unit::sizeauto;
         offset += autoSize;
         return offset;

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -645,21 +645,10 @@ int parseVec(const std::string& _value, uint8_t allowedUnits, UnitVec<T>& _vec) 
 }
 
 bool StyleParam::parseSize(const std::string &_value, uint8_t allowedUnits, SizeValue& _vec) {
-    // initialize with defaults
-    _vec.fill({NAN, Unit::pixel});
-    const size_t elements = _vec.size();
-
     int offset = 0;
-    for (size_t i = 0; i < elements; i++) {
-        offset = StyleParam::parseSizeUnitPair(_value, offset, _vec[i]);
-        if (offset < 0) { return i; }
-
-        if ( !(_vec[i].unit & allowedUnits) ) {
-            return 0;
-        }
-    }
-
-    return elements;
+    offset = StyleParam::parseSizeUnitPair(_value, offset, _vec.x);
+    offset = StyleParam::parseSizeUnitPair(_value, offset, _vec.y);
+    return (offset > 0) && ((_vec.x.unit & allowedUnits) && (_vec.y.unit & allowedUnits));
 }
 
 bool StyleParam::parseVec2(const std::string& _value, uint8_t allowedUnits, UnitVec<glm::vec2>& _vec) {

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -85,7 +85,7 @@ enum class StyleParamKey : uint8_t {
 
 constexpr size_t StyleParamKeySize = static_cast<size_t>(StyleParamKey::NUM_ELEMENTS);
 
-enum class Unit { pixel, milliseconds, meter, seconds };
+enum class Unit { pixel, milliseconds, meter, seconds, percentage, sizeauto };
 
 static inline std::string unitString(Unit unit) {
     switch(unit) {
@@ -93,6 +93,8 @@ static inline std::string unitString(Unit unit) {
         case Unit::milliseconds: return "milliseconds";
         case Unit::meter: return "meter";
         case Unit::seconds: return "seconds";
+        case Unit::percentage: return "%";
+        case Unit::sizeauto: return "auto";
         default: return "undefined";
     }
 }
@@ -121,10 +123,11 @@ struct StyleParam {
         Unit unit = Unit::meter;
 
         bool isMeter() const { return unit == Unit::meter; }
+        bool isPercentage() const { return unit == Unit::percentage; }
+        bool isAuto() const { return unit == Unit::sizeauto; }
         bool isPixel() const { return unit == Unit::pixel; }
         bool isSeconds() const { return unit == Unit::seconds; }
         bool isMilliseconds() const { return unit == Unit::milliseconds; }
-
     };
     struct Width : ValueUnitPair {
 
@@ -153,7 +156,8 @@ struct StyleParam {
         }
     };
 
-    using Value = variant<none_type, Undefined, bool, float, uint32_t, std::string, glm::vec2, Width,
+    using SizeValue = std::array<ValueUnitPair, 2>;
+    using Value = variant<none_type, Undefined, bool, float, uint32_t, std::string, glm::vec2, SizeValue, Width,
                           LabelProperty::Placement, LabelProperty::Anchors, TextSource>;
 
     StyleParam() :
@@ -195,9 +199,12 @@ struct StyleParam {
     static bool parseTime(const std::string& _value, float& _time);
 
     // values within _value string parameter must be delimited by ','
+    static bool parseSize(const std::string& _value, const std::vector<Unit>& _allowedUnits, SizeValue& _vec2);
     static bool parseVec2(const std::string& _value, const std::vector<Unit>& _allowedUnits, UnitVec<glm::vec2>& _vec2);
     static bool parseVec3(const std::string& _value, const std::vector<Unit>& _allowedUnits, UnitVec<glm::vec3>& _vec3);
 
+    static int parseSizeUnitPair(const std::string& _value, size_t start,
+                                 StyleParam::ValueUnitPair& _result);
     static int parseValueUnitPair(const std::string& _value, size_t start,
                                   StyleParam::ValueUnitPair& _result);
 

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -128,6 +128,13 @@ struct StyleParam {
         bool isPixel() const { return unit == Unit::pixel; }
         bool isSeconds() const { return unit == Unit::seconds; }
         bool isMilliseconds() const { return unit == Unit::milliseconds; }
+
+        bool operator==(const ValueUnitPair& _other) const {
+            return value == _other.value && unit == _other.unit;
+        }
+        bool operator!=(const ValueUnitPair& _other) const {
+            return value != _other.value || unit != _other.unit;
+        }
     };
     struct Width : ValueUnitPair {
 
@@ -139,13 +146,6 @@ struct StyleParam {
 
         Width(ValueUnitPair& _other) :
             ValueUnitPair(_other) {}
-
-        bool operator==(const Width& _other) const {
-            return value == _other.value && unit == _other.unit;
-        }
-        bool operator!=(const Width& _other) const {
-            return value != _other.value || unit != _other.unit;
-        }
     };
 
 

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -163,7 +163,44 @@ struct StyleParam {
         }
     };
 
-    using SizeValue = std::array<ValueUnitPair, 2>;
+    struct SizeValue {
+        ValueUnitPair x = { NAN, Unit::pixel };
+        ValueUnitPair y = { NAN, Unit::pixel };
+
+        // Apply this size value for a point with the given default sprite size, in CSS pixels.
+        // To apply no default sprite size, input a vector of NaN values.
+        // If either dimension of the output is NaN, then there is no valid size result.
+        glm::vec2 getSizePixels(glm::vec2 spriteSize) const {
+            if (x.isPercentage()) {
+                return spriteSize * (x.value * 0.01f);
+            }
+            if (x.isAuto() && y.isPixel()) {
+                return glm::vec2(y.value * spriteSize.x / spriteSize.y, y.value);
+            }
+            if (x.isPixel() && y.isAuto()) {
+                return glm::vec2(x.value, x.value * spriteSize.y / spriteSize.x);
+            }
+            if (x.isPixel() && y.isPixel()) {
+                if (std::isnan(y.value)) {
+                    if (std::isnan(x.value)) {
+                        return spriteSize;
+                    }
+                    return glm::vec2(x.value);
+                }
+                return glm::vec2(x.value, y.value);
+            }
+            return glm::vec2(NAN);
+        }
+
+        bool operator==(const SizeValue& other) const {
+            return x == other.x && y == other.y;
+        }
+
+        bool operator!=(const SizeValue& other) const {
+            return !(*this == other);
+        }
+    };
+
     using Value = variant<none_type, Undefined, bool, float, uint32_t, std::string, glm::vec2, SizeValue, Width,
                           LabelProperty::Placement, LabelProperty::Anchors, TextSource>;
 

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -85,7 +85,14 @@ enum class StyleParamKey : uint8_t {
 
 constexpr size_t StyleParamKeySize = static_cast<size_t>(StyleParamKey::NUM_ELEMENTS);
 
-enum class Unit { pixel, milliseconds, meter, seconds, percentage, sizeauto };
+enum Unit : uint8_t {
+    pixel = 1 << 0,
+    milliseconds = 1 << 1,
+    meter = 1 << 2,
+    seconds = 1 << 3,
+    percentage = 1 << 4,
+    sizeauto = 1 << 5
+};
 
 static inline std::string unitString(Unit unit) {
     switch(unit) {
@@ -199,9 +206,9 @@ struct StyleParam {
     static bool parseTime(const std::string& _value, float& _time);
 
     // values within _value string parameter must be delimited by ','
-    static bool parseSize(const std::string& _value, const std::vector<Unit>& _allowedUnits, SizeValue& _vec2);
-    static bool parseVec2(const std::string& _value, const std::vector<Unit>& _allowedUnits, UnitVec<glm::vec2>& _vec2);
-    static bool parseVec3(const std::string& _value, const std::vector<Unit>& _allowedUnits, UnitVec<glm::vec3>& _vec3);
+    static bool parseSize(const std::string& _value, uint8_t _allowedUnits, SizeValue& _vec2);
+    static bool parseVec2(const std::string& _value, uint8_t _allowedUnits, UnitVec<glm::vec2>& _vec2);
+    static bool parseVec3(const std::string& _value, uint8_t _allowedUnits, UnitVec<glm::vec3>& _vec3);
 
     static int parseSizeUnitPair(const std::string& _value, size_t start,
                                  StyleParam::ValueUnitPair& _result);
@@ -218,7 +225,7 @@ struct StyleParam {
     static bool isFontSize(StyleParamKey _key);
     static bool isRequired(StyleParamKey _key);
 
-    static const std::vector<Unit>& unitsForStyleParam(StyleParamKey _key);
+    static uint8_t unitsForStyleParam(StyleParamKey _key);
 
     static StyleParamKey getKey(const std::string& _key);
 

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -123,7 +123,7 @@ bool PointStyleBuilder::checkRule(const DrawRule& _rule) const {
     return false;
 }
 
-auto PointStyleBuilder::applyRule(const DrawRule& _rule, const Properties& _props) const -> Parameters {
+auto PointStyleBuilder::applyRule(const DrawRule& _rule) const -> Parameters {
 
     Parameters p;
     glm::vec2 size;
@@ -481,7 +481,7 @@ void PointStyleBuilder::labelPointsPlacing(const Line& _line, const glm::vec4& _
 bool PointStyleBuilder::addPoint(const Point& _point, const Properties& _props,
                                  const DrawRule& _rule) {
 
-    Parameters p = applyRule(_rule, _props);
+    Parameters p = applyRule(_rule);
     glm::vec4 uvsQuad;
     Texture* texture = nullptr;
 
@@ -497,7 +497,7 @@ bool PointStyleBuilder::addPoint(const Point& _point, const Properties& _props,
 bool PointStyleBuilder::addLine(const Line& _line, const Properties& _props,
                                 const DrawRule& _rule) {
 
-    Parameters p = applyRule(_rule, _props);
+    Parameters p = applyRule(_rule);
     glm::vec4 uvsQuad;
     Texture* texture = nullptr;
 
@@ -513,7 +513,7 @@ bool PointStyleBuilder::addLine(const Line& _line, const Properties& _props,
 bool PointStyleBuilder::addPolygon(const Polygon& _polygon, const Properties& _props,
                                    const DrawRule& _rule) {
 
-    Parameters p = applyRule(_rule, _props);
+    Parameters p = applyRule(_rule);
     glm::vec4 uvsQuad;
     Texture* texture = nullptr;
 

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -59,8 +59,6 @@ struct PointStyleBuilder : public StyleBuilder {
         m_textStyleBuilder = m_style.textStyle().createBuilder();
     }
 
-    bool getUVQuad(Parameters& _params, glm::vec4& _quad, Texture** _texture) const;
-
     Parameters applyRule(const DrawRule& _rule) const;
 
     // Gets points for label placement and appropriate angle for each label (if `auto` angle is set)
@@ -76,6 +74,26 @@ struct PointStyleBuilder : public StyleBuilder {
 
 private:
 
+    /*
+     * Resolves the aptly texture used by the point style builder
+     * Texture could be specified by:
+     * - explicit marker texture
+     * - texture name specified in the draw rules
+     * - default texture specified for the style
+     */
+    bool getTexture(const Parameters& _params, Texture** _texture) const;
+
+    /*
+     * Evaluates the size the point sprite can be drawn with:
+     * - size specified in the draw rule
+     * - Texture density information could be required if:
+     *      - no size is specified in the draw rule
+     *      - draw rule size uses '%' units, which scale the sprite texture based on the texture density
+     * - size specified in the draw rule uses "auto" which means width/height of the sprite is evaluated, keeping the
+     * same aspect ratio.
+     */
+    bool evalSizeParam(const DrawRule& _rule, Parameters& _params, const Texture* _texture) const;
+    bool getUVQuad(Parameters& _params, glm::vec4& _quad, const Texture* _texture) const;
 
     std::vector<std::unique_ptr<Label>> m_labels;
     std::vector<SpriteQuad> m_quads;

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -27,7 +27,7 @@ struct PointStyleBuilder : public StyleBuilder {
         std::string sprite;
         std::string spriteDefault;
         std::string texture;
-        glm::vec2 size;
+        glm::vec2 size = { 16.f, 16.f };
         uint32_t color = 0xffffffff;
         float outlineWidth = 0.f;
         uint32_t outlineColor = 0x00000000;

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -75,7 +75,7 @@ struct PointStyleBuilder : public StyleBuilder {
 private:
 
     /*
-     * Resolves the aptly texture used by the point style builder
+     * Resolves the apt texture used by the point style builder
      * Texture could be specified by:
      * - explicit marker texture
      * - texture name specified in the draw rules

--- a/core/src/style/pointStyleBuilder.h
+++ b/core/src/style/pointStyleBuilder.h
@@ -61,7 +61,7 @@ struct PointStyleBuilder : public StyleBuilder {
 
     bool getUVQuad(Parameters& _params, glm::vec4& _quad, Texture** _texture) const;
 
-    Parameters applyRule(const DrawRule& _rule, const Properties& _props) const;
+    Parameters applyRule(const DrawRule& _rule) const;
 
     // Gets points for label placement and appropriate angle for each label (if `auto` angle is set)
     void labelPointsPlacing(const Line& _line, const glm::vec4& _quad, Texture* _texture,

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -54,7 +54,7 @@ void TileBuilder::applyStyling(const Feature& _feature, const SceneLayer& _layer
             continue;
         }
 
-        // Apply defaul draw rules defined for this style
+        // Apply default draw rules defined for this style
         style->style().applyDefaultDrawRules(rule);
 
         if (!m_ruleSet.evaluateRuleForContext(rule, m_styleContext)) {

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -4,6 +4,8 @@
 #include "yaml-cpp/yaml.h"
 #include "util/mapProjection.h"
 
+#include <iostream>
+
 using namespace Tangram;
 
 Stops instance_color() {
@@ -160,18 +162,65 @@ TEST_CASE("Regression test - Dont crash on evaluating empty stops", "[Stops][YAM
 
 }
 
+TEST_CASE("Mixed dimension stops for StyleParam::size not allowed, exception of `%` and 2d", "[Stops][YAML]") {
+
+    // 1d, 2d
+    YAML::Node node = YAML::Load(R"END(
+        [[0, 6px], [1, [6px, 7px]]]
+    )END");
+    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+    REQUIRE(stops.frames.size() == 0);
+
+    // 2d, 1d
+    node = YAML::Load(R"END(
+        [[0, [6px, 7px]], [1, 6px]]
+    )END");
+    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    REQUIRE(stops.frames.size() == 0);
+
+    // 1d, %, 2d
+    node = YAML::Load(R"END(
+        [[0, 6px], [1, 50%], [2, [6px, 7px]]]
+    )END");
+    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    REQUIRE(stops.frames.size() == 0);
+
+    // % 1d 2d
+    node = YAML::Load(R"END(
+        [[0, 50%], [1, 6px], [2, [6px, 7px]]]
+    )END");
+    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    REQUIRE(stops.frames.size() == 0);
+
+    // % 2d 1d
+    node = YAML::Load(R"END(
+        [[0, 50%], [1, [6px, 7px]], [2, 6px]]
+    )END");
+    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    REQUIRE(stops.frames.size() == 0);
+
+    // 2d % 1d
+    node = YAML::Load(R"END(
+        [[0, 50%], [1, [6px, 7px]], [2, 6px]]
+    )END");
+    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    REQUIRE(stops.frames.size() == 0);
+}
+
 TEST_CASE("2 dimension stops for icon sizes with mixed units", "[Stops][YAML]") {
     YAML::Node node = YAML::Load(R"END(
         [[6, [18.0 px, 14px]], [13, [20 m, 15px]], [16, [24, 18]]]
     )END");
+    const glm::vec2& CSSSIZE = glm::vec2{1.f, 1.f};
+    const float ASPECTRATIO = 1.f;
 
     Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
 
     REQUIRE(stops.frames.size() == 3);
 
-    REQUIRE(stops.evalSize(0).get<glm::vec2>() == glm::vec2(18, 14));
-    REQUIRE(stops.evalSize(13).get<glm::vec2>() == glm::vec2(20, 15));
-    REQUIRE(stops.evalSize(18).get<glm::vec2>() == glm::vec2(24, 18));
+    REQUIRE(stops.evalSize(0, CSSSIZE, ASPECTRATIO, false) == glm::vec2(18, 14));
+    REQUIRE(stops.evalSize(13, CSSSIZE, ASPECTRATIO, false) == glm::vec2(20, 15));
+    REQUIRE(stops.evalSize(18, CSSSIZE, ASPECTRATIO, false) == glm::vec2(24, 18));
 }
 
 
@@ -179,12 +228,115 @@ TEST_CASE("1 dimension stops for icon sizes", "[Stops][YAML]") {
     YAML::Node node = YAML::Load(R"END(
         [[6, 18], [13, 20]]
     )END");
+    const glm::vec2& CSSSIZE = glm::vec2{1.f, 1.f};
+    const float ASPECTRATIO = 1.f;
 
     Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
 
     REQUIRE(stops.frames.size() == 2);
 
-    REQUIRE(stops.evalSize(0).get<float>() == 18);
-    REQUIRE(stops.evalSize(18).get<float>() == 20);
+    REQUIRE(stops.evalSize(0, CSSSIZE, ASPECTRATIO, false) == glm::vec2(18,18));
+    REQUIRE(stops.evalSize(18, CSSSIZE, ASPECTRATIO, false) == glm::vec2(20,20));
 }
 
+// Test for stops auto
+TEST_CASE("Stops using auto for StyleParam::size", "[Stops][YAML]") {
+    YAML::Node node = YAML::Load(R"END(
+        [[6, [18, "auto"]], [13, ["auto", 20]]]
+    )END");
+    const glm::vec2& CSSSIZE = glm::vec2{1.f, 1.f};
+    const float ASPECTRATIO = 2.f;
+
+    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+
+    REQUIRE(stops.frames.size() == 2);
+    REQUIRE(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) == glm::vec2(18, 9));
+
+    auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
+    REQUIRE(isnan(nanValue.x) == true);
+    REQUIRE(isnan(nanValue.y) == true);
+
+    REQUIRE(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) == glm::vec2(40, 20));
+}
+
+TEST_CASE("Stops using `%` for StyleParam::size", "[Stops][YAML]") {
+    YAML::Node node = YAML::Load(R"END(
+        [[6, 50%], [10, [7px, 8px]], [13, 100%]]
+    )END");
+    const glm::vec2& CSSSIZE = glm::vec2{10.f, 20.f};
+    const float ASPECTRATIO = 1.f;
+
+    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+
+    /*
+     * Make sure this has valid frames, because of mixed 1D (%) and 2D stops.
+     */
+    REQUIRE(stops.frames.size() == 3);
+
+    auto val = glm::abs(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) - glm::vec2(5.f, 10.f));
+    REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
+
+    auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
+    REQUIRE(isnan(nanValue.x) == true);
+    REQUIRE(isnan(nanValue.y) == true);
+
+    val = glm::abs(stops.evalSize(10, CSSSIZE, ASPECTRATIO, true) - glm::vec2(7.f, 8.f));
+    REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
+
+    val = glm::abs(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) - glm::vec2(10.f, 20.f));
+    REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
+}
+
+TEST_CASE("Stops using auto and `%` for StyleParam::size", "[Stops][YAML]") {
+    YAML::Node node = YAML::Load(R"END(
+        [[6, ["auto", 20]], [13, 50%]]
+    )END");
+    const glm::vec2& CSSSIZE = glm::vec2{60, 30};
+    const float ASPECTRATIO = 2.f;
+
+    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+
+    /*
+     * Make sure this has valid frames, because of mixed 2D and 1D (%) stops.
+     */
+    REQUIRE(stops.frames.size() == 2);
+
+    auto blah = stops.evalSize(0, CSSSIZE, ASPECTRATIO, true);
+    auto val = glm::abs(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) - glm::vec2(40.f, 20.f));
+    REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
+
+    auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
+    REQUIRE(isnan(nanValue.x) == true);
+    REQUIRE(isnan(nanValue.y) == true);
+
+    val = glm::abs(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) - glm::vec2(30.f, 15.f));
+    REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
+
+}
+
+TEST_CASE("Stops using `%` and auto for StyleParam::size", "[Stops][YAML]") {
+    YAML::Node node = YAML::Load(R"END(
+        [[6, 50%], [13, ["auto", 20]]]
+    )END");
+    const glm::vec2& CSSSIZE = glm::vec2{60, 30};
+    const float ASPECTRATIO = 2.f;
+
+    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+
+    /*
+     * Make sure this has valid frames, because of mixed 1D (%) and 2D stops.
+     */
+    REQUIRE(stops.frames.size() == 2);
+
+    auto blah = stops.evalSize(0, CSSSIZE, ASPECTRATIO, true);
+    auto val = glm::abs(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) - glm::vec2(30.f, 15.f));
+    REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
+
+    auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
+    REQUIRE(isnan(nanValue.x) == true);
+    REQUIRE(isnan(nanValue.y) == true);
+
+    val = glm::abs(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) - glm::vec2(40.f, 20.f));
+    REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
+
+}

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -209,16 +209,15 @@ TEST_CASE("2 dimension stops for icon sizes with mixed units", "[Stops][YAML]") 
     YAML::Node node = YAML::Load(R"END(
         [[6, [18.0 px, 14px]], [13, [20 m, 15px]], [16, [24, 18]]]
     )END");
-    const glm::vec2& CSSSIZE = glm::vec2{1.f, 1.f};
-    const float ASPECTRATIO = 1.f;
+    const glm::vec2 CSS_SIZE(1.f, 1.f);
 
     Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
 
     REQUIRE(stops.frames.size() == 3);
 
-    REQUIRE(stops.evalSize(0, CSSSIZE, ASPECTRATIO, false) == glm::vec2(18, 14));
-    REQUIRE(stops.evalSize(13, CSSSIZE, ASPECTRATIO, false) == glm::vec2(20, 15));
-    REQUIRE(stops.evalSize(18, CSSSIZE, ASPECTRATIO, false) == glm::vec2(24, 18));
+    REQUIRE(stops.evalSize(0, CSS_SIZE) == glm::vec2(18, 14));
+    REQUIRE(stops.evalSize(13, CSS_SIZE) == glm::vec2(20, 15));
+    REQUIRE(stops.evalSize(18, CSS_SIZE) == glm::vec2(24, 18));
 }
 
 
@@ -226,15 +225,14 @@ TEST_CASE("1 dimension stops for icon sizes", "[Stops][YAML]") {
     YAML::Node node = YAML::Load(R"END(
         [[6, 18], [13, 20]]
     )END");
-    const glm::vec2& CSSSIZE = glm::vec2{1.f, 1.f};
-    const float ASPECTRATIO = 1.f;
+    const glm::vec2 CSS_SIZE(1.f, 1.f);
 
     Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
 
     REQUIRE(stops.frames.size() == 2);
 
-    REQUIRE(stops.evalSize(0, CSSSIZE, ASPECTRATIO, false) == glm::vec2(18,18));
-    REQUIRE(stops.evalSize(18, CSSSIZE, ASPECTRATIO, false) == glm::vec2(20,20));
+    REQUIRE(stops.evalSize(0, CSS_SIZE) == glm::vec2(18,18));
+    REQUIRE(stops.evalSize(18, CSS_SIZE) == glm::vec2(20,20));
 }
 
 // Test for stops auto
@@ -242,27 +240,24 @@ TEST_CASE("Stops using auto for StyleParam::size", "[Stops][YAML]") {
     YAML::Node node = YAML::Load(R"END(
         [[6, [18, "auto"]], [13, ["auto", 20]]]
     )END");
-    const glm::vec2& CSSSIZE = glm::vec2{1.f, 1.f};
-    const float ASPECTRATIO = 2.f;
+    const glm::vec2 CSS_SIZE(2.f, 1.f);
 
     Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
 
     REQUIRE(stops.frames.size() == 2);
-    REQUIRE(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) == glm::vec2(18, 9));
+    REQUIRE(stops.evalSize(0, CSS_SIZE) == glm::vec2(18, 9));
 
-    auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
-    REQUIRE(std::isnan(nanValue.x) == true);
-    REQUIRE(std::isnan(nanValue.y) == true);
+    auto nanValue = stops.evalSize(0, glm::vec2(NAN));
+    REQUIRE((std::isnan(nanValue.x) || std::isnan(nanValue.y)) == true);
 
-    REQUIRE(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) == glm::vec2(40, 20));
+    REQUIRE(stops.evalSize(18, CSS_SIZE) == glm::vec2(40, 20));
 }
 
 TEST_CASE("Stops using `%` for StyleParam::size", "[Stops][YAML]") {
     YAML::Node node = YAML::Load(R"END(
         [[6, 50%], [10, [7px, 8px]], [13, 100%]]
     )END");
-    const glm::vec2& CSSSIZE = glm::vec2{10.f, 20.f};
-    const float ASPECTRATIO = 1.f;
+    const glm::vec2 CSS_SIZE(10.f, 20.f);
 
     Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
 
@@ -271,17 +266,16 @@ TEST_CASE("Stops using `%` for StyleParam::size", "[Stops][YAML]") {
      */
     REQUIRE(stops.frames.size() == 3);
 
-    auto val = glm::abs(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) - glm::vec2(5.f, 10.f));
+    auto val = glm::abs(stops.evalSize(0, CSS_SIZE) - glm::vec2(5.f, 10.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
-    auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
-    REQUIRE(std::isnan(nanValue.x) == true);
-    REQUIRE(std::isnan(nanValue.y) == true);
+    auto nanValue = stops.evalSize(0, glm::vec2(NAN));
+    REQUIRE((std::isnan(nanValue.x) || std::isnan(nanValue.y)) == true);
 
-    val = glm::abs(stops.evalSize(10, CSSSIZE, ASPECTRATIO, true) - glm::vec2(7.f, 8.f));
+    val = glm::abs(stops.evalSize(10, CSS_SIZE) - glm::vec2(7.f, 8.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
-    val = glm::abs(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) - glm::vec2(10.f, 20.f));
+    val = glm::abs(stops.evalSize(18, CSS_SIZE) - glm::vec2(10.f, 20.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 }
 
@@ -289,8 +283,7 @@ TEST_CASE("Stops using auto and `%` for StyleParam::size", "[Stops][YAML]") {
     YAML::Node node = YAML::Load(R"END(
         [[6, ["auto", 20]], [13, 50%]]
     )END");
-    const glm::vec2& CSSSIZE = glm::vec2{60, 30};
-    const float ASPECTRATIO = 2.f;
+    const glm::vec2 CSS_SIZE(60, 30);
 
     Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
 
@@ -299,14 +292,13 @@ TEST_CASE("Stops using auto and `%` for StyleParam::size", "[Stops][YAML]") {
      */
     REQUIRE(stops.frames.size() == 2);
 
-    auto val = glm::abs(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) - glm::vec2(40.f, 20.f));
+    auto val = glm::abs(stops.evalSize(0, CSS_SIZE) - glm::vec2(40.f, 20.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
-    auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
-    REQUIRE(std::isnan(nanValue.x) == true);
-    REQUIRE(std::isnan(nanValue.y) == true);
+    auto nanValue = stops.evalSize(0, glm::vec2(NAN));
+    REQUIRE((std::isnan(nanValue.x) || std::isnan(nanValue.y)) == true);
 
-    val = glm::abs(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) - glm::vec2(30.f, 15.f));
+    val = glm::abs(stops.evalSize(18, CSS_SIZE) - glm::vec2(30.f, 15.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
 }
@@ -315,8 +307,7 @@ TEST_CASE("Stops using `%` and auto for StyleParam::size", "[Stops][YAML]") {
     YAML::Node node = YAML::Load(R"END(
         [[6, 50%], [13, ["auto", 20]]]
     )END");
-    const glm::vec2& CSSSIZE = glm::vec2{60, 30};
-    const float ASPECTRATIO = 2.f;
+    const glm::vec2 CSS_SIZE(60, 30);
 
     Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
 
@@ -325,14 +316,13 @@ TEST_CASE("Stops using `%` and auto for StyleParam::size", "[Stops][YAML]") {
      */
     REQUIRE(stops.frames.size() == 2);
 
-    auto val = glm::abs(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) - glm::vec2(30.f, 15.f));
+    auto val = glm::abs(stops.evalSize(0, CSS_SIZE) - glm::vec2(30.f, 15.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
-    auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
-    REQUIRE(std::isnan(nanValue.x) == true);
-    REQUIRE(std::isnan(nanValue.y) == true);
+    auto nanValue = stops.evalSize(0, glm::vec2(NAN));
+    REQUIRE((std::isnan(nanValue.x) || std::isnan(nanValue.y)) == true);
 
-    val = glm::abs(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) - glm::vec2(40.f, 20.f));
+    val = glm::abs(stops.evalSize(18, CSS_SIZE) - glm::vec2(40.f, 20.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
 }

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -136,8 +136,8 @@ TEST_CASE("Regression test - Dont crash on evaluating empty stops", "[Stops][YAM
 
     {
         MercatorProjection proj{};
-        std::vector<Unit> units = { Unit::meter };
-        Stops stops(Stops::Widths(node, proj, units));
+        uint8_t allowedUnit = Unit::meter;
+        Stops stops(Stops::Widths(node, proj, allowedUnit));
         REQUIRE(stops.frames.size() == 0);
         stops.evalVec2(1);
     }
@@ -147,8 +147,8 @@ TEST_CASE("Regression test - Dont crash on evaluating empty stops", "[Stops][YAM
         stops.evalVec2(1);
     }
     {
-        std::vector<Unit> units = { Unit::meter };
-        Stops stops(Stops::Offsets(node, units));
+        uint8_t allowedUnit = Unit::meter;
+        Stops stops(Stops::Offsets(node, allowedUnit));
         REQUIRE(stops.frames.size() == 0);
         stops.evalVec2(1);
     }

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -4,8 +4,6 @@
 #include "yaml-cpp/yaml.h"
 #include "util/mapProjection.h"
 
-#include <iostream>
-
 using namespace Tangram;
 
 Stops instance_color() {
@@ -253,8 +251,8 @@ TEST_CASE("Stops using auto for StyleParam::size", "[Stops][YAML]") {
     REQUIRE(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) == glm::vec2(18, 9));
 
     auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
-    REQUIRE(isnan(nanValue.x) == true);
-    REQUIRE(isnan(nanValue.y) == true);
+    REQUIRE(std::isnan(nanValue.x) == true);
+    REQUIRE(std::isnan(nanValue.y) == true);
 
     REQUIRE(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) == glm::vec2(40, 20));
 }
@@ -277,8 +275,8 @@ TEST_CASE("Stops using `%` for StyleParam::size", "[Stops][YAML]") {
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
     auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
-    REQUIRE(isnan(nanValue.x) == true);
-    REQUIRE(isnan(nanValue.y) == true);
+    REQUIRE(std::isnan(nanValue.x) == true);
+    REQUIRE(std::isnan(nanValue.y) == true);
 
     val = glm::abs(stops.evalSize(10, CSSSIZE, ASPECTRATIO, true) - glm::vec2(7.f, 8.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
@@ -301,13 +299,12 @@ TEST_CASE("Stops using auto and `%` for StyleParam::size", "[Stops][YAML]") {
      */
     REQUIRE(stops.frames.size() == 2);
 
-    auto blah = stops.evalSize(0, CSSSIZE, ASPECTRATIO, true);
     auto val = glm::abs(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) - glm::vec2(40.f, 20.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
     auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
-    REQUIRE(isnan(nanValue.x) == true);
-    REQUIRE(isnan(nanValue.y) == true);
+    REQUIRE(std::isnan(nanValue.x) == true);
+    REQUIRE(std::isnan(nanValue.y) == true);
 
     val = glm::abs(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) - glm::vec2(30.f, 15.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
@@ -328,13 +325,12 @@ TEST_CASE("Stops using `%` and auto for StyleParam::size", "[Stops][YAML]") {
      */
     REQUIRE(stops.frames.size() == 2);
 
-    auto blah = stops.evalSize(0, CSSSIZE, ASPECTRATIO, true);
     auto val = glm::abs(stops.evalSize(0, CSSSIZE, ASPECTRATIO, true) - glm::vec2(30.f, 15.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));
 
     auto nanValue = stops.evalSize(0, CSSSIZE, ASPECTRATIO, false);
-    REQUIRE(isnan(nanValue.x) == true);
-    REQUIRE(isnan(nanValue.y) == true);
+    REQUIRE(std::isnan(nanValue.x) == true);
+    REQUIRE(std::isnan(nanValue.y) == true);
 
     val = glm::abs(stops.evalSize(18, CSSSIZE, ASPECTRATIO, true) - glm::vec2(40.f, 20.f));
     REQUIRE(glm::all(glm::lessThan(val, glm::vec2(FLT_EPSILON))));


### PR DESCRIPTION
Refer the [docs](https://github.com/tangrams/tangram-docs/blob/2de1ea6941d492a6008f52ebbfda7635ecac8379/pages/draw.md#size-) for details.

- Introduced `SizeValue` as a `StyleParam::Value`
- Explicit handling of size stop evaluation
- Fix to take care of mixed dimension size stops

Explanation:
Since we no longer have a single "Unit" (pixels) for size style parameter, we can not simply encode size parameter values from style sheet in a `vec2`. We will need to have the unit specified for the size in the stylesheet. 
We will also require `cssSize` and `aspect ratio` of the texture/sprite being used for the feature drawn using a point style. This means we can not pre-calculate stops as `vec2` values before build the quad for the point being drawn, as `cssSize` and `aspect ratio` of the texture/sprites can only be determined by the style builders.

TODO:
- [x] A bit more code cleanup
- [x] Fix/add unit tests 
- [x] Remove JS function string value support for `StyleParam::size` as its not supported in TangramJS