### PR TITLE
Parse StyleParam values directly from YAML nodes

### DIFF
--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1108,14 +1108,17 @@ void SceneLoader::loadSourceRasters(const std::shared_ptr<Platform>& platform, s
     }
 }
 
-void SceneLoader::parseLightPosition(Node position, PointLight& light) {
-
-    if (position.IsSequence()) {
-        UnitVec<glm::vec3> lightPos;
-        StyleParam::parseVec3(position, UnitSet{Unit::pixel, Unit::meter}, lightPos);
-        light.setPosition(lightPos);
+void SceneLoader::parseLightPosition(Node positionNode, PointLight& light) {
+    UnitVec<glm::vec3> positionResult;
+    if (StyleParam::parseVec3(positionNode, UnitSet{Unit::pixel, Unit::meter}, positionResult)) {
+        for (auto& unit : positionResult.units) {
+            if (unit == Unit::none) {
+                unit = Unit::meter;
+            }
+        }
+        light.setPosition(positionResult);
     } else {
-        LOGNode("Wrong light position parameter", position);
+        LOGNode("Invalid light position parameter:", positionNode);
     }
 }
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1805,13 +1805,12 @@ void SceneLoader::loadBackground(Node background, const std::shared_ptr<Scene>& 
     if (!background) { return; }
 
     if (Node colorNode = background["color"]) {
-        std::string str;
-        if (colorNode.IsScalar()) {
-            str = colorNode.Scalar();
-        } else if (colorNode.IsSequence()) {
-            str = YamlUtil::parseSequence(colorNode);
+        Color colorResult;
+        if (StyleParam::parseColor(colorNode, colorResult)) {
+            scene->background() = colorResult;
+        } else {
+            LOGW("Cannot parse color: %s", Dump(colorNode).c_str());
         }
-        scene->background().abgr = StyleParam::parseColor(str);
     }
 }
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -86,7 +86,7 @@ struct SceneLoader {
     static bool parseStyleUniforms(const std::shared_ptr<Platform>& platform, const Node& value,
                                    const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
 
-    static void parseLightPosition(Node position, PointLight& light);
+    static void parseLightPosition(Node positionNode, PointLight& light);
 
     static bool loadStyle(const std::shared_ptr<Platform>& platform, const std::string& styleName,
                           Node config, const std::shared_ptr<Scene>& scene);

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -93,7 +93,10 @@ auto Stops::Sizes(const YAML::Node& _node, UnitSet _units) -> Stops {
         if (StyleParam::parseSizeUnitPair(_frameNode.Scalar(), _result)) {
             if ( !_units.contains(_result.unit) ) {
                 LOGW("Size StyleParam can only take in pixel, %% or auto values in: %s", Dump(_node).c_str());
-                return false;
+                _result.unit = Unit::pixel;
+            }
+            if (_result.unit == Unit::none) {
+                _result.unit = Unit::pixel;
             }
         } else {
             LOGW("could not parse node %s\n", Dump(_frameNode).c_str());

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -163,7 +163,7 @@ auto Stops::Offsets(const YAML::Node& _node, UnitSet _units) -> Stops {
             for (const auto& sequenceNode : frameNode[1]) {
                 StyleParam::ValueUnitPair width;
                 width.unit = Unit::pixel; // default to pixel
-                if (StyleParam::parseValueUnitPair(sequenceNode.Scalar(), 0, width)) {
+                if (sequenceNode.IsScalar() && StyleParam::parseValueUnitPair(sequenceNode.Scalar(), width)) {
                     widths.push_back(width);
                     if (lastUnit != width.unit) {
                         LOGW("Mixed units not allowed for stop values", Dump(frameNode[1]).c_str());

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -76,7 +76,7 @@ auto Stops::FontSize(const YAML::Node& _node) -> Stops {
     return stops;
 }
 
-auto Stops::Sizes(const YAML::Node& _node, uint8_t _units) -> Stops {
+auto Stops::Sizes(const YAML::Node& _node, UnitSet _units) -> Stops {
     Stops stops;
 
     // mixed dim stops not allowed for sizes (except when 1D stop uses %)
@@ -91,7 +91,7 @@ auto Stops::Sizes(const YAML::Node& _node, uint8_t _units) -> Stops {
 
     auto constructFrame = [&](const auto& _frameNode, StyleParam::ValueUnitPair& _result) -> bool {
         if (StyleParam::parseSizeUnitPair(_frameNode.Scalar(), 0, _result)) {
-            if ( !(_units & _result.unit) ) {
+            if ( !_units.contains(_result.unit) ) {
                 LOGW("Size StyleParam can only take in pixel, %% or auto values in: %s", Dump(_node).c_str());
                 return false;
             }
@@ -140,7 +140,7 @@ auto Stops::Sizes(const YAML::Node& _node, uint8_t _units) -> Stops {
     return stops;
 }
 
-auto Stops::Offsets(const YAML::Node& _node, uint8_t _units) -> Stops {
+auto Stops::Offsets(const YAML::Node& _node, UnitSet _units) -> Stops {
     Stops stops;
     if (!_node.IsSequence()) {
         return stops;
@@ -174,8 +174,7 @@ auto Stops::Offsets(const YAML::Node& _node, uint8_t _units) -> Stops {
                 }
             }
             if (widths.size() == 2) {
-                if ( !(widths[0].unit & _units ) &&
-                        !(widths[1].unit & _units) ) {
+                if ( !_units.contains(widths[0].unit) && !_units.contains(widths[1].unit) ) {
                     LOGW("Non-pixel unit not allowed for multidimensionnal stop values");
                 }
                 stops.frames.emplace_back(key, glm::vec2(widths[0].value, widths[1].value));
@@ -186,7 +185,7 @@ auto Stops::Offsets(const YAML::Node& _node, uint8_t _units) -> Stops {
     return stops;
 }
 
-auto Stops::Widths(const YAML::Node& _node, const MapProjection& _projection, uint8_t _units) -> Stops {
+auto Stops::Widths(const YAML::Node& _node, const MapProjection& _projection, UnitSet _units) -> Stops {
     Stops stops;
     if (!_node.IsSequence()) { return stops; }
 
@@ -212,7 +211,7 @@ auto Stops::Widths(const YAML::Node& _node, const MapProjection& _projection, ui
 
         if (StyleParam::parseValueUnitPair(frameNode[1].Scalar(), start, width)) {
 
-            if (! (width.unit & _units) ) {
+            if (! _units.contains(width.unit) ) {
                 LOGW("Invalid unit is being used for stop %s", Dump(frameNode[1]).c_str());
             }
 

--- a/core/src/scene/stops.cpp
+++ b/core/src/scene/stops.cpp
@@ -90,7 +90,7 @@ auto Stops::Sizes(const YAML::Node& _node, UnitSet _units) -> Stops {
     float lastKey = 0;
 
     auto constructFrame = [&](const auto& _frameNode, StyleParam::ValueUnitPair& _result) -> bool {
-        if (StyleParam::parseSizeUnitPair(_frameNode.Scalar(), 0, _result)) {
+        if (StyleParam::parseSizeUnitPair(_frameNode.Scalar(), _result)) {
             if ( !_units.contains(_result.unit) ) {
                 LOGW("Size StyleParam can only take in pixel, %% or auto values in: %s", Dump(_node).c_str());
                 return false;
@@ -206,16 +206,13 @@ auto Stops::Widths(const YAML::Node& _node, const MapProjection& _projection, Un
         lastKey = key;
 
         StyleParam::ValueUnitPair width;
-        width.unit = Unit::meter;
-        size_t start = 0;
-
-        if (StyleParam::parseValueUnitPair(frameNode[1].Scalar(), start, width)) {
+        if (StyleParam::parseValueUnitPair(frameNode[1].Scalar(), width)) {
 
             if (! _units.contains(width.unit) ) {
                 LOGW("Invalid unit is being used for stop %s", Dump(frameNode[1]).c_str());
             }
 
-            if (width.unit == Unit::meter) {
+            if (width.unit == Unit::meter || width.unit == Unit::none) {
                 float w = widthMeterToPixel(key, tileSize, width.value);
                 stops.frames.emplace_back(key, w);
 

--- a/core/src/scene/stops.h
+++ b/core/src/scene/stops.h
@@ -30,10 +30,10 @@ struct Stops {
 
     std::vector<Frame> frames;
     static Stops Colors(const YAML::Node& _node);
-    static Stops Widths(const YAML::Node& _node, const MapProjection& _projection, uint8_t _units);
+    static Stops Widths(const YAML::Node& _node, const MapProjection& _projection, UnitSet _units);
     static Stops FontSize(const YAML::Node& _node);
-    static Stops Sizes(const YAML::Node& _node, uint8_t _units);
-    static Stops Offsets(const YAML::Node& _node, uint8_t _units);
+    static Stops Sizes(const YAML::Node& _node, UnitSet _units);
+    static Stops Offsets(const YAML::Node& _node, UnitSet _units);
     static Stops Numbers(const YAML::Node& node);
 
     Stops(const std::vector<Frame>& _frames) : frames(_frames) {}

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -4,18 +4,20 @@
 #include "platform.h"
 #include "style/textStyle.h"
 #include "util/builders.h" // for cap, join
+#include "util/color.h"
 #include "util/extrude.h"
 #include "util/floatFormatter.h"
 #include "util/geom.h" // for CLAMP
 
 #include "csscolorparser.hpp"
+#include "yaml-cpp/node/node.h"
+#include "yaml-cpp/node/convert.h"
+#include "yaml-cpp/node/emit.h"
 #include <algorithm>
 #include <cstring>
 #include <map>
 
 namespace Tangram {
-
-using Color = CSSColorParser::Color;
 
 const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"align", StyleParamKey::text_align},
@@ -101,17 +103,17 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"width", StyleParamKey::width},
 };
 
-const std::map<StyleParamKey, uint8_t > s_StyleParamUnits = {
-    {StyleParamKey::offset, Unit::pixel},
-    {StyleParamKey::text_offset, Unit::pixel},
-    {StyleParamKey::buffer, Unit::pixel},
-    {StyleParamKey::text_buffer, Unit::pixel},
-    {StyleParamKey::size, (Unit::pixel | Unit::percentage | Unit::sizeauto)},
-    {StyleParamKey::placement_spacing, Unit::pixel},
-    {StyleParamKey::text_font_stroke_width, Unit::pixel},
-    {StyleParamKey::width, (Unit::pixel | Unit::meter)},
-    {StyleParamKey::outline_width, (Unit::pixel | Unit::meter)}
-};
+//const std::map<StyleParamKey, uint8_t > s_StyleParamUnits = {
+//    {StyleParamKey::offset, Unit::pixel},
+//    {StyleParamKey::text_offset, Unit::pixel},
+//    {StyleParamKey::buffer, Unit::pixel},
+//    {StyleParamKey::text_buffer, Unit::pixel},
+//    {StyleParamKey::size, (Unit::pixel | Unit::percentage | Unit::sizeauto)},
+//    {StyleParamKey::placement_spacing, Unit::pixel},
+//    {StyleParamKey::text_font_stroke_width, Unit::pixel},
+//    {StyleParamKey::width, (Unit::pixel | Unit::meter)},
+//    {StyleParamKey::outline_width, (Unit::pixel | Unit::meter)}
+//};
 
 static int parseInt(const std::string& _str, int& _value) {
     try {
@@ -152,52 +154,53 @@ StyleParamKey StyleParam::getKey(const std::string& _key) {
     return it->second;
 }
 
-StyleParam::StyleParam(const std::string& _key, const std::string& _value) {
+StyleParam::StyleParam(const std::string& _key, const YAML::Node& _value) {
     key = getKey(_key);
     value = none_type{};
 
     if (key == StyleParamKey::none) {
-        LOGW("Unknown StyleParam %s:%s", _key.c_str(), _value.c_str());
+        LOGW("Unknown StyleParam %s:%s", _key.c_str(), Dump(_value).c_str());
         return;
     }
-    if (!_value.empty()) {
-        value = parseString(key, _value);
-    }
+    value = parseNode(key, _value);
 }
 
-StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& _value) {
-    auto allowedUnits = unitsForStyleParam(key);
+StyleParam::StyleParam(StyleParamKey _key, const YAML::Node& _value) {
+    key = _key;
+    value = parseNode(key, _value);
+}
+
+
+StyleParam::Value StyleParam::parseNode(StyleParamKey key, const YAML::Node& node) {
+    UnitSet allowedUnits = unitSetForStyleParam(key);
 
     switch (key) {
     case StyleParamKey::extrude: {
-        return parseExtrudeString(_value);
+        return parseExtrudeNode(node);
     }
     case StyleParamKey::text_wrap: {
-        int textWrap;
-        if (_value == "false") {
-            return std::numeric_limits<uint32_t>::max();
-        }
-        if (_value == "true") {
-            return uint32_t(15); // DEFAULT
-        }
-        if (parseInt(_value, textWrap) > 0 && textWrap > 0) {
-             return static_cast<uint32_t>(textWrap);
+        bool useWrap = false;
+        int wrapLength = 15; // Default wrap length.
+        if (YAML::convert<bool>::decode(node, useWrap) && useWrap) {
+            return (uint32_t)wrapLength;
+        } else if (YAML::convert<int>::decode(node, wrapLength) && wrapLength > 0) {
+            return (uint32_t)wrapLength;
         }
         return std::numeric_limits<uint32_t>::max();
     }
     case StyleParamKey::text_offset:
     case StyleParamKey::offset: {
         UnitVec<glm::vec2> vec;
-        if (!parseVec2(_value, allowedUnits, vec) || std::isnan(vec.value.y)) {
-            LOGW("Invalid offset parameter '%s'.", _value.c_str());
+        if (!parseVec2(node, allowedUnits, vec) || std::isnan(vec.value.y)) {
+            LOGW("Invalid offset parameter '%s'.", Dump(node).c_str());
         }
         return vec.value;
     }
     case StyleParamKey::text_buffer:
     case StyleParamKey::buffer: {
         UnitVec<glm::vec2> vec;
-        if (!parseVec2(_value, allowedUnits, vec)) {
-            LOGW("Invalid buffer parameter '%s'.", _value.c_str());
+        if (!parseVec2(node, allowedUnits, vec)) {
+            LOGW("Invalid buffer parameter '%s'.", Dump(node).c_str());
         }
         if (std::isnan(vec.value.y)) {
             vec.value.y = vec.value.x;
@@ -206,8 +209,8 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     }
     case StyleParamKey::size: {
         SizeValue vec;
-        if (!parseSize(_value, allowedUnits, vec)) {
-            LOGW("Invalid size parameter '%s'.", _value.c_str());
+        if (!parseSize(node, allowedUnits, vec)) {
+            LOGW("Invalid size parameter '%s'.", Dump(node).c_str());
         }
         return vec;
     }
@@ -218,36 +221,40 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::text_transition_show_time:
     case StyleParamKey::text_transition_selected_time: {
         float time = 0.0f;
-        if (!parseTime(_value, time)) {
-            LOGW("Invalid time param '%s'", _value.c_str());
+        if (!node.IsScalar() || !parseTime(node.Scalar(), time)) {
+            LOGW("Invalid time param '%s'", Dump(node).c_str());
         }
         return time;
     }
     case StyleParamKey::text_font_family:
     case StyleParamKey::text_font_weight:
     case StyleParamKey::text_font_style: {
-        std::string normalized = _value;
-        std::transform(normalized.begin(), normalized.end(), normalized.begin(), ::tolower);
-        return normalized;
+        std::string result;
+        if (node.IsScalar()) {
+            result = node.Scalar();
+            std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+        }
+        return result;
     }
     case StyleParamKey::anchor:
     case StyleParamKey::text_anchor: {
-        LabelProperty::Anchors anchors;
-        for (auto& anchor : splitString(_value, ',')) {
-            if (anchors.count == LabelProperty::max_anchors) { break; }
-
-            LabelProperty::Anchor labelAnchor;
-            if (LabelProperty::anchor(anchor, labelAnchor)) {
-                anchors.anchor[anchors.count++] = labelAnchor;
-            } else {
-                LOG("Invalid anchor %s", anchor.c_str());
+        LabelProperty::Anchors anchorSet;
+        LabelProperty::Anchor anchor;
+        if (node.IsScalar() && LabelProperty::anchor(node.Scalar(), anchor)) {
+            anchorSet.anchor[anchorSet.count++] = anchor;
+        } else if (node.IsSequence()) {
+            for (const auto& subNode : node) {
+                if (anchorSet.count >= LabelProperty::max_anchors) { break; }
+                if (subNode.IsScalar() && LabelProperty::anchor(subNode.Scalar(), anchor)) {
+                    anchorSet.anchor[anchorSet.count++] = anchor;
+                }
             }
         }
-        return anchors;
+        return anchorSet;
     }
     case StyleParamKey::placement: {
         LabelProperty::Placement placement = LabelProperty::Placement::vertex;
-        if (!LabelProperty::placement(_value, placement)) {
+        if (node.IsScalar() && !LabelProperty::placement(node.Scalar(), placement)) {
             LOG("Invalid placement parameter, Setting vertex as default.");
         }
         return placement;
@@ -256,15 +263,14 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::text_source_left:
     case StyleParamKey::text_source_right: {
         TextSource textSource;
-        // FIXME remove white space
-        std::string tmp;
-        if (_value.find(',') != std::string::npos) {
-            std::stringstream ss(_value);
-            while (std::getline(ss, tmp, ',')) {
-                textSource.keys.push_back(tmp);
+        if (node.IsScalar()) {
+            textSource.keys.push_back(node.Scalar());
+        } else if (node.IsSequence()) {
+            for (const auto& subNode : node) {
+                if (subNode.IsScalar()) {
+                    textSource.keys.push_back(subNode.Scalar());
+                }
             }
-        } else {
-            textSource.keys.push_back(_value);
         }
         return std::move(textSource);
     }
@@ -276,12 +282,16 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::outline_style:
     case StyleParamKey::repeat_group:
     case StyleParamKey::text_repeat_group:
-    case StyleParamKey::texture:
-        return _value;
+    case StyleParamKey::texture: {
+        if (node.IsScalar()) {
+            return node.Scalar();
+        }
+        return std::string();
+    }
     case StyleParamKey::text_font_size: {
         float fontSize = 0.f;
-        if (!parseFontSize(_value, fontSize)) {
-            LOGW("Invalid font-size '%s'.", _value.c_str());
+        if (!node.IsScalar() || !parseFontSize(node.Scalar(), fontSize)) {
+            LOGW("Invalid font-size '%s'.", node.Scalar().c_str());
         }
         return fontSize;
     }
@@ -294,11 +304,14 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::outline_visible:
     case StyleParamKey::collide:
     case StyleParamKey::text_optional:
-    case StyleParamKey::text_collide:
-        if (_value == "true") { return true; }
-        if (_value == "false") { return false; }
-        LOGW("Invalid boolean value %s for key %s", _value.c_str(), StyleParam::keyName(key).c_str());
+    case StyleParamKey::text_collide: {
+        bool result = false;
+        if (YAML::convert<bool>::decode(node, result)) {
+            return result;
+        }
+        LOGW("Invalid boolean value %s for key %s", Dump(node).c_str(), StyleParam::keyName(key).c_str());
         break;
+    }
     case StyleParamKey::text_order:
         LOGW("text:order parameter is ignored.");
         break;
@@ -307,70 +320,64 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::priority:
     case StyleParamKey::text_max_lines:
     case StyleParamKey::text_priority: {
-        int num;
-        if (parseInt(_value, num) > 0) {
-            if (num >= 0) {
-                return static_cast<uint32_t>(num);
-            }
+        int result = -1;
+        if (YAML::convert<int>::decode(node, result) && result >= 0) {
+            return static_cast<uint32_t>(result);
         }
-        LOGW("Invalid '%s' value '%s'", keyName(key).c_str(), _value.c_str());
+        LOGW("Invalid '%s' value '%s'", keyName(key).c_str(), Dump(node).c_str());
         break;
     }
     case StyleParamKey::placement_spacing: {
-        ValueUnitPair placementSpacing;
-        placementSpacing.unit = Unit::pixel;
-
-        int pos = parseValueUnitPair(_value, 0, placementSpacing);
-        if (pos < 0) {
-            LOGW("Invalid placement spacing value '%s'", _value.c_str());
-            placementSpacing.value =  80.0f;
-            placementSpacing.unit = Unit::pixel;
-        } else {
-            if (placementSpacing.unit != Unit::pixel) {
-                LOGW("Invalid unit provided for placement spacing");
+        ValueUnitPair result;
+        if (node.IsScalar() && parseValueUnitPair(node.Scalar(), result)) {
+            if (result.unit == Unit::none) {
+                result.unit = Unit::pixel;
             }
         }
-
-        return Width(placementSpacing);
+        if (result.unit != Unit::pixel) {
+            LOGW("Invalid placement spacing value '%s'", Dump(node).c_str());
+            result.value = 80.f;
+            result.unit = Unit::pixel;
+        }
+        return Width(result);
     }
     case StyleParamKey::repeat_distance:
     case StyleParamKey::text_repeat_distance: {
-        ValueUnitPair repeatDistance;
-        repeatDistance.unit = Unit::pixel;
-
-        int pos = parseValueUnitPair(_value, 0, repeatDistance);
-        if (pos < 0) {
-            LOGW("Invalid repeat distance value '%s'", _value.c_str());
-            repeatDistance.value =  256.0f;
-            repeatDistance.unit = Unit::pixel;
-        } else {
-            if (repeatDistance.unit != Unit::pixel) {
-                LOGW("Invalid unit provided for repeat distance");
+        ValueUnitPair result;
+        if (node.IsScalar() && parseValueUnitPair(node.Scalar(), result)) {
+            if (result.unit == Unit::none) {
+                result.unit = Unit::pixel;
             }
         }
-
-        return Width(repeatDistance);
+        if (result.unit != Unit::pixel) {
+            LOGW("Invalid repeat distance value '%s'", Dump(node).c_str());
+            result.value = 256.f;
+            result.unit = Unit::pixel;
+        }
+        return Width(result);
     }
     case StyleParamKey::width:
     case StyleParamKey::outline_width: {
-        ValueUnitPair width;
-        width.unit = Unit::meter;
-
-        int pos = parseValueUnitPair(_value, 0, width);
-        if (pos < 0) {
-            LOGW("Invalid width value '%s'", _value.c_str());
-            width.value =  2.0f;
-            width.unit = Unit::pixel;
+        ValueUnitPair result;
+        if (node.IsScalar() && parseValueUnitPair(node.Scalar(), result)) {
+            if (result.unit == Unit::none) {
+                result.unit = Unit::meter;
+            }
         }
-
-        return Width(width);
+        if (result.unit != Unit::meter && result.unit != Unit::pixel) {
+            LOGW("Invalid width value '%s'", Dump(node).c_str());
+            result.value = 2.f;
+            result.unit = Unit::pixel;
+        }
+        return Width(result);
     }
     case StyleParamKey::angle: {
-        double num;
-        if (_value == "auto") {
-            return std::nanf("1");
-        } else if (parseFloat(_value, num) > 0) {
-            return static_cast<float>(num);
+        if (node.IsScalar() && node.Scalar() == "auto") {
+            return NAN;
+        }
+        float number;
+        if (YAML::convert<float>::decode(node, number)) {
+            return number;
         }
         break;
     }
@@ -378,33 +385,286 @@ StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& 
     case StyleParamKey::outline_miter_limit:
     case StyleParamKey::placement_min_length_ratio:
     case StyleParamKey::text_font_stroke_width: {
-        double num;
-        if (parseFloat(_value, num) > 0) {
-             return static_cast<float>(num);
+        float number;
+        if (YAML::convert<float>::decode(node, number)) {
+            return number;
         }
         break;
     }
-
     case StyleParamKey::color:
     case StyleParamKey::outline_color:
     case StyleParamKey::text_font_fill:
-    case StyleParamKey::text_font_stroke_color:
-        return parseColor(_value);
-
+    case StyleParamKey::text_font_stroke_color: {
+        Color result;
+        if (parseColor(node, result)) {
+            return result.abgr;
+        }
+        LOGW("Invalid color value: %s", Dump(node).c_str());
+        break;
+    }
     case StyleParamKey::cap:
     case StyleParamKey::outline_cap:
-        return static_cast<uint32_t>(CapTypeFromString(_value));
-
+        if (node.IsScalar()) {
+            return static_cast<uint32_t>(CapTypeFromString(node.Scalar()));
+        }
+        break;
     case StyleParamKey::join:
     case StyleParamKey::outline_join:
-        return static_cast<uint32_t>(JoinTypeFromString(_value));
-
+        if (node.IsScalar()) {
+            return static_cast<uint32_t>(JoinTypeFromString(node.Scalar()));
+        }
+        break;
     default:
         break;
     }
 
     return none_type{};
 }
+
+StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& value) {
+    YAML::Node node(value);
+    return parseNode(key, node);
+}
+//StyleParam::Value StyleParam::parseString(StyleParamKey key, const std::string& _value) {
+//    auto allowedUnits = unitsForStyleParam(key);
+//
+//    switch (key) {
+//    case StyleParamKey::extrude: {
+//        return parseExtrudeString(_value);
+//    }
+//    case StyleParamKey::text_wrap: {
+//        int textWrap;
+//        if (_value == "false") {
+//            return std::numeric_limits<uint32_t>::max();
+//        }
+//        if (_value == "true") {
+//            return uint32_t(15); // DEFAULT
+//        }
+//        if (parseInt(_value, textWrap) > 0 && textWrap > 0) {
+//             return static_cast<uint32_t>(textWrap);
+//        }
+//        return std::numeric_limits<uint32_t>::max();
+//    }
+//    case StyleParamKey::text_offset:
+//    case StyleParamKey::offset: {
+//        UnitVec<glm::vec2> vec;
+//        if (!parseVec2(_value, allowedUnits, vec) || std::isnan(vec.value.y)) {
+//            LOGW("Invalid offset parameter '%s'.", _value.c_str());
+//        }
+//        return vec.value;
+//    }
+//    case StyleParamKey::text_buffer:
+//    case StyleParamKey::buffer: {
+//        UnitVec<glm::vec2> vec;
+//        if (!parseVec2(_value, allowedUnits, vec)) {
+//            LOGW("Invalid buffer parameter '%s'.", _value.c_str());
+//        }
+//        if (std::isnan(vec.value.y)) {
+//            vec.value.y = vec.value.x;
+//        }
+//        return vec.value;
+//    }
+//    case StyleParamKey::size: {
+//        SizeValue vec;
+//        if (!parseSize(_value, allowedUnits, vec)) {
+//            LOGW("Invalid size parameter '%s'.", _value.c_str());
+//        }
+//        return vec;
+//    }
+//    case StyleParamKey::transition_hide_time:
+//    case StyleParamKey::transition_show_time:
+//    case StyleParamKey::transition_selected_time:
+//    case StyleParamKey::text_transition_hide_time:
+//    case StyleParamKey::text_transition_show_time:
+//    case StyleParamKey::text_transition_selected_time: {
+//        float time = 0.0f;
+//        if (!parseTime(_value, time)) {
+//            LOGW("Invalid time param '%s'", _value.c_str());
+//        }
+//        return time;
+//    }
+//    case StyleParamKey::text_font_family:
+//    case StyleParamKey::text_font_weight:
+//    case StyleParamKey::text_font_style: {
+//        std::string normalized = _value;
+//        std::transform(normalized.begin(), normalized.end(), normalized.begin(), ::tolower);
+//        return normalized;
+//    }
+//    case StyleParamKey::anchor:
+//    case StyleParamKey::text_anchor: {
+//        LabelProperty::Anchors anchors;
+//        for (auto& anchor : splitString(_value, ',')) {
+//            if (anchors.count == LabelProperty::max_anchors) { break; }
+//
+//            LabelProperty::Anchor labelAnchor;
+//            if (LabelProperty::anchor(anchor, labelAnchor)) {
+//                anchors.anchor[anchors.count++] = labelAnchor;
+//            } else {
+//                LOG("Invalid anchor %s", anchor.c_str());
+//            }
+//        }
+//        return anchors;
+//    }
+//    case StyleParamKey::placement: {
+//        LabelProperty::Placement placement = LabelProperty::Placement::vertex;
+//        if (!LabelProperty::placement(_value, placement)) {
+//            LOG("Invalid placement parameter, Setting vertex as default.");
+//        }
+//        return placement;
+//    }
+//    case StyleParamKey::text_source:
+//    case StyleParamKey::text_source_left:
+//    case StyleParamKey::text_source_right: {
+//        TextSource textSource;
+//        // FIXME remove white space
+//        std::string tmp;
+//        if (_value.find(',') != std::string::npos) {
+//            std::stringstream ss(_value);
+//            while (std::getline(ss, tmp, ',')) {
+//                textSource.keys.push_back(tmp);
+//            }
+//        } else {
+//            textSource.keys.push_back(_value);
+//        }
+//        return std::move(textSource);
+//    }
+//    case StyleParamKey::text_align:
+//    case StyleParamKey::text_transform:
+//    case StyleParamKey::sprite:
+//    case StyleParamKey::sprite_default:
+//    case StyleParamKey::style:
+//    case StyleParamKey::outline_style:
+//    case StyleParamKey::repeat_group:
+//    case StyleParamKey::text_repeat_group:
+//    case StyleParamKey::texture:
+//        return _value;
+//    case StyleParamKey::text_font_size: {
+//        float fontSize = 0.f;
+//        if (!parseFontSize(_value, fontSize)) {
+//            LOGW("Invalid font-size '%s'.", _value.c_str());
+//        }
+//        return fontSize;
+//    }
+//    case StyleParamKey::flat:
+//    case StyleParamKey::interactive:
+//    case StyleParamKey::text_interactive:
+//    case StyleParamKey::tile_edges:
+//    case StyleParamKey::visible:
+//    case StyleParamKey::text_visible:
+//    case StyleParamKey::outline_visible:
+//    case StyleParamKey::collide:
+//    case StyleParamKey::text_optional:
+//    case StyleParamKey::text_collide:
+//        if (_value == "true") { return true; }
+//        if (_value == "false") { return false; }
+//        LOGW("Invalid boolean value %s for key %s", _value.c_str(), StyleParam::keyName(key).c_str());
+//        break;
+//    case StyleParamKey::text_order:
+//        LOGW("text:order parameter is ignored.");
+//        break;
+//    case StyleParamKey::order:
+//    case StyleParamKey::outline_order:
+//    case StyleParamKey::priority:
+//    case StyleParamKey::text_max_lines:
+//    case StyleParamKey::text_priority: {
+//        int num;
+//        if (parseInt(_value, num) > 0) {
+//            if (num >= 0) {
+//                return static_cast<uint32_t>(num);
+//            }
+//        }
+//        LOGW("Invalid '%s' value '%s'", keyName(key).c_str(), _value.c_str());
+//        break;
+//    }
+//    case StyleParamKey::placement_spacing: {
+//        ValueUnitPair placementSpacing;
+//        placementSpacing.unit = Unit::pixel;
+//
+//        int pos = parseValueUnitPair(_value, 0, placementSpacing);
+//        if (pos < 0) {
+//            LOGW("Invalid placement spacing value '%s'", _value.c_str());
+//            placementSpacing.value =  80.0f;
+//            placementSpacing.unit = Unit::pixel;
+//        } else {
+//            if (placementSpacing.unit != Unit::pixel) {
+//                LOGW("Invalid unit provided for placement spacing");
+//            }
+//        }
+//
+//        return Width(placementSpacing);
+//    }
+//    case StyleParamKey::repeat_distance:
+//    case StyleParamKey::text_repeat_distance: {
+//        ValueUnitPair repeatDistance;
+//        repeatDistance.unit = Unit::pixel;
+//
+//        int pos = parseValueUnitPair(_value, 0, repeatDistance);
+//        if (pos < 0) {
+//            LOGW("Invalid repeat distance value '%s'", _value.c_str());
+//            repeatDistance.value =  256.0f;
+//            repeatDistance.unit = Unit::pixel;
+//        } else {
+//            if (repeatDistance.unit != Unit::pixel) {
+//                LOGW("Invalid unit provided for repeat distance");
+//            }
+//        }
+//
+//        return Width(repeatDistance);
+//    }
+//    case StyleParamKey::width:
+//    case StyleParamKey::outline_width: {
+//        ValueUnitPair width;
+//        width.unit = Unit::meter;
+//
+//        int pos = parseValueUnitPair(_value, 0, width);
+//        if (pos < 0) {
+//            LOGW("Invalid width value '%s'", _value.c_str());
+//            width.value =  2.0f;
+//            width.unit = Unit::pixel;
+//        }
+//
+//        return Width(width);
+//    }
+//    case StyleParamKey::angle: {
+//        double num;
+//        if (_value == "auto") {
+//            return std::nanf("1");
+//        } else if (parseFloat(_value, num) > 0) {
+//            return static_cast<float>(num);
+//        }
+//        break;
+//    }
+//    case StyleParamKey::miter_limit:
+//    case StyleParamKey::outline_miter_limit:
+//    case StyleParamKey::placement_min_length_ratio:
+//    case StyleParamKey::text_font_stroke_width: {
+//        double num;
+//        if (parseFloat(_value, num) > 0) {
+//             return static_cast<float>(num);
+//        }
+//        break;
+//    }
+//
+//    case StyleParamKey::color:
+//    case StyleParamKey::outline_color:
+//    case StyleParamKey::text_font_fill:
+//    case StyleParamKey::text_font_stroke_color:
+//        return parseColor(_value);
+//
+//    case StyleParamKey::cap:
+//    case StyleParamKey::outline_cap:
+//        return static_cast<uint32_t>(CapTypeFromString(_value));
+//
+//    case StyleParamKey::join:
+//    case StyleParamKey::outline_join:
+//        return static_cast<uint32_t>(JoinTypeFromString(_value));
+//
+//    default:
+//        break;
+//    }
+//
+//    return none_type{};
+//}
 
 std::string StyleParam::toString() const {
 
@@ -569,18 +829,18 @@ int StyleParam::parseValueUnitPair(const std::string& _value, size_t offset,
 }
 
 bool StyleParam::parseTime(const std::string &_value, float &_time) {
-    ValueUnitPair p;
+    ValueUnitPair result;
 
-    if (!parseValueUnitPair(_value, 0, p)) {
+    if (!parseValueUnitPair(_value, result)) {
         return false;
     }
 
-    switch (p.unit) {
+    switch (result.unit) {
         case Unit::milliseconds:
-            _time = p.value / 1000.f;
+            _time = result.value / 1000.f;
             break;
         case Unit::seconds:
-            _time = p.value;
+            _time = result.value;
             break;
         default:
             LOGW("Invalid unit provided for time %s", _value.c_str());
@@ -619,57 +879,153 @@ int parseVec(const std::string& _value, T& _vec) {
     return elements;
 }
 
+//template<typename T>
+//int parseVec(const std::string& _value, uint8_t allowedUnits, UnitVec<T>& _vec) {
+//     // initialize with defaults
+//    const size_t elements = _vec.size;
+//    for (size_t i = 0; i < elements; i++) {
+//        _vec.units[i] = Unit::pixel;
+//        _vec.value[i] = NAN;
+//    }
+//
+//    int offset = 0;
+//    for (size_t i = 0; i < elements; i++) {
+//        StyleParam::ValueUnitPair v;
+//        offset = StyleParam::parseValueUnitPair(_value, offset, v);
+//        if (offset < 0) { return i; }
+//
+//        if ( !(v.unit & allowedUnits) ) {
+//            return 0;
+//        }
+//        _vec.units[i] = v.unit;
+//        _vec.value[i] = v.value;
+//    }
+//
+//    return elements;
+//}
+
+//bool StyleParam::parseSize(const std::string &_value, uint8_t allowedUnits, SizeValue& _vec) {
+//    int offset = 0;
+//    offset = StyleParam::parseSizeUnitPair(_value, offset, _vec.x);
+//    if (offset != _value.size()) {
+//        offset = StyleParam::parseSizeUnitPair(_value, offset, _vec.y);
+//    }
+//    return (offset > 0) && ((_vec.x.unit & allowedUnits) && (_vec.y.unit & allowedUnits));
+//}
+
+//bool StyleParam::parseVec2(const std::string& _value, uint8_t allowedUnits, UnitVec<glm::vec2>& _vec) {
+//    return parseVec(_value, allowedUnits, _vec);
+//}
+
+//bool StyleParam::parseVec3(const std::string& _value, uint8_t allowedUnits, UnitVec<glm::vec3>& _vec) {
+//    return parseVec(_value, allowedUnits, _vec);
+//}
+
 template<typename T>
-int parseVec(const std::string& _value, uint8_t allowedUnits, UnitVec<T>& _vec) {
-     // initialize with defaults
-    const size_t elements = _vec.size;
-    for (size_t i = 0; i < elements; i++) {
-        _vec.units[i] = Unit::pixel;
-        _vec.value[i] = NAN;
+bool parseVec(const YAML::Node& node, UnitSet allowedUnits, UnitVec<T>& vec) {
+    if (!node.IsSequence()) {
+        return false;
     }
-
-    int offset = 0;
-    for (size_t i = 0; i < elements; i++) {
-        StyleParam::ValueUnitPair v;
-        offset = StyleParam::parseValueUnitPair(_value, offset, v);
-        if (offset < 0) { return i; }
-
-        if ( !(v.unit & allowedUnits) ) {
-            return 0;
+    size_t nodeSize = node.size();
+    bool success = true;
+    for (size_t i = 0; i < vec.size; i++) {
+        if (i >= nodeSize) {
+            success = false;
+            break;
         }
-        _vec.units[i] = v.unit;
-        _vec.value[i] = v.value;
+        const auto& nodeElement = node[i];
+        if (!nodeElement.IsScalar()) {
+            success = false;
+            continue;
+        }
+        StyleParam::ValueUnitPair result;
+        success |= StyleParam::parseValueUnitPair(nodeElement.Scalar(), result);
+
+        if (!allowedUnits.contains(result.unit)) {
+            success = false;
+        }
+        vec.units[i] = result.unit;
+        vec.value[i] = result.value;
     }
 
-    return elements;
+    return success;
 }
 
-bool StyleParam::parseSize(const std::string &_value, uint8_t allowedUnits, SizeValue& _vec) {
+bool StyleParam::parseSize(const YAML::Node& node, UnitSet allowedUnits, SizeValue& result) {
+    bool success = false;
+    if (node.IsScalar()) {
+        success = parseSizeUnitPair(node.Scalar(), result.x);
+    }
+    if (node.IsSequence() && node.size() >= 2) {
+        const auto& nodeFirst = node[0];
+        const auto& nodeSecond = node[1];
+        success |= nodeFirst.IsScalar() && parseSizeUnitPair(nodeFirst.Scalar(), result.x);
+        success |= nodeSecond.IsScalar() && parseSizeUnitPair(nodeSecond.Scalar(), result.y);
+    }
+    return success && (allowedUnits.contains(result.x.unit) && allowedUnits.contains(result.y.unit));
+}
+
+bool StyleParam::parseVec2(const YAML::Node& node, UnitSet allowedUnits, UnitVec<glm::vec2>& result) {
+    return parseVec(node, allowedUnits, result);
+}
+
+bool StyleParam::parseVec3(const YAML::Node& node, UnitSet allowedUnits, UnitVec<glm::vec3>& result) {
+    return parseVec(node, allowedUnits, result);
+}
+
+bool StyleParam::parseSizeUnitPair(const std::string& value, StyleParam::ValueUnitPair& result) {
+    if (value == "auto") {
+        result.unit = Unit::sizeauto;
+        return true;
+    }
+    return parseValueUnitPair(value, result);
+}
+
+bool StyleParam::parseValueUnitPair(const std::string& value, StyleParam::ValueUnitPair& result) {
     int offset = 0;
-    offset = StyleParam::parseSizeUnitPair(_value, offset, _vec.x);
-    if (offset != _value.size()) {
-        offset = StyleParam::parseSizeUnitPair(_value, offset, _vec.y);
+    float number = ff::stof(&value[0], value.size(), &offset);
+    if (offset <= 0) {
+        return false;
     }
-    return (offset > 0) && ((_vec.x.unit & allowedUnits) && (_vec.y.unit & allowedUnits));
+    Unit unit = stringToUnit(value, offset, value.size() - offset);
+    result.value = number;
+    result.unit = unit;
+    return true;
 }
 
-bool StyleParam::parseVec2(const std::string& _value, uint8_t allowedUnits, UnitVec<glm::vec2>& _vec) {
-    return parseVec(_value, allowedUnits, _vec);
-}
-
-bool StyleParam::parseVec3(const std::string& _value, uint8_t allowedUnits, UnitVec<glm::vec3>& _vec) {
-    return parseVec(_value, allowedUnits, _vec);
+bool StyleParam::parseColor(const YAML::Node& node, Color &result) {
+    bool isValid = false;
+    if (node.IsScalar()) {
+        auto cssColor = CSSColorParser::parse(node.Scalar(), isValid);
+        if (isValid) {
+            result.abgr = cssColor.getInt();
+        }
+    }
+    if (node.IsSequence() && node.size() >= 3) {
+        ColorF color;
+        isValid = true;
+        isValid |= YAML::convert<float>::decode(node[0], color.r);
+        isValid |= YAML::convert<float>::decode(node[1], color.g);
+        isValid |= YAML::convert<float>::decode(node[2], color.b);
+        if (node.size() >= 4) {
+            isValid |= YAML::convert<float>::decode(node[3], color.a);
+        }
+        if (isValid) {
+            result = color.toColor();
+        }
+    }
+    return isValid;
 }
 
 uint32_t StyleParam::parseColor(const std::string& _color) {
-    Color color;
+    CSSColorParser::Color color;
 
     // First, try to parse as comma-separated rgba components.
     glm::vec4 rgba(1.0f);
     int elements = parseVec(_color, rgba);
 
     if (elements >= 3) {
-        color = Color {
+        color = {
             static_cast<uint8_t>(CLAMP((rgba[0] * 255.), 0, 255)),
             static_cast<uint8_t>(CLAMP((rgba[1] * 255.), 0, 255)),
             static_cast<uint8_t>(CLAMP((rgba[2] * 255.), 0, 255)),
@@ -782,12 +1138,31 @@ bool StyleParam::isRequired(StyleParamKey _key) {
     return std::find(requiredKeys.begin(), requiredKeys.end(), _key) != requiredKeys.end();
 }
 
-uint8_t StyleParam::unitsForStyleParam(StyleParamKey _key) {
-    auto it = s_StyleParamUnits.find(_key);
-    if (it != s_StyleParamUnits.end()) {
-        return it->second;
+//uint8_t StyleParam::unitsForStyleParam(StyleParamKey _key) {
+//    auto it = s_StyleParamUnits.find(_key);
+//    if (it != s_StyleParamUnits.end()) {
+//        return it->second;
+//    }
+//    return 0;
+//}
+
+UnitSet StyleParam::unitSetForStyleParam(StyleParamKey key) {
+    switch (key) {
+    case StyleParamKey::buffer:
+    case StyleParamKey::offset:
+    case StyleParamKey::placement_spacing:
+    case StyleParamKey::text_buffer:
+    case StyleParamKey::text_font_stroke_width:
+    case StyleParamKey::text_offset:
+        return UnitSet{ Unit::pixel };
+    case StyleParamKey::size:
+        return UnitSet{ Unit::pixel, Unit::percentage, Unit::sizeauto };
+    case StyleParamKey::width:
+    case StyleParamKey::outline_width:
+        return UnitSet{ Unit::pixel, Unit::meter };
+    default:
+        return UnitSet{};
     }
-    return 0;
 }
 
 }

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -628,9 +628,13 @@ bool StyleParam::parseSizeUnitPair(const std::string& value, StyleParam::ValueUn
 
 bool StyleParam::parseValueUnitPair(const std::string& value, StyleParam::ValueUnitPair& result) {
     int offset = 0;
-    float number = ff::stof(&value[0], value.size(), &offset);
+    float number = ff::stof(value.data(), value.size(), &offset);
     if (offset <= 0) {
         return false;
+    }
+    // Skip any leading whitespace.
+    while (std::isspace(value[offset])) {
+        offset++;
     }
     Unit unit = stringToUnit(value, offset, value.size() - offset);
     result.value = number;

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -667,14 +667,14 @@ bool StyleParam::parseFontSize(const std::string& _str, float& _pxSize) {
 
     if (_str.compare(index, end, "px") == 0) {
         return true;
-    } else if (_str.compare(index, end, "em") == 0) {
-        // FIXME: Number strings ending with 'em' fail to match this.
-        // The float parser consumes the 'e' (for scientific notation like '1.2e6').
-        _pxSize *= 16.f;
     } else if (_str.compare(index, end, "pt") == 0) {
         _pxSize /= 0.75f;
     } else if (_str.compare(index, end, "%") == 0) {
         _pxSize /= 6.25f;
+    } else if (_str.compare(index - 1, end, "em") == 0) {
+        // The float parser consumes the 'e' (for scientific notation like '1.2e6') so if the string ends with 'em'
+        // then 'e' will be the last character consumed and the substring from index-1 to end will be 'em'.
+        _pxSize *= 16.f;
     } else {
         return false;
     }

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -631,11 +631,13 @@ bool StyleParam::parseColor(const YAML::Node& node, Color &result) {
     if (node.IsSequence() && node.size() >= 3) {
         ColorF color;
         isValid = true;
-        isValid |= YAML::convert<float>::decode(node[0], color.r);
-        isValid |= YAML::convert<float>::decode(node[1], color.g);
-        isValid |= YAML::convert<float>::decode(node[2], color.b);
+        isValid &= YamlUtil::getFloat(node[0], color.r);
+        isValid &= YamlUtil::getFloat(node[1], color.g);
+        isValid &= YamlUtil::getFloat(node[2], color.b);
         if (node.size() >= 4) {
-            isValid |= YAML::convert<float>::decode(node[3], color.a);
+            isValid &= YamlUtil::getFloat(node[3], color.a);
+        } else {
+            color.a = 1.f;
         }
         if (isValid) {
             result = color.toColor();

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -120,7 +120,7 @@ struct UnitSet {
         }
     }
     bool contains(Unit unit) {
-        return (bits & static_cast<int>(unit)) != 0;
+        return (bits & (1 << static_cast<int>(unit))) != 0;
     }
 };
 

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -273,19 +273,7 @@ struct StyleParam {
     /* parse a font size (in em, pt, %) and give the appropriate size in pixel */
     static bool parseFontSize(const std::string& _size, float& _pxSize);
 
-    static uint32_t parseColor(const std::string& _color);
-
     static bool parseTime(const std::string& _value, float& _time);
-
-    // values within _value string parameter must be delimited by ','
-//    static bool parseSize(const std::string& _value, uint8_t _allowedUnits, SizeValue& _vec2);
-//    static bool parseVec2(const std::string& _value, uint8_t _allowedUnits, UnitVec<glm::vec2>& _vec2);
-//    static bool parseVec3(const std::string& _value, uint8_t _allowedUnits, UnitVec<glm::vec3>& _vec3);
-
-    static int parseSizeUnitPair(const std::string& _value, size_t start,
-                                 StyleParam::ValueUnitPair& _result);
-    static int parseValueUnitPair(const std::string& _value, size_t start,
-                                  StyleParam::ValueUnitPair& _result);
 
     static Value parseString(StyleParamKey key, const std::string& _value);
 
@@ -307,8 +295,6 @@ struct StyleParam {
     static bool isNumberType(StyleParamKey _key);
     static bool isFontSize(StyleParamKey _key);
     static bool isRequired(StyleParamKey _key);
-
-//    static uint8_t unitsForStyleParam(StyleParamKey _key);
 
     static UnitSet unitSetForStyleParam(StyleParamKey key);
 

--- a/core/src/util/extrude.cpp
+++ b/core/src/util/extrude.cpp
@@ -1,71 +1,16 @@
 #include "util/extrude.h"
 
-#include "util/floatFormatter.h"
-
-#include "yaml-cpp/node/node.h"
-#include "yaml-cpp/node/convert.h"
+#include "util/yamlUtil.h"
 #include <cmath>
-#include <cstdlib>
 
 namespace Tangram {
-
-Extrude parseExtrudeString(const std::string& _str) {
-
-    // Values specified from the stylesheet are assumed to be meters with no unit suffix
-    float first = 0, second = 0;
-
-    if (_str == "true") {
-        // "true" means use default properties for both heights, we indicate this with NANs
-        return Extrude(NAN, NAN);
-    }
-
-    if (_str == "false") {
-        // "false" means perform no extrusion
-        return Extrude(0, 0);
-    }
-
-    // Parse the first of two possible numbers
-    const char* str = _str.c_str();
-
-    // Get a float if possible & advance pos to the end of the number
-    const int length = _str.length();
-    int count = 0;
-    int offset = 0;
-
-    first = ff::stof(str, length, &count);
-    if (count == 0) {
-        // No numbers found, return zero extrusion
-        return Extrude(0, 0);
-    }
-
-    // Advance and skip the delimiter character
-    offset += count;
-    if (length - offset <= 0) {
-        return Extrude(0, first);
-    }
-    while (str[offset] == ' ') { offset++; }
-    if (str[offset++] != ',') {
-        return Extrude(0, first);
-    }
-
-    // Get a float if possible & advance pos to the end of the number
-    second = ff::stof(str + offset, length - offset, &count);
-    if (count == 0) {
-        // No second number, so return an extrusion from 0 to the first number
-        return Extrude(0, first);
-    }
-
-    // Got two numbers, so return an extrusion from first to second
-    return Extrude(first, second);
-
-}
 
 Extrude parseExtrudeNode(const YAML::Node& node) {
     // Values specified from the stylesheet are assumed to be meters with no unit suffix
     float first = 0, second = 0;
 
     bool extrudeBoolean = false;
-    if (YAML::convert<bool>::decode(node, extrudeBoolean)) {
+    if (YamlUtil::getBool(node, extrudeBoolean)) {
         if (extrudeBoolean) {
             // "true" means use default properties for both heights, we indicate this with NANs
             return Extrude(NAN, NAN);
@@ -74,16 +19,16 @@ Extrude parseExtrudeNode(const YAML::Node& node) {
         return Extrude(0, 0);
     }
 
-    if (YAML::convert<float>::decode(node, first)) {
-        // No second number, so return an extrusion from 0 to the first number
-        return Extrude(0, first);
-    }
-
     if (node.IsSequence() && node.size() >= 2) {
-        if (YAML::convert<float>::decode(node[0], first) && YAML::convert<float>::decode(node[1], second)) {
+        if (YamlUtil::getFloat(node[0], first) && YamlUtil::getFloat(node[1], second)) {
             // Got two numbers, so return an extrusion from first to second
             return Extrude(first, second);
         }
+    }
+
+    if (YamlUtil::getFloat(node, first)) {
+        // No second number, so return an extrusion from 0 to the first number
+        return Extrude(0, first);
     }
 
     // No numbers found, return zero extrusion

--- a/core/src/util/extrude.h
+++ b/core/src/util/extrude.h
@@ -5,6 +5,10 @@
 #include "glm/vec2.hpp"
 #include <string>
 
+namespace YAML {
+    class Node;
+}
+
 namespace Tangram {
 
 // Extrude is a 2-element vector that follows specific conventions to encode extrusion options
@@ -13,6 +17,7 @@ using Extrude = glm::vec2;
 // Returns an Extrude to represent the extrusion option specified in the string, one of:
 // "true", "false", a single number, or a comma-separated pair of numbers
 Extrude parseExtrudeString(const std::string& _str);
+Extrude parseExtrudeNode(const YAML::Node& node);
 
 // Returns the lower or upper extrusion values for a given Extrude and set of feature properties
 float getLowerExtrudeMeters(const Extrude& _extrude, const Properties& _props);

--- a/core/src/util/extrude.h
+++ b/core/src/util/extrude.h
@@ -14,9 +14,8 @@ namespace Tangram {
 // Extrude is a 2-element vector that follows specific conventions to encode extrusion options
 using Extrude = glm::vec2;
 
-// Returns an Extrude to represent the extrusion option specified in the string, one of:
-// "true", "false", a single number, or a comma-separated pair of numbers
-Extrude parseExtrudeString(const std::string& _str);
+// Returns an Extrude to represent the extrusion option specified in the node, one of:
+// "true", "false", a single number, or a sequence of two numbers.
 Extrude parseExtrudeNode(const YAML::Node& node);
 
 // Returns the lower or upper extrusion values for a given Extrude and set of feature properties

--- a/tests/unit/stopsTests.cpp
+++ b/tests/unit/stopsTests.cpp
@@ -136,8 +136,7 @@ TEST_CASE("Regression test - Dont crash on evaluating empty stops", "[Stops][YAM
 
     {
         MercatorProjection proj{};
-        uint8_t allowedUnit = Unit::meter;
-        Stops stops(Stops::Widths(node, proj, allowedUnit));
+        Stops stops(Stops::Widths(node, proj, UnitSet{Unit::meter}));
         REQUIRE(stops.frames.size() == 0);
         stops.evalVec2(1);
     }
@@ -147,8 +146,7 @@ TEST_CASE("Regression test - Dont crash on evaluating empty stops", "[Stops][YAM
         stops.evalVec2(1);
     }
     {
-        uint8_t allowedUnit = Unit::meter;
-        Stops stops(Stops::Offsets(node, allowedUnit));
+        Stops stops(Stops::Offsets(node, UnitSet{Unit::meter}));
         REQUIRE(stops.frames.size() == 0);
         stops.evalVec2(1);
     }
@@ -166,42 +164,42 @@ TEST_CASE("Mixed dimension stops for StyleParam::size not allowed, exception of 
     YAML::Node node = YAML::Load(R"END(
         [[0, 6px], [1, [6px, 7px]]]
     )END");
-    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+    Stops stops(Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size)));
     REQUIRE(stops.frames.size() == 0);
 
     // 2d, 1d
     node = YAML::Load(R"END(
         [[0, [6px, 7px]], [1, 6px]]
     )END");
-    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    stops = Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size));
     REQUIRE(stops.frames.size() == 0);
 
     // 1d, %, 2d
     node = YAML::Load(R"END(
         [[0, 6px], [1, 50%], [2, [6px, 7px]]]
     )END");
-    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    stops = Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size));
     REQUIRE(stops.frames.size() == 0);
 
     // % 1d 2d
     node = YAML::Load(R"END(
         [[0, 50%], [1, 6px], [2, [6px, 7px]]]
     )END");
-    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    stops = Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size));
     REQUIRE(stops.frames.size() == 0);
 
     // % 2d 1d
     node = YAML::Load(R"END(
         [[0, 50%], [1, [6px, 7px]], [2, 6px]]
     )END");
-    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    stops = Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size));
     REQUIRE(stops.frames.size() == 0);
 
     // 2d % 1d
     node = YAML::Load(R"END(
         [[0, 50%], [1, [6px, 7px]], [2, 6px]]
     )END");
-    stops = Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size));
+    stops = Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size));
     REQUIRE(stops.frames.size() == 0);
 }
 
@@ -211,7 +209,7 @@ TEST_CASE("2 dimension stops for icon sizes with mixed units", "[Stops][YAML]") 
     )END");
     const glm::vec2 CSS_SIZE(1.f, 1.f);
 
-    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+    Stops stops(Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size)));
 
     REQUIRE(stops.frames.size() == 3);
 
@@ -227,7 +225,7 @@ TEST_CASE("1 dimension stops for icon sizes", "[Stops][YAML]") {
     )END");
     const glm::vec2 CSS_SIZE(1.f, 1.f);
 
-    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+    Stops stops(Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size)));
 
     REQUIRE(stops.frames.size() == 2);
 
@@ -242,7 +240,7 @@ TEST_CASE("Stops using auto for StyleParam::size", "[Stops][YAML]") {
     )END");
     const glm::vec2 CSS_SIZE(2.f, 1.f);
 
-    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+    Stops stops(Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size)));
 
     REQUIRE(stops.frames.size() == 2);
     REQUIRE(stops.evalSize(0, CSS_SIZE) == glm::vec2(18, 9));
@@ -259,7 +257,7 @@ TEST_CASE("Stops using `%` for StyleParam::size", "[Stops][YAML]") {
     )END");
     const glm::vec2 CSS_SIZE(10.f, 20.f);
 
-    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+    Stops stops(Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size)));
 
     /*
      * Make sure this has valid frames, because of mixed 1D (%) and 2D stops.
@@ -285,7 +283,7 @@ TEST_CASE("Stops using auto and `%` for StyleParam::size", "[Stops][YAML]") {
     )END");
     const glm::vec2 CSS_SIZE(60, 30);
 
-    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+    Stops stops(Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size)));
 
     /*
      * Make sure this has valid frames, because of mixed 2D and 1D (%) stops.
@@ -309,7 +307,7 @@ TEST_CASE("Stops using `%` and auto for StyleParam::size", "[Stops][YAML]") {
     )END");
     const glm::vec2 CSS_SIZE(60, 30);
 
-    Stops stops(Stops::Sizes(node, StyleParam::unitsForStyleParam(StyleParamKey::size)));
+    Stops stops(Stops::Sizes(node, StyleParam::unitSetForStyleParam(StyleParamKey::size)));
 
     /*
      * Make sure this has valid frames, because of mixed 1D (%) and 2D stops.


### PR DESCRIPTION
Previously, style parameters were parsed from the scene file by first serializing the YAML node of the parameter into a string, then passing that string to StyleParam to parse it. This resulted in a lot of cumbersome and fragile string parsing.

This change enables StyleParam to parse values directly from YAML nodes, removing the need to encode and decode YAML structures into strings and allowing re-use of YAML conversion utilities.