### PR TITLE
Cancel and dispose network requestHandles onDestroy

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1429,15 +1429,13 @@ public class MapController implements Renderer {
     // Networking methods
     // ==================
 
-    @Keep
     void cancelAllNetworkRequests() {
-        final HttpHandler handler = httpHandler;
-        if (handler == null) {
+        if (httpHandler == null) {
             return;
         }
         synchronized (httpRequestHandles) {
             for (int i = 0; i < httpRequestHandles.size(); i++) {
-                handler.cancelRequest(httpRequestHandles.valueAt(i));
+                httpHandler.cancelRequest(httpRequestHandles.valueAt(i));
             }
             httpRequestHandles.clear();
         }


### PR DESCRIPTION
We also need to cancel any network callback before we set the `httpHandler` to null. Else network failure responses could leak network callbacks.