### PR TITLE
Treat warnings as errors in iOS projects

### DIFF
--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -97,6 +97,7 @@ set_target_properties(TangramMap PROPERTIES
   XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
   XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14"
   XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  XCODE_ATTRIBUTE_GCC_TREAT_WARNINGS_AS_ERRORS "YES"
 )
 
 ### Configure static library build target.
@@ -155,6 +156,7 @@ set_target_properties(tangram-static PROPERTIES
   XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
   XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14"
   XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  XCODE_ATTRIBUTE_GCC_TREAT_WARNINGS_AS_ERRORS "YES"
   # The Xcode settings below are to pre-link our static libraries into a single
   # archive. Xcode will take the objects from this target and from all of the
   # pre-link libraries, combine them, and resolve the symbols into one "master"

--- a/platforms/ios/demo/TangramDemo.xcodeproj/project.pbxproj
+++ b/platforms/ios/demo/TangramDemo.xcodeproj/project.pbxproj
@@ -383,6 +383,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -399,6 +400,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/platforms/ios/framework/src/TGMarker.mm
+++ b/platforms/ios/framework/src/TGMarker.mm
@@ -111,7 +111,7 @@
 
     auto polylineCoords = reinterpret_cast<Tangram::LngLat*>([polyline coordinates]);
 
-    if (!tangramInstance->markerSetPolyline(self.identifier, polylineCoords, polyline.count)) {
+    if (!tangramInstance->markerSetPolyline(self.identifier, polylineCoords, static_cast<int>(polyline.count))) {
         [self createNSError];
     }
 }
@@ -123,7 +123,7 @@
 
     auto polygonCoords = reinterpret_cast<Tangram::LngLat*>([polygon coordinates]);
 
-    if (!tangramInstance->markerSetPolygon(self.identifier, polygonCoords, [polygon rings], [polygon ringsCount])) {
+    if (!tangramInstance->markerSetPolygon(self.identifier, polygonCoords, [polygon rings], static_cast<int>([polygon ringsCount]))) {
         [self createNSError];
     }
 }
@@ -186,7 +186,7 @@
         }
     }
 
-    if (!tangramInstance->markerSetBitmap(self.identifier, w, h, bitmap.data())) {
+    if (!tangramInstance->markerSetBitmap(self.identifier, static_cast<int>(w), static_cast<int>(h), bitmap.data())) {
         [self createNSError];
     }
 }


### PR DESCRIPTION
This should catch problems like the missing method implementation that I just had to fix, as well as other potential bugs.

This only applies to the Tangram iOS framework and iOS demo projects, not the core library. The core library produces many warnings right now (mostly about integer precision loss) and I didn't want to tackle all of those at once.