### PR TITLE
Revert Android Gradle plugin to 3.0.1

### DIFF
--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -5,7 +5,7 @@ allprojects {
       google()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:3.1.2'
+      classpath 'com.android.tools.build:gradle:3.0.1'
       classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
   }

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -1,8 +1,8 @@
 allprojects {
   buildscript {
     repositories {
-      jcenter()
       google()
+      jcenter()
     }
     dependencies {
       classpath 'com.android.tools.build:gradle:3.0.1'
@@ -12,8 +12,8 @@ allprojects {
 
   dependencies {
     repositories {
-      jcenter()
       google()
+      jcenter()
     }
   }
 }


### PR DESCRIPTION
Version 3.1 has a bug that omits the 'res' folder from AARs. The 'res' folder is required for the AAR format as documented by Google, and this omission breaks other build tools like Buck.

See: https://partnerissuetracker.corp.google.com/issues/77591523