### PR TITLE
Add zoom stops for scene.background.color.

### DIFF
--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -540,10 +540,17 @@ void Map::render() {
         impl->selectionQueries.clear();
     }
 
+    // Get background color for frame based on zoom level, if there are stops
+    auto background = impl->scene->background();
+    if (impl->scene->backgroundStops().frames.size() > 0) {
+        background = impl->scene->backgroundStops().evalColor(getZoom());
+    }
+
     // Setup default framebuffer for a new frame
     glm::vec2 viewport(impl->view.getWidth(), impl->view.getHeight());
+
     FrameBuffer::apply(impl->renderState, impl->renderState.defaultFrameBuffer(),
-                       viewport, impl->scene->background().toColorF());
+                       viewport, background.toColorF());
 
     if (drawSelectionBuffer) {
         impl->selectionBuffer->drawDebug(impl->renderState, viewport);

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -2,6 +2,7 @@
 
 #include "map.h"
 #include "platform.h"
+#include "stops.h"
 #include "util/color.h"
 #include "util/url.h"
 #include "util/yamlPath.h"
@@ -32,7 +33,6 @@ class Style;
 class Texture;
 class TileSource;
 class ZipArchive;
-struct Stops;
 
 // Delimiter used in sceneloader for style params and layer-sublayer naming
 const std::string DELIMITER = ":";
@@ -88,6 +88,7 @@ public:
     auto& functions() { return m_jsFunctions; }
     auto& stops() { return m_stops; }
     auto& background() { return m_background; }
+    auto& backgroundStops() { return m_backgroundStops; }
     auto& fontContext() { return m_fontContext; }
     auto& globalRefs() { return m_globalRefs; }
     auto& featureSelection() { return m_featureSelection; }
@@ -192,6 +193,7 @@ private:
     std::list<Stops> m_stops;
 
     Color m_background;
+    Stops m_backgroundStops;
 
     std::shared_ptr<FontContext> m_fontContext;
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1824,6 +1824,9 @@ void SceneLoader::loadBackground(Node background, const std::shared_ptr<Scene>& 
             str = colorNode.Scalar();
         } else if (colorNode.IsSequence()) {
             str = YamlUtil::parseSequence(colorNode);
+            if (str == "") {
+               scene->backgroundStops() = Stops::Colors(colorNode);
+            }
         }
         scene->background().abgr = StyleParam::parseColor(str);
     }


### PR DESCRIPTION
I had a requirement to alter the background color based on zoom level. 
This pull request adds a zoom stop specification for scene.background.color and applies it
to the rendering of the map.
```
scene:
   background:
      color: [[1,blue],[5,orange],[15,black]]
```
The colors are interpolated between the zoom stops. 
Its a pretty nifty effect.

You can still use the default, such as a color in name, hash, or rgb sequence.
