### PR TITLE
[wip] Fix remove tile duplicates

### DIFF
--- a/core/include/tangram/tile/tileID.h
+++ b/core/include/tangram/tile/tileID.h
@@ -29,7 +29,11 @@ struct TileID {
     TileID(const TileID& _rhs) = default;
 
     bool operator< (const TileID& _rhs) const {
-        return s > _rhs.s || (s == _rhs.s && (z > _rhs.z || (z == _rhs.z && (x < _rhs.x || (x == _rhs.x && (y < _rhs.y || (y == _rhs.y && wrap < _rhs.wrap)))))));
+        if (z != _rhs.z) { return z > _rhs.z; }
+        if (x != _rhs.x) { return x < _rhs.x; }
+        if (y != _rhs.y) { return y < _rhs.y; }
+        if (wrap != _rhs.wrap) { return wrap < _rhs.wrap; }
+        return s > _rhs.s;
     }
     bool operator> (const TileID& _rhs) const { return _rhs < const_cast<TileID&>(*this); }
     bool operator<=(const TileID& _rhs) const { return !(*this > _rhs); }

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -263,7 +263,7 @@ void TileManager::updateTileSets(const View& _view) {
             tileSet.visibleTiles.clear();
         }
 
-        auto tileCb = [&, zoom = _view.getZoom()](TileID _tileID){
+        auto tileCb = [&](TileID _tileID){
             for (auto& tileSet : m_tileSets) {
                 auto zoomBias = tileSet.source->zoomBias();
                 auto maxZoom = tileSet.source->maxZoom();
@@ -274,6 +274,29 @@ void TileManager::updateTileSets(const View& _view) {
         };
 
         _view.getVisibleTiles(tileCb);
+
+        for (auto& tileSet : m_tileSets) {
+            if (tileSet.source->maxZoom() >= _view.getZoom()) { continue; }
+            // Remove tiles with the same coordinates but different styling zoom.
+            // Keep tile with highest style zoom.
+            // TODO can this be done on insert?
+            auto it = tileSet.visibleTiles.begin();
+            auto end = tileSet.visibleTiles.end();
+            if (it != end) {
+                auto next = it;
+                while (++next != end) {
+                    auto ta = *it;
+                    auto tb = *next;
+                    if (ta.z == tb.z && ta.x == tb.x && ta.y == tb.y && ta.wrap == tb.wrap) {
+                        tileSet.visibleTiles.erase(next);
+                        next = it;
+                        //LOG(">>>>>> drop");
+                    } else {
+                        it = next;
+                    }
+                }
+            }
+        }
     }
 
     for (auto& tileSet : m_tileSets) {
@@ -288,13 +311,30 @@ void TileManager::updateTileSets(const View& _view) {
     // Make m_tiles an unique list of tiles for rendering sorted from
     // high to low zoom-levels.
     std::sort(m_tiles.begin(), m_tiles.end(), [](auto& a, auto& b) {
-            return a->sourceID() == b->sourceID() ?
-                a->getID() < b->getID() :
-                a->sourceID() < b->sourceID(); }
-        );
+            if (a->sourceID() != b->sourceID()) {
+                return a->sourceID() < b->sourceID();
+            }
+            return a->getID() < b->getID();
+        });
 
-    // Remove duplicates: Proxy tiles could have been added more than once
-    m_tiles.erase(std::unique(m_tiles.begin(), m_tiles.end()), m_tiles.end());
+    // Remove duplicates: Proxy tiles could have been added more than once,
+    // or tiles with the same coordinates but different styling
+    auto drop = std::unique(m_tiles.begin(), m_tiles.end(), [](auto& a, auto& b) {
+            if (a->sourceID() != b->sourceID()) { return false; }
+            auto ta = a->getID();
+            auto tb = b->getID();
+            if (ta.z == tb.z && ta.x == tb.x && ta.y == tb.y && ta.wrap == tb.wrap) {
+                //LOG("----------- drop %d", (ta == tb));
+                return true;
+            }
+            return false;
+        });
+
+    // if (drop != m_tiles.end()) {
+    //     LOG("-----");
+    // }
+
+    m_tiles.erase(drop, m_tiles.end());
 }
 
 void TileManager::updateTileSet(TileSet& _tileSet, const ViewState& _view) {


### PR DESCRIPTION
We sometimes have duplicate tile IDs in visible tileset when max styling zoom is greater than max source zoom and 2x tiles are used. This patch filters out duplicates and keeps the one with higher styling zoom.