### PR TITLE
Instantiate MapController asyncly

### DIFF
--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -9,7 +9,6 @@ import android.view.Window;
 import android.widget.Toast;
 
 import com.mapzen.tangram.CameraPosition;
-import com.mapzen.tangram.CameraUpdate;
 import com.mapzen.tangram.CameraUpdateFactory;
 import com.mapzen.tangram.LabelPickResult;
 import com.mapzen.tangram.LngLat;
@@ -71,7 +70,7 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
     PresetSelectionTextView sceneSelector;
 
     String pointStylingPath = "layers.touch.point.draw.icons";
-    ArrayList<Marker> pointMarkers = new ArrayList<Marker>();
+    ArrayList<Marker> pointMarkers = new ArrayList<>();
 
     boolean showTileInfo = false;
 

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -44,7 +44,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 
 public class MainActivity extends AppCompatActivity implements MapController.SceneLoadListener, TapResponder,
-        DoubleTapResponder, LongPressResponder, FeaturePickListener, LabelPickListener, MarkerPickListener {
+        DoubleTapResponder, LongPressResponder, FeaturePickListener, LabelPickListener, MarkerPickListener,
+        MapView.MapReadyCallback {
 
     private static final String NEXTZEN_API_KEY = BuildConfig.NEXTZEN_API_KEY;
 
@@ -112,9 +113,14 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
         // The AutoCompleteTextView preserves its contents from previous instances, so if a URL was
         // set previously we want to apply it again. The text is restored in onRestoreInstanceState,
         // which occurs after onCreate and onStart, but before onPostCreate, so we get the URL here.
-        String sceneUrl = sceneSelector.getCurrentString();
 
-        map = view.getMap(this, getHttpHandler());
+        view.getMapAsync(this, this, getHttpHandler());
+    }
+
+    @Override
+    public void onMapReady(MapController mapController) {
+        map = mapController;
+        String sceneUrl = sceneSelector.getCurrentString();
         map.loadSceneFile(sceneUrl, sceneUpdates);
         map.updateCameraPosition(CameraUpdateFactory.newLngLatZoom(new LngLat(-74.00976419448854, 40.70532700869127), 16));
         map.setTapResponder(this);

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -2,6 +2,7 @@ package com.mapzen.tangram.android;
 
 import android.graphics.PointF;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Window;
@@ -109,7 +110,10 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
     }
 
     @Override
-    public void onMapReady(MapController mapController) {
+    public void onMapReady(@Nullable MapController mapController) {
+        if (mapController == null) {
+            return;
+        }
         map = mapController;
         String sceneUrl = sceneSelector.getCurrentString();
         map.setSceneLoadListener(this);

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -105,22 +105,14 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
 
         // Grab a reference to our map view.
         view = (MapView)findViewById(R.id.map);
-    }
-
-    @Override
-    public void onPostCreate(Bundle savedInstanceState) {
-        super.onPostCreate(savedInstanceState);
-        // The AutoCompleteTextView preserves its contents from previous instances, so if a URL was
-        // set previously we want to apply it again. The text is restored in onRestoreInstanceState,
-        // which occurs after onCreate and onStart, but before onPostCreate, so we get the URL here.
-
-        view.getMapAsync(this, this, getHttpHandler());
+        view.getMapAsync(this, getHttpHandler());
     }
 
     @Override
     public void onMapReady(MapController mapController) {
         map = mapController;
         String sceneUrl = sceneSelector.getCurrentString();
+        map.setSceneLoadListener(this);
         map.loadSceneFile(sceneUrl, sceneUpdates);
         map.updateCameraPosition(CameraUpdateFactory.newLngLatZoom(new LngLat(-74.00976419448854, 40.70532700869127), 16));
         map.setTapResponder(this);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1313,11 +1313,6 @@ public class MapController implements Renderer {
     // Native methods
     // ==============
 
-    static {
-        System.loadLibrary("c++_shared");
-        System.loadLibrary("tangram");
-    }
-
     private synchronized native void nativeOnLowMemory(long mapPtr);
     private synchronized native long nativeInit(MapController instance, AssetManager assetManager);
     private synchronized native void nativeDispose(long mapPtr);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -254,7 +254,7 @@ public class MapController implements Renderer {
      * Responsible to configure {@link MapController} configuration on the ui thread.
      * Must be called from the ui thread post instantiation of {@link MapController}
      */
-    void postInit() {
+    void UIThreadInit() {
         // Set up MapView
         mapView.setRenderer(this);
         mapView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -225,11 +225,7 @@ public class MapController implements Renderer {
         }
         markers = new LongSparseArray<>();
 
-        // Set up MapView
         mapView = view;
-        view.setRenderer(this);
-        view.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
-        view.setPreserveEGLContextOnPause(true);
     }
 
     /**
@@ -268,6 +264,11 @@ public class MapController implements Renderer {
      * Must be called from the ui thread post instantiation of {@link MapController}
      */
     void postInit() {
+        // Set up MapView
+        mapView.setRenderer(this);
+        mapView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
+        mapView.setPreserveEGLContextOnPause(true);
+
         touchInput = new TouchInput(mapView.getContext());
         mapView.setOnTouchListener(touchInput);
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -217,7 +217,8 @@ public class MapController implements Renderer {
      * bundle for this activity must contain all the local files that the map
      * will need.
      */
-    protected MapController(@NonNull final GLSurfaceView view) {
+    protected MapController(@NonNull final GLSurfaceView view, @NonNull final Context context,
+                            @Nullable final HttpHandler handler) {
         if (Build.VERSION.SDK_INT > 18) {
             clientTileSources = new ArrayMap<>();
         } else {
@@ -226,17 +227,7 @@ public class MapController implements Renderer {
         markers = new LongSparseArray<>();
 
         mapView = view;
-    }
 
-    /**
-     * Initialize native Tangram component. This must be called before any use
-     * of the MapController!
-     * This function is separated from MapController constructor to allow usage of underlying GLSurfaceView
-     * context on a non-ui thread
-     * @param context Context from underlying GLSurfaceView
-     * @param handler {@link HttpHandler} to use for retrieving remote map resources
-     */
-    void init(@NonNull final Context context, @Nullable final HttpHandler handler) {
         // Get configuration info from application
         displayMetrics = context.getResources().getDisplayMetrics();
         assetManager = context.getAssets();

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1,5 +1,6 @@
 package com.mapzen.tangram;
 
+import android.content.Context;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.PointF;
@@ -229,22 +230,6 @@ public class MapController implements Renderer {
         view.setRenderer(this);
         view.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
         view.setPreserveEGLContextOnPause(true);
-
-        touchInput = new TouchInput(view.getContext());
-        view.setOnTouchListener(touchInput);
-
-        setPanResponder(null);
-        setScaleResponder(null);
-        setRotateResponder(null);
-        setShoveResponder(null);
-
-        touchInput.setSimultaneousDetectionAllowed(Gestures.SHOVE, Gestures.ROTATE, false);
-        touchInput.setSimultaneousDetectionAllowed(Gestures.ROTATE, Gestures.SHOVE, false);
-        touchInput.setSimultaneousDetectionAllowed(Gestures.SHOVE, Gestures.SCALE, false);
-        touchInput.setSimultaneousDetectionAllowed(Gestures.SHOVE, Gestures.PAN, false);
-        touchInput.setSimultaneousDetectionAllowed(Gestures.SCALE, Gestures.LONG_PRESS, false);
-
-        uiThreadHandler = new Handler(view.getContext().getMainLooper());
     }
 
     /**
@@ -254,10 +239,10 @@ public class MapController implements Renderer {
      * initialization and loading of the Scene on a background thread.
      * @param handler {@link HttpHandler} to use for retrieving remote map resources
      */
-    void init(@Nullable final HttpHandler handler) {
+    void init(@NonNull final Context context, @Nullable final HttpHandler handler) {
         // Get configuration info from application
-        displayMetrics = mapView.getContext().getResources().getDisplayMetrics();
-        assetManager = mapView.getContext().getAssets();
+        displayMetrics = context.getResources().getDisplayMetrics();
+        assetManager = context.getAssets();
 
         fontFileParser = new FontFileParser();
 
@@ -275,6 +260,24 @@ public class MapController implements Renderer {
         if (mapPointer <= 0) {
             throw new RuntimeException("Unable to create a native Map object! There may be insufficient memory available.");
         }
+    }
+
+    void postInit() {
+        touchInput = new TouchInput(mapView.getContext());
+        mapView.setOnTouchListener(touchInput);
+
+        setPanResponder(null);
+        setScaleResponder(null);
+        setRotateResponder(null);
+        setShoveResponder(null);
+
+        touchInput.setSimultaneousDetectionAllowed(Gestures.SHOVE, Gestures.ROTATE, false);
+        touchInput.setSimultaneousDetectionAllowed(Gestures.ROTATE, Gestures.SHOVE, false);
+        touchInput.setSimultaneousDetectionAllowed(Gestures.SHOVE, Gestures.SCALE, false);
+        touchInput.setSimultaneousDetectionAllowed(Gestures.SHOVE, Gestures.PAN, false);
+        touchInput.setSimultaneousDetectionAllowed(Gestures.SCALE, Gestures.LONG_PRESS, false);
+
+        uiThreadHandler = new Handler(mapView.getContext().getMainLooper());
     }
 
     void dispose() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -216,6 +216,8 @@ public class MapController implements Renderer {
      * It also provides the Context in which the map will function; the asset
      * bundle for this activity must contain all the local files that the map
      * will need.
+     * @param context glsurfaceview's context used in the background thread for initialization
+     * @param handler {@link HttpHandler} to initialize httpHandler for network handling
      */
     protected MapController(@NonNull final GLSurfaceView view, @NonNull final Context context,
                             @Nullable final HttpHandler handler) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -216,11 +216,9 @@ public class MapController implements Renderer {
      * It also provides the Context in which the map will function; the asset
      * bundle for this activity must contain all the local files that the map
      * will need.
-     * @param context glsurfaceview's context used in the background thread for initialization
      * @param handler {@link HttpHandler} to initialize httpHandler for network handling
      */
-    protected MapController(@NonNull final GLSurfaceView view, @NonNull final Context context,
-                            @Nullable final HttpHandler handler) {
+    protected MapController(@NonNull final GLSurfaceView view, @Nullable final HttpHandler handler) {
         if (Build.VERSION.SDK_INT > 18) {
             clientTileSources = new ArrayMap<>();
         } else {
@@ -231,8 +229,8 @@ public class MapController implements Renderer {
         mapView = view;
 
         // Get configuration info from application
-        displayMetrics = context.getResources().getDisplayMetrics();
-        assetManager = context.getAssets();
+        displayMetrics = mapView.getContext().getResources().getDisplayMetrics();
+        assetManager = mapView.getContext().getAssets();
 
         fontFileParser = new FontFileParser();
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -235,8 +235,9 @@ public class MapController implements Renderer {
     /**
      * Initialize native Tangram component. This must be called before any use
      * of the MapController!
-     * This function is separated from MapController constructor to allow
-     * initialization and loading of the Scene on a background thread.
+     * This function is separated from MapController constructor to allow usage of underlying GLSurfaceView
+     * context on a non-ui thread
+     * @param context Context from underlying GLSurfaceView
      * @param handler {@link HttpHandler} to use for retrieving remote map resources
      */
     void init(@NonNull final Context context, @Nullable final HttpHandler handler) {
@@ -262,6 +263,10 @@ public class MapController implements Renderer {
         }
     }
 
+    /**
+     * Responsible to configure {@link MapController} configuration on the ui thread.
+     * Must be called from the ui thread post instantiation of {@link MapController}
+     */
     void postInit() {
         touchInput = new TouchInput(mapView.getContext());
         mapView.setOnTouchListener(touchInput);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -77,8 +77,7 @@ public class MapView extends FrameLayout {
                         return mapController;
                     }
                 }
-                MapController controller = getMapInstance();
-                controller.init(ctx, handler);
+                MapController controller = getMapInstance(ctx, handler);
 
                 return controller;
             }
@@ -105,8 +104,8 @@ public class MapView extends FrameLayout {
     }
 
     @NonNull
-    protected MapController getMapInstance() {
-        return new MapController(glSurfaceView);
+    protected MapController getMapInstance(@NonNull final Context context, @Nullable final HttpHandler handler) {
+        return new MapController(glSurfaceView, context, handler);
     }
 
     protected void configureGLSurfaceView() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -56,19 +56,26 @@ public class MapView extends FrameLayout {
         @Override
         protected MapController doInBackground(Void... voids) {
             MapView view = mapViewRef.get();
+            if (view == null) {
+                return null;
+            }
             return view.mapInitInBackground(httpHandler);
         }
 
         @Override
         protected void onPostExecute(MapController controller) {
             MapView view = mapViewRef.get();
-            view.onMapInitOnUIThread(controller, mapReadyCallback);
+            if (view != null) {
+                view.onMapInitOnUIThread(controller, mapReadyCallback);
+            }
         }
 
         @Override
         protected void onCancelled(MapController controller) {
             MapView view = mapViewRef.get();
-            view.onMapInitCancelled(controller);
+            if (view != null) {
+                view.onMapInitCancelled(controller);
+            }
         }
     }
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -112,39 +112,6 @@ public class MapView extends FrameLayout {
 
     }
 
-    /**
-     * Construct a {@code MapController}; may only be called from the UI thread
-     * Map instance uses {@link DefaultHttpHandler} for retrieving remote map resources
-     * @param listener The listener to receive to receive scene load events;
-     * the callback will be made on the UI thread
-     */
-    @NonNull
-    public MapController getMap(@Nullable final MapController.SceneLoadListener listener) {
-        return getMap(listener, null);
-    }
-
-    /**
-     * Construct a {@code MapController}; may only be called from the UI thread
-     * @param listener The listener to receive to receive scene load events;
-     * @param handler Set the client implemented {@link HttpHandler} for retrieving remote map resources
-     *                when null {@link DefaultHttpHandler} is used
-     * the callback will be made on the UI thread
-     */
-    @NonNull
-    public MapController getMap(@Nullable final MapController.SceneLoadListener listener, @Nullable final HttpHandler handler) {
-        disposeMapReadyTask();
-        if (mapController != null) {
-            return mapController;
-        }
-        mapController = getMapInstance();
-
-        mapController.setSceneLoadListener(listener);
-        mapController.init(glSurfaceView.getContext(), handler);
-        mapController.postInit();
-
-        return mapController;
-    }
-
     @NonNull
     protected MapController getMapInstance() {
         return new MapController(glSurfaceView);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -100,7 +100,7 @@ public class MapView extends FrameLayout {
             if (mapController == null) {
                 mapController = controller;
                 configureGLSurfaceView();
-                mapController.postInit();
+                mapController.UIThreadInit();
             }
             if (callback != null) {
                 callback.onMapReady(mapController);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -21,6 +21,10 @@ public class MapView extends FrameLayout {
     protected MapController mapController;
     protected AsyncTask<Void, Void, MapController> getMapAsyncTask;
 
+    /**
+     * MapReadyCallback interface
+     * onMapReady gets invoked on the ui thread when {@link MapController} is instantiated and ready to be used
+     */
     public interface MapReadyCallback {
         void onMapReady(MapController mapController);
     }
@@ -35,15 +39,38 @@ public class MapView extends FrameLayout {
         configureGLSurfaceView();
     }
 
+    /**
+     * Construct a {@code MapController} in an async thread; may only be called from the UI thread
+     * Map instance uses {@link DefaultHttpHandler} for retrieving remote map resources
+     * @param readyCallback {@link MapReadyCallback#onMapReady(MapController)} to be invoked when
+     * {@link MapController} is instantiated and ready to be used. The callback will be made on the UI thread
+     */
     public void getMapAsync(@Nullable final MapReadyCallback readyCallback) {
         getMapAsync(readyCallback, null, null);
     }
 
+    /**
+     * Construct a {@code MapController} in an async thread; may only be called from the UI thread
+     * Map instance uses {@link DefaultHttpHandler} for retrieving remote map resources
+     * @param readyCallback {@link MapReadyCallback#onMapReady(MapController)} to be invoked when
+     * {@link MapController} is instantiated and ready to be used. The callback will be made on the UI thread
+     * @param sceneLoadListener The listener to receive to receive scene load events;
+     * the callback will be made on the UI thread
+     */
     public void getMapAsync(@Nullable final MapReadyCallback readyCallback,
                             @Nullable final MapController.SceneLoadListener sceneLoadListener) {
         getMapAsync(readyCallback, sceneLoadListener, null);
     }
 
+    /**
+     * Construct a {@code MapController} in an async thread; may only be called from the UI thread
+     * Map instance uses {@link DefaultHttpHandler} for retrieving remote map resources
+     * @param readyCallback {@link MapReadyCallback#onMapReady(MapController)} to be invoked when
+     * {@link MapController} is instantiated and ready to be used. The callback will be made on the UI thread
+     * @param sceneLoadListener The listener to receive to receive scene load events;
+     * @param handler Set the client implemented {@link HttpHandler} for retrieving remote map resources
+     *                when null {@link DefaultHttpHandler} is used
+     */
     public void getMapAsync(@Nullable final MapReadyCallback readyCallback,
                             @Nullable final MapController.SceneLoadListener sceneLoadListener,
                             @Nullable final HttpHandler handler) {
@@ -131,6 +158,9 @@ public class MapView extends FrameLayout {
         addView(glSurfaceView);
     }
 
+    /**
+     * Responsible to dispose any getMapReadyTask
+     */
     protected void disposeMapReadyTask() {
         if (getMapAsyncTask != null) {
             getMapAsyncTask.cancel(true);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -47,7 +47,7 @@ public class MapView extends FrameLayout {
 
         WeakReference<MapView> mapViewRef;
 
-        MapAsyncTask(@NonNull final MapView mapView, @Nullable final MapReadyCallback callback, @Nullable final HttpHandler handler) {
+        MapAsyncTask(@NonNull final MapView mapView, @NonNull final MapReadyCallback callback, @Nullable final HttpHandler handler) {
             mapViewRef = new WeakReference<>(mapView);
             httpHandler = handler;
             mapReadyCallback = callback;
@@ -102,16 +102,14 @@ public class MapView extends FrameLayout {
      * @param controller {@link MapController} created in a background thread
      * @param callback {@link MapReadyCallback}
      */
-    protected void onMapInitOnUIThread(@Nullable final MapController controller, @Nullable final MapReadyCallback callback) {
+    protected void onMapInitOnUIThread(@Nullable final MapController controller, @NonNull final MapReadyCallback callback) {
         synchronized (lock) {
             if (mapController == null && controller != null) {
                 mapController = controller;
                 configureGLSurfaceView();
                 mapController.UIThreadInit();
             }
-            if (callback != null) {
-                callback.onMapReady(mapController);
-            }
+            callback.onMapReady(mapController);
         }
     }
 
@@ -133,7 +131,7 @@ public class MapView extends FrameLayout {
      * @param handler Set the client implemented {@link HttpHandler} for retrieving remote map resources
      *                when null {@link DefaultHttpHandler} is used
      */
-    protected void executeMapAsyncTask(@Nullable final MapReadyCallback callback, @Nullable final HttpHandler handler) {
+    protected void executeMapAsyncTask(@NonNull final MapReadyCallback callback, @Nullable final HttpHandler handler) {
         getMapAsyncTask = new MapAsyncTask(this, callback, handler);
         getMapAsyncTask.execute();
     }
@@ -156,7 +154,7 @@ public class MapView extends FrameLayout {
      * {@link MapController} is instantiated and ready to be used. The callback will be made on the UI thread
      * the callback will be made on the UI thread
      */
-    public void getMapAsync(@Nullable final MapReadyCallback readyCallback) {
+    public void getMapAsync(@NonNull final MapReadyCallback readyCallback) {
         getMapAsync(readyCallback, null);
     }
 
@@ -168,7 +166,7 @@ public class MapView extends FrameLayout {
      * @param handler Set the client implemented {@link HttpHandler} for retrieving remote map resources
      *                when null {@link DefaultHttpHandler} is used
      */
-    public void getMapAsync(@Nullable final MapReadyCallback readyCallback,
+    public void getMapAsync(@NonNull final MapReadyCallback readyCallback,
                             @Nullable final HttpHandler handler) {
 
         disposeMapReadyTask();

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -90,8 +90,8 @@ public class MapView extends FrameLayout {
             if (mapController != null) {
                 return mapController;
             }
-            return getMapInstance(context, handler);
         }
+        return getMapInstance(context, handler);
     }
 
     /**

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -30,7 +30,7 @@ public class MapView extends FrameLayout {
      * onMapReady gets invoked on the ui thread when {@link MapController} is instantiated and ready to be used
      */
     public interface MapReadyCallback {
-        void onMapReady(MapController mapController);
+        void onMapReady(@Nullable MapController mapController);
     }
 
     public MapView(@NonNull final Context context) {
@@ -83,6 +83,10 @@ public class MapView extends FrameLayout {
      */
     protected MapController mapInitInBackground(@NonNull final Context context, @Nullable final HttpHandler handler) {
         synchronized (lock) {
+            if (NativeLibraryLoader.sNativeLibraryLoaded == false) {
+                android.util.Log.e("Tangram", "Unable to initialize MapController, because failed to initialize native libraries");
+                return null;
+            }
             if (mapController != null) {
                 return mapController;
             }
@@ -95,9 +99,9 @@ public class MapView extends FrameLayout {
      * @param controller {@link MapController} created in a background thread
      * @param callback {@link MapReadyCallback}
      */
-    protected void onMapInitOnUIThread(@NonNull final MapController controller, @Nullable final MapReadyCallback callback) {
+    protected void onMapInitOnUIThread(@Nullable final MapController controller, @Nullable final MapReadyCallback callback) {
         synchronized (lock) {
-            if (mapController == null) {
+            if (mapController == null && controller != null) {
                 mapController = controller;
                 configureGLSurfaceView();
                 mapController.UIThreadInit();
@@ -112,7 +116,7 @@ public class MapView extends FrameLayout {
      * To be executed by the async task implementation during cancellation of a mapInit task
      * @param controller {@link MapController} created by a background task which is no longer required
      */
-    protected void onMapInitCancelled(MapController controller) {
+    protected void onMapInitCancelled(@Nullable final MapController controller) {
         if (controller != null) {
             controller.dispose();
         }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -46,11 +46,9 @@ public class MapView extends FrameLayout {
         HttpHandler httpHandler;
 
         WeakReference<MapView> mapViewRef;
-        WeakReference<Context> contextRef;
 
         MapAsyncTask(@NonNull final MapView mapView, @Nullable final MapReadyCallback callback, @Nullable final HttpHandler handler) {
             mapViewRef = new WeakReference<>(mapView);
-            contextRef = new WeakReference<>(mapView.glSurfaceView.getContext());
             httpHandler = handler;
             mapReadyCallback = callback;
         }
@@ -58,8 +56,7 @@ public class MapView extends FrameLayout {
         @Override
         protected MapController doInBackground(Void... voids) {
             MapView view = mapViewRef.get();
-            Context ctx = contextRef.get();
-            return view.mapInitInBackground(ctx, httpHandler);
+            return view.mapInitInBackground(httpHandler);
         }
 
         @Override
@@ -77,11 +74,10 @@ public class MapView extends FrameLayout {
 
     /**
      * Responsible for doing the actual map init. Should be executed from a non-ui thread.
-     * @param context {@link GLSurfaceView} context used for MapController initialization
      * @param handler {@link HttpHandler} required for network handling
      * @return new or previously initialized {@link MapController}
      */
-    protected MapController mapInitInBackground(@NonNull final Context context, @Nullable final HttpHandler handler) {
+    protected MapController mapInitInBackground(@Nullable final HttpHandler handler) {
         synchronized (lock) {
             if (!NativeLibraryLoader.sNativeLibraryLoaded) {
                 android.util.Log.e("Tangram", "Unable to initialize MapController, because failed to initialize native libraries");
@@ -91,7 +87,7 @@ public class MapView extends FrameLayout {
                 return mapController;
             }
         }
-        return getMapInstance(context, handler);
+        return getMapInstance(handler);
     }
 
     /**
@@ -176,8 +172,8 @@ public class MapView extends FrameLayout {
     }
 
     @NonNull
-    protected MapController getMapInstance(@NonNull final Context context, @Nullable final HttpHandler handler) {
-        return new MapController(glSurfaceView, context, handler);
+    protected MapController getMapInstance(@Nullable final HttpHandler handler) {
+        return new MapController(glSurfaceView, handler);
     }
 
     protected void configureGLSurfaceView() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -83,7 +83,7 @@ public class MapView extends FrameLayout {
      */
     protected MapController mapInitInBackground(@NonNull final Context context, @Nullable final HttpHandler handler) {
         synchronized (lock) {
-            if (NativeLibraryLoader.sNativeLibraryLoaded == false) {
+            if (!NativeLibraryLoader.sNativeLibraryLoaded) {
                 android.util.Log.e("Tangram", "Unable to initialize MapController, because failed to initialize native libraries");
                 return null;
             }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeLibraryLoader.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeLibraryLoader.java
@@ -1,14 +1,14 @@
 package com.mapzen.tangram;
 
-public class NativeLibraryLoader {
-    public static final boolean sNativeLibraryLoaded = loadLibrary();
+class NativeLibraryLoader {
+    static final boolean sNativeLibraryLoaded = loadLibrary();
 
     private static synchronized boolean loadLibrary() {
         try {
             System.loadLibrary("c++_shared");
             System.loadLibrary("tangram");
             return true;
-        } catch (final Exception e) {
+        } catch (final SecurityException | UnsatisfiedLinkError | NullPointerException e) {
             android.util.Log.e("Tangram", "Failed to load native tangram libraries", e);
             return false;
         }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeLibraryLoader.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeLibraryLoader.java
@@ -1,0 +1,16 @@
+package com.mapzen.tangram;
+
+public class NativeLibraryLoader {
+    public static final boolean sNativeLibraryLoaded = loadLibrary();
+
+    private static synchronized boolean loadLibrary() {
+        try {
+            System.loadLibrary("c++_shared");
+            System.loadLibrary("tangram");
+            return true;
+        } catch (final Exception e) {
+            android.util.Log.e("Tangram", "Failed to load native tangram libraries", e);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Reason:
- MapController instantiation results in loading of native libraries on the main thread
- MapController.init calls were also performed on the main thread which caused system font files to be read on the main thread.

Following map initialization api from google maps sdk, this PR provides a way to instantiate and initialize MapController on a async thread thus preventing any file read/native system libraries to be loaded on the main thread. With this approach user of the tangram android sdk can provide implementation for `MapReadyCallBack.onMapReady` which will be invoked when `MapController` is instantiated, initialized and ready to be used.

TODO:
- [x] With this approach `SceneLoadListener` can be perceived as a map state event, and can be handled aptly.