### PR TITLE
lngLatToScreenPosition can return out-of-view positions

### DIFF
--- a/platforms/ios/framework/src/TGMapView.h
+++ b/platforms/ios/framework/src/TGMapView.h
@@ -276,8 +276,8 @@ TG_EXPORT
 /**
  Convert a longitude and latitude to a view position.
 
- @param lngLat The geographic coordinate to convert.
- @return The view position of the input coordinate, or `(NAN, NAN)` if the coordinate is not visible in the view.
+ @param lngLat The geographic coordinate to convert
+ @return The view position of the input coordinate
  */
 - (CGPoint)lngLatToScreenPosition:(TGGeoPoint)lngLat;
 
@@ -286,7 +286,7 @@ TG_EXPORT
  location corresponding to that point.
 
  @param viewPosition the 2d screen position to convert
- @return the longitude and latitude, or `(NAN, NAN)` if the point is not visible on the screen.
+ @return the longitude and latitude
  */
 - (TGGeoPoint)screenPositionToLngLat:(CGPoint)viewPosition;
 

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -546,28 +546,19 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 
 - (CGPoint)lngLatToScreenPosition:(TGGeoPoint)lngLat
 {
-    static const CGPoint nullCGPoint = {(CGFloat)NAN, (CGFloat)NAN};
-
-    if (!self.map) { return nullCGPoint; }
+    if (!self.map) { return CGPointZero; }
 
     double screenPosition[2];
-    if (self.map->lngLatToScreenPosition(lngLat.longitude, lngLat.latitude,
-        &screenPosition[0], &screenPosition[1])) {
+    self.map->lngLatToScreenPosition(lngLat.longitude, lngLat.latitude, &screenPosition[0], &screenPosition[1]);
+    screenPosition[0] /= self.contentScaleFactor;
+    screenPosition[1] /= self.contentScaleFactor;
 
-        screenPosition[0] /= self.contentScaleFactor;
-        screenPosition[1] /= self.contentScaleFactor;
-
-        return CGPointMake((CGFloat)screenPosition[0], (CGFloat)screenPosition[1]);
-    }
-
-    return nullCGPoint;
+    return CGPointMake((CGFloat)screenPosition[0], (CGFloat)screenPosition[1]);
 }
 
 - (TGGeoPoint)screenPositionToLngLat:(CGPoint)screenPosition
 {
-    static const TGGeoPoint nullTangramGeoPoint = {NAN, NAN};
-
-    if (!self.map) { return nullTangramGeoPoint; }
+    if (!self.map) { return TGGeoPointMake(0, 0); }
 
     screenPosition.x *= self.contentScaleFactor;
     screenPosition.y *= self.contentScaleFactor;
@@ -578,7 +569,7 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
         return lngLat;
     }
 
-    return nullTangramGeoPoint;
+    return TGGeoPointMake(0, 0);
 }
 
 #pragma mark Picking Map Objects


### PR DESCRIPTION
This is more useful behavior than returning `NaN` to signal an out-of-view position. It's simple to check whether the screen position is within view bounds (`CGRectContainsPoint(view.bounds, point)`) and using `NaN` as a sentinel value is ambiguous (`NaN` could also be the result of an internal math error).