### PR TITLE
Fix NPE on GlSurfaceView.mThread

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -249,6 +249,7 @@ public class MapController implements Renderer {
     void UIThreadInit() {
         // Set up MapView
         mapView.setRenderer(this);
+        isGLRendererSet = true;
         mapView.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
         mapView.setPreserveEGLContextOnPause(true);
 
@@ -270,6 +271,9 @@ public class MapController implements Renderer {
     }
 
     void dispose() {
+        // No GL setup from UI Thread, early return
+        if (!isGLRendererSet) { return; }
+
         // Disposing native resources involves GL calls, so we need to run on the GL thread.
         queueEvent(new Runnable() {
             @Override
@@ -1583,6 +1587,7 @@ public class MapController implements Renderer {
     private boolean zoomGesturesEnabled = true;
     private boolean rotateGesturesEnabled = true;
     private boolean tiltGesturesEnabled = true;
+    private boolean isGLRendererSet = false;
 
     // GLSurfaceView.Renderer methods
     // ==============================

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -119,7 +119,6 @@ public class MapView extends FrameLayout {
      */
     protected void onMapInitCancelled(@Nullable final MapController controller) {
         if (controller != null) {
-            controller.UIThreadInit();
             controller.dispose();
         }
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -119,6 +119,7 @@ public class MapView extends FrameLayout {
      */
     protected void onMapInitCancelled(@Nullable final MapController controller) {
         if (controller != null) {
+            controller.UIThreadInit();
             controller.dispose();
         }
     }


### PR DESCRIPTION
- cancellation for map init async task, does not do full initialization
  for newly constructed MapController from the backgroundTask, before
  trying to dispose it during onCancelled task.
  - This causes Renderer to be not set for glSurfaceView associated with the
  MapController, hence causing a NPE when invoking queueEvent on the
  GLSurfaceView.mGLThread