### PR TITLE
[WIP] Best practices with atomics (1)

### DIFF
--- a/core/src/data/tileSource.cpp
+++ b/core/src/data/tileSource.cpp
@@ -24,7 +24,7 @@ TileSource::TileSource(const std::string& _name, std::unique_ptr<DataSource> _so
 
     static std::atomic<int32_t> s_serial;
 
-    m_id = s_serial++;
+    m_id = s_serial.fetch_add(1, std::memory_order_relaxed);
 }
 
 TileSource::~TileSource() {

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -95,12 +95,12 @@ public:
     SceneReadyCallback onSceneReady = nullptr;
 
     void sceneLoadBegin() {
-        sceneLoadTasks++;
+        sceneLoadTasks.fetch_add(1, std::memory_order_relaxed);
     }
 
     void sceneLoadEnd() {
-        sceneLoadTasks--;
-        assert(sceneLoadTasks >= 0);
+        sceneLoadTasks.fetch_sub(1, std::memory_order_relaxed);
+        assert(sceneLoadTasks.load(std::memory_order_relaxed) >= 0);
 
         sceneLoadCondition.notify_one();
     }
@@ -199,7 +199,7 @@ SceneID Map::loadScene(std::shared_ptr<Scene> scene,
     {
         std::unique_lock<std::mutex> lock(impl->sceneMutex);
 
-        impl->sceneLoadCondition.wait(lock, [&]{ return impl->sceneLoadTasks == 0; });
+        impl->sceneLoadCondition.wait(lock, [&]{ return impl->sceneLoadTasks.load(std::memory_order_relaxed) == 0; });
 
         impl->lastValidScene.reset();
     }
@@ -394,7 +394,8 @@ bool Map::update(float _dt) {
     impl->jobQueue.runJobs();
 
     // Wait until font and texture resources are fully loaded
-    if (impl->scene->pendingFonts > 0 || impl->scene->pendingTextures > 0) {
+    if (impl->scene->pendingFonts.load(std::memory_order_relaxed) > 0 ||
+            impl->scene->pendingTextures.load(std::memory_order_relaxed) > 0) {
         platform->requestRender();
         return false;
     }
@@ -452,7 +453,8 @@ bool Map::update(float _dt) {
     bool tilesLoading = impl->tileManager.hasLoadingTiles();
     bool labelsNeedUpdate = impl->labels.needUpdate();
 
-    if (viewChanged || tilesChanged || tilesLoading || labelsNeedUpdate || impl->sceneLoadTasks > 0) {
+    if (viewChanged || tilesChanged || tilesLoading || labelsNeedUpdate ||
+            impl->sceneLoadTasks.load(std::memory_order_relaxed) > 0) {
         viewComplete = false;
     }
 
@@ -489,7 +491,7 @@ void Map::pickMarkerAt(float _x, float _y, MarkerPickCallback _onMarkerPickCallb
 void Map::render() {
 
     // Do not render if any texture resources are in process of being downloaded
-    if (impl->scene->pendingTextures > 0) {
+    if (impl->scene->pendingTextures.load(std::memory_order_relaxed) > 0) {
         return;
     }
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -21,10 +21,10 @@ namespace Tangram {
 
 static std::atomic<int32_t> s_serial;
 
-Scene::Scene() : id(s_serial++) {}
+Scene::Scene() : id (s_serial.fetch_add(1, std::memory_order_relaxed)) {}
 
 Scene::Scene(std::shared_ptr<const Platform> _platform, const Url& _url)
-    : id(s_serial++),
+    : id(s_serial.fetch_add(1, std::memory_order_relaxed)),
       m_url(_url),
       m_fontContext(std::make_shared<FontContext>(_platform)),
       m_featureSelection(std::make_unique<FeatureSelection>()) {
@@ -35,7 +35,7 @@ Scene::Scene(std::shared_ptr<const Platform> _platform, const Url& _url)
 }
 
 Scene::Scene(std::shared_ptr<const Platform> _platform, const std::string& _yaml, const Url& _url)
-    : id(s_serial++),
+    : id(s_serial.fetch_add(1, std::memory_order_relaxed)),
       m_fontContext(std::make_shared<FontContext>(_platform)),
       m_featureSelection(std::make_unique<FeatureSelection>()) {
 

--- a/core/src/selection/featureSelection.cpp
+++ b/core/src/selection/featureSelection.cpp
@@ -8,11 +8,11 @@ FeatureSelection::FeatureSelection() :
 
 uint32_t FeatureSelection::nextColorIdentifier() {
 
-    uint32_t entry = m_entry++;
+    uint32_t entry = m_entry.fetch_add(1, std::memory_order_relaxed);
 
     // skip zero every 2^32 features
     while (entry == 0) {
-        entry = m_entry++;
+        entry = m_entry.fetch_add(1, std::memory_order_relaxed);
     }
 
     return entry;

--- a/core/src/util/jobQueue.cpp
+++ b/core/src/util/jobQueue.cpp
@@ -9,7 +9,7 @@ JobQueue::~JobQueue() {
 
 void JobQueue::add(Job job) {
 
-    if (!m_stopped.load()) {
+    if (!m_stopped.load(std::memory_order_relaxed)) {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_jobs.push_back(std::move(job));
     } else {

--- a/core/src/util/jobQueue.cpp
+++ b/core/src/util/jobQueue.cpp
@@ -9,7 +9,7 @@ JobQueue::~JobQueue() {
 
 void JobQueue::add(Job job) {
 
-    if (!m_stopped) {
+    if (!m_stopped.load()) {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_jobs.push_back(std::move(job));
     } else {

--- a/core/src/util/jobQueue.h
+++ b/core/src/util/jobQueue.h
@@ -27,7 +27,7 @@ public:
     void runJobs();
 
     void stop() {
-        m_stopped = true;
+        m_stopped.store(true);
         runJobs();
     }
 private:

--- a/core/src/util/jobQueue.h
+++ b/core/src/util/jobQueue.h
@@ -27,7 +27,7 @@ public:
     void runJobs();
 
     void stop() {
-        m_stopped.store(true);
+        m_stopped.store(true, std::memory_order_relaxed);
         runJobs();
     }
 private:

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -302,7 +302,7 @@ UrlRequestHandle AndroidPlatform::startUrlRequest(Url _url, UrlCallback _callbac
     JniThreadBinding jniEnv(jvm);
 
     // Get the current value of the request counter and add one, atomically.
-    UrlRequestHandle requestHandle = m_urlRequestCount++;
+    UrlRequestHandle requestHandle = m_urlRequestCount.fetch_add(1, std::memory_order_relaxed);
 
     // If the requested URL does not use HTTP or HTTPS, retrieve it synchronously.
     if (!_url.hasHttpScheme()) {


### PR DESCRIPTION
- Its recommended to use the member functions
- Specially for atomic counters one can get the max speed up with
std::memory_order_relaxed, as no operations/data writes/data reads are
dependent on the memory write/read orders.


I will see if I can benchmark before and after affects of this change. Based on my readings one should get some speed up as the default memory fence ordering when using `operator++`/`fetch_add` or `operator--`/`fetch_sub` is `std::std::memory_order_seq_cst`, which can be very strict for the purposes of a counter. Refer: http://en.cppreference.com/w/cpp/atomic/memory_order#Sequentially-consistent_ordering