### PR TITLE
Android view holder abstraction

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -117,7 +117,7 @@ public class MapView extends FrameLayout {
         }
 
         if (controller != null) {
-            viewHolder = createViewHolder(viewHolderFactory);
+            viewHolder = viewHolderFactory.build(getContext());
             if (viewHolder == null) {
                 android.util.Log.e("Tangram", "Unable to initialize MapController: Failed to initialize OpenGL view");
                 controller.dispose();
@@ -128,32 +128,6 @@ public class MapView extends FrameLayout {
             }
         }
         callback.onMapReady(mapController);
-    }
-
-    protected GLViewHolder createViewHolder(@NonNull GLViewHolderFactory viewHolderFactory) {
-        GLViewHolder view = viewHolderFactory.build(getContext());
-        view.setEGLContextClientVersion(2);
-        view.setPreserveEGLContextOnPause(true);
-        try {
-            view.setEGLConfigChooser(new ConfigChooser(8, 8, 8, 0, 16, 8));
-            return view;
-        } catch(IllegalArgumentException e) {
-            // TODO: print available configs to check whether we could support them
-            android.util.Log.e("Tangram", "EGLConfig 8-8-8-0 not supported");
-        }
-        try {
-            view.setEGLConfigChooser(new ConfigChooser(8, 8, 8, 8, 16, 8));
-            return view;
-        } catch(IllegalArgumentException e) {
-            android.util.Log.e("Tangram", "EGLConfig 8-8-8-8 not supported");
-        }
-        try {
-            view.setEGLConfigChooser(new ConfigChooser(5, 6, 5, 0, 16, 8));
-            return view;
-        } catch(IllegalArgumentException e) {
-            android.util.Log.e("Tangram", "EGLConfig 5-6-5-0 not supported");
-        }
-        return null;
     }
 
     /**

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/ConfigChooser.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/ConfigChooser.java
@@ -11,7 +11,7 @@
  * governing permissions and limitations under the License.
  */
 
-package com.mapzen.tangram;
+package com.mapzen.tangram.viewholder;
 
 import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLConfig;

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLSurfaceViewHolder.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLSurfaceViewHolder.java
@@ -51,26 +51,6 @@ public class GLSurfaceViewHolder implements GLViewHolder {
     }
 
     @Override
-    public void setPreserveEGLContextOnPause(boolean preserveOnPause) {
-        glSurfaceView.setPreserveEGLContextOnPause(preserveOnPause);
-    }
-
-    @Override
-    public boolean getPreserveEGLContextOnPause() {
-        return glSurfaceView.getPreserveEGLContextOnPause();
-    }
-
-    @Override
-    public void setEGLConfigChooser(GLSurfaceView.EGLConfigChooser configChooser) {
-        glSurfaceView.setEGLConfigChooser(configChooser);
-    }
-
-    @Override
-    public void setEGLContextClientVersion(int version) {
-        glSurfaceView.setEGLContextClientVersion(version);
-    }
-
-    @Override
     public void queueEvent(@NonNull final Runnable r) {
         glSurfaceView.queueEvent(r);
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLSurfaceViewHolder.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLSurfaceViewHolder.java
@@ -1,0 +1,96 @@
+package com.mapzen.tangram.viewholder;
+
+import android.opengl.GLSurfaceView;
+import android.support.annotation.NonNull;
+import android.view.View;
+
+
+public class GLSurfaceViewHolder implements GLViewHolder {
+    private GLSurfaceView glSurfaceView;
+
+    public GLSurfaceViewHolder(final GLSurfaceView glSurfaceView) {
+        this.glSurfaceView = glSurfaceView;
+    }
+
+    // GLViewHolder Methods
+    // =========================
+
+    @Override
+    public void setRenderer(GLSurfaceView.Renderer renderer) {
+        glSurfaceView.setRenderer(renderer);
+    }
+
+    @Override
+    public void requestRender() {
+        glSurfaceView.requestRender();
+    }
+
+    @Override
+    public void setRenderMode(RenderMode renderMode) {
+        switch (renderMode) {
+            case RENDER_WHEN_DIRTY:
+                glSurfaceView.setRenderMode(0);
+                break;
+            case RENDER_CONTINUOUSLY:
+                glSurfaceView.setRenderMode(1);
+            default:
+        }
+    }
+
+    @Override
+    public RenderMode getRenderMode() {
+        int renderMode = glSurfaceView.getRenderMode();
+        switch (renderMode) {
+            case 0:
+                return RenderMode.RENDER_WHEN_DIRTY;
+            case 1:
+            default:
+                // Returns the default continuous value getRenderMode() returns an invalid int value
+                return RenderMode.RENDER_CONTINUOUSLY;
+        }
+    }
+
+    @Override
+    public void setPreserveEGLContextOnPause(boolean preserveOnPause) {
+        glSurfaceView.setPreserveEGLContextOnPause(preserveOnPause);
+    }
+
+    @Override
+    public boolean getPreserveEGLContextOnPause() {
+        return glSurfaceView.getPreserveEGLContextOnPause();
+    }
+
+    @Override
+    public void setEGLConfigChooser(GLSurfaceView.EGLConfigChooser configChooser) {
+        glSurfaceView.setEGLConfigChooser(configChooser);
+    }
+
+    @Override
+    public void setEGLContextClientVersion(int version) {
+        glSurfaceView.setEGLContextClientVersion(version);
+    }
+
+    @Override
+    public void queueEvent(@NonNull final Runnable r) {
+        glSurfaceView.queueEvent(r);
+    }
+
+    @Override
+    public void onPause() {
+        glSurfaceView.onPause();
+    }
+
+    @Override
+    public void onResume() {
+        glSurfaceView.onResume();
+    }
+
+    @Override
+    public void onDestroy() {}
+
+    @Override
+    @NonNull
+    public View getView() {
+        return this.glSurfaceView;
+    }
+}

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLSurfaceViewHolderFactory.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLSurfaceViewHolderFactory.java
@@ -2,7 +2,6 @@ package com.mapzen.tangram.viewholder;
 
 import android.content.Context;
 import android.opengl.GLSurfaceView;
-import android.support.annotation.NonNull;
 
 public class GLSurfaceViewHolderFactory implements GLViewHolderFactory {
 
@@ -13,9 +12,30 @@ public class GLSurfaceViewHolderFactory implements GLViewHolderFactory {
      * @return {@link GLSurfaceViewHolder}
      */
     @Override
-    @NonNull
     public GLViewHolder build(Context context) {
-        GLSurfaceView glSurfaceView = new GLSurfaceView(context);
-        return new GLSurfaceViewHolder(glSurfaceView);
+        GLSurfaceView view = new GLSurfaceView(context);
+
+        view.setEGLContextClientVersion(2);
+        view.setPreserveEGLContextOnPause(true);
+        try {
+            view.setEGLConfigChooser(new ConfigChooser(8, 8, 8, 0, 16, 8));
+            return new GLSurfaceViewHolder(view);
+        } catch(IllegalArgumentException e) {
+            // TODO: print available configs to check whether we could support them
+            android.util.Log.e("Tangram", "EGLConfig 8-8-8-0 not supported");
+        }
+        try {
+            view.setEGLConfigChooser(new ConfigChooser(8, 8, 8, 8, 16, 8));
+            return new GLSurfaceViewHolder(view);
+        } catch(IllegalArgumentException e) {
+            android.util.Log.e("Tangram", "EGLConfig 8-8-8-8 not supported");
+        }
+        try {
+            view.setEGLConfigChooser(new ConfigChooser(5, 6, 5, 0, 16, 8));
+            return new GLSurfaceViewHolder(view);
+        } catch(IllegalArgumentException e) {
+            android.util.Log.e("Tangram", "EGLConfig 5-6-5-0 not supported");
+        }
+        return null;
     }
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLSurfaceViewHolderFactory.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLSurfaceViewHolderFactory.java
@@ -1,0 +1,21 @@
+package com.mapzen.tangram.viewholder;
+
+import android.content.Context;
+import android.opengl.GLSurfaceView;
+import android.support.annotation.NonNull;
+
+public class GLSurfaceViewHolderFactory implements GLViewHolderFactory {
+
+    /**
+     * Responsible to create an instance of {@link GLSurfaceViewHolder} which holds
+     * an instance of {@link GLSurfaceView} for map display.
+     * @param context Application Context
+     * @return {@link GLSurfaceViewHolder}
+     */
+    @Override
+    @NonNull
+    public GLViewHolder build(Context context) {
+        GLSurfaceView glSurfaceView = new GLSurfaceView(context);
+        return new GLSurfaceViewHolder(glSurfaceView);
+    }
+}

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLViewHolder.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLViewHolder.java
@@ -1,0 +1,99 @@
+package com.mapzen.tangram.viewholder;
+
+import android.opengl.GLSurfaceView;
+import android.support.annotation.NonNull;
+import android.view.View;
+
+
+/**
+ * Interface which holds a GL View, used to display Tangram Map
+ */
+public interface GLViewHolder {
+
+    enum RenderMode {
+        RENDER_WHEN_DIRTY,
+        RENDER_CONTINUOUSLY
+    };
+
+    /**
+     * Set the renderer associated with this view. Also starts the thread that
+     * will call the renderer, which in turn causes the rendering to start.
+     * @param renderer the renderer to use to perform OpenGL drawing.
+     */
+    void setRenderer(GLSurfaceView.Renderer renderer);
+
+    /**
+     * Control whether the EGL context is preserved when the GLSurfaceView is paused and
+     * resumed.
+     * @param preserveOnPause preserve the EGL context when paused
+     */
+    void setPreserveEGLContextOnPause(boolean preserveOnPause);
+
+    /**
+     * @return true if the EGL context will be preserved when paused
+     */
+    boolean getPreserveEGLContextOnPause();
+
+    /**
+     * Set the rendering mode. When {@link RenderMode} is
+     * RENDER_CONTINUOUSLY, the renderer is called
+     * repeatedly to re-render the scene. When {@link RenderMode}
+     * is RENDER_WHEN_DIRTY, the renderer only rendered when the surface
+     * is created, or when {@link #requestRender} is called. Defaults to RENDER_CONTINUOUSLY.
+     * @param renderMode one of the {@link RenderMode} enums
+     */
+    void setRenderMode(RenderMode renderMode);
+
+    /**
+     * Get the current rendering mode.
+     * @return the current rendering mode.
+     */
+    RenderMode getRenderMode();
+
+    /**
+     * Install a custom EGLConfigChooser.
+     * @param configChooser
+     */
+    void setEGLConfigChooser(GLSurfaceView.EGLConfigChooser configChooser);
+
+    /**
+     * Inform the EGLContext and EGLConfigChooser
+     * which EGLContext client version to pick.
+     */
+    void setEGLContextClientVersion(int version);
+
+    /**
+     * Request that the renderer render a frame.
+     */
+    void requestRender();
+
+    /**
+     * Queue a runnable to be run on the GL rendering thread.
+     * @param r the runnable to be run on the GL rendering thread.
+     */
+    void queueEvent(@NonNull final Runnable r);
+
+    /**
+     * Pause the rendering thread, optionally tearing down the EGL context
+     * depending upon the value of preserveEGLContextOnPause.
+     */
+    void onPause();
+
+    /**
+     * Resumes the rendering thread, re-creating the OpenGL context if necessary.
+     */
+    void onResume();
+
+    /**
+     * Destroys the GL Thread associated with the GLViewHolder
+     */
+    void onDestroy();
+
+    /**
+     * Can be used by the client to get access to the underlying view to pass any view controls
+     * @return {@link GLSurfaceView} or Client provided implementation for a view held by {@link GLViewHolder}
+     */
+    @NonNull
+    View getView();
+
+}

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLViewHolder.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLViewHolder.java
@@ -23,18 +23,6 @@ public interface GLViewHolder {
     void setRenderer(GLSurfaceView.Renderer renderer);
 
     /**
-     * Control whether the EGL context is preserved when the GLSurfaceView is paused and
-     * resumed.
-     * @param preserveOnPause preserve the EGL context when paused
-     */
-    void setPreserveEGLContextOnPause(boolean preserveOnPause);
-
-    /**
-     * @return true if the EGL context will be preserved when paused
-     */
-    boolean getPreserveEGLContextOnPause();
-
-    /**
      * Set the rendering mode. When {@link RenderMode} is
      * RENDER_CONTINUOUSLY, the renderer is called
      * repeatedly to re-render the scene. When {@link RenderMode}
@@ -49,18 +37,6 @@ public interface GLViewHolder {
      * @return the current rendering mode.
      */
     RenderMode getRenderMode();
-
-    /**
-     * Install a custom EGLConfigChooser.
-     * @param configChooser
-     */
-    void setEGLConfigChooser(GLSurfaceView.EGLConfigChooser configChooser);
-
-    /**
-     * Inform the EGLContext and EGLConfigChooser
-     * which EGLContext client version to pick.
-     */
-    void setEGLContextClientVersion(int version);
 
     /**
      * Request that the renderer render a frame.

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLViewHolderFactory.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLViewHolderFactory.java
@@ -1,0 +1,14 @@
+package com.mapzen.tangram.viewholder;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+public interface GLViewHolderFactory {
+    /**
+     * Responsible to create an instance of {@link GLSurfaceViewHolder} or client provided implementation
+     * for {@link GLViewHolder}
+     * @param context Application Context
+     */
+    @NonNull
+    GLViewHolder build(Context context);
+}

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLViewHolderFactory.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/viewholder/GLViewHolderFactory.java
@@ -9,6 +9,5 @@ public interface GLViewHolderFactory {
      * for {@link GLViewHolder}
      * @param context Application Context
      */
-    @NonNull
     GLViewHolder build(Context context);
 }


### PR DESCRIPTION
PR defines a ViewHolder interface, which is used by the MapController to hold either GLSurfaceView or a client provided SurfaceView implementation for map rendering purposes.

The client application has an option to either use GLSurfaceView or other SurfaceView implementations for rendering by specifying a specific GLViewHolderFactory: GLSurfaceViewHolderFactory or appropriate client implemented SurfaceViewHolderFactory.

GLSurfaceViewHolderFactory implement GLViewHolderFactory interface and are responsible to build GLSurfaceViewHolder, which holds a reference to GLSurfaceView. This can also be used as a reference implementation for clients to provide their own SurfaceView implementation.

GLSurfaceViewHolder is just a wrapper around GLSurfaceView and forwards most of the ViewHolder interface calls to the GLSurfaceView instance. 

However if client code wants to implement its own GLViewHolder implementation using a explicit SurfaceView, they will have to manage EGLContext and Render Thread behavior. Another helpful example explaining this can be found [here]( https://github.com/google/grafika/blob/master/app/src/main/java/com/android/grafika/TextureViewGLActivity.java).