### PR TITLE
fixes circle ios builds?

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,28 +26,26 @@ jobs:
       - run: cd platforms/android && ./gradlew uploadArchives
   build-ios:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.4.0"
     steps:
       # Check out repository with submodules.
       - checkout
       - run: git submodule update --init
       # Install dependencies.
-      # For unclear reasons, 'jazzy' fails to install on CircleCI if 'atomos' is not installed first.
-      - run: sudo gem install atomos jazzy
+      - run: sudo gem install jazzy --no-document
       - run: brew install cmake
       # Build framework and docs.
       - run: make ios TANGRAM_IOS_FRAMEWORK_SLIM=1
       - run: make ios-docs
   build-deploy-ios-snapshot:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.4.0"
     steps:
       # Check out repository with submodules.
       - checkout
       - run: git submodule update --init
       # Install dependencies.
-      # For unclear reasons, 'jazzy' fails to install on CircleCI if 'atomos' is not installed first.
-      - run: sudo gem install atomos jazzy
+      - run: sudo gem install jazzy --no-document
       - run: brew install cmake
       # Build the framework in debug mode and package it into pod.zip
       - run: make ios-framework-universal DEBUG=1
@@ -61,7 +59,7 @@ jobs:
           path: ~/pod.zip
   build-deploy-macos-snapshot:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.4.0"
     steps:
       # Check out repository with submodules.
       - checkout
@@ -76,14 +74,13 @@ jobs:
           path: ~/demo.zip
   build-deploy-ios-release:
     macos:
-      xcode: "9.2.0"
+      xcode: "9.4.0"
     steps:
       # Check out repository with submodules.
       - checkout
       - run: git submodule update --init
       # Install dependencies.
-      # For unclear reasons, 'jazzy' fails to install on CircleCI if 'atomos' is not installed first.
-      - run: sudo gem install atomos jazzy
+      - run: gem install atomos jazzy --no-document
       - run: brew install cmake jfrog-cli-go
       # Build the framework in release mode and package it into pod.zip
       - run: make ios-framework-universal RELEASE=1


### PR DESCRIPTION
- updated to use 9.4.0 xcode version
        - updates the ruby version to avoid SSL issues with rubygems
- no need to install atomos
- no need to install jazzy with documentation