### PR TITLE
Camera API tweaks

### DIFF
--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -122,7 +122,7 @@ struct CameraUpdate {
     float tilt = 0;
     float tiltBy = 0;
     std::array<LngLat,2> bounds;
-    int boundsPadding = 0;
+    std::array<int, 4> padding = {{0}};
 };
 
 class Map {
@@ -230,8 +230,9 @@ public:
     // Get the tilt angle of the view in radians; 0 corresponds to straight down
     float getTilt();
 
-    // Get the CameraPosition that encloses the bounds given by _a and _b
-    CameraPosition getEnclosingCameraPosition(LngLat a, LngLat b, int buffer);
+    // Get the CameraPosition that encloses the bounds given by _a and _b and
+    // leaves at least the given amount of padding on each side (in logical pixels).
+    CameraPosition getEnclosingCameraPosition(LngLat _a, LngLat _b, int _leftPad, int _topPad, int _rightPad, int _bottomPad);
 
     // Run flight animation to change postion and zoom  of the map
     // If _duration is 0, speed is used as factor to change the duration that is

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -100,6 +100,18 @@ struct CameraPosition {
     float tilt = 0;
 };
 
+struct EdgePadding {
+    int left = 0;
+    int top = 0;
+    int right = 0;
+    int bottom = 0;
+
+    EdgePadding() {}
+
+    EdgePadding(int left, int top, int right, int bottom)
+        : left(left), top(top), right(right), bottom(bottom) {}
+};
+
 struct CameraUpdate {
     enum Flags {
         SET_LNGLAT = 1 << 0,
@@ -122,7 +134,7 @@ struct CameraUpdate {
     float tilt = 0;
     float tiltBy = 0;
     std::array<LngLat,2> bounds;
-    std::array<int, 4> padding = {{0}};
+    EdgePadding padding;
 };
 
 class Map {
@@ -232,7 +244,7 @@ public:
 
     // Get the CameraPosition that encloses the bounds given by _a and _b and
     // leaves at least the given amount of padding on each side (in logical pixels).
-    CameraPosition getEnclosingCameraPosition(LngLat _a, LngLat _b, int _leftPad, int _topPad, int _rightPad, int _bottomPad);
+    CameraPosition getEnclosingCameraPosition(LngLat _a, LngLat _b, EdgePadding _pad);
 
     // Run flight animation to change postion and zoom  of the map
     // If _duration is 0, speed is used as factor to change the duration that is

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -678,7 +678,7 @@ void Map::updateCameraPosition(const CameraUpdate& _update, float _duration, Eas
         camera = getCameraPosition();
     }
     if ((_update.set & CameraUpdate::SET_BOUNDS) != 0) {
-        camera = getEnclosingCameraPosition(_update.bounds[0], _update.bounds[1], _update.padding[0], _update.padding[1], _update.padding[2], _update.padding[3]);
+        camera = getEnclosingCameraPosition(_update.bounds[0], _update.bounds[1], _update.padding);
     }
     if ((_update.set & CameraUpdate::SET_LNGLAT) != 0) {
         camera.longitude = _update.lngLat.longitude;
@@ -760,7 +760,7 @@ float Map::getTilt() {
     return impl->view.getPitch();
 }
 
-CameraPosition Map::getEnclosingCameraPosition(LngLat _a, LngLat _b, int _leftPad, int _topPad, int _rightPad, int _bottomPad) {
+CameraPosition Map::getEnclosingCameraPosition(LngLat _a, LngLat _b, EdgePadding _pad) {
     const View& view = impl->view;
     const MapProjection& projection = view.getMapProjection();
 
@@ -771,7 +771,7 @@ CameraPosition Map::getEnclosingCameraPosition(LngLat _a, LngLat _b, int _leftPa
 
     // Calculate the inner size of the view that the bounds must fit within.
     glm::dvec2 innerSize(view.getWidth() / view.pixelScale(), view.getHeight() / view.pixelScale());
-    innerSize -= glm::dvec2((_leftPad + _rightPad), (_topPad + _bottomPad));
+    innerSize -= glm::dvec2((_pad.left + _pad.right), (_pad.top + _pad.bottom));
 
     // Calculate the map scale that fits the bounds into the inner size in each dimension.
     glm::dvec2 metersPerPixel = dMeters / innerSize;
@@ -781,7 +781,7 @@ CameraPosition Map::getEnclosingCameraPosition(LngLat _a, LngLat _b, int _leftPa
     double zoom = -std::log2(maxMetersPerPixel * projection.TileSize() / MapProjection::CIRCUMFERENCE);
 
     // Adjust the center of the final visible region using the padding converted to Mercator meters.
-    glm::dvec2 paddingMeters = glm::dvec2(_rightPad - _leftPad, _topPad - _bottomPad) * maxMetersPerPixel;
+    glm::dvec2 paddingMeters = glm::dvec2(_pad.right - _pad.left, _pad.top - _pad.bottom) * maxMetersPerPixel;
     glm::dvec2 centerMeters = 0.5 * (aMeters + bMeters + paddingMeters);
 
     glm::dvec2 centerLngLat = projection.MetersToLonLat(centerMeters);

--- a/core/src/util/mapProjection.h
+++ b/core/src/util/mapProjection.h
@@ -1,8 +1,5 @@
 #pragma once
 
-//Define global constants
-#define R_EARTH 6378137.0
-
 #include "tile/tileID.h"
 #include "util/geom.h"
 
@@ -19,7 +16,9 @@ protected:
 public:
     constexpr static double INV_360 = 1.0/360.0;
     constexpr static double INV_180 = 1.0/180.0;
+    constexpr static double R_EARTH = 6378137.0;
     constexpr static double HALF_CIRCUMFERENCE = PI * R_EARTH;
+    constexpr static double CIRCUMFERENCE = 2 * PI * R_EARTH;
     /*
      * 256 is default tile size
      */

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -89,18 +89,18 @@ extern "C" {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
-        bool ret = map->screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
+        bool result = map->screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
         jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
-        return ret;
+        return static_cast<jboolean>(result);
     }
 
     JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeLngLatToScreenPosition(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdoubleArray coordinates) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
-        bool ret = map->lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
+        bool result = map->lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
         jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
-        return ret;
+        return static_cast<jboolean>(result);
     }
 
     JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager) {
@@ -187,10 +187,11 @@ extern "C" {
         map->resize(width, height);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeUpdate(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat dt) {
+    JNIEXPORT jboolean bool JNICALL Java_com_mapzen_tangram_MapController_nativeUpdate(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat dt) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        return map->update(dt);
+        auto result = map->update(dt);
+        return static_cast<jboolean>(result);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeRender(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
@@ -315,54 +316,54 @@ extern "C" {
         return static_cast<jlong>(markerID);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerRemove(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerRemove(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerRemove(static_cast<unsigned int>(markerID));
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetStylingFromString(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jstring styling) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetStylingFromString(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jstring styling) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto styleString = stringFromJString(jniEnv, styling);
         auto result = map->markerSetStylingFromString(static_cast<unsigned int>(markerID), styleString.c_str());
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetStylingFromPath(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jstring path) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetStylingFromPath(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jstring path) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto pathString = stringFromJString(jniEnv, path);
         auto result = map->markerSetStylingFromPath(static_cast<unsigned int>(markerID), pathString.c_str());
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetBitmap(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jint width, jint height, jintArray data) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetBitmap(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jint width, jint height, jintArray data) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jint* ptr = jniEnv->GetIntArrayElements(data, NULL);
         unsigned int* imgData = reinterpret_cast<unsigned int*>(ptr);
         jniEnv->ReleaseIntArrayElements(data, ptr, JNI_ABORT);
         auto result = map->markerSetBitmap(static_cast<unsigned int>(markerID), width, height, imgData);
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPoint(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdouble lng, jdouble lat) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPoint(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdouble lng, jdouble lat) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerSetPoint(static_cast<unsigned int>(markerID), Tangram::LngLat(lng, lat));
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPointEased(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdouble lng, jdouble lat, jfloat duration, jint ease) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPointEased(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdouble lng, jdouble lat, jfloat duration, jint ease) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerSetPointEased(static_cast<unsigned int>(markerID), Tangram::LngLat(lng, lat), duration, static_cast<Tangram::EaseType>(ease));
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPolyline(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdoubleArray jcoordinates, jint count) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPolyline(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdoubleArray jcoordinates, jint count) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         if (!jcoordinates || count == 0) { return false; }
@@ -376,10 +377,10 @@ extern "C" {
         }
 
         auto result = map->markerSetPolyline(static_cast<unsigned int>(markerID), polyline.data(), count);
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPolygon(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdoubleArray jcoordinates, jintArray jcounts, jint rings) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPolygon(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdoubleArray jcoordinates, jintArray jcounts, jint rings) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         if (!jcoordinates || !jcounts || rings == 0) { return false; }
@@ -400,21 +401,21 @@ extern "C" {
         }
 
         auto result = map->markerSetPolygon(static_cast<unsigned int>(markerID), polygonCoords.data(), counts, rings);
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetVisible(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jboolean visible) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetVisible(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jboolean visible) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerSetVisible(static_cast<unsigned int>(markerID), visible);
-        return result;
+        return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT bool JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetDrawOrder(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jint drawOrder) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetDrawOrder(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jint drawOrder) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerSetDrawOrder(markerID, drawOrder);
-        return result;
+        return static_cast<jboolean>(result);
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerRemoveAll(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/CameraUpdate.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/CameraUpdate.java
@@ -24,7 +24,7 @@ public class CameraUpdate {
     double boundsLat1;
     double boundsLon2;
     double boundsLat2;
-    float boundsPadding;
+    int[] padding;
     int set;
 
     CameraUpdate() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/CameraUpdateFactory.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/CameraUpdateFactory.java
@@ -1,5 +1,6 @@
 package com.mapzen.tangram;
 
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
 
 public class CameraUpdateFactory {
@@ -161,14 +162,14 @@ public class CameraUpdateFactory {
      * @return The update
      */
     @NonNull
-    public static CameraUpdate newLatLngBounds(@NonNull LngLat sw, @NonNull LngLat ne, float padding) {
+    public static CameraUpdate newLatLngBounds(@NonNull LngLat sw, @NonNull LngLat ne, Rect padding) {
         CameraUpdate update = new CameraUpdate();
         update.set = CameraUpdate.SET_BOUNDS;
         update.boundsLon1 = sw.longitude;
         update.boundsLat1 = sw.latitude;
         update.boundsLon2 = ne.longitude;
         update.boundsLat2 = ne.latitude;
-        update.boundsPadding = padding;
+        update.padding = new int[]{padding.left, padding.top, padding.right, padding.bottom};
         return update;
     }
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -480,7 +480,7 @@ public class MapController implements Renderer {
 
         nativeUpdateCameraPosition(mapPointer, update.set, update.longitude, update.latitude, update.zoom,
                 update.zoomBy, update.rotation, update.rotationBy, update.tilt, update.tiltBy,
-                update.boundsLon1, update.boundsLat1, update.boundsLon2, update.boundsLat2, update.boundsPadding,
+                update.boundsLon1, update.boundsLat1, update.boundsLon2, update.boundsLat2, update.padding,
                 seconds, ease.ordinal());
 
         if (cb != null) {
@@ -1154,7 +1154,7 @@ public class MapController implements Renderer {
     private synchronized native void nativeGetCameraPosition(long mapPtr, double[] lonLatOut, float[] zoomRotationTiltOut);
     private synchronized native void nativeUpdateCameraPosition(long mapPtr, int set, double lon, double lat, float zoom, float zoomBy,
                                                                 float rotation, float rotateBy, float tilt, float tiltBy,
-                                                                double b1lon, double b1lat, double b2lon, double b2lat, float bPadding,
+                                                                double b1lon, double b1lat, double b2lon, double b2lat, int[] padding,
                                                                 float duration, int ease);
     private synchronized native void nativeFlyTo(long mapPtr, double lon, double lat, float zoom, float duration, float speed);
     private synchronized native void nativeGetEnclosingViewPosition(long mapPtr, double aLng, double aLat, double bLng, double bLat, int buffer, double[] lngLatZoom);

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -313,7 +313,7 @@ void mouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
             map->screenPositionToLngLat(last_x, last_y, &coords[1].longitude, &coords[1].latitude);
 
             map->markerSetPolyline(polyline, coords, 2);
-            auto cam = map->getEnclosingCameraPosition(coords[0], coords[1], 200, 100, 200, 100);
+            auto cam = map->getEnclosingCameraPosition(coords[0], coords[1], EdgePadding(200, 100, 200, 100));
 
             map->setCameraPosition(cam);
         }

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -313,7 +313,7 @@ void mouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
             map->screenPositionToLngLat(last_x, last_y, &coords[1].longitude, &coords[1].latitude);
 
             map->markerSetPolyline(polyline, coords, 2);
-            auto cam = map->getEnclosingCameraPosition(coords[0], coords[1], 10);
+            auto cam = map->getEnclosingCameraPosition(coords[0], coords[1], 200, 100, 200, 100);
 
             map->setCameraPosition(cam);
         }


### PR DESCRIPTION
- Change "ease" member in Map from a vector to a single unique_ptr, since we only have one at a time.
- Allow specifying separate padding values for each side of the view when fitting a camera to a region.
- Fix some JNI warnings in Android Studio