### PR TITLE
Faster PR builds for iOS on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ jobs:
   build-ios:
     macos:
       xcode: "9.4.0"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       # Check out repository with submodules.
       - checkout
@@ -41,6 +43,8 @@ jobs:
   build-deploy-ios-snapshot:
     macos:
       xcode: "9.4.0"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       # Check out repository with submodules.
       - checkout
@@ -61,6 +65,8 @@ jobs:
   build-deploy-macos-snapshot:
     macos:
       xcode: "9.4.0"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       # Check out repository with submodules.
       - checkout
@@ -76,6 +82,8 @@ jobs:
   build-deploy-ios-release:
     macos:
       xcode: "9.4.0"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       # Check out repository with submodules.
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,10 @@ jobs:
       - checkout
       - run: git submodule update --init
       # Install dependencies.
-      - run: sudo gem install jazzy --no-document
       - run: brew install cmake
       # Build framework and docs.
       - run: make ios-sim BUILD_TYPE=Debug
       - run: make ios-static-sim BUILD_TYPE=Debug
-      - run: make ios-docs
   build-deploy-ios-snapshot:
     macos:
       xcode: "9.4.0"


### PR DESCRIPTION
Brings the `build-ios` job from ~7.5 minutes down to ~3 minutes.