### PR TITLE
Configure demo app Info plist with Nextzen API key from env

### DIFF
--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -10,6 +10,10 @@ set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "9.3")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
 execute_process(COMMAND xcrun --sdk iphoneos --show-sdk-version OUTPUT_VARIABLE IOS_SDK_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+# Configure the API key in the Info.plist for the demo app.
+set(NEXTZEN_API_KEY $ENV{NEXTZEN_API_KEY})
+configure_file(${PROJECT_SOURCE_DIR}/platforms/ios/demo/Info.plist.in ${PROJECT_BINARY_DIR}/Info.plist)
+
 # Tell SQLiteCpp to not build its own copy of SQLite, we will use the system library instead.
 if (IOS_SDK_VERSION VERSION_LESS 11.0)
   set(SQLITE_USE_LEGACY_STRUCT ON CACHE BOOL "")

--- a/platforms/ios/demo/Info.plist.in
+++ b/platforms/ios/demo/Info.plist.in
@@ -25,7 +25,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NEXTZEN_API_KEY</key>
-	<string>$(NEXTZEN_API_KEY)</string>
+	<string>${NEXTZEN_API_KEY}</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Need location to enable marker tracking.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/platforms/ios/demo/TangramDemo.xcodeproj/project.pbxproj
+++ b/platforms/ios/demo/TangramDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D20C4A55212B6D94005BDB9A /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D20C4A54212B6D93005BDB9A /* GLKit.framework */; };
+		D222B92521642BCA007E6FD6 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D222B92321642BCA007E6FD6 /* Info.plist */; };
 		D298723520D05F6F009A0AB8 /* MapViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D298723120D05F6E009A0AB8 /* MapViewController.m */; };
 		D298723620D05F6F009A0AB8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D298723220D05F6E009A0AB8 /* main.m */; };
 		D298723720D05F6F009A0AB8 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D298723320D05F6E009A0AB8 /* AppDelegate.m */; };
@@ -45,6 +46,7 @@
 
 /* Begin PBXFileReference section */
 		D20C4A54212B6D93005BDB9A /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		D222B92321642BCA007E6FD6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../../../build/ios/Info.plist; sourceTree = "<group>"; };
 		D298721620D05D8E009A0AB8 /* TangramDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TangramDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D298723020D05F6E009A0AB8 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		D298723120D05F6E009A0AB8 /* MapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MapViewController.m; sourceTree = "<group>"; };
@@ -54,7 +56,6 @@
 		D298723920D05F7A009A0AB8 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		D298723A20D05F7A009A0AB8 /* Main_iPhone.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main_iPhone.storyboard; sourceTree = "<group>"; };
 		D298723B20D05F7A009A0AB8 /* Main_iPad.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main_iPad.storyboard; sourceTree = "<group>"; };
-		D298723F20D05F88009A0AB8 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D2DB6A9320DAE14A0043E74F /* TangramMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = TangramMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F0601F20E6DFAF00CB442F /* TangramDemo-static.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TangramDemo-static.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F0603A20E6E31200CB442F /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
@@ -103,7 +104,7 @@
 		D298720D20D05D8E009A0AB8 = {
 			isa = PBXGroup;
 			children = (
-				D298723F20D05F88009A0AB8 /* Info.plist */,
+				D222B92321642BCA007E6FD6 /* Info.plist */,
 				D298723820D05F7A009A0AB8 /* resources */,
 				D298722F20D05F6E009A0AB8 /* src */,
 				D298721720D05D8E009A0AB8 /* Products */,
@@ -233,6 +234,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D222B92521642BCA007E6FD6 /* Info.plist in Resources */,
 				D2F0604320EA9AD000CB442F /* LaunchScreen.xib in Resources */,
 				D2F0604420EA9AD000CB442F /* Main_iPhone.storyboard in Resources */,
 				D2F0604520EA9AD000CB442F /* Main_iPad.storyboard in Resources */,
@@ -384,7 +386,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
-				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_FILE = ../../../build/ios/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapzen.ios.TangramDemo;
@@ -401,7 +403,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
-				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_FILE = ../../../build/ios/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
@@ -419,7 +421,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = ../../../build/ios/Include;
-				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_FILE = ../../../build/ios/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "";
@@ -437,7 +439,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = ../../../build/ios/Include;
-				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_FILE = ../../../build/ios/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "";

--- a/platforms/ios/demo/TangramDemo.xcodeproj/xcshareddata/xcschemes/TangramDemo-static.xcscheme
+++ b/platforms/ios/demo/TangramDemo.xcodeproj/xcshareddata/xcschemes/TangramDemo-static.xcscheme
@@ -61,13 +61,6 @@
             ReferencedContainer = "container:TangramDemo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "NEXTZEN_API_KEY"
-            value = "KXcYNjp0QXigFSMc5a7eEA"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/platforms/ios/demo/TangramDemo.xcodeproj/xcshareddata/xcschemes/TangramDemo.xcscheme
+++ b/platforms/ios/demo/TangramDemo.xcodeproj/xcshareddata/xcschemes/TangramDemo.xcscheme
@@ -61,19 +61,6 @@
             ReferencedContainer = "container:TangramDemo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "NEXTZEN_API_KEY=KXcYNjp0QXigFSMc5a7eEA"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "NEXTZEN_API_KEY"
-            value = "KXcYNjp0QXigFSMc5a7eEA"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
This resolves two issues with the current iOS demo build process:
 - Since the Nextzen API key used for tiles is set as an environment variable for the app, it is missing when run from outside of Xcode (e.g. by clicking on the app icon on the phone). Therefore, the demo app aborts when run from outside of Xcode.
 - All builds of the demo app were using a single API key, since it was unintentionally included in the demo build schemes XD

CMake provides a convenient method to "configure" files: it replaces any `${VARS}` with their current value in the CMake script and copies the result to the output location. This makes is easy to grab the user's `NEXTZEN_API_KEY` from their shell environment and bake it into the Info.plist used by the demo app.