### PR TITLE
[Android] Drop map usage for marker, raise minSDK to 19

### DIFF
--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -6,7 +6,7 @@ android {
   def apiKey = project.hasProperty('nextzenApiKey') ? nextzenApiKey : System.getenv('NEXTZEN_API_KEY')
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 19
     targetSdkVersion 27
     buildConfigField 'String', 'NEXTZEN_API_KEY', '"' + apiKey + '"'
   }

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -18,7 +18,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 19
     targetSdkVersion 27
     versionCode buildVersionCode()
     versionName VERSION_NAME

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/FontFileParser.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/FontFileParser.java
@@ -1,24 +1,22 @@
 package com.mapzen.tangram;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.FileNotFoundException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ArrayList;
+import android.support.annotation.NonNull;
+import android.util.ArrayMap;
+import android.util.SparseArray;
+import android.util.Xml;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
-import android.os.Build;
-import android.util.ArrayMap;
-import android.util.SparseArray;
-import android.util.Xml;
-import android.support.annotation.NonNull;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 class FontFileParser {
 
@@ -34,12 +32,7 @@ class FontFileParser {
     private static final String oldFontXMLFallbackPath = "/system/etc/fallback_fonts.xml";
 
     public FontFileParser() {
-        if (Build.VERSION.SDK_INT > 18) {
-            fontDict = new ArrayMap<>();
-        }
-        else {
-            fontDict = new HashMap<>();
-        }
+        fontDict = new ArrayMap<>();
         fallbackFontDict = new SparseArray<>();
     }
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/HttpHandler.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/HttpHandler.java
@@ -147,7 +147,7 @@ public class HttpHandler {
             };
         }
 
-        if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22) {
+        if (Build.VERSION.SDK_INT < 22) {
             try {
                 final SSLContext sc = SSLContext.getInstance("TLSv1.2");
                 sc.init(null, null, null);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -5,32 +5,29 @@ import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.opengl.GLSurfaceView;
 import android.opengl.GLSurfaceView.Renderer;
-import android.os.Build;
 import android.os.Handler;
-import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.ArrayMap;
 import android.util.DisplayMetrics;
+import android.util.LongSparseArray;
 
 import com.mapzen.tangram.TouchInput.Gestures;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 import java.io.IOException;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 /**
  * {@code MapController} is the main class for interacting with a Tangram map.
@@ -215,14 +212,8 @@ public class MapController implements Renderer {
      * will need.
      */
     protected MapController(@NonNull final GLSurfaceView view) {
-        if (Build.VERSION.SDK_INT > 18) {
-            markers = new ArrayMap<>();
-            clientTileSources = new ArrayMap<>();
-        }
-        else {
-            markers = new HashMap<>();
-            clientTileSources = new HashMap<>();
-        }
+        markers = new LongSparseArray<>();
+        clientTileSources = new ArrayMap<>();
 
         // Set up MapView
         mapView = view;
@@ -1022,7 +1013,8 @@ public class MapController implements Renderer {
         nativeMarkerRemoveAll(mapPointer);
 
         // Invalidate all markers so their ids are unusable
-        for (final Marker marker : markers.values()) {
+        for (int i = 0; i < markers.size(); ++i) {
+            final Marker marker = markers.valueAt(i);
             marker.invalidate();
         }
 
@@ -1301,8 +1293,12 @@ public class MapController implements Renderer {
     private FrameCaptureCallback frameCaptureCallback;
     private boolean frameCaptureAwaitCompleteView;
     private Map<String, MapData> clientTileSources;
-    private Map<Long, Marker> markers; // Consider change to SparseLongArray<Marker> when drop API < 18
     private Handler uiThreadHandler;
+
+    // Protected members
+    // ===============
+
+    protected LongSparseArray<Marker> markers;
 
     // GLSurfaceView.Renderer methods
     // ==============================

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -17,7 +17,7 @@ import java.util.Map;
 public class MapData {
 
     String name;
-    long pointer = 0;
+    long pointer;
     MapController map;
 
     /**


### PR DESCRIPTION
Raise Android minSDK to 19 (Android 4.4) :  Current minSDK 15 has been released in 2011, and it not be used anymore (0.4%  -> near same usage of Android 2.3).

This allow to use "new" (5 year ago) classes, permits to reduce memory footprint.

