### PR TITLE
Fix for issue 1864. Segfault reading bad scene file.

### DIFF
--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -144,13 +144,15 @@ std::vector<Url> Importer::getResolvedImportUrls(const Node& sceneNode, const Ur
         base = getBaseUrlForZipArchive(baseUrl);
     }
 
-    if (const Node& import = sceneNode["import"]) {
-        if (import.IsScalar()) {
-            sceneUrls.push_back(Url(import.Scalar()).resolved(base));
-        } else if (import.IsSequence()) {
-            for (const auto& path : import) {
-                if (path.IsScalar()) {
-                    sceneUrls.push_back(Url(path.Scalar()).resolved(base));
+    if (sceneNode.IsMap()) {
+        if (const Node& import = sceneNode["import"]) {
+            if (import.IsScalar()) {
+                sceneUrls.push_back(Url(import.Scalar()).resolved(base));
+            } else if (import.IsSequence()) {
+                for (const auto &path : import) {
+                    if (path.IsScalar()) {
+                        sceneUrls.push_back(Url(path.Scalar()).resolved(base));
+                    }
                 }
             }
         }


### PR DESCRIPTION
The Importer was reading a sceneNode from YAML::Load as a Yaml Map without checking for it being a Map first, causing the error.