### PR TITLE
[Android] Fixes (proguard, exceptions) & annotations

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/CachePolicy.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/CachePolicy.java
@@ -1,5 +1,7 @@
 package com.mapzen.tangram;
 
+import android.support.annotation.NonNull;
+
 import okhttp3.CacheControl;
 import okhttp3.HttpUrl;
 
@@ -13,5 +15,5 @@ public interface CachePolicy {
      * @param url The URL being requested
      * @return The CacheControl to apply to the request, or {@code null} for the default behavior.
      */
-    CacheControl apply(final HttpUrl url);
+    CacheControl apply(@NonNull final HttpUrl url);
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -19,6 +19,7 @@ import com.mapzen.tangram.TouchInput.Gestures;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -1356,7 +1357,7 @@ public class MapController implements Renderer {
     }
 
     @Keep
-    void startUrlRequest(final String url, final long requestHandle) {
+    void startUrlRequest(@NonNull final String url, final long requestHandle) {
         if (httpHandler == null) {
             return;
         }
@@ -1373,8 +1374,14 @@ public class MapController implements Renderer {
                     nativeOnUrlComplete(mapPointer, requestHandle, null, response.message());
                     throw new IOException("Unexpected response code: " + response + " for URL: " + url);
                 }
-                final byte[] bytes = response.body().bytes();
-                nativeOnUrlComplete(mapPointer, requestHandle, bytes, null);
+                final ResponseBody body = response.body();
+                if (body == null) {
+                    throw new IOException("Unexpected null body for URL: " + url);
+                }
+                else {
+                    final byte[] bytes = body.bytes();
+                    nativeOnUrlComplete(mapPointer, requestHandle, bytes, null);
+                }
             }
         };
 
@@ -1382,6 +1389,7 @@ public class MapController implements Renderer {
     }
 
     // Called from JNI on worker or render-thread.
+    @Keep
     void sceneReadyCallback(final int sceneId, final SceneError error) {
 
         final SceneLoadListener cb = sceneLoadListener;

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1376,6 +1376,7 @@ public class MapController implements Renderer {
                 }
                 final ResponseBody body = response.body();
                 if (body == null) {
+                    nativeOnUrlComplete(mapPointer, requestHandle, null, response.message());
                     throw new IOException("Unexpected null body for URL: " + url);
                 }
                 else {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -2,7 +2,6 @@ package com.mapzen.tangram;
 
 import android.content.Context;
 import android.opengl.GLSurfaceView;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -33,7 +32,7 @@ public class MapView extends FrameLayout {
      * the callback will be made on the UI thread
      */
     @NonNull
-    public MapController getMap(final MapController.SceneLoadListener listener) {
+    public MapController getMap(@Nullable final MapController.SceneLoadListener listener) {
         if (mapController != null) {
             return mapController;
         }
@@ -61,8 +60,8 @@ public class MapView extends FrameLayout {
         if (mapController != null) {
             // MapController has been initialized, so we'll dispose it now.
             mapController.dispose();
+            mapController = null;
         }
-        mapController = null;
     }
 
     /**


### PR DESCRIPTION
- Add missing `@Keep`  annotation to `MapController#sceneReadyCallback` causing build processed with proguard crash at runtime.
- Prevent some unexpected exceptions
- add some NonNull / Nullable annotations