### PR TITLE
Angle style param should respect numeric value from JS Function

### DIFF
--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -466,6 +466,7 @@ void StyleContext::parseStyleResult(StyleParamKey _key, StyleParam::Value& _val)
                 _val = StyleParam::Width{static_cast<float>(v)};
                 break;
             }
+            case StyleParamKey::angle:
             case StyleParamKey::text_font_stroke_width:
             case StyleParamKey::placement_min_length_ratio: {
                 _val = static_cast<float>(duk_get_number(m_ctx, -1));


### PR DESCRIPTION
Refer discussion https://github.com/tangrams/tangram-docs/issues/250