### PR TITLE
Ensure memory used by texture data is returned to system after GL upload

### DIFF
--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -213,6 +213,8 @@ void Texture::update(RenderState& rs, GLuint _textureUnit) {
     update(rs, _textureUnit, data);
 
     m_data.clear();
+    // Free the allocated buffer by swapping with an empty vector.
+    std::vector<GLuint>().swap(m_data);
 }
 
 void Texture::update(RenderState& rs, GLuint _textureUnit, const GLuint* data) {


### PR DESCRIPTION
Calling `clear()` on the data buffer in `Texture` doesn't actually free the memory, it just changes the `size` value. `shrink_to_fit()` will request that the buffer is actually freed. (https://en.cppreference.com/w/cpp/container/vector/shrink_to_fit)

In practice this can reduce runtime memory usage by 10-15 MB