### PR TITLE
Ensure shaders are deleted exactly once

### DIFF
--- a/core/src/gl/renderState.cpp
+++ b/core/src/gl/renderState.cpp
@@ -62,12 +62,6 @@ void RenderState::flushResourceDeletion() {
         }
         m_programDeletionList.clear();
     }
-    if (m_shaderDeletionList.size()) {
-        for (GLuint shader : m_shaderDeletionList) {
-            GL::deleteShader(shader);
-        }
-        m_shaderDeletionList.clear();
-    }
 }
 
 void RenderState::queueFramebufferDeletion(GLuint framebuffer) {
@@ -75,11 +69,9 @@ void RenderState::queueFramebufferDeletion(GLuint framebuffer) {
     m_framebufferDeletionList.push_back(framebuffer);
 }
 
-void RenderState::queueProgramDeletion(GLuint program, GLuint fragShader, GLuint vertShader) {
+void RenderState::queueProgramDeletion(GLuint program) {
     std::lock_guard<std::mutex> guard(m_deletionListMutex);
     m_programDeletionList.push_back(program);
-    m_shaderDeletionList.push_back(fragShader);
-    m_shaderDeletionList.push_back(vertShader);
 }
 
 void RenderState::queueTextureDeletion(GLuint texture) {

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -28,8 +28,16 @@ public:
     RenderState& operator=(const RenderState&) = delete;
     RenderState& operator=(RenderState&&) = delete;
 
-    // Reset the render states.
+    // Reset the GL state cache and resource handles.
+    // Call this after GL context loss.
     void invalidate();
+
+    // Reset the GL state cache.
+    // Call this when outside code may have changed OpenGL states.
+    void invalidateStates();
+
+    // Reset the resource handle cache.
+    void invalidateHandles();
 
     // Get the texture slot from a texture unit from 0 to TANGRAM_MAX_TEXTURE_UNIT-1.
     static GLuint getTextureUnit(GLuint _unit);

--- a/core/src/gl/renderState.h
+++ b/core/src/gl/renderState.h
@@ -118,7 +118,7 @@ public:
 
     void queueFramebufferDeletion(GLuint framebuffer);
 
-    void queueProgramDeletion(GLuint program, GLuint fragShader, GLuint vertShader);
+    void queueProgramDeletion(GLuint program);
 
     std::array<GLuint, MAX_ATTRIBUTES> attributeBindings = { { 0 } };
 

--- a/core/src/gl/shaderProgram.cpp
+++ b/core/src/gl/shaderProgram.cpp
@@ -17,8 +17,12 @@ ShaderProgram::ShaderProgram() {
 
 ShaderProgram::~ShaderProgram() {
     if (m_rs) {
-        if (m_glProgram || m_glFragmentShader || m_glVertexShader) {
-            m_rs->queueProgramDeletion(m_glProgram, m_glFragmentShader, m_glVertexShader);
+        if (m_glProgram) {
+            // Delete only the program, separate shaders are cached and eventually deleted by RenderState.
+            // TODO: This approach leaves shaders in memory even if they aren't used by any programs until
+            // the entire Map (and its RenderState) is destroyed. Ideally we could use a reference-counted
+            // cache to keep shaders in memory only while at least one program uses them. (MEB 2018/5/17)
+            m_rs->queueProgramDeletion(m_glProgram);
         }
     }
 }

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -502,7 +502,7 @@ void Map::render() {
 
     // Invalidate render states for new frame
     if (!impl->cacheGlState) {
-        impl->renderState.invalidate();
+        impl->renderState.invalidateStates();
     }
 
     // Delete batch of gl resources


### PR DESCRIPTION
This addresses two things:

1. `RenderState::invalidate` was being misused. We call `invalidate` on every frame to ensure that our state cache isn't thrown off by external code making GL calls. But the implementation of `invalidate` treats it like a GL context loss and throws out our shader caches. This means that shaders were leaked from the cache and never deleted by `~RenderState`. The solution for this was to separate `invalidate` into `invalidateState` (to call on every frame) and `invalidateHandles` (to call after GL context loss).

2. Once `RenderState` was properly retaining and deleting shaders from the cache, I realized we were trying to delete each shader more than once: first from each `~ShaderProgram` invoked on a program using the shader, and then from `~RenderState`.  Deleting shaders from `~ShaderProgram` is bad because the cache in `RenderState` doesn't know the handles are deleted and will re-use them. So I resolved this by removing shader deletion from `~ShaderProgram` and letting `RenderState` delete all the cached shaders in its destructor. Ideally we would use a reference-counted cache for shaders, but that's more effort and I'd rather put that off until it's a more pressing need.