### PR TITLE
Texture cleanup

### DIFF
--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -72,8 +72,7 @@ RasterSource::RasterSource(const std::string& _name, std::unique_ptr<DataSource>
     : TileSource(_name, std::move(_sources), _zoomOptions),
       m_texOptions(_options) {
 
-    std::vector<char> data = {};
-    m_emptyTexture = std::make_shared<Texture>(data, m_texOptions);
+    m_emptyTexture = std::make_shared<Texture>(m_texOptions);
 }
 
 std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _rawTileData) {
@@ -81,7 +80,9 @@ std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _r
         return m_emptyTexture;
     }
 
-    auto texture = std::make_shared<Texture>(_rawTileData, m_texOptions);
+    auto data = reinterpret_cast<const uint8_t*>(_rawTileData.data());
+    auto length = _rawTileData.size();
+    auto texture = std::make_shared<Texture>(data, length, m_texOptions);
 
     return texture;
 }

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -68,14 +68,12 @@ public:
 
 
 RasterSource::RasterSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
-                           TextureOptions _options, TileSource::ZoomOptions _zoomOptions,
-                           bool _genMipmap)
+                           TextureOptions _options, TileSource::ZoomOptions _zoomOptions)
     : TileSource(_name, std::move(_sources), _zoomOptions),
-      m_texOptions(_options),
-      m_genMipmap(_genMipmap) {
+      m_texOptions(_options) {
 
     std::vector<char> data = {};
-    m_emptyTexture = std::make_shared<Texture>(data, m_texOptions, m_genMipmap);
+    m_emptyTexture = std::make_shared<Texture>(data, m_texOptions);
 }
 
 std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _rawTileData) {
@@ -83,7 +81,7 @@ std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _r
         return m_emptyTexture;
     }
 
-    auto texture = std::make_shared<Texture>(_rawTileData, m_texOptions, m_genMipmap);
+    auto texture = std::make_shared<Texture>(_rawTileData, m_texOptions);
 
     return texture;
 }

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -76,7 +76,7 @@ RasterSource::RasterSource(const std::string& _name, std::unique_ptr<DataSource>
 }
 
 std::shared_ptr<Texture> RasterSource::createTexture(const std::vector<char>& _rawTileData) {
-    if (_rawTileData.size() == 0) {
+    if (_rawTileData.empty()) {
         return m_emptyTexture;
     }
 

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -16,7 +16,6 @@ class RasterTileTask;
 class RasterSource : public TileSource {
 
     TextureOptions m_texOptions;
-    bool m_genMipmap;
     std::unordered_map<TileID, std::shared_ptr<Texture>> m_textures;
 
     std::shared_ptr<Texture> m_emptyTexture;
@@ -28,8 +27,7 @@ protected:
 public:
 
     RasterSource(const std::string& _name, std::unique_ptr<DataSource> _sources,
-                 TextureOptions _options, TileSource::ZoomOptions _zoomOptions = {},
-                 bool genMipmap = false);
+                 TextureOptions _options, TileSource::ZoomOptions _zoomOptions = {});
 
     // TODO Is this always PNG or can it also be JPEG?
     virtual const char* mimeType() const override { return "image/png"; };

--- a/core/src/gl/framebuffer.cpp
+++ b/core/src/gl/framebuffer.cpp
@@ -117,7 +117,8 @@ void FrameBuffer::init(RenderState& _rs) {
         options.minFilter = TextureMinFilter::NEAREST;
         options.magFilter = TextureMagFilter::NEAREST;
 
-        m_texture = std::make_unique<Texture>(m_width, m_height, options);
+        m_texture = std::make_unique<Texture>(options);
+        m_texture->resize(m_width, m_height);
         m_texture->update(_rs, 0);
 
         GL::framebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,

--- a/core/src/gl/framebuffer.cpp
+++ b/core/src/gl/framebuffer.cpp
@@ -113,11 +113,9 @@ void FrameBuffer::init(RenderState& _rs) {
         GL::framebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                                     GL_RENDERBUFFER, m_glColorRenderBufferHandle);
     } else {
-        TextureOptions options =
-            {GL_RGBA, GL_RGBA,
-            {GL_NEAREST, GL_NEAREST},
-            {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}
-        };
+        TextureOptions options;
+        options.minFilter = TextureMinFilter::NEAREST;
+        options.magFilter = TextureMagFilter::NEAREST;
 
         m_texture = std::make_unique<Texture>(m_width, m_height, options);
         m_texture->update(_rs, 0);

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -52,7 +52,7 @@ bool Texture::loadImageFromMemory(const uint8_t* data, size_t length) {
 
         resize(width, height);
 
-        setPixelData(rgbaPixels, static_cast<size_t>(width * height));
+        setPixelData(rgbaPixels, width * height);
 
         stbi_image_free(pixels);
 
@@ -87,7 +87,7 @@ Texture& Texture::operator=(Texture&& _other) noexcept {
     return *this;
 }
 
-void Texture::setPixelData(const GLuint *data, size_t length) {
+void Texture::setPixelData(const GLuint* data, size_t length) {
 
     m_data.clear();
 

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -40,7 +40,7 @@ Texture::~Texture() {
 bool Texture::loadImageFromMemory(const uint8_t* data, size_t length) {
     unsigned char* pixels = nullptr;
     int width = 0, height = 0, comp = 0;
-    pixels = stbi_load_from_memory(data, length, &width, &height, &comp, STBI_rgb_alpha);
+    pixels = stbi_load_from_memory(data, static_cast<int>(length), &width, &height, &comp, STBI_rgb_alpha);
 
     if (pixels) {
         // stbi_load_from_memory loads the image as a series of scanlines starting from
@@ -52,7 +52,7 @@ bool Texture::loadImageFromMemory(const uint8_t* data, size_t length) {
 
         resize(width, height);
 
-        setPixelData(rgbaPixels, width * height);
+        setPixelData(rgbaPixels, static_cast<size_t>(width * height));
 
         stbi_image_free(pixels);
 
@@ -68,11 +68,11 @@ bool Texture::loadImageFromMemory(const uint8_t* data, size_t length) {
     return false;
 }
 
-Texture::Texture(Texture&& _other) {
+Texture::Texture(Texture&& _other) noexcept {
     *this = std::move(_other);
 }
 
-Texture& Texture::operator=(Texture&& _other) {
+Texture& Texture::operator=(Texture&& _other) noexcept {
     m_glHandle = _other.m_glHandle;
     _other.m_glHandle = 0;
 
@@ -172,13 +172,13 @@ void Texture::update(RenderState& rs, GLuint _textureUnit) {
     }
 
     if (m_glHandle == 0) {
-        if (m_data.size() == 0) {
+        if (m_data.empty()) {
             size_t divisor = sizeof(GLuint) / getBytesPerPixel();
             m_data.resize((m_width * m_height) / divisor, 0);
         }
     }
 
-    GLuint* data = m_data.size() > 0 ? m_data.data() : nullptr;
+    GLuint* data = m_data.empty() ? nullptr : m_data.data();
 
     update(rs, _textureUnit, data);
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -44,7 +44,7 @@ struct TextureOptions {
     TextureWrap wrapS = TextureWrap::CLAMP_TO_EDGE;
     TextureWrap wrapT = TextureWrap::CLAMP_TO_EDGE;
     PixelFormat pixelFormat = PixelFormat::RGBA;
-    float density = 1.f;
+    float displayScale = 1.f; // 0.5 for a "@2x" image.
     bool generateMipmaps = false;
 };
 
@@ -86,7 +86,7 @@ public:
 
     GLuint getGlHandle() const { return m_glHandle; }
 
-    float getDensity() const { return m_options.density; }
+    float getDisplayScale() const { return m_options.displayScale; }
 
     const auto& getSpriteAtlas() const { return m_spriteAtlas; }
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -52,12 +52,12 @@ class Texture {
 
 public:
 
-    Texture(TextureOptions _options);
+    explicit Texture(TextureOptions _options);
 
     Texture(const uint8_t* data, size_t length, TextureOptions _options);
 
-    Texture(Texture&& _other);
-    Texture& operator=(Texture&& _other);
+    Texture(Texture&& _other) noexcept;
+    Texture& operator=(Texture&& _other) noexcept;
 
     virtual ~Texture();
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -52,9 +52,9 @@ class Texture {
 
 public:
 
-    Texture(unsigned int _width, unsigned int _height, TextureOptions _options);
+    Texture(TextureOptions _options);
 
-    Texture(const std::vector<char>& _data, TextureOptions _options);
+    Texture(const uint8_t* data, size_t length, TextureOptions _options);
 
     Texture(Texture&& _other);
     Texture& operator=(Texture&& _other);
@@ -67,11 +67,11 @@ public:
     virtual void update(RenderState& rs, GLuint _textureSlot, const GLuint* data);
 
     /* Resize the texture */
-    void resize(const unsigned int _width, const unsigned int _height);
+    void resize(int width, int height);
 
     /* Width and Height texture getters */
-    unsigned int getWidth() const { return m_width; }
-    unsigned int getHeight() const { return m_height; }
+    int getWidth() const { return m_width; }
+    int getHeight() const { return m_height; }
 
     void bind(RenderState& rs, GLuint _unit);
 
@@ -83,7 +83,7 @@ public:
      *
      * Has less priority than set sub data
      */
-    void setData(const GLuint* _data, unsigned int _dataSize);
+    void setData(const GLuint* data, size_t length);
 
     /* Update a region of the texture */
     void setSubData(const GLuint* _subData, uint16_t _xoff, uint16_t _yoff,
@@ -96,7 +96,7 @@ public:
 
     static void invalidateAllTextures();
 
-    bool loadImageFromMemory(const std::vector<char>& _data);
+    bool loadImageFromMemory(const uint8_t* data, size_t length);
 
     static void flipImageData(unsigned char *result, int w, int h, int depth);
     static void flipImageData(GLuint *result, int w, int h);
@@ -115,7 +115,7 @@ protected:
 
     TextureOptions m_options;
     std::vector<GLuint> m_data;
-    GLuint m_glHandle;
+    GLuint m_glHandle = 0;
 
     struct DirtyRange {
         size_t min;
@@ -123,12 +123,12 @@ protected:
     };
     std::vector<DirtyRange> m_dirtyRanges;
 
-    bool m_shouldResize;
+    bool m_shouldResize = false;
 
-    unsigned int m_width;
-    unsigned int m_height;
+    int m_width = 0;
+    int m_height = 0;
 
-    GLenum m_target;
+    GLenum m_target = GL_TEXTURE_2D;
 
     RenderState* m_rs = nullptr;
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -61,6 +61,15 @@ public:
 
     virtual ~Texture();
 
+    bool loadImageFromMemory(const uint8_t* data, size_t length);
+
+    /* Sets texture pixel data */
+    void setPixelData(const GLuint* data, size_t length);
+
+    void setRowsDirty(int start, int count);
+
+    void setSpriteAtlas(std::unique_ptr<SpriteAtlas> sprites);
+
     /* Perform texture updates, should be called at least once and after adding data or resizing */
     virtual void update(RenderState& rs, GLuint _textureSlot);
 
@@ -69,66 +78,48 @@ public:
     /* Resize the texture */
     void resize(int width, int height);
 
+    void bind(RenderState& rs, GLuint _unit);
+
     /* Width and Height texture getters */
     int getWidth() const { return m_width; }
     int getHeight() const { return m_height; }
 
-    void bind(RenderState& rs, GLuint _unit);
+    GLuint getGlHandle() const { return m_glHandle; }
 
-    void setDirty(size_t yOffset, size_t height);
+    float getDensity() const { return m_options.density; }
 
-    GLuint getGlHandle() { return m_glHandle; }
-
-    /* Sets texture data
-     *
-     * Has less priority than set sub data
-     */
-    void setData(const GLuint* data, size_t length);
-
-    /* Update a region of the texture */
-    void setSubData(const GLuint* _subData, uint16_t _xoff, uint16_t _yoff,
-                    uint16_t _width, uint16_t _height, uint16_t _stride);
+    const auto& getSpriteAtlas() const { return m_spriteAtlas; }
 
     /* Checks whether the texture has valid data and has been successfully uploaded to GPU */
     bool isValid() const;
 
-    typedef std::pair<GLuint, GLuint> TextureSlot;
+    size_t getBytesPerPixel() const;
 
-    static void invalidateAllTextures();
+    size_t getBufferSize() const;
 
-    bool loadImageFromMemory(const uint8_t* data, size_t length);
-
-    static void flipImageData(unsigned char *result, int w, int h, int depth);
-    static void flipImageData(GLuint *result, int w, int h);
-
-    size_t bytesPerPixel();
-    size_t bufferSize();
-
-    auto& spriteAtlas() { return m_spriteAtlas; }
-    const auto& spriteAtlas() const { return m_spriteAtlas; }
-
-    float density() const { return m_options.density; }
+    static void flipImageData(GLuint* result, int width, int height);
 
 protected:
+
+    struct DirtyRowRange {
+        int min;
+        int max;
+    };
 
     void generate(RenderState& rs, GLuint _textureUnit);
 
     TextureOptions m_options;
-    std::vector<GLuint> m_data;
-    GLuint m_glHandle = 0;
 
-    struct DirtyRange {
-        size_t min;
-        size_t max;
-    };
-    std::vector<DirtyRange> m_dirtyRanges;
+    std::vector<GLuint> m_data;
+
+    std::vector<DirtyRowRange> m_dirtyRows;
+
+    GLuint m_glHandle = 0;
 
     bool m_shouldResize = false;
 
     int m_width = 0;
     int m_height = 0;
-
-    GLenum m_target = GL_TEXTURE_2D;
 
     RenderState* m_rs = nullptr;
 
@@ -138,4 +129,4 @@ private:
 
 };
 
-}
+} // namespace Tangram

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -11,37 +11,50 @@ namespace Tangram {
 
 class RenderState;
 
-struct TextureFiltering {
-    GLenum min;
-    GLenum mag;
+enum class TextureMinFilter : GLenum {
+    NEAREST = GL_NEAREST,
+    LINEAR = GL_LINEAR,
+    NEAREST_MIPMAP_NEAREST = GL_NEAREST_MIPMAP_NEAREST,
+    LINEAR_MIPMAP_NEAREST = GL_LINEAR_MIPMAP_NEAREST,
+    NEAREST_MIPMAP_LINEAR = GL_NEAREST_MIPMAP_LINEAR,
+    LINEAR_MIPMAP_LINEAR = GL_LINEAR_MIPMAP_LINEAR,
 };
 
-struct TextureWrapping {
-    GLenum wraps;
-    GLenum wrapt;
+enum class TextureMagFilter : GLenum {
+    NEAREST = GL_NEAREST,
+    LINEAR = GL_LINEAR,
+};
+
+enum class TextureWrap : GLenum {
+    CLAMP_TO_EDGE = GL_CLAMP_TO_EDGE,
+    REPEAT = GL_REPEAT,
+};
+
+enum class PixelFormat : GLenum {
+    ALPHA = GL_ALPHA,
+    LUMINANCE = GL_LUMINANCE,
+    LUMINANCE_ALPHA = GL_LUMINANCE_ALPHA,
+    RGB = GL_RGB,
+    RGBA = GL_RGBA,
 };
 
 struct TextureOptions {
-    GLenum internalFormat;
-    GLenum format;
-    TextureFiltering filtering;
-    TextureWrapping wrapping;
+    TextureMinFilter minFilter = TextureMinFilter::LINEAR;
+    TextureMagFilter magFilter = TextureMagFilter::LINEAR;
+    TextureWrap wrapS = TextureWrap::CLAMP_TO_EDGE;
+    TextureWrap wrapT = TextureWrap::CLAMP_TO_EDGE;
+    PixelFormat pixelFormat = PixelFormat::RGBA;
+    float density = 1.f;
+    bool generateMipmaps = false;
 };
-
-#define DEFAULT_TEXTURE_OPTION \
-    {GL_ALPHA, GL_ALPHA, \
-    {GL_LINEAR, GL_LINEAR}, \
-    {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}}
 
 class Texture {
 
 public:
 
-    Texture(unsigned int _width, unsigned int _height, TextureOptions _options = DEFAULT_TEXTURE_OPTION,
-            bool _generateMipmaps = false, float _density = 1.f);
+    Texture(unsigned int _width, unsigned int _height, TextureOptions _options);
 
-    Texture(const std::vector<char>& _data, TextureOptions _options = DEFAULT_TEXTURE_OPTION,
-            bool _generateMipmaps = false, float _density = 1.f);
+    Texture(const std::vector<char>& _data, TextureOptions _options);
 
     Texture(Texture&& _other);
     Texture& operator=(Texture&& _other);
@@ -83,8 +96,6 @@ public:
 
     static void invalidateAllTextures();
 
-    static bool isRepeatWrapping(TextureWrapping _wrapping);
-
     bool loadImageFromMemory(const std::vector<char>& _data);
 
     static void flipImageData(unsigned char *result, int w, int h, int depth);
@@ -96,7 +107,7 @@ public:
     auto& spriteAtlas() { return m_spriteAtlas; }
     const auto& spriteAtlas() const { return m_spriteAtlas; }
 
-    float invDensity() const { return m_invDensity; }
+    float density() const { return m_options.density; }
 
 protected:
 
@@ -122,10 +133,6 @@ protected:
     RenderState* m_rs = nullptr;
 
 private:
-
-    bool m_generateMipmaps;
-    // used to determine css size by using as a multiplier with the defined texture size/sprite size
-    float m_invDensity = 1.f;
 
     std::unique_ptr<SpriteAtlas> m_spriteAtlas;
 

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -89,7 +89,7 @@ bool MarkerManager::setBitmap(MarkerID markerID, int width, int height, const un
     TextureOptions options;
     auto texture = std::make_unique<Texture>(options);
     texture->resize(width, height);
-    texture->setData(bitmapData, width * height);
+    texture->setPixelData(bitmapData, width * height);
 
     marker->setTexture(std::move(texture));
 

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -86,7 +86,7 @@ bool MarkerManager::setBitmap(MarkerID markerID, int width, int height, const un
 
     m_dirty = true;
 
-    TextureOptions options = { GL_RGBA, GL_RGBA, { GL_LINEAR, GL_LINEAR }, { GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE } };
+    TextureOptions options;
     auto texture = std::make_unique<Texture>(width, height, options);
     unsigned int size = width * height;
     texture->setData(bitmapData, size);

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -87,9 +87,9 @@ bool MarkerManager::setBitmap(MarkerID markerID, int width, int height, const un
     m_dirty = true;
 
     TextureOptions options;
-    auto texture = std::make_unique<Texture>(width, height, options);
-    unsigned int size = width * height;
-    texture->setData(bitmapData, size);
+    auto texture = std::make_unique<Texture>(options);
+    texture->resize(width, height);
+    texture->setData(bitmapData, width * height);
 
     marker->setTexture(std::move(texture));
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -591,7 +591,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platfor
         }
     } else {
         texture = std::make_shared<Texture>(options);
-        texture->spriteAtlas() = std::move(_atlas);
+        texture->setSpriteAtlas(std::move(_atlas));
 
         scene->pendingTextures++;
         scene->startUrlRequest(platform, url, [&, url, scene, texture](UrlResponse&& response) {
@@ -604,8 +604,8 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platfor
                         if (!texture->loadImageFromMemory(data, length)) {
                             LOGE("Invalid texture data from URL '%s'", url.string().c_str());
                         }
-                        if (texture->spriteAtlas()) {
-                            texture->spriteAtlas()->updateSpriteNodes({texture->getWidth(), texture->getHeight()});
+                        if (texture->getSpriteAtlas()) {
+                            texture->getSpriteAtlas()->updateSpriteNodes({texture->getWidth(), texture->getHeight()});
                         }
                     }
                 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -584,16 +584,13 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platfor
             LOGE("Can't decode Base64 texture");
             return nullptr;
         }
-        texture = std::make_shared<Texture>(0, 0, options);
+        texture = std::make_shared<Texture>(options);
 
-        std::vector<char> textureData;
-        auto cdata = reinterpret_cast<char*>(blob.data());
-        textureData.insert(textureData.begin(), cdata, cdata + blob.size());
-        if (!texture->loadImageFromMemory(textureData)) {
+        if (!texture->loadImageFromMemory(blob.data(), blob.size())) {
             LOGE("Invalid Base64 texture");
         }
     } else {
-        texture = std::make_shared<Texture>(std::vector<char>(), options);
+        texture = std::make_shared<Texture>(options);
         texture->spriteAtlas() = std::move(_atlas);
 
         scene->pendingTextures++;
@@ -602,7 +599,9 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platfor
                     LOGE("Error retrieving URL '%s': %s", url.string().c_str(), response.error);
                 } else {
                     if (texture) {
-                        if (!texture->loadImageFromMemory(std::move(response.content))) {
+                        auto data = reinterpret_cast<const uint8_t*>(response.content.data());
+                        auto length = response.content.size();
+                        if (!texture->loadImageFromMemory(data, length)) {
                             LOGE("Invalid texture data from URL '%s'", url.string().c_str());
                         }
                         if (texture->spriteAtlas()) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -667,7 +667,7 @@ void SceneLoader::loadTexture(const std::shared_ptr<Platform>& platform, const s
     }
 
     if (Node density = textureConfig["density"]) {
-        YamlUtil::getFloat(density, options.density);
+        options.displayScale = 1.f / YamlUtil::getFloatOrDefault(density, 1.f);
     }
 
     std::unique_ptr<SpriteAtlas> atlas;

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -19,13 +19,13 @@ class SceneLayer;
 class ShaderProgram;
 class SpriteAtlas;
 class Style;
+class Texture;
 class TileManager;
 class TileSource;
 class View;
 struct Filter;
 struct MaterialTexture;
 struct StyleParam;
-struct TextureFiltering;
 struct TextureOptions;
 
 // 0: type, 1: values
@@ -71,10 +71,10 @@ struct SceneLoader {
     /* loads a texture with default texture properties */
     static std::shared_ptr<Texture> getOrLoadTexture(const std::shared_ptr<Platform>& platform, const std::string& url, const std::shared_ptr<Scene>& scene);
     static std::shared_ptr<Texture> fetchTexture(const std::shared_ptr<Platform>& platform, const std::string& name, const std::string& url,
-                                                 const TextureOptions& options, bool generateMipmaps, const std::shared_ptr<Scene>& scene,
-                                                 float density = 1.f, std::unique_ptr<SpriteAtlas> _atlas = nullptr);
+                                                 const TextureOptions& options, const std::shared_ptr<Scene>& scene,
+                                                 std::unique_ptr<SpriteAtlas> _atlas = nullptr);
 
-    static bool extractTexFiltering(Node& filtering, TextureFiltering& filter);
+    static bool parseTexFiltering(Node& filteringNode, TextureOptions& options);
 
     static MaterialTexture loadMaterialTexture(const std::shared_ptr<Platform>& platform, Node matCompNode,
                                                const std::shared_ptr<Scene>& scene, Style& style);

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -310,7 +310,7 @@ bool PointStyleBuilder::evalSizeParam(const DrawRule& _rule, Parameters& _params
     glm::vec2 spriteSize(NAN);
 
     if (_texture) {
-        spriteSize = glm::vec2{_texture->getWidth(), _texture->getHeight()} * _texture->invDensity();
+        spriteSize = glm::vec2{_texture->getWidth(), _texture->getHeight()} / _texture->density();
 
         const auto &atlas = _texture->spriteAtlas();
         if (atlas) {
@@ -318,7 +318,7 @@ bool PointStyleBuilder::evalSizeParam(const DrawRule& _rule, Parameters& _params
                 !atlas->getSpriteNode(_params.spriteDefault, spriteNode)) {
                 return false;
             }
-            spriteSize = spriteNode.m_size * _texture->invDensity();
+            spriteSize = spriteNode.m_size / _texture->density();
         } else if ( !_params.sprite.empty() || !_params.spriteDefault.empty()) {
             // missing sprite atlas for texture but sprite specified in draw rule
             return false;

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -310,7 +310,7 @@ bool PointStyleBuilder::evalSizeParam(const DrawRule& _rule, Parameters& _params
     glm::vec2 spriteSize(NAN);
 
     if (_texture) {
-        spriteSize = glm::vec2{_texture->getWidth(), _texture->getHeight()} / _texture->getDensity();
+        spriteSize = glm::vec2{_texture->getWidth(), _texture->getHeight()} * _texture->getDisplayScale();
 
         const auto &atlas = _texture->getSpriteAtlas();
         if (atlas) {
@@ -318,7 +318,7 @@ bool PointStyleBuilder::evalSizeParam(const DrawRule& _rule, Parameters& _params
                 !atlas->getSpriteNode(_params.spriteDefault, spriteNode)) {
                 return false;
             }
-            spriteSize = spriteNode.m_size / _texture->getDensity();
+            spriteSize = spriteNode.m_size * _texture->getDisplayScale();
         } else if ( !_params.sprite.empty() || !_params.spriteDefault.empty()) {
             // missing sprite atlas for texture but sprite specified in draw rule
             return false;

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -310,15 +310,15 @@ bool PointStyleBuilder::evalSizeParam(const DrawRule& _rule, Parameters& _params
     glm::vec2 spriteSize(NAN);
 
     if (_texture) {
-        spriteSize = glm::vec2{_texture->getWidth(), _texture->getHeight()} / _texture->density();
+        spriteSize = glm::vec2{_texture->getWidth(), _texture->getHeight()} / _texture->getDensity();
 
-        const auto &atlas = _texture->spriteAtlas();
+        const auto &atlas = _texture->getSpriteAtlas();
         if (atlas) {
             if (!atlas->getSpriteNode(_params.sprite, spriteNode) &&
                 !atlas->getSpriteNode(_params.spriteDefault, spriteNode)) {
                 return false;
             }
-            spriteSize = spriteNode.m_size / _texture->density();
+            spriteSize = spriteNode.m_size / _texture->getDensity();
         } else if ( !_params.sprite.empty() || !_params.spriteDefault.empty()) {
             // missing sprite atlas for texture but sprite specified in draw rule
             return false;
@@ -358,7 +358,7 @@ bool PointStyleBuilder::getUVQuad(Parameters& _params, glm::vec4& _quad, const T
     _quad = glm::vec4(0.0, 1.0, 1.0, 0.0);
 
     if (_texture) {
-        const auto& atlas = _texture->spriteAtlas();
+        const auto& atlas = _texture->getSpriteAtlas();
         if (atlas) {
             SpriteNode spriteNode;
             if (!atlas->getSpriteNode(_params.sprite, spriteNode) &&

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -123,7 +123,7 @@ void PolylineStyle::constructShaderProgram() {
 
         m_texture = std::make_shared<Texture>(options);
         m_texture->resize(1, pixels.size());
-        m_texture->setData(pixels.data(), pixels.size());
+        m_texture->setPixelData(pixels.data(), pixels.size());
 
         if (m_dashBackground) {
             m_shaderSource->addSourceBlock("defines", "#define TANGRAM_LINE_BACKGROUND_COLOR vec3(" +

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -115,7 +115,9 @@ void PolylineStyle::constructShaderProgram() {
     m_shaderSource->setSourceStrings(polyline_fs, polyline_vs);
 
     if (m_dashArray.size() > 0) {
-        TextureOptions options {GL_RGBA, GL_RGBA, {GL_NEAREST, GL_NEAREST}, {GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE}};
+        TextureOptions options;
+        options.minFilter = TextureMinFilter::NEAREST;
+        options.magFilter = TextureMagFilter::NEAREST;
         // provides precision for dash patterns that are a fraction of line width
         auto pixels = DashArray::render(m_dashArray, dash_scale);
 

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -121,7 +121,8 @@ void PolylineStyle::constructShaderProgram() {
         // provides precision for dash patterns that are a fraction of line width
         auto pixels = DashArray::render(m_dashArray, dash_scale);
 
-        m_texture = std::make_shared<Texture>(1, pixels.size(), options);
+        m_texture = std::make_shared<Texture>(options);
+        m_texture->resize(1, pixels.size());
         m_texture->setData(pixels.data(), pixels.size());
 
         if (m_dashBackground) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -106,7 +106,7 @@ void FontContext::addGlyph(alfons::AtlasID id, uint16_t gx, uint16_t gy, uint16_
                                  dst, gw, gh, width,
                                  &m_sdfBuffer[0]);
 
-    texture.setDirty(gy, gh);
+    texture.setRowsDirty(gy, gh);
     m_textures[id].dirty = true;
 }
 

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -26,7 +26,13 @@ struct GlyphTexture {
 
     static constexpr int size = 256;
 
-    GlyphTexture() : texture(size, size) {
+    static constexpr TextureOptions textureOptions() {
+        TextureOptions options;
+        options.pixelFormat = PixelFormat::ALPHA;
+        return options;
+    }
+
+    GlyphTexture() : texture(size, size, textureOptions()) {
         texData.resize(size * size);
     }
 

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -32,7 +32,8 @@ struct GlyphTexture {
         return options;
     }
 
-    GlyphTexture() : texture(size, size, textureOptions()) {
+    GlyphTexture() : texture(textureOptions()) {
+        texture.resize(size, size);
         texData.resize(size * size);
     }
 

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -95,7 +95,7 @@ size_t Tile::getMemoryUsage() const {
         }
         for (auto& raster : m_rasters) {
             if (raster.texture) {
-                m_memoryUsage += raster.texture->bufferSize();
+                m_memoryUsage += raster.texture->getBufferSize();
             }
         }
     }

--- a/tests/unit/textureTests.cpp
+++ b/tests/unit/textureTests.cpp
@@ -8,7 +8,7 @@ using namespace Tangram;
 class TestTexture : public Texture {
 public:
     using Texture::Texture;
-    const std::vector<DirtyRange>& dirtyRanges() { return m_dirtyRanges; }
+    const std::vector<DirtyRowRange>& dirtyRanges() { return m_dirtyRows; }
 };
 
 TEST_CASE("Merging of dirty Regions - Non overlapping, test ordering", "[Texture]") {
@@ -16,15 +16,15 @@ TEST_CASE("Merging of dirty Regions - Non overlapping, test ordering", "[Texture
     REQUIRE(texture.dirtyRanges().size() == 0);
 
     // A range from 20-30
-    texture.setDirty(20, 10);
+    texture.setRowsDirty(20, 10);
     REQUIRE(texture.dirtyRanges().size() == 1);
 
     // B range from 0-10
-    texture.setDirty(0, 10);
+    texture.setRowsDirty(0, 10);
     REQUIRE(texture.dirtyRanges().size() == 2);
 
     // C range from 40-60
-    texture.setDirty(40, 20);
+    texture.setRowsDirty(40, 20);
     REQUIRE(texture.dirtyRanges().size() == 3);
 
     // B
@@ -46,11 +46,11 @@ TEST_CASE("Merging of dirty Regions - Merge overlapping", "[Texture]") {
     REQUIRE(texture.dirtyRanges().size() == 0);
 
     // range from 50-100
-    texture.setDirty(50, 50);
+    texture.setRowsDirty(50, 50);
     REQUIRE(texture.dirtyRanges().size() == 1);
 
     // range from 20-70
-    texture.setDirty(20, 50);
+    texture.setRowsDirty(20, 50);
     REQUIRE(texture.dirtyRanges().size() == 1);
 
     REQUIRE(texture.dirtyRanges()[0].min == 20);
@@ -64,19 +64,19 @@ TEST_CASE("Merging of dirty Regions - Merge three regions, when 3rd region is ad
         REQUIRE(texture.dirtyRanges().size() == 0);
 
         // range from 50-100
-        texture.setDirty(50, 50);
+        texture.setRowsDirty(50, 50);
         REQUIRE(texture.dirtyRanges().size() == 1);
         REQUIRE(texture.dirtyRanges()[0].min == 50);
         REQUIRE(texture.dirtyRanges()[0].max == 100);
 
         // range from 200-250
-        texture.setDirty(200, 50);
+        texture.setRowsDirty(200, 50);
         REQUIRE(texture.dirtyRanges().size() == 2);
         REQUIRE(texture.dirtyRanges()[1].min == 200);
         REQUIRE(texture.dirtyRanges()[1].max == 250);
 
         // range from 100-200
-        texture.setDirty(100, 100);
+        texture.setRowsDirty(100, 100);
         REQUIRE(texture.dirtyRanges().size() == 1);
         REQUIRE(texture.dirtyRanges()[0].min == 50);
         REQUIRE(texture.dirtyRanges()[0].max == 250);
@@ -88,25 +88,25 @@ TEST_CASE("Merging of dirty Regions - Merge three regions, when 3rd region is ad
         REQUIRE(texture.dirtyRanges().size() == 0);
 
         // range from 50-150
-        texture.setDirty(50, 100);
+        texture.setRowsDirty(50, 100);
         REQUIRE(texture.dirtyRanges().size() == 1);
         REQUIRE(texture.dirtyRanges()[0].min == 50);
         REQUIRE(texture.dirtyRanges()[0].max == 150);
 
         // range from 200-250
-        texture.setDirty(200, 50);
+        texture.setRowsDirty(200, 50);
         REQUIRE(texture.dirtyRanges().size() == 2);
         REQUIRE(texture.dirtyRanges()[1].min == 200);
         REQUIRE(texture.dirtyRanges()[1].max == 250);
 
         // range from 300-350
-        texture.setDirty(300, 50);
+        texture.setRowsDirty(300, 50);
         REQUIRE(texture.dirtyRanges().size() == 3);
         REQUIRE(texture.dirtyRanges()[2].min == 300);
         REQUIRE(texture.dirtyRanges()[2].max == 350);
 
         // range from 100-300
-        texture.setDirty(100, 200);
+        texture.setRowsDirty(100, 200);
         REQUIRE(texture.dirtyRanges().size() == 1);
         REQUIRE(texture.dirtyRanges()[0].min == 50);
         REQUIRE(texture.dirtyRanges()[0].max == 350);

--- a/tests/unit/textureTests.cpp
+++ b/tests/unit/textureTests.cpp
@@ -12,7 +12,8 @@ public:
 };
 
 TEST_CASE("Merging of dirty Regions - Non overlapping, test ordering", "[Texture]") {
-    TestTexture texture(512, 512);
+    TestTexture texture(TextureOptions{});
+    texture.resize(512, 512);
     REQUIRE(texture.dirtyRanges().size() == 0);
 
     // A range from 20-30
@@ -42,7 +43,8 @@ TEST_CASE("Merging of dirty Regions - Non overlapping, test ordering", "[Texture
 }
 
 TEST_CASE("Merging of dirty Regions - Merge overlapping", "[Texture]") {
-    TestTexture texture(512, 512);
+    TestTexture texture(TextureOptions{});
+    texture.resize(512, 512);
     REQUIRE(texture.dirtyRanges().size() == 0);
 
     // range from 50-100
@@ -60,7 +62,8 @@ TEST_CASE("Merging of dirty Regions - Merge overlapping", "[Texture]") {
 TEST_CASE("Merging of dirty Regions - Merge three regions, when 3rd region is added", "[Texture]") {
     { // just touching
 
-        TestTexture texture(512, 512);
+        TestTexture texture(TextureOptions{});
+        texture.resize(512, 512);
         REQUIRE(texture.dirtyRanges().size() == 0);
 
         // range from 50-100
@@ -84,7 +87,8 @@ TEST_CASE("Merging of dirty Regions - Merge three regions, when 3rd region is ad
 
     { // overlapping
 
-        TestTexture texture(512, 512);
+        TestTexture texture(TextureOptions{});
+        texture.resize(512, 512);
         REQUIRE(texture.dirtyRanges().size() == 0);
 
         // range from 50-150


### PR DESCRIPTION
- TextureOptions now includes `generateMipmaps` and `density` parameters.
- TextureOptions has default values.
- Texture constructor doesn't require width and height.
- Filtering, Wrapping, and PixelFormat are now typed enums (I often forget which options belong to which parameter).
- Texture loads image data from pointer and size instead of vector (this saves us from copying the data in some cases where the vector type doesn't match)
- Reorganized and renamed Texture methods for consistency (use `get` for getters, `setData` -> `setPixelData`, `setDirty` -> `setRowsDirty`).
- Applied suggestions from clang-tidy.