### PR TITLE
Enable choosing Android ABIs to build through Gradle property

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: cd platforms/android && ./gradlew demo:assembleDebug -Pandroid.injected.build.abi=armeabi-v7a
+      - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=armeabi-v7a
   build-deploy-android-snapshot:
     docker:
       - image: lakoo/android-ndk:25-26.0.1-r15c

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -9,6 +9,14 @@ apply from: 'versioning.gradle'
 android {
   compileSdkVersion 27
 
+  // Specific ABI targets can be chosen with the 'abis' property as a comma-separated list of ABIs.
+  // From the command line, add '-Ptangram.abis=armeabi-v7a,x86,...' to only build those ABIs.
+  // When building from Android Studio, the ABI for the target device is injected and takes precedence.
+  def abi = 'all'
+  if (!project.hasProperty('android.injected.invoked.from.ide') && project.hasProperty('tangram.abis')) {
+    abi = project.getProperty('tangram.abis')
+  }
+
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 27
@@ -33,7 +41,12 @@ android {
                  '-Wmissing-field-initializers',
                  '-Wno-format-pedantic'
 
-        abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'
+        if (abi == 'all') {
+          abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'
+        } else {
+          abiFilters abi.split(',')
+        }
+
       }
     }
   }


### PR DESCRIPTION
This lets us build a reduced set of architectures when they aren't all needed (such as CI builds). 