### PR TITLE
Define Tangram::Point as vec2

### DIFF
--- a/bench/src/builders.cpp
+++ b/bench/src/builders.cpp
@@ -10,15 +10,15 @@
 
 using namespace Tangram;
 
-std::vector<glm::vec3> line = {
-    {0.0, 0.0, 0.0},
-    {1.0, 0.0, 0.0},
-    {1.0, 1.0, 0.0},
-    {0.0, 1.0, 0.0},
+std::vector<glm::vec2> line = {
+    {0.0, 0.0},
+    {1.0, 0.0},
+    {1.0, 1.0},
+    {0.0, 1.0},
 };
 
 struct PosNormEnormColVertex {
-    glm::vec3 pos;
+    glm::vec2 pos;
     glm::vec2 texcoord;
     glm::vec2 enorm;
     GLfloat ewidth;
@@ -30,7 +30,7 @@ static void BM_Tangram_BuildButtMiterLine(benchmark::State& state) {
     while(state.KeepRunning()) {
         std::vector<PosNormEnormColVertex> vertices;
         PolyLineBuilder builder {
-            [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {
+            [&](const glm::vec2& coord, const glm::vec2& normal, const glm::vec2& uv) {
                 vertices.push_back({ coord, uv, normal, 0.5f, 0xffffff, 0.f });
             },
             CapTypes::butt,
@@ -46,7 +46,7 @@ static void BM_Tangram_BuildRoundRoundLine(benchmark::State& state) {
     while(state.KeepRunning()) {
         std::vector<PosNormEnormColVertex> vertices;
         PolyLineBuilder builder {
-            [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {
+            [&](const glm::vec2& coord, const glm::vec2& normal, const glm::vec2& uv) {
                 vertices.push_back({ coord, uv, normal, 0.5f, 0xffffff, 0.f });
             },
             CapTypes::round,

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -278,7 +278,7 @@ struct add_geometry {
 
     // Transform a geojsonvt::TilePoint into the corresponding Tangram::Point
     Point transformPoint(geometry::point<int16_t> pt) {
-        return { pt.x / extent, 1. - pt.y / extent, 0 };
+        return { pt.x / extent, 1. - pt.y / extent };
     }
 
     Feature& feature;

--- a/core/src/data/formats/geoJson.cpp
+++ b/core/src/data/formats/geoJson.cpp
@@ -183,7 +183,6 @@ std::shared_ptr<TileData> GeoJson::parseTile(const TileTask& _task, const MapPro
         return Point {
             (tmp.x - tileOrigin.x) * tileInverseScale,
             (tmp.y - tileOrigin.y) * tileInverseScale,
-             0
         };
     };
 

--- a/core/src/data/formats/topoJson.cpp
+++ b/core/src/data/formats/topoJson.cpp
@@ -270,7 +270,6 @@ std::shared_ptr<TileData> TopoJson::parseTile(const TileTask& _task, const MapPr
         return Point {
             (tmp.x - tileOrigin.x) * tileInverseScale,
             (tmp.y - tileOrigin.y) * tileInverseScale,
-             0
         };
     };
 

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -110,11 +110,11 @@ std::shared_ptr<TileData> RasterSource::parse(const TileTask& _task, const MapPr
     Feature rasterFeature;
     rasterFeature.geometryType = GeometryType::polygons;
     rasterFeature.polygons = { { {
-                                         {0.0f, 0.0f, 0.0f},
-                                         {1.0f, 0.0f, 0.0f},
-                                         {1.0f, 1.0f, 0.0f},
-                                         {0.0f, 1.0f, 0.0f},
-                                         {0.0f, 0.0f, 0.0f}
+                                         {0.0f, 0.0f},
+                                         {1.0f, 0.0f},
+                                         {1.0f, 1.0f},
+                                         {0.0f, 1.0f},
+                                         {0.0f, 0.0f}
                                  } } };
     rasterFeature.props = Properties();
 

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -60,11 +60,11 @@ enum GeometryType {
     polygons
 };
 
-typedef glm::vec2 Point;
+using Point = glm::vec2;
 
-typedef std::vector<Point> Line;
+using Line = std::vector<Point>;
 
-typedef std::vector<Line> Polygon;
+using Polygon = std::vector<Line>;
 
 struct Feature {
     Feature() {}

--- a/core/src/data/tileData.h
+++ b/core/src/data/tileData.h
@@ -11,7 +11,7 @@
 Tile Coordinates:
 
   A point in the geometry of a tile is represented with 32-bit floating point
-  x, y, and z coordinates. Coordinates represent normalized displacement from
+  x and y coordinates. Coordinates represent normalized displacement from
   the origin (i.e. lower-left corner) of a tile.
 
   (0.0, 1.0) ---------- (1.0, 1.0)
@@ -24,8 +24,6 @@ Tile Coordinates:
   Coordinates that fall outside the range [0.0, 1.0] are permissible, as tile
   servers may choose not to clip certain geometries to tile boundaries, but these
   points are clipped in the client-side geometry processing.
-
-  Z coordinates are expected to be normalized to the same scale as x, y coordinates.
 
 Data heirarchy:
 
@@ -50,8 +48,7 @@ Data heirarchy:
 
   A <Line> is a collection of <Point>s.
 
-  A <Point> is 3 32-bit floating point coordinates representing x, y, and z
-  (in that order).
+  A <Point> is 2 32-bit floating point coordinates representing x and y.
 
 */
 namespace Tangram {
@@ -63,7 +60,7 @@ enum GeometryType {
     polygons
 };
 
-typedef glm::vec3 Point;
+typedef glm::vec2 Point;
 
 typedef std::vector<Point> Line;
 

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -210,7 +210,7 @@ bool MarkerManager::setPolyline(MarkerID markerID, LngLat* coordinates, int coun
     for (int i = 0; i < count; ++i) {
         auto degrees = glm::dvec2(coordinates[i].longitude, coordinates[i].latitude);
         auto meters = m_mapProjection->LonLatToMeters(degrees);
-        line.emplace_back((meters.x - origin.x) * scale, (meters.y - origin.y) * scale, 0.f);
+        line.emplace_back((meters.x - origin.x) * scale, (meters.y - origin.y) * scale);
     }
 
     // Update the feature data for the marker.
@@ -273,7 +273,7 @@ bool MarkerManager::setPolygon(MarkerID markerID, LngLat* coordinates, int* coun
         for (int j = 0; j < count; ++j) {
             auto degrees = glm::dvec2(ring[j].longitude, ring[j].latitude);
             auto meters = m_mapProjection->LonLatToMeters(degrees);
-            line.emplace_back((meters.x - origin.x) * scale, (meters.y - origin.y) * scale, 0.f);
+            line.emplace_back((meters.x - origin.x) * scale, (meters.y - origin.y) * scale);
         }
         ring += count;
     }

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -442,7 +442,7 @@ void PointStyleBuilder::labelPointsPlacing(const Line& _line, const glm::vec4& _
             }
             break;
         case LabelProperty::Placement::spaced: {
-            LineSampler<std::vector<Point>> sampler;
+            LineSampler<std::vector<glm::vec3>> sampler;
 
             sampler.set(_line);
 
@@ -467,7 +467,7 @@ void PointStyleBuilder::labelPointsPlacing(const Line& _line, const glm::vec4& _
                     params.labelOptions.angle = RAD_TO_DEG * atan2(r.x, r.y);
                 }
 
-                addLabel({p.x, p.y, 0.f}, _uvsQuad, _texture, params, _rule);
+                addLabel({p.x, p.y}, _uvsQuad, _texture, params, _rule);
 
             } while (sampler.advance(spacing, p, r));
         }
@@ -527,7 +527,7 @@ bool PointStyleBuilder::addPolygon(const Polygon& _polygon, const Properties& _p
         }
     } else {
         if (!_polygon.empty()) {
-            glm::vec3 c;
+            glm::vec2 c;
             c = centroid(_polygon.front().begin(), _polygon.front().end());
             addLabel(c, uvsQuad, texture, p, _rule);
         }

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -429,7 +429,7 @@ void PolylineStyleBuilder<V>::buildLine(const Line& _line, const typename Parame
                                         MeshData<V>& _mesh, GLuint selection) {
 
     float zoom = m_overzoom2;
-    m_builder.addVertex = [&](const glm::vec3& coord, const glm::vec2& normal, const glm::vec2& uv) {
+    m_builder.addVertex = [&](const glm::vec2& coord, const glm::vec2& normal, const glm::vec2& uv) {
         _mesh.vertices.push_back({{ coord.x,coord.y }, normal, { uv.x, uv.y * zoom },
                                   _att.width, _att.height, _att.color, selection});
     };

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -283,7 +283,7 @@ bool TextStyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) {
             const auto& polygons = _feat.polygons;
             for (const auto& polygon : polygons) {
                 if (!polygon.empty()) {
-                    glm::vec3 c;
+                    glm::vec2 c;
                     c = centroid(polygon.front().begin(), polygon.front().end());
                     addLabel(Label::Type::point, {{ c }}, params, attrib, _rule);
                 }

--- a/core/src/util/builders.cpp
+++ b/core/src/util/builders.cpp
@@ -115,8 +115,8 @@ void Builders::buildPolygonExtrusion(const Polygon& _polygon, float _minHeight, 
 
         for (size_t i = 0; i < lineSize - 1; i++) {
 
-            glm::vec3 a(line[i]);
-            glm::vec3 b(line[i+1]);
+            glm::vec3 a(line[i], 0.f);
+            glm::vec3 b(line[i+1], 0.f);
 
             normalVector = glm::cross(upVector, b - a);
             normalVector = glm::normalize(normalVector);
@@ -160,12 +160,12 @@ void Builders::buildPolygonExtrusion(const Polygon& _polygon, float _minHeight, 
 }
 
 // Get 2D perpendicular of two points
-glm::vec2 perp2d(const glm::vec3& _v1, const glm::vec3& _v2 ){
+glm::vec2 perp2d(const glm::vec2& _v1, const glm::vec2& _v2 ){
     return glm::vec2(_v2.y - _v1.y, _v1.x - _v2.x);
 }
 
 // Helper function for polyline tesselation
-inline void addPolyLineVertex(const glm::vec3& _coord, const glm::vec2& _normal, const glm::vec2& _uv, PolyLineBuilder& _ctx) {
+inline void addPolyLineVertex(const glm::vec2& _coord, const glm::vec2& _normal, const glm::vec2& _uv, PolyLineBuilder& _ctx) {
     _ctx.numVertices++;
     _ctx.addVertex(_coord, _normal, _uv);
 }
@@ -188,7 +188,7 @@ void indexPairs( int _nPairs, int _nVertices, std::vector<uint16_t>& _indicesOut
 //  and interpolating their UVs               \ p /
 //                                             \./
 //                                              C
-void addFan(const glm::vec3& _pC,
+void addFan(const glm::vec2& _pC,
             const glm::vec2& _nA, const glm::vec2& _nB, const glm::vec2& _nC,
             const glm::vec2& _uA, const glm::vec2& _uB, const glm::vec2& _uC,
             int _numTriangles, PolyLineBuilder& _ctx) {
@@ -227,7 +227,7 @@ void addFan(const glm::vec3& _pC,
 }
 
 // Function to add the vertices for line caps
-void addCap(const glm::vec3& _coord, const glm::vec2& _normal, int _numCorners, bool _isBeginning, PolyLineBuilder& _ctx) {
+void addCap(const glm::vec2& _coord, const glm::vec2& _normal, int _numCorners, bool _isBeginning, PolyLineBuilder& _ctx) {
 
     float v = _isBeginning ? 0.f : 1.f; // length-wise tex coord
 
@@ -257,7 +257,7 @@ void addCap(const glm::vec3& _coord, const glm::vec2& _normal, int _numCorners, 
 }
 
 // Tests if a line segment (from point A to B) is outside the edge of a tile
-bool isOutsideTile(const glm::vec3& _a, const glm::vec3& _b) {
+bool isOutsideTile(const glm::vec2& _a, const glm::vec2& _b) {
 
     // tweak this adjust if catching too few/many line segments near tile edges
     // TODO: make tolerance configurable by source if necessary
@@ -288,9 +288,9 @@ void buildPolyLineSegment(const Line& _line, PolyLineBuilder& _ctx, size_t _star
                    (origLineSize - _startIndex + _endIndex));
     if (lineSize < 2) { return; }
 
-    glm::vec3 coordCurr(_line[_startIndex]);
+    glm::vec2 coordCurr(_line[_startIndex]);
     // get the Point using wrapped index in the original line geometry
-    glm::vec3 coordNext(_line[(_startIndex + 1) % origLineSize]);
+    glm::vec2 coordNext(_line[(_startIndex + 1) % origLineSize]);
     glm::vec2 normPrev, normNext, miterVec;
 
     int cornersOnCap = (int)_ctx.cap;
@@ -411,8 +411,8 @@ void Builders::buildPolyLine(const Line& _line, PolyLineBuilder& _ctx) {
 
         // Determine cuts
         for (size_t i = 0; i < lineSize - 1; i++) {
-            const glm::vec3& coordCurr = _line[i];
-            const glm::vec3& coordNext = _line[i+1];
+            const glm::vec2& coordCurr = _line[i];
+            const glm::vec2& coordNext = _line[i+1];
             if (isOutsideTile(coordCurr, coordNext)) {
                 if (cut == 0) {
                     firstCutEnd = i + 1;

--- a/core/src/util/builders.h
+++ b/core/src/util/builders.h
@@ -63,7 +63,7 @@ struct PolygonBuilder {
  * @enormal extrusion vector of the output coordinate
  * @uv      texture coordinate of the output coordinate
  */
-typedef std::function<void(const glm::vec3& coord, const glm::vec2& enormal, const glm::vec2& uv)> PolyLineVertexFn;
+typedef std::function<void(const glm::vec2& coord, const glm::vec2& enormal, const glm::vec2& uv)> PolyLineVertexFn;
 
 /* PolyLineBuilder context,
  * see Builders::buildPolyLine()


### PR DESCRIPTION
The z component of Point in TileData was never used. This should reduce the size of allocations for `Feature`s.