### PR TITLE
Simplified antimeridian wrapping

### DIFF
--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -73,7 +73,7 @@ struct TestContext {
     }
 
     void parseTile() {
-        Tile tile({0,0,10,10,0}, s_projection);
+        Tile tile({0,0,10,10}, s_projection);
         source = *scene->tileSources().begin();
         auto task = source->createTask(tile.getID());
         auto& t = dynamic_cast<BinaryTileTask&>(*task);
@@ -105,7 +105,7 @@ BENCHMARK_DEFINE_F(TileLoadingFixture, BuildTest)(benchmark::State& st) {
         ctx.parseTile();
         if (!ctx.tileData) { break; }
 
-        result = ctx.tileBuilder->build({0,0,10,10,0}, *ctx.tileData, *ctx.source);
+        result = ctx.tileBuilder->build({0,0,10,10}, *ctx.tileData, *ctx.source);
 
         LOG("ok %d / bytes - %d", bool(result), result->getMemoryUsage());
     }

--- a/core/include/tangram/tile/tileID.h
+++ b/core/include/tangram/tile/tileID.h
@@ -20,21 +20,20 @@ struct TileID {
     int32_t y; // Index from top edge of projection space
     int8_t  z; // Data zoom
     int8_t  s; // Styling zoom
-    int16_t wrap;
 
-    TileID(int32_t _x, int32_t _y, int32_t _z, int32_t _s, int32_t _wrap) : x(_x), y(_y), z(_z), s(_s), wrap(_wrap) {}
+    TileID(int32_t _x, int32_t _y, int32_t _z, int32_t _s) : x(_x), y(_y), z(_z), s(_s) {}
 
-    TileID(int32_t _x, int32_t _y, int32_t _z) : TileID(_x, _y, _z, _z, 0) {}
+    TileID(int32_t _x, int32_t _y, int32_t _z) : TileID(_x, _y, _z, _z) {}
 
     TileID(const TileID& _rhs) = default;
 
     bool operator< (const TileID& _rhs) const {
-        return s > _rhs.s || (s == _rhs.s && (z > _rhs.z || (z == _rhs.z && (x < _rhs.x || (x == _rhs.x && (y < _rhs.y || (y == _rhs.y && wrap < _rhs.wrap)))))));
+        return s > _rhs.s || (s == _rhs.s && (z > _rhs.z || (z == _rhs.z && (x < _rhs.x || (x == _rhs.x && (y < _rhs.y))))));
     }
     bool operator> (const TileID& _rhs) const { return _rhs < const_cast<TileID&>(*this); }
     bool operator<=(const TileID& _rhs) const { return !(*this > _rhs); }
     bool operator>=(const TileID& _rhs) const { return !(*this < _rhs); }
-    bool operator==(const TileID& _rhs) const { return x == _rhs.x && y == _rhs.y && z == _rhs.z && s == _rhs.s && wrap == _rhs.wrap; }
+    bool operator==(const TileID& _rhs) const { return x == _rhs.x && y == _rhs.y && z == _rhs.z && s == _rhs.s; }
     bool operator!=(const TileID& _rhs) const { return !(*this == _rhs); }
 
     bool isValid() const {
@@ -54,7 +53,7 @@ struct TileID {
 
         int32_t over = z - _maxZoom;
 
-        return TileID(x >> over, y >> over, _maxZoom, s, wrap);
+        return TileID(x >> over, y >> over, _maxZoom, s);
     }
 
     TileID zoomBiasAdjusted(int32_t _zoomBias) const {
@@ -63,20 +62,20 @@ struct TileID {
         if (!_zoomBias) { return *this; }
 
         auto scaledZ = std::max(0, z - _zoomBias);
-        return TileID(x >> _zoomBias, y >> _zoomBias, scaledZ, z, wrap);
+        return TileID(x >> _zoomBias, y >> _zoomBias, scaledZ, z);
     }
 
     TileID getParent(int32_t _zoomBias = 0) const {
         if (s > (z + _zoomBias)) {
             // Over-zoomed, keep the same data coordinates
-            return TileID(x, y, z, s - 1, wrap);
+            return TileID(x, y, z, s - 1);
         }
-        return TileID(x >> 1, y >> 1, z - 1, s - 1, wrap);
+        return TileID(x >> 1, y >> 1, z - 1, s - 1);
     }
 
     TileID getChild(int32_t _index, int32_t _maxZoom) const {
         if (_index > 3 || _index < 0) {
-            return TileID(-1, -1, -1, -1, -1);
+            return TileID(-1, -1, -1, -1);
         }
 
         int i = _index / 2;
@@ -86,7 +85,7 @@ struct TileID {
         // i:      0, 0, 1, 1
         // j:      0, 1, 0, 1
 
-        auto childID = TileID((x<<1)+i, (y<<1)+j, z + 1, s + 1, wrap);
+        auto childID = TileID((x<<1)+i, (y<<1)+j, z + 1, s + 1);
         return childID.withMaxSourceZoom(_maxZoom);
     }
 
@@ -96,6 +95,6 @@ struct TileID {
 
 };
 
-static const TileID NOT_A_TILE(-1, -1, -1, -1, -1);
+static const TileID NOT_A_TILE(-1, -1, -1, -1);
 
 }

--- a/core/src/debug/frameInfo.cpp
+++ b/core/src/debug/frameInfo.cpp
@@ -123,6 +123,8 @@ void FrameInfo::draw(RenderState& rs, const View& _view, TileManager& _tileManag
             debuginfos.push_back("zoom:" + std::to_string(_view.getZoom()));
             debuginfos.push_back("pos:" + std::to_string(_view.getPosition().x) + "/"
                                  + std::to_string(_view.getPosition().y));
+            auto center = _view.getCenterCoordinates();
+            debuginfos.push_back("LngLat:" + std::to_string(center.longitude) + ", " + std::to_string(center.latitude));
             debuginfos.push_back("tilt:" + std::to_string(_view.getPitch() * 57.3) + "deg");
             debuginfos.push_back("pixel scale:" + std::to_string(_view.pixelScale()));
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -161,8 +161,8 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
     }
 
     if (scene->useScenePosition) {
-        glm::dvec2 projPos = view.getMapProjection().LonLatToMeters(scene->startPosition);
-        view.setPosition(projPos.x, projPos.y);
+        auto position = scene->startPosition;
+        view.setCenterCoordinates({position.x, position.y});
         view.setZoom(scene->startZoom);
     }
 
@@ -611,8 +611,7 @@ void Map::cancelCameraAnimation() {
 void Map::setCameraPosition(const CameraPosition& _camera) {
     cancelCameraAnimation();
 
-    glm::dvec2 meters = impl->view.getMapProjection().LonLatToMeters({ _camera.longitude, _camera.latitude});
-    impl->view.setPosition(meters.x, meters.y);
+    impl->view.setCenterCoordinates(LngLat(_camera.longitude, _camera.latitude));
     impl->view.setZoom(_camera.zoom);
     impl->view.setRoll(_camera.rotation);
     impl->view.setPitch(_camera.tilt);
@@ -720,10 +719,9 @@ void Map::setPosition(double _lon, double _lat) {
 }
 
 void Map::getPosition(double& _lon, double& _lat) {
-    glm::dvec2 meters(impl->view.getPosition().x, impl->view.getPosition().y);
-    glm::dvec2 degrees = impl->view.getMapProjection().MetersToLonLat(meters);
-    _lon = LngLat::wrapLongitude(degrees.x);
-    _lat = degrees.y;
+    LngLat degrees = impl->view.getCenterCoordinates();
+    _lon = degrees.longitude;
+    _lat = degrees.latitude;
 }
 
 void Map::setZoom(float _z) {

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -84,9 +84,6 @@ public:
     /* Update the Tile considering the current view */
     void update(float _dt, const View& _view);
 
-    /* Update tile origin based on wraping for this tile */
-    void updateTileOrigin(const int _wrap);
-
     void resetState();
 
     /* Get the sum in bytes of static <Mesh>es */

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -521,11 +521,7 @@ bool TileManager::addTile(TileSet& _tileSet, const TileID& _tileID) {
         if (tile->sourceGeneration() == _tileSet.source->generation()) {
             m_tiles.push_back(tile);
 
-            // Update tile origin based on wrap (set in the new tileID)
-            tile->updateTileOrigin(_tileID.wrap);
-
             // Reset tile on potential internal dynamic data set
-            // TODO rename to resetState() to avoid ambiguity
             tile->resetState();
         } else {
             // Clear stale tile data

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -2,6 +2,7 @@
 
 #include "tile/tileID.h"
 #include "util/mapProjection.h"
+#include "util/types.h"
 #include "view/viewConstraint.h"
 
 #include "glm/mat4x4.hpp"
@@ -115,6 +116,8 @@ public:
     void setPosition(const glm::dvec3 pos) { setPosition(pos.x, pos.y); }
     void setPosition(const glm::dvec2 pos) { setPosition(pos.x, pos.y); }
 
+    void setCenterCoordinates(LngLat center);
+
     /* Sets the zoom level of the view */
     void setZoom(float _z);
 
@@ -150,6 +153,8 @@ public:
 
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
     const glm::dvec3& getPosition() const { return m_pos; }
+
+    LngLat getCenterCoordinates() const;
 
     /* Gets the transformation from global space into view (camera) space; Due to precision limits, this
        does not contain the translation of the view from the global origin (you must apply that separately) */

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -197,6 +197,10 @@ public:
     /* Gets the screen position from a latitude/longitude */
     glm::vec2 lonLatToScreenPosition(double lon, double lat, bool& clipped) const;
 
+    // For a position on the map in projected meters, this returns the displacement vector *from* the view *to* that
+    // position, accounting for wrapping around the 180th meridian to get the smallest magnitude displacement.
+    glm::dvec2 getRelativeMeters(glm::dvec2 projectedMeters) const;
+
     /* Returns the set of all tiles visible at the current position and zoom */
     void getVisibleTiles(const std::function<void(TileID)>& _tileCb) const;
 

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -260,66 +260,13 @@ void mouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
         // Single tap recognized
         Tangram::LngLat p;
         map->screenPositionToLngLat(x, y, &p.longitude, &p.latitude);
+        double xx, yy;
+        map->lngLatToScreenPosition(p.longitude, p.latitude, &xx, &yy);
 
-
-        if (!marker) {
-            marker = map->markerAdd();
-
-            map->markerSetStylingFromPath(marker, markerStylingPath.c_str());
-            map->markerSetPoint(marker, p);
-            map->markerSetDrawOrder(marker, mods);
-            logMsg("Added Marker with zOrder: %d\n", mods);
-        } else {
-            static bool visible = true;
-            map->markerSetPoint(marker, p);
-            map->markerSetVisible(marker, visible);
-            visible = !visible;
-        }
-
-        map->pickFeatureAt(x, y, [](const Tangram::FeaturePickResult* featurePickResult) {
-            if (!featurePickResult) { return; }
-            std::string name;
-            if (featurePickResult->properties->getString("name", name)) {
-                logMsg("Selected %s", name.c_str());
-            }
-        });
-
-        map->pickLabelAt(x, y, [&](const Tangram::LabelPickResult* labelPickResult) {
-            if (!labelPickResult) { return; }
-            std::string type = labelPickResult->type == Tangram::LabelType::text ? "text" : "icon";
-            std::string name;
-            if (labelPickResult->touchItem.properties->getString("name", name)) {
-                logMsg("Touched label %s %s", type.c_str(), name.c_str());
-            }
-            map->markerSetPoint(marker, labelPickResult->coordinates);
-            map->markerSetVisible(marker, true);
-        });
-
-        map->pickMarkerAt(x, y, [](const Tangram::MarkerPickResult* markerPickResult) {
-            if (!markerPickResult) { return; }
-            logMsg("Selected marker id %d", markerPickResult->id);
-        });
-
-        static double last_x = 0, last_y = 0;
-
-        if (!polyline) {
-            polyline = map->markerAdd();
-            map->markerSetStylingFromString(polyline, polylineStyle.c_str());
-        }
-
-        if (last_x != 0) {
-            Tangram::LngLat coords[2];
-            map->screenPositionToLngLat(x, y, &coords[0].longitude, &coords[0].latitude);
-            map->screenPositionToLngLat(last_x, last_y, &coords[1].longitude, &coords[1].latitude);
-
-            map->markerSetPolyline(polyline, coords, 2);
-            auto cam = map->getEnclosingCameraPosition(coords[0], coords[1], EdgePadding(200, 100, 200, 100));
-
-            map->setCameraPosition(cam);
-        }
-
-        last_x = x;
-        last_y = y;
+        logMsg("------\n");
+        logMsg("LngLat: %f, %f\n", p.longitude, p.latitude);
+        logMsg("Clicked:  %f, %f\n", x, y);
+        logMsg("Remapped: %f, %f\n", xx, yy);
 
         platform->requestRender();
     }

--- a/tests/unit/tileIDTests.cpp
+++ b/tests/unit/tileIDTests.cpp
@@ -81,25 +81,25 @@ TEST_CASE("TileID correctly applies source zoom limits", "[Core][TileID]") {
 
     auto a = TileID(1, 2, 4);
     REQUIRE(a.withMaxSourceZoom(4) == a);
-    REQUIRE(a.withMaxSourceZoom(3) == TileID(0, 1, 3, 4, 0));
-    REQUIRE(a.withMaxSourceZoom(2) == TileID(0, 0, 2, 4, 0));
+    REQUIRE(a.withMaxSourceZoom(3) == TileID(0, 1, 3, 4));
+    REQUIRE(a.withMaxSourceZoom(2) == TileID(0, 0, 2, 4));
 
-    auto b = TileID(2, 1, 4, 6, 0); // Over-zoomed to zoom 6 with a limit of 4
+    auto b = TileID(2, 1, 4, 6); // Over-zoomed to zoom 6 with a limit of 4
     auto c = b.getParent();
     auto d = c.getParent();
     auto e = d.getParent();
-    REQUIRE(c == TileID(2, 1, 4, 5, 0));
-    REQUIRE(d == TileID(2, 1, 4, 4, 0));
-    REQUIRE(e == TileID(1, 0, 3, 3, 0));
+    REQUIRE(c == TileID(2, 1, 4, 5));
+    REQUIRE(d == TileID(2, 1, 4, 4));
+    REQUIRE(e == TileID(1, 0, 3, 3));
 
     //Child tiles
-    auto f = TileID(2, 1, 4, 4, 0);
+    auto f = TileID(2, 1, 4, 4);
     auto g = f.getChild(0, 5);
     auto h = g.getChild(0, 5);
     auto i = h.getChild(0, 5);
-    REQUIRE(g == TileID(4, 2, 5, 5, 0));
-    REQUIRE(h == TileID(4, 2, 5, 6, 0));
-    REQUIRE(i == TileID(4, 2, 5, 7, 0));
+    REQUIRE(g == TileID(4, 2, 5, 5));
+    REQUIRE(h == TileID(4, 2, 5, 6));
+    REQUIRE(i == TileID(4, 2, 5, 7));
 }
 
 TEST_CASE("TileID correctly applies source zoom limits for scaled tiles", "[Core][TileID]") {
@@ -110,37 +110,37 @@ TEST_CASE("TileID correctly applies source zoom limits for scaled tiles", "[Core
     auto aScaledMax5 = aScaled.withMaxSourceZoom(5);
     auto aScaledMax4 = aScaled.withMaxSourceZoom(4);
 
-    REQUIRE(aScaled ==  TileID(4, 2, 5, 6, 0));
-    REQUIRE(aScaledMax5 == TileID(4, 2, 5, 6, 0));
-    REQUIRE(aScaledMax4 == TileID(2, 1, 4, 6, 0));
+    REQUIRE(aScaled ==  TileID(4, 2, 5, 6));
+    REQUIRE(aScaledMax5 == TileID(4, 2, 5, 6));
+    REQUIRE(aScaledMax4 == TileID(2, 1, 4, 6));
 
     auto b = aScaled.getParent(1);
     auto c = aScaledMax5.getParent(1);
     auto d = aScaledMax4.getParent(1);
-    REQUIRE(b == TileID(2, 1, 4, 5, 0));
-    REQUIRE(c == TileID(2, 1, 4, 5, 0));
-    REQUIRE(d == TileID(2, 1, 4, 5, 0));
+    REQUIRE(b == TileID(2, 1, 4, 5));
+    REQUIRE(c == TileID(2, 1, 4, 5));
+    REQUIRE(d == TileID(2, 1, 4, 5));
 
     auto e = b.getParent(1); // grand parent of original aScaled tile
     auto f = e.getParent(1); // grand grand
     auto g = f.getParent(1); // grand grand grand
-    REQUIRE(e == TileID(1, 0, 3, 4, 0));
-    REQUIRE(f == TileID(0, 0, 2, 3, 0));
-    REQUIRE(g == TileID(0, 0, 1, 2, 0));
+    REQUIRE(e == TileID(1, 0, 3, 4));
+    REQUIRE(f == TileID(0, 0, 2, 3));
+    REQUIRE(g == TileID(0, 0, 1, 2));
 
     // child tiles
     b = aScaled.getChild(0, 6);
     c = aScaledMax5.getChild(0, 5);
     d = aScaledMax4.getChild(0, 4);
-    REQUIRE(b == TileID(8, 4, 6, 7, 0));
-    REQUIRE(c == TileID(4, 2, 5, 7, 0));
-    REQUIRE(d == TileID(2, 1, 4, 7, 0));
+    REQUIRE(b == TileID(8, 4, 6, 7));
+    REQUIRE(c == TileID(4, 2, 5, 7));
+    REQUIRE(d == TileID(2, 1, 4, 7));
 
     e = b.getChild(0, 6);
     f = e.getChild(0, 6);
     g = f.getChild(0, 6);
-    REQUIRE(e == TileID(8, 4, 6, 8, 0));
-    REQUIRE(f == TileID(8, 4, 6, 9, 0));
-    REQUIRE(g == TileID(8, 4, 6, 10, 0));
+    REQUIRE(e == TileID(8, 4, 6, 8));
+    REQUIRE(f == TileID(8, 4, 6, 9));
+    REQUIRE(g == TileID(8, 4, 6, 10));
 
 }


### PR DESCRIPTION
This is a new way of handling the map looping past 180° longitude. Rather than creating distinct tile addresses for the areas past the 180th meridian, we now use the same tile addresses and translate them to the appropriate location when area is visible past the 180th meridian. The view position is now kept within the canonical longitude range as well. Converting from LngLat to screen position also accounts for this behavior now, so that converting from screen position to LngLat and then back to screen position always produces the original value (this was not true before).