### PR TITLE
Using fallback tile when tile is not available in DataSource

### DIFF
--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -55,6 +55,8 @@ public:
 
         virtual bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) = 0;
 
+        virtual TileID getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) = 0;
+
         /* Stops any running I/O tasks pertaining to @_tile */
         virtual void cancelLoadingTile(TileTask& _task) {
             if (next) { next->cancelLoadingTile(_task); }
@@ -90,6 +92,8 @@ public:
      * @return the mime-type of the DataSource.
      */
     virtual const char* mimeType() const;
+
+    TileID getFallbackTileID(const TileID& _tileID);
 
     /* Fetches data for the map tile specified by @_tileID
      *

--- a/core/src/data/mbtilesDataSource.cpp
+++ b/core/src/data/mbtilesDataSource.cpp
@@ -446,31 +446,29 @@ void MBTilesDataSource::initSchema(SQLite::Database& db, std::string _name, std:
 
 bool MBTilesDataSource::hasTileData(const TileID& _tileId) {
 
-    for (int i = 0; i < m_queries.size(); ++i) {
-        auto &stmt = m_queries[i]->getTileData;
-        try {
-            // Google TMS to WMTS
-            // https://github.com/mapbox/node-mbtiles/blob/
-            // 4bbfaf991969ce01c31b95184c4f6d5485f717c3/lib/mbtiles.js#L149
-            int z = _tileId.z;
-            int y = (1 << z) - 1 - _tileId.y;
+    auto& stmt = m_queries->getTileData;
+    try {
+        // Google TMS to WMTS
+        // https://github.com/mapbox/node-mbtiles/blob/
+        // 4bbfaf991969ce01c31b95184c4f6d5485f717c3/lib/mbtiles.js#L149
+        int z = _tileId.z;
+        int y = (1 << z) - 1 - _tileId.y;
 
-            stmt.bind(1, z);
-            stmt.bind(2, _tileId.x);
-            stmt.bind(3, y);
+        stmt.bind(1, z);
+        stmt.bind(2, _tileId.x);
+        stmt.bind(3, y);
 
-            if (stmt.executeStep()) {
-                stmt.reset();
-                return true;
-            }
-
-        } catch (std::exception &e) {
-            LOGE("MBTiles SQLite get tile_data statement failed: %s", e.what());
-        }
-        try {
+        if (stmt.executeStep()) {
             stmt.reset();
-        } catch (...) {}
+            return true;
+        }
+
+    } catch (std::exception& e) {
+        LOGE("MBTiles SQLite get tile_data statement failed: %s", e.what());
     }
+    try {
+        stmt.reset();
+    } catch(...) {}
 
     return false;
 }

--- a/core/src/data/mbtilesDataSource.h
+++ b/core/src/data/mbtilesDataSource.h
@@ -22,11 +22,14 @@ public:
 
     ~MBTilesDataSource();
 
+    TileID getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) override;
+
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
     void clear() override {}
 
 private:
+    bool hasTileData(const TileID& _tileId);
     bool getTileData(const TileID& _tileId, std::vector<char>& _data);
     void storeTileData(const TileID& _tileId, const std::vector<char>& _data);
     bool loadNextSource(std::shared_ptr<TileTask> _task, TileTaskCb _cb);

--- a/core/src/data/memoryCacheDataSource.cpp
+++ b/core/src/data/memoryCacheDataSource.cpp
@@ -22,8 +22,17 @@ struct RawCache {
 
     CacheMap m_cacheMap;
     CacheList m_cacheList;
-    int m_usage = 0;
-    int m_maxUsage = 0;
+    size_t m_usage = 0;
+    size_t m_maxUsage = 0;
+
+    bool has(const TileID& _tileID) {
+
+        if (m_maxUsage <= 0) { return false; }
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        return m_cacheMap.find(_tileID) != m_cacheMap.end();
+    }
 
     bool get(BinaryTileTask& _task) {
 
@@ -93,12 +102,55 @@ void MemoryCacheDataSource::setCacheSize(size_t _cacheSize) {
     m_cache->m_maxUsage = _cacheSize;
 }
 
+bool MemoryCacheDataSource::hasCache(const TileID& _tileID) {
+    return m_cache->has(_tileID);
+}
+
 bool MemoryCacheDataSource::cacheGet(BinaryTileTask& _task) {
     return m_cache->get(_task);
 }
 
 void MemoryCacheDataSource::cachePut(const TileID& _tileID, std::shared_ptr<std::vector<char>> _rawDataRef) {
     m_cache->put(_tileID, _rawDataRef);
+}
+
+TileID MemoryCacheDataSource::getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) {
+
+    if (hasCache(_tileID.zoomBiasAdjusted(_zoomBias).withMaxSourceZoom(_maxZoom))) {
+        if (next) {
+            TileID nextTileID = next->getFallbackTileID(_tileID, _maxZoom, _zoomBias);
+            return (_tileID.z > nextTileID.z) ? _tileID : nextTileID;
+        }
+
+        return _tileID;
+    }
+
+    TileID tileID(_tileID);
+    bool isCached = false;
+
+    if (_zoomBias > 0) {
+        while (!(isCached = hasCache(tileID.zoomBiasAdjusted(_zoomBias))) && tileID.z > _zoomBias) {
+            tileID = tileID.zoomBiasAdjusted(_zoomBias);
+        }
+    }
+    else {
+        while (!(isCached = hasCache(tileID)) && tileID.z > 0) {
+            tileID = tileID.getParent(_zoomBias);
+        }
+    }
+
+    if (next) {
+        TileID nextTileID = next->getFallbackTileID(_tileID, _maxZoom, _zoomBias);
+
+        if (isCached) {
+            return (tileID.z > nextTileID.z) ? tileID : nextTileID;
+        }
+        else {
+            return nextTileID;
+        }
+    }
+
+    return _tileID;
 }
 
 bool MemoryCacheDataSource::loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) {

--- a/core/src/data/memoryCacheDataSource.h
+++ b/core/src/data/memoryCacheDataSource.h
@@ -10,6 +10,8 @@ public:
     MemoryCacheDataSource();
     ~MemoryCacheDataSource();
 
+    TileID getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) override;
+
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
     void clear() override;
@@ -20,6 +22,7 @@ public:
     void setCacheSize(size_t _cacheSize);
 
 private:
+    bool hasCache(const TileID& _tileID);
     bool cacheGet(BinaryTileTask& _task);
 
     void cachePut(const TileID& _tileID, std::shared_ptr<std::vector<char>> _rawDataRef);

--- a/core/src/data/networkDataSource.h
+++ b/core/src/data/networkDataSource.h
@@ -15,6 +15,8 @@ public:
     NetworkDataSource(std::shared_ptr<Platform> _platform, const std::string& _urlTemplate,
                       std::vector<std::string>&& _urlSubdomains, bool _isTms);
 
+    TileID getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) override { return _tileID; }
+
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
     void cancelLoadingTile(TileTask& _task) override;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -268,8 +268,10 @@ void TileManager::updateTileSets(const View& _view) {
                 auto zoomBias = tileSet.source->zoomBias();
                 auto maxZoom = tileSet.source->maxZoom();
 
+                TileID fallbackTile = tileSet.source->getFallbackTileID(_tileID);
+
                 // Insert scaled and maxZoom mapped tileID in the visible set
-                tileSet.visibleTiles.insert(_tileID.zoomBiasAdjusted(zoomBias).withMaxSourceZoom(maxZoom));
+                tileSet.visibleTiles.insert(fallbackTile.zoomBiasAdjusted(zoomBias).withMaxSourceZoom(maxZoom));
             }
         };
 


### PR DESCRIPTION
I have created new pull request for based on previous https://github.com/tangrams/tangram-es/pull/1626 because I didn't created separate branch for it. I am also attaching comment from previous pull request:

I have added fallback to tiles from lower zoom levels when tiles for higher zoom levels are not available. I have tested this on different repo on Android device with mbtiles Data Source. Sometimes it is not able to get tiles when using `MemoryCacheDataSource` before `MBTilesDataSource`, however I haven't found why. Maybe you will see it immediately why in some cases it does not work as I was also unable to attach native debugger to Android device.

This also closes #1553