### PR TITLE
Fix AndroidPlatform::fontFallbackPath called twice for importance=0

### DIFF
--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -230,7 +230,7 @@ std::vector<FontSourceHandle> AndroidPlatform::systemFontFallbacksHandle() const
     while (!fallbackPath.empty()) {
         handles.emplace_back(Url(fallbackPath));
 
-        fallbackPath = fontFallbackPath(importance++, weightHint);
+        fallbackPath = fontFallbackPath(++importance, weightHint);
     }
 
     return handles;


### PR DESCRIPTION
Resolves #1806 