### PR TITLE
Configurable zoom limits

### DIFF
--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -228,6 +228,22 @@ public:
     // Get the fractional zoom level of the view
     float getZoom();
 
+    // Set the minimum zoom level for the view; values less than 0 will be
+    // clamped to 0; values greater than the current maximum zoom level will set
+    // the maximum zoom to this value.
+    void setMinZoom(float _minZoom);
+
+    // Get the minimum zoom level for the view.
+    float getMinZoom();
+
+    // Set the maximum zoom level for the view; values greater than 20.5 will be
+    // clamped to 20.5; values less than the current minimum zoom level will set
+    // the minimum zoom to this value.
+    void setMaxZoom(float _maxZoom);
+
+    // Get the maximum zoom level for the view.
+    float getMaxZoom();
+
     // Set the counter-clockwise rotation of the view in radians; 0 corresponds to
     // North pointing up
     void setRotation(float _radians);

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -738,6 +738,22 @@ float Map::getZoom() {
     return impl->view.getZoom();
 }
 
+void Map::setMinZoom(float _minZoom) {
+    impl->view.setMinZoom(_minZoom);
+}
+
+float Map::getMinZoom() {
+    return impl->view.getMinZoom();
+}
+
+void Map::setMaxZoom(float _maxZoom) {
+    impl->view.setMaxZoom(_maxZoom);
+}
+
+float Map::getMaxZoom() {
+    return impl->view.getMaxZoom();
+}
+
 void Map::setRotation(float _radians) {
     cancelCameraAnimation();
 

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -81,6 +81,18 @@ public:
     // field-of-view angle.
     float getFocalLength() const;
 
+    // Set the minimum zoom level. Clamped to >=0.
+    void setMinZoom(float minZoom);
+
+    // Get the minimum zoom level.
+    float getMinZoom() const { return m_minZoom; }
+
+    // Set the maximum zoom level. Clamped to <= 20.5.
+    void setMaxZoom(float maxZoom);
+
+    // Get the maximum zoom level.
+    float getMaxZoom() const { return m_maxZoom; }
+
     // Set the maximum pitch angle in degrees.
     void setMaxPitch(float degrees);
 
@@ -186,9 +198,6 @@ public:
     /* Returns true if the view properties have changed since the last call to update() */
     bool changedOnLastUpdate() const { return m_changed; }
 
-    /* TODO: API for setting these */
-    constexpr static float s_maxZoom = 20.5;
-    constexpr static float s_minZoom = 0.0;
     constexpr static float s_pixelsPerTile = 256.0;
 
     const glm::mat4& getOrthoViewportMatrix() const { return m_orthoViewport; };
@@ -238,6 +247,8 @@ protected:
     float m_pixelScale = 1.0f;
     float m_fov = 0.25 * PI;
     float m_maxPitch = 90.f;
+    float m_minZoom = 0.f;
+    float m_maxZoom = 20.5f;
 
     CameraType m_type;
 

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -234,6 +234,30 @@ extern "C" {
         return map->getCameraType();
     }
 
+    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetMinZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        return map->getMinZoom();
+    }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetMinZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat minZoom) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setMinZoom(minZoom);
+    }
+
+    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetMaxZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        return map->getMaxZoom();
+    }
+
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetMaxZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat maxZoom) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setMaxZoom(maxZoom);
+    }
+
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleTapGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -553,6 +553,48 @@ public class MapController implements Renderer {
     }
 
     /**
+     * Get the minimum zoom level of the map view. The default minimum zoom is 0.
+     * @return The zoom level
+     */
+    public float getMinimumZoomLevel() {
+        checkPointer(mapPointer);
+        return nativeGetMinZoom(mapPointer);
+    }
+
+    /**
+     * Set the minimum zoom level of the map view.
+     *
+     * Values less than the default minimum zoom will be clamped. Assigning a value greater than the
+     * current maximum zoom will set the maximum zoom to this value.
+     * @param minimumZoom The zoom level
+     */
+    public void setMinimumZoomLevel(float minimumZoom) {
+        checkPointer(mapPointer);
+        nativeSetMinZoom(mapPointer, minimumZoom);
+    }
+
+    /**
+     * Get the maximum zoom level of the map view. The default maximum zoom is 20.5.
+     * @return The zoom level
+     */
+    public float getMaximumZoomLevel() {
+        checkPointer(mapPointer);
+        return nativeGetMaxZoom(mapPointer);
+    }
+
+    /**
+     * Set the maximum zoom level of the map view.
+     *
+     * Values greater than the default maximum zoom will be clamped. Assigning a value less than the
+     * current minimum zoom will set the minimum zoom to this value.
+     * @param maximumZoom The zoom level
+     */
+    public void setMaximumZoomLevel(float maximumZoom) {
+        checkPointer(mapPointer);
+        nativeSetMaxZoom(mapPointer, maximumZoom);
+    }
+
+    /**
      * Find the geographic coordinates corresponding to the given position on screen
      * @param screenPosition Position in pixels from the top-left corner of the map area
      * @return LngLat corresponding to the given point, or null if the screen position
@@ -1163,6 +1205,10 @@ public class MapController implements Renderer {
     private synchronized native void nativeSetPixelScale(long mapPtr, float scale);
     private synchronized native void nativeSetCameraType(long mapPtr, int type);
     private synchronized native int nativeGetCameraType(long mapPtr);
+    private synchronized native float nativeGetMinZoom(long mapPtr);
+    private synchronized native void nativeSetMinZoom(long mapPtr, float minZoom);
+    private synchronized native float nativeGetMaxZoom(long mapPtr);
+    private synchronized native void nativeSetMaxZoom(long mapPtr, float maxZoom);
     private synchronized native void nativeHandleTapGesture(long mapPtr, float posX, float posY);
     private synchronized native void nativeHandleDoubleTapGesture(long mapPtr, float posX, float posY);
     private synchronized native void nativeHandlePanGesture(long mapPtr, float startX, float startY, float endX, float endY);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1199,7 +1199,7 @@ public class MapController implements Renderer {
                                                                 double b1lon, double b1lat, double b2lon, double b2lat, int[] padding,
                                                                 float duration, int ease);
     private synchronized native void nativeFlyTo(long mapPtr, double lon, double lat, float zoom, float duration, float speed);
-    private synchronized native void nativeGetEnclosingViewPosition(long mapPtr, double aLng, double aLat, double bLng, double bLat, int buffer, double[] lngLatZoom);
+    private synchronized native void nativeGetEnclosingViewPosition(long mapPtr, double aLng, double aLat, double bLng, double bLat, int[] buffer, double[] lngLatZoom);
     private synchronized native boolean nativeScreenPositionToLngLat(long mapPtr, double[] coordinates);
     private synchronized native boolean nativeLngLatToScreenPosition(long mapPtr, double[] coordinates);
     private synchronized native void nativeSetPixelScale(long mapPtr, float scale);

--- a/platforms/ios/framework/src/TGMapView.h
+++ b/platforms/ios/framework/src/TGMapView.h
@@ -178,6 +178,16 @@ TG_EXPORT
 #pragma mark Camera Properties
 
 /**
+ TODO
+ */
+@property (assign, nonatomic) double minimumZoomLevel;
+
+/**
+ TODO
+ */
+@property (assign, nonatomic) double maximumZoomLevel;
+
+/**
  Assign a `TGCameraType` to the view camera
  */
 @property (assign, nonatomic) TGCameraType cameraType;

--- a/platforms/ios/framework/src/TGMapView.h
+++ b/platforms/ios/framework/src/TGMapView.h
@@ -178,14 +178,20 @@ TG_EXPORT
 #pragma mark Camera Properties
 
 /**
- TODO
+ The minimum zoom level for the map view.
+
+ The default minimum zoom is 0. Values less than the default will be clamped. Assigning a value greater than the current
+ maximum zoom will set the maximum zoom to this value.
  */
-@property (assign, nonatomic) double minimumZoomLevel;
+@property (assign, nonatomic) float minimumZoomLevel;
 
 /**
- TODO
+ The maximum zoom level for the map view.
+
+ The default maximum zoom is 20.5. Values greater than the default will be clamped. Assigning a value less than the
+ current minimum zoom will set the minimum zoom to this value.
  */
-@property (assign, nonatomic) double maximumZoomLevel;
+@property (assign, nonatomic) float maximumZoomLevel;
 
 /**
  Assign a `TGCameraType` to the view camera

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -702,6 +702,8 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 
 #pragma mark Camera Properties
 
+
+
 - (void)setPosition:(TGGeoPoint)position {
     if (!self.map) { return; }
 

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -702,7 +702,29 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 
 #pragma mark Camera Properties
 
+- (float)minimumZoomLevel
+{
+    if (!self.map) { return 0; }
+    return self.map->getMinZoom();
+}
 
+- (void)setMinimumZoomLevel:(float)minimumZoomLevel
+{
+    if (!self.map) { return; }
+    self.map->setMinZoom(minimumZoomLevel);
+}
+
+- (float)maximumZoomLevel
+{
+    if (!self.map) { return 0; }
+    return self.map->getMaxZoom();
+}
+
+- (void)setMaximumZoomLevel:(float)maximumZoomLevel
+{
+    if (!self.map) { return; }
+    self.map->setMaxZoom(maximumZoomLevel);
+}
 
 - (void)setPosition:(TGGeoPoint)position {
     if (!self.map) { return; }


### PR DESCRIPTION
- Adds configurable minimum and maximum zoom levels in core, iOS, and Android
- Zoom limits are clamped to the default range of 0 to 20.5, inclusive
- If you assign a min zoom _greater than_ the max zoom or a max zoom _less than_ the min zoom, the zoom limits become equal