### PR TITLE
Dispose all listener and callbacks

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -288,7 +288,8 @@ public class MapController implements Renderer {
             }
         });
 
-        // set all mapController listener references to null
+        // Dispose all listener and callbacks associated with mapController
+        // This will help prevent leaks of references from the client code, possibly used in these listener/callbacks
         touchInput = null;
         mapChangeListener = null;
         featurePickListener = null;

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -289,6 +289,7 @@ public class MapController implements Renderer {
         });
 
         // set all mapController listener references to null
+        touchInput = null;
         mapChangeListener = null;
         featurePickListener = null;
         sceneLoadListener = null;

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -287,6 +287,15 @@ public class MapController implements Renderer {
                 markers.clear();
             }
         });
+
+        // set all mapController listener references to null
+        mapChangeListener = null;
+        featurePickListener = null;
+        sceneLoadListener = null;
+        labelPickListener = null;
+        markerPickListener = null;
+        cameraAnimationCallback = null;
+        frameCaptureCallback = null;
     }
 
     /**


### PR DESCRIPTION
- dispose all listener and callbacks associated with mapController
        - prevent potential leaks in client implementations
- [x] dispose app context from `TouchInput`