### PR TITLE
Map changing events and map change state management

### DIFF
--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -193,7 +193,7 @@ public:
     bool update(float _dt);
 
     // Render a new frame of the map view (if needed)
-    void render();
+    bool render();
 
     // Gets the viewport height in physical pixels (framebuffer size)
     int getViewportHeight();

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -415,11 +415,7 @@ bool Map::update(float _dt) {
     }
 
     bool isFlinging = impl->inputHandler.update(_dt);
-    if (!isEasing && !isFlinging) {
-        impl->isCameraEasing = false;
-    } else {
-        impl->isCameraEasing = true;
-    }
+    impl->isCameraEasing = (isEasing || isFlinging);
 
     impl->view.update();
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -398,6 +398,7 @@ bool Map::update(float _dt) {
     bool viewComplete = true;
     bool markersNeedUpdate = false;
 
+    bool isEasing = false;
     if (impl->ease) {
         auto& ease = *(impl->ease);
         ease.update(_dt);
@@ -407,13 +408,18 @@ bool Map::update(float _dt) {
                 impl->cameraAnimationListener(true);
             }
             impl->ease.reset();
-            impl->isCameraEasing = false;
+            isEasing = false;
         } else {
-            impl->isCameraEasing = true;
+            isEasing = true;
         }
     }
 
-    impl->inputHandler.update(_dt);
+    bool isFlinging = impl->inputHandler.update(_dt);
+    if (!isEasing && !isFlinging) {
+        impl->isCameraEasing = false;
+    } else {
+        impl->isCameraEasing = true;
+    }
 
     impl->view.update();
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -90,6 +90,7 @@ public:
 
     bool cacheGlState = false;
     float pickRadius = .5f;
+    bool isCameraEasing = false;
 
     std::vector<SelectionQuery> selectionQueries;
 
@@ -396,7 +397,6 @@ bool Map::update(float _dt) {
 
     bool viewComplete = true;
     bool markersNeedUpdate = false;
-    bool cameraEasing = false;
 
     if (impl->ease) {
         auto& ease = *(impl->ease);
@@ -407,8 +407,9 @@ bool Map::update(float _dt) {
                 impl->cameraAnimationListener(true);
             }
             impl->ease.reset();
+            impl->isCameraEasing = false;
         } else {
-            cameraEasing = true;
+            impl->isCameraEasing = true;
         }
     }
 
@@ -456,7 +457,7 @@ bool Map::update(float _dt) {
     }
 
     // Request render if labels are in fading states or markers are easing.
-    if (cameraEasing || labelsNeedUpdate || markersNeedUpdate) {
+    if (impl->isCameraEasing || labelsNeedUpdate || markersNeedUpdate) {
         platform->requestRender();
     }
 
@@ -485,11 +486,11 @@ void Map::pickMarkerAt(float _x, float _y, MarkerPickCallback _onMarkerPickCallb
     platform->requestRender();
 }
 
-void Map::render() {
+bool Map::render() {
 
     // Do not render if any texture resources are in process of being downloaded
     if (impl->scene->pendingTextures > 0) {
-        return;
+        return impl->isCameraEasing;
     }
 
     bool drawSelectionBuffer = getDebugFlag(DebugFlags::selection_buffer);
@@ -542,7 +543,7 @@ void Map::render() {
     if (drawSelectionBuffer) {
         impl->selectionBuffer->drawDebug(impl->renderState, viewport);
         FrameInfo::draw(impl->renderState, impl->view, impl->tileManager);
-        return;
+        return impl->isCameraEasing;
     }
 
     bool drawnAnimatedStyle = false;
@@ -570,6 +571,8 @@ void Map::render() {
     impl->labels.drawDebug(impl->renderState, impl->view);
 
     FrameInfo::draw(impl->renderState, impl->view, impl->tileManager);
+
+    return impl->isCameraEasing;
 }
 
 int Map::getViewportHeight() {
@@ -604,6 +607,7 @@ void Map::cancelCameraAnimation() {
     impl->inputHandler.cancelFling();
 
     impl->ease.reset();
+    impl->isCameraEasing = false;
 
     if (impl->cameraAnimationListener) {
         impl->cameraAnimationListener(false);

--- a/core/src/util/inputHandler.cpp
+++ b/core/src/util/inputHandler.cpp
@@ -28,7 +28,7 @@ namespace Tangram {
 
 InputHandler::InputHandler(std::shared_ptr<Platform> _platform, View& _view) : m_platform(_platform), m_view(_view) {}
 
-void InputHandler::update(float _dt) {
+bool InputHandler::update(float _dt) {
 
     auto velocityPanPixels = m_view.pixelsPerMeter() / m_view.pixelScale() * m_velocityPan;
 
@@ -45,6 +45,8 @@ void InputHandler::update(float _dt) {
 
         m_platform->requestRender();
     }
+
+    return isFlinging;
 }
 
 void InputHandler::handleTapGesture(float _posX, float _posY) {

--- a/core/src/util/inputHandler.h
+++ b/core/src/util/inputHandler.h
@@ -22,6 +22,9 @@ public:
     void handleRotateGesture(float _posX, float _posY, float _radians);
     void handleShoveGesture(float _distance);
 
+    /*
+     * Returns true if the update results in any flinging from the inputHandler
+     */
     bool update(float _dt);
 
     void cancelFling();

--- a/core/src/util/inputHandler.h
+++ b/core/src/util/inputHandler.h
@@ -22,7 +22,7 @@ public:
     void handleRotateGesture(float _posX, float _posY, float _radians);
     void handleShoveGesture(float _distance);
 
-    void update(float _dt);
+    bool update(float _dt);
 
     void cancelFling();
 

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -247,7 +247,7 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
         map.pickLabel(x, y);
         map.pickMarker(x, y);
 
-        map.updateCameraPosition(CameraUpdateFactory.setPosition(tappedPoint), 1000, new MapController.CameraAnimationCallback() {
+        map.updateCameraPosition(CameraUpdateFactory.setPosition(tappedPoint), 0, new MapController.CameraAnimationCallback() {
             @Override
             public void onFinish() {
                 Log.d("Tangram","finished!");
@@ -272,7 +272,7 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
         camera.latitude = .5 * (tapped.latitude + camera.latitude);
         camera.zoom += 1;
         map.updateCameraPosition(CameraUpdateFactory.newCameraPosition(camera),
-                    500, MapController.EaseType.CUBIC);
+                    5000, MapController.EaseType.CUBIC);
         return true;
     }
 
@@ -283,6 +283,21 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
         markers.clear();
         showTileInfo = !showTileInfo;
         map.setDebugFlag(MapController.DebugFlag.TILE_INFOS, showTileInfo);
+        CameraPosition camera = map.getCameraPosition();
+        camera.longitude = 79.9531794;
+        camera.latitude = 28.6468935;
+        camera.zoom = 16;
+        map.flyToCameraPosition(camera, 10000, new MapController.CameraAnimationCallback() {
+            @Override
+            public void onFinish() {
+                Log.d("Tangram", "flyTo finished");
+            }
+
+            @Override
+            public void onCancel() {
+                Log.d("Tangram", "flyTo canceled");
+            }
+        });
     }
 
     @Override

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -118,7 +118,6 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
         String sceneUrl = sceneSelector.getCurrentString();
         map.setSceneLoadListener(this);
         map.loadSceneFile(sceneUrl, sceneUpdates);
-        map.updateCameraPosition(CameraUpdateFactory.newLngLatZoom(new LngLat(-74.00976419448854, 40.70532700869127), 16));
 
         TouchInput touchInput = map.getTouchInput();
         touchInput.setTapResponder(this);
@@ -150,6 +149,8 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
                 Log.d(TAG, "On Region Did Change Animated: " + animated);
             }
         });
+
+        map.updateCameraPosition(CameraUpdateFactory.newLngLatZoom(new LngLat(-74.00976419448854, 40.70532700869127), 16));
 
         markers = map.addDataLayer("touch");
     }

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -221,10 +221,10 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeRender(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeRender(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        map->render();
+        return map->render();
     }
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetupGL(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -91,7 +91,7 @@ public class MapController implements Renderer {
         SELECTION_BUFFER,
     }
 
-    public enum MapRegionChangeState {
+    private enum MapRegionChangeState {
         IDLE,
         JUMPING,
         ANIMATING,
@@ -1095,8 +1095,6 @@ public class MapController implements Renderer {
                         mapChangeListener.onRegionDidChange(true);
                     } else if (state == MapRegionChangeState.ANIMATING) {
                         mapChangeListener.onRegionIsChanging();
-                    } else { // ?? ANIMATING -> JUMPING?? Possible?
-                        mapChangeListener.onRegionWillChange(false);
                     }
                     break;
             }
@@ -1355,6 +1353,12 @@ public class MapController implements Renderer {
     private CameraAnimationCallback pendingCameraAnimationCallback;
     private final Object cameraAnimationCallbackLock = new Object();
     private boolean isGLRendererSet = false;
+    private Runnable setMapRegionAnimatingRunnable = new Runnable() {
+        @Override
+        public void run() {
+            setMapRegionState(MapRegionChangeState.ANIMATING);
+        }
+    };
 
     // GLSurfaceView.Renderer methods
     // ==============================
@@ -1379,7 +1383,7 @@ public class MapController implements Renderer {
         }
 
         if (isCameraEasing) {
-            setMapRegionState(MapRegionChangeState.ANIMATING);
+            uiThreadHandler.post(setMapRegionAnimatingRunnable);
         }
 
         if (viewComplete) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -798,13 +798,13 @@ public class MapController implements Renderer {
         return new TouchInput.PanResponder() {
             @Override
             public boolean onPanBegin() {
-                setMapRegionState(MapRegionChangeState.ANIMATING);
+                setMapRegionState(MapRegionChangeState.JUMPING);
                 return true;
             }
 
             @Override
             public boolean onPan(final float startX, final float startY, final float endX, final float endY) {
-                setMapRegionState(MapRegionChangeState.ANIMATING);
+                setMapRegionState(MapRegionChangeState.JUMPING);
                 nativeHandlePanGesture(mapPointer, startX, startY, endX, endY);
                 return true;
             }
@@ -836,13 +836,13 @@ public class MapController implements Renderer {
         return new TouchInput.RotateResponder() {
             @Override
             public boolean onRotateBegin() {
-                setMapRegionState(MapRegionChangeState.ANIMATING);
+                setMapRegionState(MapRegionChangeState.JUMPING);
                 return true;
             }
 
             @Override
             public boolean onRotate(final float x, final float y, final float rotation) {
-                setMapRegionState(MapRegionChangeState.ANIMATING);
+                setMapRegionState(MapRegionChangeState.JUMPING);
                 nativeHandleRotateGesture(mapPointer, x, y, rotation);
                 return true;
             }
@@ -862,13 +862,13 @@ public class MapController implements Renderer {
         return new TouchInput.ScaleResponder() {
             @Override
             public boolean onScaleBegin() {
-                setMapRegionState(MapRegionChangeState.ANIMATING);
+                setMapRegionState(MapRegionChangeState.JUMPING);
                 return true;
             }
 
             @Override
             public boolean onScale(final float x, final float y, final float scale, final float velocity) {
-                setMapRegionState(MapRegionChangeState.ANIMATING);
+                setMapRegionState(MapRegionChangeState.JUMPING);
                 nativeHandlePinchGesture(mapPointer, x, y, scale, velocity);
                 return true;
             }
@@ -888,13 +888,13 @@ public class MapController implements Renderer {
         return new TouchInput.ShoveResponder() {
             @Override
             public boolean onShoveBegin() {
-                setMapRegionState(MapRegionChangeState.ANIMATING);
+                setMapRegionState(MapRegionChangeState.JUMPING);
                 return true;
             }
 
             @Override
             public boolean onShove(final float distance) {
-                setMapRegionState(MapRegionChangeState.ANIMATING);
+                setMapRegionState(MapRegionChangeState.JUMPING);
                 nativeHandleShoveGesture(mapPointer, distance);
                 return true;
             }
@@ -1084,6 +1084,8 @@ public class MapController implements Renderer {
                 case JUMPING:
                     if (state == MapRegionChangeState.IDLE) {
                         mapChangeListener.onRegionDidChange(false);
+                    } else if (state == MapRegionChangeState.JUMPING) {
+                        mapChangeListener.onRegionIsChanging();
                     }
                     break;
                 case ANIMATING:

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1248,7 +1248,7 @@ public class MapController implements Renderer {
     private synchronized native void nativeSetupGL(long mapPtr);
     private synchronized native void nativeResize(long mapPtr, int width, int height);
     private synchronized native boolean nativeUpdate(long mapPtr, float dt);
-    private synchronized native void nativeRender(long mapPtr);
+    private synchronized native boolean nativeRender(long mapPtr);
     private synchronized native void nativeGetCameraPosition(long mapPtr, double[] lonLatOut, float[] zoomRotationTiltOut);
     private synchronized native void nativeUpdateCameraPosition(long mapPtr, int set, double lon, double lat, float zoom, float zoomBy,
                                                                 float rotation, float rotateBy, float tilt, float tiltBy,
@@ -1349,9 +1349,14 @@ public class MapController implements Renderer {
         }
 
         boolean viewComplete;
+        boolean isCameraEasing;
         synchronized(this) {
             viewComplete = nativeUpdate(mapPointer, delta);
-            nativeRender(mapPointer);
+            isCameraEasing = nativeRender(mapPointer);
+        }
+
+        if (isCameraEasing) {
+            onRegionIsChanging();
         }
 
         if (viewComplete) {

--- a/platforms/ios/demo/src/MapViewController.h
+++ b/platforms/ios/demo/src/MapViewController.h
@@ -18,6 +18,7 @@
 - (void)mapView:(nonnull TGMapView *)view didCaptureScreenshot:(nonnull UIImage *)screenshot;
 
 - (void)mapView:(nonnull TGMapView *)view recognizer:(nonnull UIGestureRecognizer *)recognizer didRecognizeSingleTapGesture:(CGPoint)location;
+- (void)mapView:(TGMapView *)view recognizer:(UIGestureRecognizer *)recognizer didRecognizeDoubleTapGesture:(CGPoint)location;
 - (void)mapView:(nonnull TGMapView *)view recognizer:(nonnull UIGestureRecognizer *)recognizer didRecognizeLongPressGesture:(CGPoint)location;
 
 @end

--- a/platforms/ios/demo/src/MapViewController.m
+++ b/platforms/ios/demo/src/MapViewController.m
@@ -28,6 +28,21 @@
     NSLog(@"Did capture screenshot");
 }
 
+- (void)mapViewRegionIsChanging:(TGMapView *)mapView
+{
+    NSLog(@"Region Is Changing");
+}
+
+- (void)mapView:(TGMapView *)mapView regionWillChangeAnimated:(BOOL)animated
+{
+    NSLog(@"Region Will Change animated: %d", animated);
+}
+
+- (void)mapView:(TGMapView *)mapView regionDidChangeAnimated:(BOOL)animated
+{
+    NSLog(@"Region Did Change animated: %d", animated);
+}
+
 - (void)mapViewDidCompleteLoading:(TGMapView *)mapView
 {
     NSLog(@"Did complete view");
@@ -104,7 +119,7 @@
     CLLocationCoordinate2D coordinates = [view coordinateFromViewPosition:location];
 
     // Add polyline data layer
-    {
+    /*{
         TGFeatureProperties* properties = @{ @"type" : @"line", @"color" : @"#D2655F" };
         static CLLocationCoordinate2D lastCoordinates = {NAN, NAN};
 
@@ -150,18 +165,32 @@
     // Request feature picking
     [view pickFeatureAt:location];
     [view pickLabelAt:location];
-    // [view pickMarkerAt:location];
+    // [view pickMarkerAt:location];*/
 
     TGCameraPosition* camera = [view cameraPosition];
     camera.center = CLLocationCoordinate2DMake(coordinates.latitude, coordinates.longitude);
-    [view setCameraPosition:camera withDuration:0.5 easeType:TGEaseTypeCubic callback: ^(BOOL canceled){
+    [view setCameraPosition:camera withDuration:0 easeType:TGEaseTypeCubic callback: ^(BOOL canceled){
+        NSLog(@"Animation completed %d", !canceled);
+    }];
+}
+
+- (void)mapView:(TGMapView *)view recognizer:(UIGestureRecognizer *)recognizer didRecognizeDoubleTapGesture:(CGPoint)location {
+    CLLocationCoordinate2D coordinates = [view coordinateFromViewPosition:location];
+    TGCameraPosition* camera = [view cameraPosition];
+    camera.center = CLLocationCoordinate2DMake(coordinates.latitude, coordinates.longitude);
+    camera.zoom += 1;
+    [view setCameraPosition:camera withDuration:5000 easeType:TGEaseTypeCubic callback: ^(BOOL canceled){
         NSLog(@"Animation completed %d", !canceled);
     }];
 }
 
 - (void)mapView:(TGMapView *)mapView recognizer:(UIGestureRecognizer *)recognizer didRecognizeLongPressGesture:(CGPoint)location
 {
-    NSLog(@"Did long press at %f %f", location.x, location.y);
+    TGCameraPosition* camera = [mapView cameraPosition];
+    camera.center = CLLocationCoordinate2DMake(8.6468935, 76.9531794);
+    [mapView flyToCameraPosition:camera withDuration:1000 callback: ^(BOOL canceled) {
+        NSLog(@"FlyToAnimation completed %d", !canceled);
+    }];
 }
 
 - (void)addAlert:(NSString *)message withTitle:(NSString *)title

--- a/platforms/ios/framework/src/TGMapView.h
+++ b/platforms/ios/framework/src/TGMapView.h
@@ -399,6 +399,26 @@ TG_EXPORT
  */
 @property (strong, nonatomic) UILongPressGestureRecognizer* longPressGestureRecognizer;
 
+#pragma mark Map region change state notifiers
+
+/**
+ Client can use these to trigger explicit `TGMapRegionChangeStates` changes
+ Notifies that client is going to begin map region animation
+ */
+- (void)notifyGestureDidBegin;
+
+/**
+ Client can use these to trigger explicit `TGMapRegionChangeStates` changes
+ Notifies that client is animating map region
+ */
+- (void)notifyGestureIsChanging;
+
+/**
+ Client can use these to trigger explicit `TGMapRegionChangeStates` changes
+ Notifies that client is stopping animating map region
+ */
+- (void)notifyGestureDidEnd;
+
 #pragma mark Data Layers
 
 /**

--- a/platforms/ios/framework/src/TGMapView.h
+++ b/platforms/ios/framework/src/TGMapView.h
@@ -402,19 +402,19 @@ TG_EXPORT
 #pragma mark Map region change state notifiers
 
 /**
- Client can use these to trigger explicit `TGMapRegionChangeStates` changes
+ Client can use these to trigger explicit `TGMapRegionChangeState` changes
  Notifies that client is going to begin map region animation
  */
 - (void)notifyGestureDidBegin;
 
 /**
- Client can use these to trigger explicit `TGMapRegionChangeStates` changes
+ Client can use these to trigger explicit `TGMapRegionChangeState` changes
  Notifies that client is animating map region
  */
 - (void)notifyGestureIsChanging;
 
 /**
- Client can use these to trigger explicit `TGMapRegionChangeStates` changes
+ Client can use these to trigger explicit `TGMapRegionChangeState` changes
  Notifies that client is stopping animating map region
  */
 - (void)notifyGestureDidEnd;

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -165,9 +165,9 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeStates) {
         void (^callback)(BOOL) = weakSelf.cameraAnimationCallback;
         if (callback) {
             callback(!finished);
+            [weakSelf setMapRegionChangeState:IDLE];
         }
         weakSelf.cameraAnimationCallback = nil;
-        [weakSelf setMapRegionChangeState:IDLE];
     });
 }
 

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -42,6 +42,7 @@ inline CLLocationDirection convertRotationRadiansToBearingDegrees(float rotation
     BOOL _shouldCaptureFrame;
     BOOL _captureFrameWaitForViewComplete;
     BOOL _viewComplete;
+    BOOL _isCameraEasing;
     BOOL _viewInBackground;
     BOOL _renderRequested;
 }
@@ -130,6 +131,7 @@ inline CLLocationDirection convertRotationRadiansToBearingDegrees(float rotation
     _viewInBackground = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
     _renderRequested = YES;
     _continuous = NO;
+    _isCameraEasing = NO;
     _preferredFramesPerSecond = 60;
     _markersById = [[NSMutableDictionary alloc] init];
     _dataLayersByName = [[NSMutableDictionary alloc] init];
@@ -349,7 +351,9 @@ inline CLLocationDirection convertRotationRadiansToBearingDegrees(float rotation
         return;
     }
 
-    self.map->render();
+    if (self.map->render()) {
+        [self regionIsChanging];
+    }
 }
 
 #pragma mark Screenshots

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -62,6 +62,7 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeStates) {
 @property (strong, nonatomic) NSMutableDictionary<NSString *, TGMapData *> *dataLayersByName;
 @property (nonatomic, copy, nullable) void (^cameraAnimationCallback)(BOOL);
 @property TGMapRegionChangeStates currentState;
+@property BOOL prevCameraEasing;
 
 @end // interface TGMapView
 
@@ -145,6 +146,7 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeStates) {
     _dataLayersByName = [[NSMutableDictionary alloc] init];
     _resourceRoot = [[NSBundle mainBundle] resourceURL];
     _currentState = IDLE;
+    _prevCameraEasing = false;
 
     self.clipsToBounds = YES;
     self.opaque = YES;
@@ -360,9 +362,14 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeStates) {
         return;
     }
 
-    if (self.map->render()) {
+    BOOL cameraEasing = self.map->render();
+    if (cameraEasing) {
         [self setMapRegionChangeState:ANIMATING];
+    } else if (_prevCameraEasing) {
+        [self setMapRegionChangeState:IDLE];
     }
+
+    _prevCameraEasing = cameraEasing;
 }
 
 #pragma mark Screenshots

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -1174,9 +1174,27 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
     [shoveRecognizer setTranslation:CGPointZero inView:_glView];
 }
 
+#pragma mark Map region change state notifiers
+
+- (void)notifyGestureDidBegin
+{
+    [self setMapRegionChangeState:ANIMATING];
+}
+
+- (void)notifyGestureIsChanging
+{
+    [self setMapRegionChangeState:ANIMATING];
+}
+
+- (void)notifyGestureDidEnd
+{
+    [self setMapRegionChangeState:IDLE];
+}
+
 #pragma mark Internal Logic
 
-- (void)setMapRegionChangeState:(TGMapRegionChangeStates)state {
+- (void)setMapRegionChangeState:(TGMapRegionChangeStates)state
+{
     switch (_currentState) {
         case IDLE:
             if (state == JUMPING) {

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -42,9 +42,9 @@ inline CLLocationDirection convertRotationRadiansToBearingDegrees(float rotation
  Map region change states
  */
 typedef NS_ENUM(NSInteger, TGMapRegionChangeStates) {
-    IDLE = 0,
-    JUMPING,
-    ANIMATING,
+    TGMapRegionIdle = 0,
+    TGMapRegionJumping,
+    TGMapRegionAnimating,
 };
 
 @interface TGMapView () <UIGestureRecognizerDelegate, GLKViewDelegate> {
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeStates) {
     _markersById = [[NSMutableDictionary alloc] init];
     _dataLayersByName = [[NSMutableDictionary alloc] init];
     _resourceRoot = [[NSBundle mainBundle] resourceURL];
-    _currentState = IDLE;
+    _currentState = TGMapRegionIdle;
     _prevCameraEasing = false;
 
     self.clipsToBounds = YES;
@@ -167,7 +167,7 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeStates) {
         void (^callback)(BOOL) = weakSelf.cameraAnimationCallback;
         if (callback) {
             callback(!finished);
-            [weakSelf setMapRegionChangeState:IDLE];
+            [weakSelf setMapRegionChangeState:TGMapRegionIdle];
         }
         weakSelf.cameraAnimationCallback = nil;
     });
@@ -364,9 +364,9 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeStates) {
 
     BOOL cameraEasing = self.map->render();
     if (cameraEasing) {
-        [self setMapRegionChangeState:ANIMATING];
+        [self setMapRegionChangeState:TGMapRegionAnimating];
     } else if (_prevCameraEasing) {
-        [self setMapRegionChangeState:IDLE];
+        [self setMapRegionChangeState:TGMapRegionIdle];
     }
 
     _prevCameraEasing = cameraEasing;
@@ -759,9 +759,9 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 - (void)setPosition:(CLLocationCoordinate2D)position {
     if (!self.map) { return; }
 
-    [self setMapRegionChangeState:JUMPING];
+    [self setMapRegionChangeState:TGMapRegionJumping];
     self.map->setPosition(position.longitude, position.latitude);
-    [self setMapRegionChangeState:IDLE];
+    [self setMapRegionChangeState:TGMapRegionIdle];
 }
 
 - (CLLocationCoordinate2D)position
@@ -778,9 +778,9 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 {
     if (!self.map) { return; }
 
-    [self setMapRegionChangeState:JUMPING];
+    [self setMapRegionChangeState:TGMapRegionJumping];
     self.map->setZoom(zoom);
-    [self setMapRegionChangeState:IDLE];
+    [self setMapRegionChangeState:TGMapRegionIdle];
 }
 
 - (CGFloat)zoom
@@ -794,10 +794,10 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 {
     if (!self.map) { return; }
 
-    [self setMapRegionChangeState:JUMPING];
+    [self setMapRegionChangeState:TGMapRegionJumping];
     float rotation = convertBearingDegreesToRotationRadians(bearing);
     self.map->setRotation(rotation);
-    [self setMapRegionChangeState:IDLE];
+    [self setMapRegionChangeState:TGMapRegionIdle];
 }
 
 - (CLLocationDirection)bearing
@@ -820,10 +820,10 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 {
     if (!self.map) { return; }
 
-    [self setMapRegionChangeState:JUMPING];
+    [self setMapRegionChangeState:TGMapRegionJumping];
     float tilt = TGRadiansFromDegrees(pitch);
     self.map->setTilt(tilt);
-    [self setMapRegionChangeState:IDLE];
+    [self setMapRegionChangeState:TGMapRegionIdle];
 }
 
 - (TGCameraPosition *)cameraPosition
@@ -836,9 +836,9 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 - (void)setCameraPosition:(TGCameraPosition *)cameraPosition
 {
     Tangram::CameraPosition result = [cameraPosition convertToCoreCamera];
-    [self setMapRegionChangeState:JUMPING];
+    [self setMapRegionChangeState:TGMapRegionJumping];
     self.map->setCameraPosition(result);
-    [self setMapRegionChangeState:IDLE];
+    [self setMapRegionChangeState:TGMapRegionIdle];
 }
 
 - (void)setCameraPosition:(TGCameraPosition *)cameraPosition
@@ -849,9 +849,9 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
     Tangram::CameraPosition camera = [cameraPosition convertToCoreCamera];
     Tangram::EaseType ease = TGConvertTGEaseTypeToCoreEaseType(easeType);
     if (duration > 0) {
-        [self setMapRegionChangeState:ANIMATING];
+        [self setMapRegionChangeState:TGMapRegionAnimating];
     } else {
-        [self setMapRegionChangeState:JUMPING];
+        [self setMapRegionChangeState:TGMapRegionJumping];
     }
     self.map->setCameraPositionEased(camera, duration, ease);
     self.cameraAnimationCallback = callback;
@@ -868,9 +868,9 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 {
     Tangram::CameraPosition camera = [cameraPosition convertToCoreCamera];
     if (duration > 0) {
-        [self setMapRegionChangeState:ANIMATING];
+        [self setMapRegionChangeState:TGMapRegionAnimating];
     } else {
-        [self setMapRegionChangeState:JUMPING];
+        [self setMapRegionChangeState:TGMapRegionJumping];
     }
     self.map->flyTo(camera, duration);
     self.cameraAnimationCallback = callback;
@@ -1051,15 +1051,15 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 
     switch (panRecognizer.state) {
         case UIGestureRecognizerStateBegan:
-            [self setMapRegionChangeState:ANIMATING];
+            [self setMapRegionChangeState:TGMapRegionAnimating];
             break;
         case UIGestureRecognizerStateChanged:
-            [self setMapRegionChangeState:ANIMATING];
+            [self setMapRegionChangeState:TGMapRegionAnimating];
             self.map->handlePanGesture(start.x * self.contentScaleFactor, start.y * self.contentScaleFactor, end.x * self.contentScaleFactor, end.y * self.contentScaleFactor);
             break;
         case UIGestureRecognizerStateEnded:
             self.map->handleFlingGesture(end.x * self.contentScaleFactor, end.y * self.contentScaleFactor, velocity.x * self.contentScaleFactor, velocity.y * self.contentScaleFactor);
-            [self setMapRegionChangeState:IDLE];
+            [self setMapRegionChangeState:TGMapRegionIdle];
             break;
         default:
             break;
@@ -1085,10 +1085,10 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
     CGFloat scale = pinchRecognizer.scale;
     switch (pinchRecognizer.state) {
         case UIGestureRecognizerStateBegan:
-            [self setMapRegionChangeState:ANIMATING];
+            [self setMapRegionChangeState:TGMapRegionAnimating];
             break;
         case UIGestureRecognizerStateChanged:
-            [self setMapRegionChangeState:ANIMATING];
+            [self setMapRegionChangeState:TGMapRegionAnimating];
             if ([self.gestureDelegate respondsToSelector:@selector(pinchFocus:recognizer:)]) {
                 CGPoint focusPosition = [self.gestureDelegate pinchFocus:self recognizer:pinchRecognizer];
                 self.map->handlePinchGesture(focusPosition.x * self.contentScaleFactor, focusPosition.y * self.contentScaleFactor, scale, pinchRecognizer.velocity);
@@ -1097,7 +1097,7 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
             }
             break;
         case UIGestureRecognizerStateEnded:
-            [self setMapRegionChangeState:IDLE];
+            [self setMapRegionChangeState:TGMapRegionIdle];
             break;
         default:
             break;
@@ -1123,10 +1123,10 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
     CGFloat rotation = rotationRecognizer.rotation;
     switch (rotationRecognizer.state) {
         case UIGestureRecognizerStateBegan:
-            [self setMapRegionChangeState:ANIMATING];
+            [self setMapRegionChangeState:TGMapRegionAnimating];
             break;
         case UIGestureRecognizerStateChanged:
-            [self setMapRegionChangeState:ANIMATING];
+            [self setMapRegionChangeState:TGMapRegionAnimating];
             if ([self.gestureDelegate respondsToSelector:@selector(rotationFocus:recognizer:)]) {
                 CGPoint focusPosition = [self.gestureDelegate rotationFocus:self recognizer:rotationRecognizer];
                 self.map->handleRotateGesture(focusPosition.x * self.contentScaleFactor, focusPosition.y * self.contentScaleFactor, rotation);
@@ -1135,7 +1135,7 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
             }
             break;
         case UIGestureRecognizerStateEnded:
-            [self setMapRegionChangeState:IDLE];
+            [self setMapRegionChangeState:TGMapRegionIdle];
             break;
         default:
             break;
@@ -1161,17 +1161,17 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 
     switch (shoveRecognizer.state) {
         case UIGestureRecognizerStateBegan:
-            [self setMapRegionChangeState:ANIMATING];
+            [self setMapRegionChangeState:TGMapRegionAnimating];
             break;
         case UIGestureRecognizerStateChanged:
-            [self setMapRegionChangeState:ANIMATING];
+            [self setMapRegionChangeState:TGMapRegionAnimating];
             self.map->handleShoveGesture(displacement.y);
             if ([self.gestureDelegate respondsToSelector:@selector(mapView:recognizer:didRecognizeShoveGesture:)]) {
                 [self.gestureDelegate mapView:self recognizer:shoveRecognizer didRecognizeShoveGesture:displacement];
             }
             break;
         case UIGestureRecognizerStateEnded:
-            [self setMapRegionChangeState:IDLE];
+            [self setMapRegionChangeState:TGMapRegionIdle];
             break;
         default:
             break;
@@ -1185,17 +1185,17 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 
 - (void)notifyGestureDidBegin
 {
-    [self setMapRegionChangeState:ANIMATING];
+    [self setMapRegionChangeState:TGMapRegionAnimating];
 }
 
 - (void)notifyGestureIsChanging
 {
-    [self setMapRegionChangeState:ANIMATING];
+    [self setMapRegionChangeState:TGMapRegionAnimating];
 }
 
 - (void)notifyGestureDidEnd
 {
-    [self setMapRegionChangeState:IDLE];
+    [self setMapRegionChangeState:TGMapRegionIdle];
 }
 
 #pragma mark Internal Logic
@@ -1203,22 +1203,22 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 - (void)setMapRegionChangeState:(TGMapRegionChangeStates)state
 {
     switch (_currentState) {
-        case IDLE:
-            if (state == JUMPING) {
+        case TGMapRegionIdle:
+            if (state == TGMapRegionJumping) {
                 [self regionWillChangeAnimated:NO];
-            } else if (state == ANIMATING) {
+            } else if (state == TGMapRegionAnimating) {
                 [self regionWillChangeAnimated:YES];
             }
             break;
-        case JUMPING:
-            if (state == IDLE) {
+        case TGMapRegionJumping:
+            if (state == TGMapRegionIdle) {
                 [self regionDidChangeAnimated:NO];
             }
             break;
-        case ANIMATING:
-            if (state == IDLE) {
+        case TGMapRegionAnimating:
+            if (state == TGMapRegionIdle) {
                 [self regionDidChangeAnimated:YES];
-            } else if (state == ANIMATING) {
+            } else if (state == TGMapRegionAnimating) {
                 [self regionIsChanging];
             }
             break;


### PR DESCRIPTION
- Provides access to platform code to check if camera is in an animating state.
- Adds logic to use this camera animating state to aptly invoke map changing MapChangeListener interface methods for both iOS and android platforms.
- [Android] Adds MapChangeStateManager to aptly manage map change states (`will update`, `will update animated`, `is updating`, `did update`, `did update animated`).
- [x] Implement the above mentioned StateManager for iOS
- [x] implement state change notifier for iOS

This also fixes (3ec875c) a regression which was causing make `DID_CHANGE` to be called repeated irrespective of a cameraAnimationCallback being set or not. (https://github.com/tangrams/tangram-es/pull/1853/commits/0908a17cd8a556b57a075f77ada21dfaf784863c)