### PR TITLE
Toggle continuous rendering depending on drawn style's animated state

### DIFF
--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -545,7 +545,7 @@ void Map::render() {
         return;
     }
 
-    bool drawnAnimatedStyle = impl->scene->animated() == Scene::animate::yes;
+    bool drawnAnimatedStyle = false;
     {
         std::lock_guard<std::mutex> lock(impl->tilesMutex);
 
@@ -561,7 +561,9 @@ void Map::render() {
         }
     }
 
-    if (impl->scene->animated() != Scene::animate::no && drawnAnimatedStyle != platform->isContinuousRendering()) {
+    if (impl->scene->animated() != Scene::animate::no &&
+        drawnAnimatedStyle != platform->isContinuousRendering()) {
+
         platform->setContinuousRendering(drawnAnimatedStyle);
     }
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -561,7 +561,7 @@ void Map::render() {
         }
     }
 
-    if (drawnAnimatedStyle != platform->isContinuousRendering()) {
+    if (impl->scene->animated() != Scene::animate::no && drawnAnimatedStyle != platform->isContinuousRendering()) {
         platform->setContinuousRendering(drawnAnimatedStyle);
     }
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -173,12 +173,6 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
 
     bool animated = scene->animated() == Scene::animate::yes;
 
-    if (scene->animated() == Scene::animate::none) {
-        for (const auto& style : scene->styles()) {
-            animated |= style->isAnimated();
-        }
-    }
-
     if (animated != platform->isContinuousRendering()) {
         platform->setContinuousRendering(animated);
     }
@@ -551,18 +545,24 @@ void Map::render() {
         return;
     }
 
+    bool drawnAnimatedStyle = impl->scene->animated() == Scene::animate::yes;
     {
         std::lock_guard<std::mutex> lock(impl->tilesMutex);
 
         // Loop over all styles
         for (const auto& style : impl->scene->styles()) {
 
-            style->draw(impl->renderState,
-                        impl->view, *(impl->scene),
-                        impl->tileManager.getVisibleTiles(),
-                        impl->markerManager.markers());
+            bool styleDrawn = style->draw(impl->renderState,
+                                impl->view, *(impl->scene),
+                                impl->tileManager.getVisibleTiles(),
+                                impl->markerManager.markers());
 
+            drawnAnimatedStyle |= (styleDrawn && style->isAnimated());
         }
+    }
+
+    if (drawnAnimatedStyle != platform->isContinuousRendering()) {
+        platform->setContinuousRendering(drawnAnimatedStyle);
     }
 
     impl->labels.drawDebug(impl->renderState, impl->view);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -766,7 +766,6 @@ void SceneLoader::loadStyleProps(const std::shared_ptr<Platform>& platform, Styl
     }
 
     if (Node animatedNode = styleNode["animated"]) {
-        LOGW("'animated' property will be set but not yet implemented in styles"); // TODO
         if (!animatedNode.IsScalar()) { LOGW("animated flag should be a scalar"); }
         else {
             bool animate;

--- a/core/src/style/pointStyle.h
+++ b/core/src/style/pointStyle.h
@@ -28,8 +28,8 @@ public:
     virtual void onBeginDrawFrame(RenderState& rs, const View& _view, Scene& _scene) override;
     virtual void onBeginFrame(RenderState& rs) override;
     virtual void onBeginDrawSelectionFrame(RenderState& rs, const View& _view, Scene& _scene) override;
-    virtual void draw(RenderState& rs, const Tile& _tile) override {}
-    virtual void draw(RenderState& rs, const Marker& _marker) override {}
+    virtual bool draw(RenderState& rs, const Tile& _tile) override { return true; }
+    virtual bool draw(RenderState& rs, const Marker& _marker) override { return true; }
 
     void setTextures(const std::unordered_map<std::string, std::shared_ptr<Texture>>& _textures) {
         m_textures = &_textures;

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -390,7 +390,7 @@ void Style::drawSelectionFrame(Tangram::RenderState& rs, const Tangram::Tile &_t
 
 }
 
-void Style::draw(RenderState& rs, const View& _view, Scene& _scene,
+bool Style::draw(RenderState& rs, const View& _view, Scene& _scene,
                  const std::vector<std::shared_ptr<Tile>>& _tiles,
                  const std::vector<std::unique_ptr<Marker>>& _markers) {
 
@@ -400,10 +400,12 @@ void Style::draw(RenderState& rs, const View& _view, Scene& _scene,
     auto markerIt = std::find_if(std::begin(_markers), std::end(_markers),
                                [this](const auto& m){ return m->styleId() == this->m_id && m->mesh(); });
 
+    bool meshDrawn = false;
+
     // Skip when no mesh is to be rendered.
     // This also compiles shaders when they are first used.
     if (tileIt == std::end(_tiles) && markerIt == std::end(_markers)) {
-        return;
+        return false;
     }
 
     onBeginDrawFrame(rs, _view, _scene);
@@ -412,35 +414,44 @@ void Style::draw(RenderState& rs, const View& _view, Scene& _scene,
         rs.colorMask(false, false, false, false);
     }
 
-    for (const auto& tile : _tiles) { draw(rs, *tile); }
-    for (const auto& marker : _markers) { draw(rs, *marker); }
+    for (const auto& tile : _tiles) {
+        meshDrawn |= draw(rs, *tile);
+    }
+    for (const auto& marker : _markers) {
+        meshDrawn |= draw(rs, *marker);
+    }
 
-    if (m_blend == Blending::translucent) {
-        rs.colorMask(true, true, true, true);
-        GL::depthFunc(GL_EQUAL);
+    if (meshDrawn) {
+        if (m_blend == Blending::translucent) {
+            rs.colorMask(true, true, true, true);
+            GL::depthFunc(GL_EQUAL);
 
-        GL::enable(GL_STENCIL_TEST);
-        GL::clear(GL_STENCIL_BUFFER_BIT);
-        GL::stencilFunc(GL_EQUAL, GL_ZERO, 0xFF);
-        GL::stencilOp(GL_KEEP, GL_KEEP, GL_INCR);
+            GL::enable(GL_STENCIL_TEST);
+            GL::clear(GL_STENCIL_BUFFER_BIT);
+            GL::stencilFunc(GL_EQUAL, GL_ZERO, 0xFF);
+            GL::stencilOp(GL_KEEP, GL_KEEP, GL_INCR);
 
-        for (const auto& tile : _tiles) { draw(rs, *tile); }
-        for (const auto& marker : _markers) { draw(rs, *marker); }
+            for (const auto &tile : _tiles) { draw(rs, *tile); }
+            for (const auto &marker : _markers) { draw(rs, *marker); }
 
-        GL::disable(GL_STENCIL_TEST);
-        GL::depthFunc(GL_LESS);
+            GL::disable(GL_STENCIL_TEST);
+            GL::depthFunc(GL_LESS);
+        }
     }
 
     onEndDrawFrame(rs, _view, _scene);
+
+    return meshDrawn;
 }
 
 
-void Style::draw(RenderState& rs, const Tile& _tile) {
+bool Style::draw(RenderState& rs, const Tile& _tile) {
 
     auto& styleMesh = _tile.getMesh(*this);
 
-    if (!styleMesh) { return; }
+    if (!styleMesh) { return false; }
 
+    bool styleMeshDrawn = true;
     TileID tileID = _tile.getID();
 
     if (hasRasters() && !_tile.rasters().empty()) {
@@ -488,6 +499,7 @@ void Style::draw(RenderState& rs, const Tile& _tile) {
 
     if (!styleMesh->draw(rs, *m_shaderProgram)) {
         LOGN("Mesh built by style %s cannot be drawn", m_name.c_str());
+        styleMeshDrawn = false;
     }
 
     if (hasRasters()) {
@@ -497,15 +509,18 @@ void Style::draw(RenderState& rs, const Tile& _tile) {
             }
         }
     }
+
+    return styleMeshDrawn;
 }
 
-void Style::draw(RenderState& rs, const Marker& marker) {
+bool Style::draw(RenderState& rs, const Marker& marker) {
 
-    if (marker.styleId() != m_id || !marker.isVisible()) { return; }
+    if (marker.styleId() != m_id || !marker.isVisible()) { return false; }
 
     auto* mesh = marker.mesh();
 
-    if (!mesh) { return; }
+    if (!mesh) { return false; }
+    bool styleMeshDrawn = true;
 
     m_shaderProgram->setUniformMatrix4f(rs, m_mainUniforms.uModel, marker.modelMatrix());
     m_shaderProgram->setUniformf(rs, m_mainUniforms.uTileOrigin,
@@ -514,7 +529,10 @@ void Style::draw(RenderState& rs, const Marker& marker) {
 
     if (!mesh->draw(rs, *m_shaderProgram)) {
         LOGN("Mesh built by style %s cannot be drawn", m_name.c_str());
+        styleMeshDrawn = false;
     }
+
+    return styleMeshDrawn;
 }
 
 void Style::setDefaultDrawRule(std::unique_ptr<DrawRuleData>&& _rule) {

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -258,12 +258,15 @@ public:
     /* Perform any unsetup needed after drawing each frame */
     virtual void onEndDrawFrame(RenderState& rs, const View& _view, Scene& _scene) {}
 
-    /* Draws the geometry associated with this <Style> */
-    virtual void draw(RenderState& rs, const Tile& _tile);
+    /* Draws the geometry associated with this <Style>
+     * returns true when meshes associated with this style are successfully drawn,
+     * false otherwise.
+     */
+    virtual bool draw(RenderState& rs, const Tile& _tile);
 
-    virtual void draw(RenderState& rs, const Marker& _marker);
+    virtual bool draw(RenderState& rs, const Marker& _marker);
 
-    virtual void draw(RenderState& rs, const View& _view, Scene& _scene,
+    virtual bool draw(RenderState& rs, const View& _view, Scene& _scene,
                       const std::vector<std::shared_ptr<Tile>>& _tiles,
                       const std::vector<std::unique_ptr<Marker>>& _markers);
 

--- a/core/src/style/textStyle.h
+++ b/core/src/style/textStyle.h
@@ -89,9 +89,9 @@ public:
 
     virtual void onBeginDrawSelectionFrame(RenderState& rs, const View& _view, Scene& _scene) override;
 
-    virtual void draw(RenderState& rs, const Tile& _tile) override {}
+    virtual bool draw(RenderState& rs, const Tile& _tile) override { return true; }
 
-    virtual void draw(RenderState& rs, const Marker& _marker) override {}
+    virtual bool draw(RenderState& rs, const Marker& _marker) override { return true; }
 
     std::unique_ptr<StyleBuilder> createBuilder() const override;
 


### PR DESCRIPTION
Currently continuous rendering was enabled for the entire scene if any of the style was marked as animated irrespective of the state of meshes in these animated styles.

This PR adds logic to enable/disable continuous rendering depending on the whether the meshes corresponding to an animated style is drawn.