### PR TITLE
Move Android Marker Bitmap conversion into native code

### DIFF
--- a/platforms/android/config.cmake
+++ b/platforms/android/config.cmake
@@ -21,4 +21,5 @@ target_link_libraries(tangram
   GLESv2
   log
   z
+  jnigraphics
 )

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -410,19 +410,20 @@ extern "C" {
         uint32_t* pixelOutput = new uint32_t[height * width];
         int i = 0;
         for (int row = 0; row < height; row++) {
+            // Flips image upside-down
+            int flippedRow = (height - 1 - row) * width;
             for (int col = 0; col < width; col++) {
                 uint32_t pixel = pixelInput[i++];
                 // Undo alpha pre-multiplication.
                 auto rgba = reinterpret_cast<uint8_t*>(&pixel);
                 int a = rgba[3];
                 if (a != 0) {
-                    auto alphaInv = 1.f/a;
-                    rgba[0] = static_cast<uint8_t>(rgba[0] * 255 * alphaInv);
-                    rgba[1] = static_cast<uint8_t>(rgba[1] * 255 * alphaInv );
-                    rgba[2] = static_cast<uint8_t>(rgba[2] * 255 * alphaInv);
+                    auto alphaInv = 255.f/a;
+                    rgba[0] = static_cast<uint8_t>(rgba[0] * alphaInv);
+                    rgba[1] = static_cast<uint8_t>(rgba[1] * alphaInv );
+                    rgba[2] = static_cast<uint8_t>(rgba[2] * alphaInv);
                 }
-                int flippedIndex = (height - 1 - row) * width + col;
-                pixelOutput[flippedIndex] = pixel;
+                pixelOutput[flippedRow + col] = pixel;
             }
         }
         AndroidBitmap_unlockPixels(jniEnv, jbitmap);

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -416,9 +416,10 @@ extern "C" {
                 auto rgba = reinterpret_cast<uint8_t*>(&pixel);
                 int a = rgba[3];
                 if (a != 0) {
-                    rgba[0] = static_cast<uint8_t>(rgba[0] * 255 / a);
-                    rgba[1] = static_cast<uint8_t>(rgba[1] * 255 / a);
-                    rgba[2] = static_cast<uint8_t>(rgba[2] * 255 / a);
+                    auto alphaInv = 1.f/a;
+                    rgba[0] = static_cast<uint8_t>(rgba[0] * 255 * alphaInv);
+                    rgba[1] = static_cast<uint8_t>(rgba[1] * 255 * alphaInv );
+                    rgba[2] = static_cast<uint8_t>(rgba[2] * 255 * alphaInv);
                 }
                 int flippedIndex = (height - 1 - row) * width + col;
                 pixelOutput[flippedIndex] = pixel;

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -394,7 +394,7 @@ extern "C" {
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jint* argbInput;
         int locked = AndroidBitmap_lockPixels(jniEnv, jbitmap, (void**)&argbInput);
-        if (locked) {
+        if (locked == ANDROID_BITMAP_RESULT_SUCCESS) {
             int length = width * height;
             int* abgrOutput = new int[length];
             int i = 0;

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -407,7 +407,7 @@ extern "C" {
         }
         int width = bitmapInfo.width;
         int height = bitmapInfo.height;
-        uint32_t* pixelOutput = new uint32_t[height * bitmapInfo.stride];
+        uint32_t* pixelOutput = new uint32_t[height * width];
         int i = 0;
         for (int row = 0; row < height; row++) {
             for (int col = 0; col < width; col++) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1155,10 +1155,10 @@ public class MapController implements Renderer {
         return nativeMarkerSetStylingFromPath(mapPointer, markerId, path);
     }
 
-    boolean setMarkerBitmap(final long markerId, final int width, final int height, final int[] data) {
+    boolean setMarkerBitmap(final long markerId, final int width, final int height, Bitmap bitmap) {
         checkPointer(mapPointer);
         checkId(markerId);
-        return nativeMarkerSetBitmap(mapPointer, markerId, width, height, data);
+        return nativeMarkerSetBitmap(mapPointer, markerId, width, height, bitmap);
     }
 
     boolean setMarkerPoint(final long markerId, final double lng, final double lat) {
@@ -1246,7 +1246,7 @@ public class MapController implements Renderer {
     private synchronized native boolean nativeMarkerRemove(long mapPtr, long markerID);
     private synchronized native boolean nativeMarkerSetStylingFromString(long mapPtr, long markerID, String styling);
     private synchronized native boolean nativeMarkerSetStylingFromPath(long mapPtr, long markerID, String path);
-    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, int width, int height, int[] data);
+    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, int width, int height, Bitmap bitmapPtr);
     private synchronized native boolean nativeMarkerSetPoint(long mapPtr, long markerID, double lng, double lat);
     private synchronized native boolean nativeMarkerSetPointEased(long mapPtr, long markerID, double lng, double lat, float duration, int ease);
     private synchronized native boolean nativeMarkerSetPolyline(long mapPtr, long markerID, double[] coordinates, int count);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1155,10 +1155,10 @@ public class MapController implements Renderer {
         return nativeMarkerSetStylingFromPath(mapPointer, markerId, path);
     }
 
-    boolean setMarkerBitmap(final long markerId, final int width, final int height, Bitmap bitmap) {
+    boolean setMarkerBitmap(final long markerId, Bitmap bitmap) {
         checkPointer(mapPointer);
         checkId(markerId);
-        return nativeMarkerSetBitmap(mapPointer, markerId, width, height, bitmap);
+        return nativeMarkerSetBitmap(mapPointer, markerId, bitmap);
     }
 
     boolean setMarkerPoint(final long markerId, final double lng, final double lat) {
@@ -1246,7 +1246,7 @@ public class MapController implements Renderer {
     private synchronized native boolean nativeMarkerRemove(long mapPtr, long markerID);
     private synchronized native boolean nativeMarkerSetStylingFromString(long mapPtr, long markerID, String styling);
     private synchronized native boolean nativeMarkerSetStylingFromPath(long mapPtr, long markerID, String path);
-    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, int width, int height, Bitmap bitmapPtr);
+    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, Bitmap bitmap);
     private synchronized native boolean nativeMarkerSetPoint(long mapPtr, long markerID, double lng, double lat);
     private synchronized native boolean nativeMarkerSetPointEased(long mapPtr, long markerID, double lng, double lat, float duration, int ease);
     private synchronized native boolean nativeMarkerSetPolyline(long mapPtr, long markerID, double[] coordinates, int count);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
@@ -214,10 +214,7 @@ public class Marker {
         final int density = context.getResources().getDisplayMetrics().densityDpi;
         final int width = bitmap.getScaledWidth(density);
         final int height = bitmap.getScaledHeight(density);
-        final int[] argb = new int[width * height];
-        bitmap.getPixels(argb, 0, width, 0, 0, width, height);
-
-        return map.setMarkerBitmap(markerId, width, height, argb);
+        return map.setMarkerBitmap(markerId, width, height, bitmap);
     }
 
     void invalidate() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
@@ -91,7 +91,7 @@ public class Marker {
      * <li>{ style: 'polygons', color: '#06a6d4', width: 5px, order: 2000 }</li>
      * </ul>
      *
-     * @param styleStr the style string
+     * @param styleString the style string
      * @return whether the style was successfully set
      */
     public boolean setStylingFromString(final String styleString) {
@@ -100,7 +100,7 @@ public class Marker {
 
     /**
      * Sets the drawable resource id to be used to load a bitmap. When displaying a drawable, a
-     * 'points' style must also be set on the marker (see {@link Marker#setStyling(String)}.
+     * 'points' style must also be set on the marker (see {@link Marker#setStylingFromString(String)}.
      *
      * @param drawableId the drawable resource id
      * @return whether the drawable's bitmap was successfully set
@@ -114,7 +114,7 @@ public class Marker {
 
     /**
      * Sets the drawable to be used to load a bitmap. When displaying a drawable, a
-     * 'points' style must also be set on the marker (see {@link Marker#setStyling(String)}.
+     * 'points' style must also be set on the marker (see {@link Marker#setStylingFromString(String)}.
      *
      * @param drawable the drawable
      * @return whether the drawable's bitmap was successfully set
@@ -154,7 +154,7 @@ public class Marker {
 
     /**
      * Sets the polyline to be displayed. When using this method, a 'polyline' style must also be
-     * set. See {@link Marker#setStyling(String)}.
+     * set. See {@link Marker#setStylingFromString(String)}.
      * @param polyline the polyline to display
      * @return whether the polyline was successfully set
      */
@@ -168,7 +168,7 @@ public class Marker {
 
     /**
      * Sets the polygon to be displayed. When using this method, a 'polygon' style must also be
-     * set. See {@link Marker#setStyling(String)}.
+     * set. See {@link Marker#setStylingFromString(String)}.
      * @param polygon the polygon to display
      * @return whether the polygon was successfully set
      */
@@ -214,24 +214,10 @@ public class Marker {
         final int density = context.getResources().getDisplayMetrics().densityDpi;
         final int width = bitmap.getScaledWidth(density);
         final int height = bitmap.getScaledHeight(density);
-
         final int[] argb = new int[width * height];
         bitmap.getPixels(argb, 0, width, 0, 0, width, height);
 
-        final int[] abgr = new int[width * height];
-        int row, col;
-        for (int i = 0; i < argb.length; i++) {
-            col = i % width;
-            row = i / width;
-            final int pix = argb[i];
-            final int pb = (pix >> 16) & 0xff;
-            final int pr = (pix << 16) & 0x00ff0000;
-            final int pix1 = (pix & 0xff00ff00) | pr | pb;
-            final int flippedIndex = (height - 1 - row) * width + col;
-            abgr[flippedIndex] = pix1;
-        }
-
-        return map.setMarkerBitmap(markerId, width, height, abgr);
+        return map.setMarkerBitmap(markerId, width, height, argb);
     }
 
     void invalidate() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
@@ -211,10 +211,7 @@ public class Marker {
     }
 
     private boolean setBitmap(@NonNull final Bitmap bitmap) {
-        final int density = context.getResources().getDisplayMetrics().densityDpi;
-        final int width = bitmap.getScaledWidth(density);
-        final int height = bitmap.getScaledHeight(density);
-        return map.setMarkerBitmap(markerId, width, height, bitmap);
+        return map.setMarkerBitmap(markerId, bitmap);
     }
 
     void invalidate() {


### PR DESCRIPTION
This should reduce some of the CPU cost of applying Bitmaps to Markers on Android.