### PR TITLE
Add a static library build target for iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
       - run: brew install cmake
       # Build framework and docs.
       - run: make ios-sim
+      - run: make ios-static-sim
       - run: make ios-docs
   build-deploy-ios-snapshot:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
       - run: sudo gem install jazzy --no-document
       - run: brew install cmake
       # Build framework and docs.
-      - run: make ios-sim
-      - run: make ios-static-sim
+      - run: make ios-sim BUILD_TYPE=Debug
+      - run: make ios-static-sim BUILD_TYPE=Debug
       - run: make ios-docs
   build-deploy-ios-snapshot:
     macos:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ IOS_FRAMEWORK_XCODE_PROJ = tangram.xcodeproj
 ifeq (, $(shell which xcpretty))
 	XCPRETTY =
 else
-	XCPRETTY = | xcpretty
+	XCPRETTY = | xcpretty && exit \${PIPESTATUS[0]}
 endif
 
 # Default build type is Release

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,8 @@ else
 endif
 
 # Default build type is Release
-BUILD_TYPE = Release
-ifdef DEBUG
-	BUILD_TYPE = Debug
+ifndef BUILD_TYPE
+	BUILD_TYPE = Release
 endif
 
 BENCH_CMAKE_PARAMS = \

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,18 @@ ios-framework-universal: ios-framework ios-framework-sim
 		${IOS_BUILD_DIR}/${BUILD_TYPE}-iphonesimulator/TangramMap.framework/TangramMap \
 		-create -output ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal/TangramMap.framework/TangramMap
 
+ios-static: cmake-ios
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
+
+ios-static-sim: cmake-ios
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
+
+ios-static-universal: ios-static ios-static-sim
+	@mkdir -p ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal
+	lipo ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphoneos/libtangram-static.a \
+		${IOS_BUILD_DIR}/${BUILD_TYPE}-iphonesimulator/libtangram-static.a \
+		-create -output ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal/libtangram-static.a
+
 rpi: cmake-rpi
 	cmake --build ${RPI_BUILD_DIR}
 

--- a/Makefile
+++ b/Makefile
@@ -226,12 +226,18 @@ ios-framework-universal: ios-framework ios-framework-sim
 		-create -output ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal/TangramMap.framework/TangramMap
 
 ios-static: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-static-sim: cmake-ios
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
+
+ios-static-lib: cmake-ios
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
+
+ios-static-lib-sim: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
 
-ios-static-universal: ios-static ios-static-sim
+ios-static-lib-universal: ios-static-lib ios-static-lib-sim
 	@mkdir -p ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal
 	lipo ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphoneos/libtangram-static.a \
 		${IOS_BUILD_DIR}/${BUILD_TYPE}-iphonesimulator/libtangram-static.a \

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -34,7 +34,7 @@ Building the iOS demo application requires Xcode 9.0 or newer. From the root dir
 make ios NEXTZEN_API_KEY=yourApiKeyHere
 ```
 
-You can optionally append `DEBUG=1` or `RELEASE=1` to choose the build type.
+You can optionally append a `BUILD_TYPE` variable to choose the build type, for example `BUILD_TYPE=Debug`.
 
 This will generate and compile an Xcode project for the Tangram iOS framework and demo application. To run/debug the demo application, open the projects in the iOS Xcode workspace:
 

--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -7,6 +7,7 @@ set(IOS TRUE)
 set(CMAKE_OSX_SYSROOT "iphoneos")
 set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator")
 set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "9.3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
 execute_process(COMMAND xcrun --sdk iphoneos --show-sdk-version OUTPUT_VARIABLE IOS_SDK_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # Tell SQLiteCpp to not build its own copy of SQLite, we will use the system library instead.
@@ -19,6 +20,7 @@ set(SQLITECPP_INTERNAL_SQLITE OFF CACHE BOOL "")
 # static library target, relative paths cause it to fail with an error.
 set(TANGRAM_FRAMEWORK_HEADERS
   ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TangramMap.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGExport.h
   ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGGeoPolyline.h
   ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGGeoPolygon.h
   ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGGeoPoint.h

--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -15,22 +15,24 @@ if (IOS_SDK_VERSION VERSION_LESS 11.0)
 endif()
 set(SQLITECPP_INTERNAL_SQLITE OFF CACHE BOOL "")
 
+# Headers must be absolute paths for the copy_if_different command on the
+# static library target, relative paths cause it to fail with an error.
 set(TANGRAM_FRAMEWORK_HEADERS
-  platforms/ios/framework/src/TangramMap.h
-  platforms/ios/framework/src/TGGeoPolyline.h
-  platforms/ios/framework/src/TGGeoPolygon.h
-  platforms/ios/framework/src/TGGeoPoint.h
-  platforms/ios/framework/src/TGMarker.h
-  platforms/ios/framework/src/TGSceneUpdate.h
-  platforms/ios/framework/src/TGMapData.h
-  platforms/ios/framework/src/TGTypes.h
-  platforms/ios/framework/src/TGHttpHandler.h
-  platforms/ios/framework/src/TGLabelPickResult.h
-  platforms/ios/framework/src/TGMarkerPickResult.h
-  platforms/ios/framework/src/TGMapViewController.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TangramMap.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGGeoPolyline.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGGeoPolygon.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGGeoPoint.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGMarker.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGSceneUpdate.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGMapData.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGTypes.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGHttpHandler.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGLabelPickResult.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGMarkerPickResult.h
+  ${PROJECT_SOURCE_DIR}/platforms/ios/framework/src/TGMapViewController.h
 )
 
-add_library(TangramMap SHARED
+set(TANGRAM_FRAMEWORK_SOURCES
   ${TANGRAM_FRAMEWORK_HEADERS}
   platforms/common/platform_gl.cpp
   platforms/common/appleAllowedFonts.h
@@ -54,6 +56,12 @@ add_library(TangramMap SHARED
   platforms/ios/framework/src/TGTypes.mm
   platforms/ios/framework/src/TGMapViewController+Internal.h
   platforms/ios/framework/src/TGMapViewController.mm
+)
+
+### Configure dynamic framework build target. 
+
+add_library(TangramMap SHARED
+  ${TANGRAM_FRAMEWORK_SOURCES}
 )
 
 target_link_libraries(TangramMap PRIVATE
@@ -81,4 +89,79 @@ set_target_properties(TangramMap PROPERTIES
   XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
   XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14"
   XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+)
+
+### Configure static library build target.
+
+add_library(tangram-static STATIC
+  ${TANGRAM_FRAMEWORK_SOURCES}
+)
+
+target_link_libraries(tangram-static PRIVATE
+  tangram-core
+  sqlite3
+  # Frameworks: use quotes so "-framework X" is treated as a single linker flag.
+  "-framework CoreFoundation"
+  "-framework CoreGraphics"
+  "-framework CoreText"
+  "-framework GLKit"
+  "-framework OpenGLES"
+  "-framework UIKit"
+)
+
+target_include_directories(tangram-static PRIVATE
+  platforms/common
+)
+
+# To produce a distributable version of our iOS SDK as a static library, we
+# need to collect all the symbols that will be needed in a final, linked
+# executable. CMake normally makes these symbols available by propagating link
+# flags from dependencies, but users who aren't building the SDK from source
+# won't have the dependency libraries in a build tree. We solve this by pre-
+# linking all of the dependency libraries that we would normally pass as flags.
+
+# Here we manually list the library files for all of our compiled dependencies.
+# I haven't found a way to get a full, recursive library list from CMake
+# so this list will need to be updated when any new library dependencies are
+# added. Note the quotes: this is needed to not make it a "list", which CMake
+# delimits with semicolons. Xcode expects a space-delimited list.
+set(TANGRAM_STATIC_DEPENDENCIES "\
+  $<TARGET_FILE:tangram-core>
+  $<TARGET_FILE:duktape>
+  $<TARGET_FILE:css-color-parser-cpp>
+  $<TARGET_FILE:yaml-cpp>
+  $<TARGET_FILE:alfons>
+  $<TARGET_FILE:linebreak>
+  $<TARGET_FILE:harfbuzz>
+  $<TARGET_FILE:freetype>
+  $<TARGET_FILE:icucommon>
+  $<TARGET_FILE:SQLiteCpp>
+  $<TARGET_FILE:double-conversion>
+  $<TARGET_FILE:miniz>
+  "
+)
+
+set_target_properties(tangram-static PROPERTIES
+  XCODE_ATTRIBUTE_CURRENT_PROJECT_VERSION "${TANGRAM_FRAMEWORK_VERSION}"
+  XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
+  XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14"
+  XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  # The Xcode settings below are to pre-link our static libraries into a single
+  # archive. Xcode will take the objects from this target and from all of the
+  # pre-link libraries, combine them, and resolve the symbols into one "master"
+  # object file before outputting an archive.
+  XCODE_ATTRIBUTE_GENERATE_MASTER_OBJECT_FILE "YES"
+  XCODE_ATTRIBUTE_PRELINK_LIBS "${TANGRAM_STATIC_DEPENDENCIES}"
+)
+
+# Copy the framework headers into a directory in the build folder, for use by
+# the static demo app build and for distribution.
+add_custom_command(TARGET tangram-static POST_BUILD
+  COMMAND
+  ${CMAKE_COMMAND} -E make_directory
+  "${PROJECT_BINARY_DIR}/Include/TangramMap/"
+  COMMAND
+  ${CMAKE_COMMAND} -E copy_if_different
+  ${TANGRAM_FRAMEWORK_HEADERS}
+  "${PROJECT_BINARY_DIR}/Include/TangramMap/"
 )

--- a/platforms/ios/demo/TangramDemo.xcodeproj/project.pbxproj
+++ b/platforms/ios/demo/TangramDemo.xcodeproj/project.pbxproj
@@ -15,6 +15,18 @@
 		D298723E20D05F7A009A0AB8 /* Main_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D298723B20D05F7A009A0AB8 /* Main_iPad.storyboard */; };
 		D2DB6A9420DAE14A0043E74F /* TangramMap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DB6A9320DAE14A0043E74F /* TangramMap.framework */; };
 		D2DB6A9520DAE1500043E74F /* TangramMap.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D2DB6A9320DAE14A0043E74F /* TangramMap.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2F0603520E6E01700CB442F /* AppDelegate.h in Sources */ = {isa = PBXBuildFile; fileRef = D298723020D05F6E009A0AB8 /* AppDelegate.h */; };
+		D2F0603620E6E01700CB442F /* MapViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D298723120D05F6E009A0AB8 /* MapViewController.m */; };
+		D2F0603720E6E01700CB442F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D298723220D05F6E009A0AB8 /* main.m */; };
+		D2F0603820E6E01700CB442F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D298723320D05F6E009A0AB8 /* AppDelegate.m */; };
+		D2F0603920E6E01700CB442F /* MapViewController.h in Sources */ = {isa = PBXBuildFile; fileRef = D298723420D05F6E009A0AB8 /* MapViewController.h */; };
+		D2F0603B20E6E31200CB442F /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F0603A20E6E31200CB442F /* libsqlite3.tbd */; };
+		D2F0603D20E6E32200CB442F /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F0603C20E6E32200CB442F /* libz.tbd */; };
+		D2F0603F20E6E33300CB442F /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F0603E20E6E33300CB442F /* libc++.tbd */; };
+		D2F0604320EA9AD000CB442F /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = D298723920D05F7A009A0AB8 /* LaunchScreen.xib */; };
+		D2F0604420EA9AD000CB442F /* Main_iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D298723A20D05F7A009A0AB8 /* Main_iPhone.storyboard */; };
+		D2F0604520EA9AD000CB442F /* Main_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D298723B20D05F7A009A0AB8 /* Main_iPad.storyboard */; };
+		D2F0604720EACEB700CB442F /* libtangram-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F0604620EACEB700CB442F /* libtangram-static.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -42,6 +54,11 @@
 		D298723B20D05F7A009A0AB8 /* Main_iPad.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main_iPad.storyboard; sourceTree = "<group>"; };
 		D298723F20D05F88009A0AB8 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D2DB6A9320DAE14A0043E74F /* TangramMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = TangramMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2F0601F20E6DFAF00CB442F /* TangramDemo-static.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TangramDemo-static.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2F0603A20E6E31200CB442F /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
+		D2F0603C20E6E32200CB442F /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		D2F0603E20E6E33300CB442F /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
+		D2F0604620EACEB700CB442F /* libtangram-static.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libtangram-static.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,12 +70,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D2F0601C20E6DFAF00CB442F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2F0604720EACEB700CB442F /* libtangram-static.a in Frameworks */,
+				D2F0603F20E6E33300CB442F /* libc++.tbd in Frameworks */,
+				D2F0603D20E6E32200CB442F /* libz.tbd in Frameworks */,
+				D2F0603B20E6E31200CB442F /* libsqlite3.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		D235656F20D9BA77006E3D13 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D2F0604620EACEB700CB442F /* libtangram-static.a */,
+				D2F0603E20E6E33300CB442F /* libc++.tbd */,
+				D2F0603C20E6E32200CB442F /* libz.tbd */,
+				D2F0603A20E6E31200CB442F /* libsqlite3.tbd */,
 				D2DB6A9320DAE14A0043E74F /* TangramMap.framework */,
 			);
 			name = Frameworks;
@@ -79,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				D298721620D05D8E009A0AB8 /* TangramDemo.app */,
+				D2F0601F20E6DFAF00CB442F /* TangramDemo-static.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -126,6 +159,23 @@
 			productReference = D298721620D05D8E009A0AB8 /* TangramDemo.app */;
 			productType = "com.apple.product-type.application";
 		};
+		D2F0601E20E6DFAF00CB442F /* TangramDemo-static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D2F0603220E6DFB200CB442F /* Build configuration list for PBXNativeTarget "TangramDemo-static" */;
+			buildPhases = (
+				D2F0601B20E6DFAF00CB442F /* Sources */,
+				D2F0601C20E6DFAF00CB442F /* Frameworks */,
+				D2F0601D20E6DFAF00CB442F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TangramDemo-static";
+			productName = "TangramDemo-static";
+			productReference = D2F0601F20E6DFAF00CB442F /* TangramDemo-static.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -137,6 +187,10 @@
 				TargetAttributes = {
 					D298721520D05D8E009A0AB8 = {
 						CreatedOnToolsVersion = 9.3;
+						ProvisioningStyle = Automatic;
+					};
+					D2F0601E20E6DFAF00CB442F = {
+						CreatedOnToolsVersion = 9.4.1;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -155,6 +209,7 @@
 			projectRoot = "";
 			targets = (
 				D298721520D05D8E009A0AB8 /* TangramDemo */,
+				D2F0601E20E6DFAF00CB442F /* TangramDemo-static */,
 			);
 		};
 /* End PBXProject section */
@@ -170,6 +225,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D2F0601D20E6DFAF00CB442F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2F0604320EA9AD000CB442F /* LaunchScreen.xib in Resources */,
+				D2F0604420EA9AD000CB442F /* Main_iPhone.storyboard in Resources */,
+				D2F0604520EA9AD000CB442F /* Main_iPad.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -180,6 +245,18 @@
 				D298723620D05F6F009A0AB8 /* main.m in Sources */,
 				D298723520D05F6F009A0AB8 /* MapViewController.m in Sources */,
 				D298723720D05F6F009A0AB8 /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2F0601B20E6DFAF00CB442F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2F0603520E6E01700CB442F /* AppDelegate.h in Sources */,
+				D2F0603620E6E01700CB442F /* MapViewController.m in Sources */,
+				D2F0603720E6E01700CB442F /* main.m in Sources */,
+				D2F0603820E6E01700CB442F /* AppDelegate.m in Sources */,
+				D2F0603920E6E01700CB442F /* MapViewController.h in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -329,6 +406,42 @@
 			};
 			name = Release;
 		};
+		D2F0603320E6DFB200CB442F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				HEADER_SEARCH_PATHS = ../../../build/ios/Include;
+				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapzen.ios.TangramDemo-static";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYMROOT = ../../../build/ios;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D2F0603420E6DFB200CB442F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				HEADER_SEARCH_PATHS = ../../../build/ios/Include;
+				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapzen.ios.TangramDemo-static";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYMROOT = ../../../build/ios;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -346,6 +459,15 @@
 			buildConfigurations = (
 				D298722D20D05D91009A0AB8 /* Debug */,
 				D298722E20D05D91009A0AB8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D2F0603220E6DFB200CB442F /* Build configuration list for PBXNativeTarget "TangramDemo-static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D2F0603320E6DFB200CB442F /* Debug */,
+				D2F0603420E6DFB200CB442F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/platforms/ios/demo/TangramDemo.xcodeproj/xcshareddata/xcschemes/TangramDemo-static.xcscheme
+++ b/platforms/ios/demo/TangramDemo.xcodeproj/xcshareddata/xcschemes/TangramDemo-static.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2F0601E20E6DFAF00CB442F"
+               BuildableName = "TangramDemo-static.app"
+               BlueprintName = "TangramDemo-static"
+               ReferencedContainer = "container:TangramDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D2F0601E20E6DFAF00CB442F"
+            BuildableName = "TangramDemo-static.app"
+            BlueprintName = "TangramDemo-static"
+            ReferencedContainer = "container:TangramDemo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D2F0601E20E6DFAF00CB442F"
+            BuildableName = "TangramDemo-static.app"
+            BlueprintName = "TangramDemo-static"
+            ReferencedContainer = "container:TangramDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "NEXTZEN_API_KEY"
+            value = "KXcYNjp0QXigFSMc5a7eEA"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D2F0601E20E6DFAF00CB442F"
+            BuildableName = "TangramDemo-static.app"
+            BlueprintName = "TangramDemo-static"
+            ReferencedContainer = "container:TangramDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/platforms/ios/demo/src/MapViewController.h
+++ b/platforms/ios/demo/src/MapViewController.h
@@ -6,7 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <TangramMap/TangramMap.h>
+#import "TangramMap/TangramMap.h"
 
 @interface MapViewControllerDelegate : NSObject <TGMapViewDelegate>
 

--- a/platforms/ios/framework/src/TGExport.h
+++ b/platforms/ios/framework/src/TGExport.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define TG_EXPORT __attribute__((visibility ("default")))

--- a/platforms/ios/framework/src/TGGeoPoint.h
+++ b/platforms/ios/framework/src/TGGeoPoint.h
@@ -7,6 +7,7 @@
 //
 
 #pragma once
+#import "TGExport.h"
 
 /**
  Structure holding a geographics coordinate (longitude and latitude)
@@ -30,7 +31,7 @@ typedef struct TGGeoPoint TGGeoPoint;
  @param lat the latitude coordinate
  @return a `TGGeoPoint` holding the longitude and latitude
  */
-static inline TGGeoPoint TGGeoPointMake(double lon, double lat)
+TG_EXPORT static inline TGGeoPoint TGGeoPointMake(double lon, double lat)
 {
     TGGeoPoint p;
     p.latitude = lat;

--- a/platforms/ios/framework/src/TGGeoPolygon.h
+++ b/platforms/ios/framework/src/TGGeoPolygon.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "TGExport.h"
 #import "TGGeoPoint.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -17,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
  The polygon winding order and internal polygons must be set according to the <a href="http://geojson.org/geojson-spec.html#polygon">
  GeoJSON specification</a>.
  */
+TG_EXPORT
 @interface TGGeoPolygon : NSObject
 
 /**

--- a/platforms/ios/framework/src/TGGeoPolyline.h
+++ b/platforms/ios/framework/src/TGGeoPolyline.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "TGExport.h"
 #import "TGGeoPoint.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -19,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
  with possibly different geometry types; returns true if the marker ID was found and
  successfully updated, otherwise returns false.
  */
+TG_EXPORT
 @interface TGGeoPolyline : NSObject
 
 /**

--- a/platforms/ios/framework/src/TGHttpHandler.h
+++ b/platforms/ios/framework/src/TGHttpHandler.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "TGExport.h"
 
 /**
  A network request completion callback, called when a download request of `TGHttpHandler`
@@ -28,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  To change this configuration, create a new http handler and set it to the map view with
  `-[TGMapViewController httpHandler]`.
  */
+TG_EXPORT
 @interface TGHttpHandler : NSObject
 
 

--- a/platforms/ios/framework/src/TGLabelPickResult.h
+++ b/platforms/ios/framework/src/TGLabelPickResult.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "TGExport.h"
 #import "TGGeoPoint.h"
 #import "TGMapData.h"
 
@@ -25,6 +26,7 @@ typedef NS_ENUM(NSInteger, TGLabelType) {
 
  See `-[TGMapViewController pickLabelAt:]` and `[TGMapViewDelegate mapView:didSelectLabel:atScreenPosition:]`.
  */
+TG_EXPORT
 @interface TGLabelPickResult : NSObject
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platforms/ios/framework/src/TGMapData.h
+++ b/platforms/ios/framework/src/TGMapData.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "TGExport.h"
 #import "TGGeoPoint.h"
 #import "TGGeoPolygon.h"
 #import "TGGeoPolyline.h"
@@ -54,6 +55,7 @@ typedef NSDictionary<NSString *, NSString *> TGFeatureProperties;
  dataLayer.add(polyline: line, properties: properties);
  ```
  */
+TG_EXPORT
 @interface TGMapData : NSObject
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platforms/ios/framework/src/TGMapViewController.h
+++ b/platforms/ios/framework/src/TGMapViewController.h
@@ -318,6 +318,7 @@ NS_ASSUME_NONNULL_BEGIN
  your application.
 
  */
+TG_EXPORT
 @interface TGMapViewController : GLKViewController <UIGestureRecognizerDelegate>
 
 /**

--- a/platforms/ios/framework/src/TGMarker.h
+++ b/platforms/ios/framework/src/TGMarker.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-
+#import "TGExport.h"
 #import "TGGeoPoint.h"
 #import "TGGeoPolygon.h"
 #import "TGGeoPolyline.h"
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  The marker style should defined using the <a href="https://mapzen.com/documentation/tangram/Styles-Overview">
  Tangram YAML syntax</a>.
  */
+TG_EXPORT
 @interface TGMarker : NSObject
 
 /**

--- a/platforms/ios/framework/src/TGMarkerPickResult.h
+++ b/platforms/ios/framework/src/TGMarkerPickResult.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "TGExport.h"
 #import "TGGeoPoint.h"
 #import "TGMarker.h"
 
@@ -17,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  See `-[TGMapViewController pickMarkerAt:]` and `[TGMapViewDelegate mapView:didSelectMarker:atScreenPosition:]`.
  */
+TG_EXPORT
 @interface TGMarkerPickResult : NSObject
 
 /// The geographic coordinates of the selected label

--- a/platforms/ios/framework/src/TGSceneUpdate.h
+++ b/platforms/ios/framework/src/TGSceneUpdate.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "TGExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  view.applySceneUpdates()
  ```
  */
+TG_EXPORT
 @interface TGSceneUpdate : NSObject
 
 /**

--- a/platforms/ios/framework/src/TGTypes.h
+++ b/platforms/ios/framework/src/TGTypes.h
@@ -7,9 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "TGExport.h"
 
 /// Indicates an error occurred in the Tangram Framework.
-extern NSString* const TGErrorDomain;
+extern TG_EXPORT NSString* const TGErrorDomain;
 
 /**
  Describes ease functions to be used for camera or other transition animation.

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -45,7 +45,7 @@ To build the executable demo application:
 make linux
 ```
 
-You can optionally use `make -j` to parallelize the build and append `DEBUG=1` or `RELEASE=1` to choose the build type.
+You can optionally use `make -j` to parallelize the build and append a `BUILD_TYPE` variable to choose the build type, for example `BUILD_TYPE=Debug`.
 
 Then run it from the output folder:
 

--- a/platforms/osx/README.md
+++ b/platforms/osx/README.md
@@ -41,7 +41,7 @@ To build a runnable OS X application bundle, run:
 make osx
 ```
 
-You can optionally use `make -j` to parallelize the build and append `DEBUG=1` or `RELEASE=1` to choose the build type.
+You can optionally use `make -j` to parallelize the build and append a `BUILD_TYPE` variable to choose the build type, for example `BUILD_TYPE=Debug`.
 
 Then open the application with:
 

--- a/platforms/rpi/README.md
+++ b/platforms/rpi/README.md
@@ -40,7 +40,7 @@ Compile the demo application with:
 make rpi
 ```
 
-You can optionally use `make -j` to parallelize the build and append `DEBUG=1` or `RELEASE=1` to choose the build type.
+You can optionally use `make -j` to parallelize the build and append a `BUILD_TYPE` variable to choose the build type, for example `BUILD_TYPE=Debug`.
 
 Run the demo program from the output folder:
 ```


### PR DESCRIPTION
 - Adds new build targets that produce static library archives of the TangramMap framework for iOS
 - Adds a build target to the demo application project that compiles a demo app using the static library target
 - Modifies the Makefile to allow passing any string for `BUILD_TYPE`