### PR TITLE
Allow MapController extensions to be initialized

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -88,7 +88,7 @@ public class MapView extends FrameLayout {
             return null;
         }
 
-        return new MapController(this.getContext());
+        return getMapInstance();
     }
 
     /**
@@ -199,6 +199,10 @@ public class MapView extends FrameLayout {
             mapController.dispose();
             mapController = null;
         }
+    }
+
+    protected MapController getMapInstance() {
+        return new MapController(this.getContext());
     }
 
     /**


### PR DESCRIPTION
- reintroduce MapView.getMapInstance