### PR TITLE
Abort iOS URL callbacks after the TGMapView is dealloc'ed

### DIFF
--- a/platforms/ios/framework/src/iosPlatform.mm
+++ b/platforms/ios/framework/src/iosPlatform.mm
@@ -158,6 +158,12 @@ UrlRequestHandle iOSPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
 
     TGDownloadCompletionHandler handler = ^void (NSData* data, NSURLResponse* response, NSError* error) {
 
+        __strong TGMapView* mapView = m_mapView;
+        if (!mapView) {
+            // Map was disposed before the request completed, so abort the completion handler.
+            return;
+        }
+        
         // Create our response object. The '__block' specifier is to allow mutation in the data-copy block below.
         __block UrlResponse urlResponse;
 


### PR DESCRIPTION
If the URL handler for the map outlives the TGMapView then these callbacks can be executed after the objects they reference are freed - causing a crash.