### PR TITLE
Adding density parameter to Marker.setBitmap.

### DIFF
--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -324,7 +324,7 @@ public:
     // Set a bitmap to use as the image for a point marker; _data is a buffer of RGBA pixel data with
     // length of _width * _height; pixels are in row-major order beginning from the bottom-left of the
     // image; returns true if the marker ID was found and successfully updated, otherwise returns false.
-    bool markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data);
+    bool markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data, float density);
 
     // Set the geometry of a marker to a point at the given coordinates; markers can have their
     // geometry set multiple times with possibly different geometry types; returns true if the

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -986,8 +986,8 @@ bool Map::markerSetStylingFromPath(MarkerID _marker, const char* _path) {
     return success;
 }
 
-bool Map::markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data) {
-    bool success = impl->markerManager.setBitmap(_marker, _width, _height, _data);
+bool Map::markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data, float _density) {
+    bool success = impl->markerManager.setBitmap(_marker, _width, _height, _data, _density);
     platform->requestRender();
     return success;
 }

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -80,14 +80,14 @@ bool MarkerManager::setStyling(MarkerID markerID, const char* styling, bool isPa
     return true;
 }
 
-bool MarkerManager::setBitmap(MarkerID markerID, int width, int height, const unsigned int* bitmapData) {
+bool MarkerManager::setBitmap(MarkerID markerID, int width, int height, const unsigned int* bitmapData, float density) {
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
 
     m_dirty = true;
 
     TextureOptions options = { GL_RGBA, GL_RGBA, { GL_LINEAR, GL_LINEAR }, { GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE } };
-    auto texture = std::make_unique<Texture>(width, height, options);
+    auto texture = std::make_unique<Texture>(width, height, options, false, density);
     unsigned int size = width * height;
     texture->setData(bitmapData, size);
 

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -42,7 +42,7 @@ public:
         return setStyling(markerID, path, true);
     }
 
-    bool setBitmap(MarkerID markerID, int width, int height, const unsigned int* bitmapData);
+    bool setBitmap(MarkerID markerID, int width, int height, const unsigned int* bitmapData, float density);
 
     // Set whether a marker should be visible; returns true if the marker was found and updated.
     bool setVisible(MarkerID markerID, bool visible);

--- a/platforms/android/config.cmake
+++ b/platforms/android/config.cmake
@@ -1,5 +1,14 @@
 add_definitions(-DTANGRAM_ANDROID)
 
+if ($ENV{CIRCLECI})
+  # Force Ninja on CircleCI to use a specific number of concurrent jobs.
+  # Otherwise it guesses concurrency based on the physical CPU (which has a lot of cores!) and runs out of memory.
+  message(STATUS "Limiting concurrent jobs due to CI environment.")
+  set_property(GLOBAL APPEND PROPERTY JOB_POOLS compile_pool=4 link_pool=2)
+  set(CMAKE_JOB_POOL_COMPILE compile_pool)
+  set(CMAKE_JOB_POOL_LINK link_pool)
+endif()
+
 add_library(tangram SHARED
   platforms/common/platform_gl.cpp
   platforms/android/tangram/src/main/cpp/jniExports.cpp

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -389,7 +389,7 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetBitmap(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jobject jbitmap) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetBitmap(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jobject jbitmap, jfloat density) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
 
@@ -427,7 +427,7 @@ extern "C" {
             }
         }
         AndroidBitmap_unlockPixels(jniEnv, jbitmap);
-        auto result = map->markerSetBitmap(static_cast<unsigned int>(markerID), width, height, pixelOutput);
+        auto result = map->markerSetBitmap(static_cast<unsigned int>(markerID), width, height, pixelOutput, density);
         delete[] pixelOutput;
         return static_cast<jboolean>(result);
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1191,10 +1191,10 @@ public class MapController implements Renderer {
         return nativeMarkerSetStylingFromPath(mapPointer, markerId, path);
     }
 
-    boolean setMarkerBitmap(final long markerId, Bitmap bitmap) {
+    boolean setMarkerBitmap(final long markerId, Bitmap bitmap, float density) {
         checkPointer(mapPointer);
         checkId(markerId);
-        return nativeMarkerSetBitmap(mapPointer, markerId, bitmap);
+        return nativeMarkerSetBitmap(mapPointer, markerId, bitmap, density);
     }
 
     boolean setMarkerPoint(final long markerId, final double lng, final double lat) {
@@ -1282,7 +1282,7 @@ public class MapController implements Renderer {
     private synchronized native boolean nativeMarkerRemove(long mapPtr, long markerID);
     private synchronized native boolean nativeMarkerSetStylingFromString(long mapPtr, long markerID, String styling);
     private synchronized native boolean nativeMarkerSetStylingFromPath(long mapPtr, long markerID, String path);
-    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, Bitmap bitmap);
+    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, Bitmap bitmap, float density);
     private synchronized native boolean nativeMarkerSetPoint(long mapPtr, long markerID, double lng, double lat);
     private synchronized native boolean nativeMarkerSetPointEased(long mapPtr, long markerID, double lng, double lat, float duration, int ease);
     private synchronized native boolean nativeMarkerSetPolyline(long mapPtr, long markerID, double[] coordinates, int count);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
@@ -106,10 +106,11 @@ public class Marker {
      * @return whether the drawable's bitmap was successfully set
      */
     public boolean setDrawable(final int drawableId) {
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
         BitmapFactory.Options options = new BitmapFactory.Options();
-        options.inTargetDensity = context.getResources().getDisplayMetrics().densityDpi;
+        options.inTargetDensity = metrics.densityDpi;
         Bitmap bitmap = BitmapFactory.decodeResource(context.getResources(), drawableId, options);
-        return setBitmap(bitmap);
+        return setBitmap(bitmap, metrics.density);
     }
 
     /**
@@ -120,12 +121,15 @@ public class Marker {
      * @return whether the drawable's bitmap was successfully set
      */
     public boolean setDrawable(@NonNull final Drawable drawable) {
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+
+        float screenDensity = metrics.density;
         int density = context.getResources().getDisplayMetrics().densityDpi;
         BitmapDrawable bitmapDrawable = (BitmapDrawable) drawable;
         bitmapDrawable.setTargetDensity(density);
         Bitmap bitmap = bitmapDrawable.getBitmap();
         bitmap.setDensity(density);
-        return setBitmap(bitmap);
+        return setBitmap(bitmap, screenDensity);
     }
 
     /**
@@ -210,8 +214,8 @@ public class Marker {
         return visible;
     }
 
-    private boolean setBitmap(@NonNull final Bitmap bitmap) {
-        return map.setMarkerBitmap(markerId, bitmap);
+    private boolean setBitmap(@NonNull final Bitmap bitmap, float density) {
+        return map.setMarkerBitmap(markerId, bitmap, density);
     }
 
     void invalidate() {

--- a/platforms/ios/framework/src/TGMarker.mm
+++ b/platforms/ios/framework/src/TGMarker.mm
@@ -196,7 +196,7 @@
         }
     }
 
-    if (!tangramInstance->markerSetBitmap(self.identifier, static_cast<int>(w), static_cast<int>(h), bitmap.data())) {
+    if (!tangramInstance->markerSetBitmap(self.identifier, static_cast<int>(w), static_cast<int>(h), bitmap.data(), [UIScreen mainScreen].scale)) {
         [self createNSError];
     }
 }


### PR DESCRIPTION
This pull requests addresses the following issue: https://github.com/tangrams/tangram-es/issues/1925 
Previously, bitmaps were not transferred to the Texture object with a density parameter, which lead to scaled up bitmaps on the map when the device density is higher than 1.