### PR TITLE
Refactor screenPositionToLngLat into View and validate matrices

### DIFF
--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -861,20 +861,18 @@ void Map::flyTo(const CameraPosition& _camera, float _duration, float _speed) {
 
 bool Map::screenPositionToLngLat(double _x, double _y, double* _lng, double* _lat) {
 
-    double intersection = impl->view.screenToGroundPlane(_x, _y);
-    glm::dvec3 eye = impl->view.getPosition();
-    glm::dvec2 meters(_x + eye.x, _y + eye.y);
-    glm::dvec2 lngLat = impl->view.getMapProjection().MetersToLonLat(meters);
-    *_lng = LngLat::wrapLongitude(lngLat.x);
-    *_lat = lngLat.y;
+    bool intersection = false;
+    LngLat lngLat = impl->view.screenPositionToLngLat(_x, _y, intersection);
+    *_lng = lngLat.longitude;
+    *_lat = lngLat.latitude;
 
-    return (intersection >= 0);
+    return intersection;
 }
 
 bool Map::lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _y) {
     bool clipped = false;
 
-    glm::vec2 screenCoords = impl->view.lonLatToScreenPosition(_lng, _lat, clipped);
+    glm::vec2 screenCoords = impl->view.lngLatToScreenPosition(_lng, _lat, clipped);
 
     *_x = screenCoords.x;
     *_y = screenCoords.y;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -195,7 +195,9 @@ public:
     double screenToGroundPlane(double& _screenX, double& _screenY);
 
     /* Gets the screen position from a latitude/longitude */
-    glm::vec2 lonLatToScreenPosition(double lon, double lat, bool& clipped) const;
+    glm::vec2 lngLatToScreenPosition(double lng, double lat, bool& clipped);
+
+    LngLat screenPositionToLngLat(float x, float y, bool& intersection);
 
     // For a position on the map in projected meters, this returns the displacement vector *from* the view *to* that
     // position, accounting for wrapping around the 180th meridian to get the smallest magnitude displacement.


### PR DESCRIPTION
Moved `screenPositionToLngLat` logic into `View`, renamed methods for consistency, and fixed an issue where calls to `screenPositionToLngLat` could use out-of-date view matrices.