### PR TITLE
Portability fixes

### DIFF
--- a/platforms/common/linuxSystemFontHelper.cpp
+++ b/platforms/common/linuxSystemFontHelper.cpp
@@ -1,6 +1,7 @@
 #include "linuxSystemFontHelper.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 
 namespace Tangram {

--- a/platforms/linux/src/linuxPlatform.cpp
+++ b/platforms/linux/src/linuxPlatform.cpp
@@ -78,8 +78,7 @@ void LinuxPlatform::cancelUrlRequest(UrlRequestHandle _request) {
 LinuxPlatform::~LinuxPlatform() {}
 
 void setCurrentThreadPriority(int priority) {
-    int tid = syscall(SYS_gettid);
-    setpriority(PRIO_PROCESS, tid, priority);
+    setpriority(PRIO_PROCESS, 0, priority);
 }
 
 void initGLExtensions() {


### PR DESCRIPTION
* ISO C specifies that atoi() is part of stdlib.h.
* POSIX specifies that passing 0 to setpriority selects the current process. Avoiding the Linux‐specific gettid syscall allows Tangram to build on OpenBSD.