### PR TITLE
Update iOS gesture recognizers to more closely match Apple Maps and others

### DIFF
--- a/platforms/ios/framework/src/TGMapView.h
+++ b/platforms/ios/framework/src/TGMapView.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  regarding _Coordinate Systems and Drawing in iOS_ for more information.
  */
 TG_EXPORT
-@interface TGMapView : UIView
+@interface TGMapView : UIView <UIGestureRecognizerDelegate>
 
 #pragma mark Initialize the View
 

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -38,7 +38,7 @@ inline CLLocationDirection convertRotationRadiansToBearingDegrees(float rotation
     return TGDegreesFromRadians(-rotation);
 }
 
-@interface TGMapView () <UIGestureRecognizerDelegate, GLKViewDelegate> {
+@interface TGMapView () <GLKViewDelegate> {
     BOOL _shouldCaptureFrame;
     BOOL _captureFrameWaitForViewComplete;
     BOOL _viewComplete;
@@ -245,7 +245,7 @@ inline CLLocationDirection convertRotationRadiansToBearingDegrees(float rotation
     [_tapGestureRecognizer requireGestureRecognizerToFail:_doubleTapGestureRecognizer];
 
     _panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(respondToPanGesture:)];
-    _panGestureRecognizer.maximumNumberOfTouches = 1;
+    _panGestureRecognizer.maximumNumberOfTouches = 2;
 
     _pinchGestureRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(respondToPinchGesture:)];
     _rotationGestureRecognizer = [[UIRotationGestureRecognizer alloc] initWithTarget:self action:@selector(respondToRotationGesture:)];
@@ -962,11 +962,8 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(NSArray<TGSceneUpdate *> *s
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
     // make shove gesture exclusive
-    if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
-        return [gestureRecognizer numberOfTouches] != 2;
-    }
-    if ([otherGestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
-        return [otherGestureRecognizer numberOfTouches] != 2;
+    if ([gestureRecognizer isEqual:_shoveGestureRecognizer] || [otherGestureRecognizer isEqual:_shoveGestureRecognizer]) {
+        return NO;
     }
     return YES;
 }


### PR DESCRIPTION
Two small changes here for the recognizer setup on iOS.

First, the current iOS gesture recognizers are a little strict in how panning is handled versus how users tend to interact with maps. The general expectation is to be able to pinch/zoom AND pan at the same time, which allows the user to alter the viewport slightly but generally feels much better than the current setup. We still want the shove gesture recognizer to be exclusive though, which matches how apple maps works.

For developers, I moved `UIGestureRecognizerDelegate` conformance into the public header so that the compiler will allow implementing devs to subclass `TGMapView` and override `shouldRecognizeSimultaneouslyWithGestureRecognizer:` functionality. This allows devs to call the `super` implementation, versus having the conformance privately declared prohibits this entirely in Swift, and is frustrating to work around in objective-c. 