### PR TITLE
Expose MapController.dispose() to be overloaded

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -269,7 +269,11 @@ public class MapController implements Renderer {
         uiThreadHandler = new Handler(mapView.getContext().getMainLooper());
     }
 
-    void dispose() {
+    /**
+     * Responsible to dispose internals of MapController during Map teardown.
+     * If client code extends MapController and overrides this method, then it must call super.dispose()
+     */
+    protected void dispose() {
 
         httpHandler = null;
 


### PR DESCRIPTION
Client code extending MapController might be required to do some cleanup when its being destroyed, and hence needs to be made `protected`