### PR TITLE
[wip] Big scene refactor

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -7,6 +7,7 @@ target_compile_options(benchmark PRIVATE -O3 -DNDEBUG)
 set(BENCH_SOURCES
   src/builders.cpp
   src/tileLoading.cpp
+  src/benchStyleContext.cpp
 )
 
 # create an executable per bench

--- a/bench/src/benchStyleContext.cpp
+++ b/bench/src/benchStyleContext.cpp
@@ -1,0 +1,59 @@
+#include "benchmark/benchmark_api.h"
+#include "benchmark/benchmark.h"
+
+#include "scene/styleContext.h"
+#include "data/tileData.h"
+
+using namespace Tangram;
+
+
+class Bench1Fixture : public benchmark::Fixture {
+public:
+    StyleContext ctx;
+    Feature feature;
+
+    void SetUp() override {
+        feature.props.set("message", "Hello World!");
+
+        ctx.setFeature(feature);
+        ctx.setFunctions({R"(function () { return feature.message; })"});
+    }
+    void TearDown() override {
+    }
+};
+BENCHMARK_DEFINE_F(Bench1Fixture, Bench1)(benchmark::State& st) {
+    StyleParam::Value value;
+
+    while (st.KeepRunning()) {
+        ctx.evalStyle(0, StyleParamKey::text_source, value);
+    }
+}
+BENCHMARK_REGISTER_F(Bench1Fixture, Bench1);
+
+
+
+class Bench2Fixture : public benchmark::Fixture {
+public:
+    Feature feature;
+
+    void SetUp() override {
+        feature.props.set("message", "Hello World!");
+    }
+    void TearDown() override {
+    }
+};
+BENCHMARK_DEFINE_F(Bench2Fixture, Bench2)(benchmark::State& st) {
+    StyleParam::Value value;
+
+    while (st.KeepRunning()) {
+        const auto v = feature.props.get("message");
+        if (v.is<std::string>()) {
+            value = v.get<std::string>();
+        } else {
+            printf("eerrr\n");
+        }
+    }
+}
+BENCHMARK_REGISTER_F(Bench2Fixture, Bench2);
+
+BENCHMARK_MAIN();

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -52,6 +52,9 @@ struct TestContext {
             LOGE("Parsing scene config '%s'", e.what());
             return;
         }
+        SceneLoader::applyGlobals(*scene);
+        SceneLoader::applySources(platform, *scene);
+
         SceneLoader::applyConfig(platform, scene);
 
         scene->fontContext()->loadFonts();
@@ -60,7 +63,7 @@ struct TestContext {
         styleContext.setKeywordZoom(0);
 
         source = *scene->tileSources().begin();
-        tileBuilder = std::make_unique<TileBuilder>(scene);
+        tileBuilder = std::make_unique<TileBuilder>(*scene);
     }
 
     void loadTile(const char* path){

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -24,7 +24,7 @@ using namespace Tangram;
 
 struct TestContext {
 
-    std::shared_ptr<MockPlatform> platform = std::make_shared<MockPlatform>();
+    MockPlatform platform;
 
     std::shared_ptr<Scene> scene;
     StyleContext styleContext;
@@ -40,9 +40,9 @@ struct TestContext {
     void loadScene(const char* path) {
 
         Url sceneUrl(path);
-        platform->putMockUrlContents(sceneUrl, MockPlatform::getBytesFromFile(path));
+        platform.putMockUrlContents(sceneUrl, MockPlatform::getBytesFromFile(path));
 
-        scene = std::make_shared<Scene>(platform, sceneUrl, std::make_unique<View>());
+        scene = std::make_shared<Scene>(platform, std::make_unique<SceneOptions>(sceneUrl));
         Importer importer(scene);
 
         try {
@@ -53,7 +53,7 @@ struct TestContext {
             return;
         }
         SceneLoader::applyGlobals(*scene);
-        SceneLoader::applySources(platform, *scene);
+        SceneLoader::applySources(*scene);
 
         //SceneLoader::applyConfig(platform, scene);
 

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -75,7 +75,7 @@ struct TestContext {
     void parseTile() {
         Tile tile({0,0,10,10});
         source = *scene->tileSources().begin();
-        auto task = source->createTask(tile.getID());
+        auto task = source->createTask(*scene, tile.getID());
         auto& t = dynamic_cast<BinaryTileTask&>(*task);
         t.rawTileData = std::make_shared<std::vector<char>>(rawTileData);
 

--- a/bench/src/tileLoading.cpp
+++ b/bench/src/tileLoading.cpp
@@ -42,7 +42,7 @@ struct TestContext {
         Url sceneUrl(path);
         platform->putMockUrlContents(sceneUrl, MockPlatform::getBytesFromFile(path));
 
-        scene = std::make_shared<Scene>(platform, sceneUrl);
+        scene = std::make_shared<Scene>(platform, sceneUrl, std::make_unique<View>());
         Importer importer(scene);
 
         try {
@@ -55,7 +55,7 @@ struct TestContext {
         SceneLoader::applyGlobals(*scene);
         SceneLoader::applySources(platform, *scene);
 
-        SceneLoader::applyConfig(platform, scene);
+        //SceneLoader::applyConfig(platform, scene);
 
         scene->fontContext()->loadFonts();
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(tangram-core
   src/labels/labelCollider.cpp
   src/labels/labelProperty.cpp
   src/labels/labelSet.cpp
-  src/labels/labels.cpp
+  src/labels/labelManager.cpp
   src/labels/spriteLabel.cpp
   src/labels/textLabel.cpp
   src/marker/marker.cpp

--- a/core/deps/stb/stb_image.h
+++ b/core/deps/stb/stb_image.h
@@ -1,5 +1,5 @@
-/* stb_image - v2.12 - public domain image loader - http://nothings.org/stb_image.h
-                                     no warranty implied; use at your own risk
+/* stb_image - v2.19 - public domain image loader - http://nothings.org/stb
+                                  no warranty implied; use at your own risk
 
    Do this:
       #define STB_IMAGE_IMPLEMENTATION
@@ -21,7 +21,7 @@
           avoid problematic images and only need the trivial interface
 
       JPEG baseline & progressive (12 bpc/arithmetic not supported, same as stock IJG lib)
-      PNG 1/2/4/8-bit-per-channel (16 bpc not supported)
+      PNG 1/2/4/8/16-bit-per-channel
 
       TGA (not sure what subset, if a subset)
       BMP non-1bpp, non-RLE
@@ -42,110 +42,19 @@
    Full documentation under "DOCUMENTATION" below.
 
 
-   Revision 2.00 release notes:
+LICENSE
 
-      - Progressive JPEG is now supported.
+  See end of file for license information.
 
-      - PPM and PGM binary formats are now supported, thanks to Ken Miller.
+RECENT REVISION HISTORY:
 
-      - x86 platforms now make use of SSE2 SIMD instructions for
-        JPEG decoding, and ARM platforms can use NEON SIMD if requested.
-        This work was done by Fabian "ryg" Giesen. SSE2 is used by
-        default, but NEON must be enabled explicitly; see docs.
-
-        With other JPEG optimizations included in this version, we see
-        2x speedup on a JPEG on an x86 machine, and a 1.5x speedup
-        on a JPEG on an ARM machine, relative to previous versions of this
-        library. The same results will not obtain for all JPGs and for all
-        x86/ARM machines. (Note that progressive JPEGs are significantly
-        slower to decode than regular JPEGs.) This doesn't mean that this
-        is the fastest JPEG decoder in the land; rather, it brings it
-        closer to parity with standard libraries. If you want the fastest
-        decode, look elsewhere. (See "Philosophy" section of docs below.)
-
-        See final bullet items below for more info on SIMD.
-
-      - Added STBI_MALLOC, STBI_REALLOC, and STBI_FREE macros for replacing
-        the memory allocator. Unlike other STBI libraries, these macros don't
-        support a context parameter, so if you need to pass a context in to
-        the allocator, you'll have to store it in a global or a thread-local
-        variable.
-
-      - Split existing STBI_NO_HDR flag into two flags, STBI_NO_HDR and
-        STBI_NO_LINEAR.
-            STBI_NO_HDR:     suppress implementation of .hdr reader format
-            STBI_NO_LINEAR:  suppress high-dynamic-range light-linear float API
-
-      - You can suppress implementation of any of the decoders to reduce
-        your code footprint by #defining one or more of the following
-        symbols before creating the implementation.
-
-            STBI_NO_JPEG
-            STBI_NO_PNG
-            STBI_NO_BMP
-            STBI_NO_PSD
-            STBI_NO_TGA
-            STBI_NO_GIF
-            STBI_NO_HDR
-            STBI_NO_PIC
-            STBI_NO_PNM   (.ppm and .pgm)
-
-      - You can request *only* certain decoders and suppress all other ones
-        (this will be more forward-compatible, as addition of new decoders
-        doesn't require you to disable them explicitly):
-
-            STBI_ONLY_JPEG
-            STBI_ONLY_PNG
-            STBI_ONLY_BMP
-            STBI_ONLY_PSD
-            STBI_ONLY_TGA
-            STBI_ONLY_GIF
-            STBI_ONLY_HDR
-            STBI_ONLY_PIC
-            STBI_ONLY_PNM   (.ppm and .pgm)
-
-         Note that you can define multiples of these, and you will get all
-         of them ("only x" and "only y" is interpreted to mean "only x&y").
-
-       - If you use STBI_NO_PNG (or _ONLY_ without PNG), and you still
-         want the zlib decoder to be available, #define STBI_SUPPORT_ZLIB
-
-      - Compilation of all SIMD code can be suppressed with
-            #define STBI_NO_SIMD
-        It should not be necessary to disable SIMD unless you have issues
-        compiling (e.g. using an x86 compiler which doesn't support SSE
-        intrinsics or that doesn't support the method used to detect
-        SSE2 support at run-time), and even those can be reported as
-        bugs so I can refine the built-in compile-time checking to be
-        smarter.
-
-      - The old STBI_SIMD system which allowed installing a user-defined
-        IDCT etc. has been removed. If you need this, don't upgrade. My
-        assumption is that almost nobody was doing this, and those who
-        were will find the built-in SIMD more satisfactory anyway.
-
-      - RGB values computed for JPEG images are slightly different from
-        previous versions of stb_image. (This is due to using less
-        integer precision in SIMD.) The C code has been adjusted so
-        that the same RGB values will be computed regardless of whether
-        SIMD support is available, so your app should always produce
-        consistent results. But these results are slightly different from
-        previous versions. (Specifically, about 3% of available YCbCr values
-        will compute different RGB results from pre-1.49 versions by +-1;
-        most of the deviating values are one smaller in the G channel.)
-
-      - If you must produce consistent results with previous versions of
-        stb_image, #define STBI_JPEG_OLD and you will get the same results
-        you used to; however, you will not get the SIMD speedups for
-        the YCbCr-to-RGB conversion step (although you should still see
-        significant JPEG speedup from the other changes).
-
-        Please note that STBI_JPEG_OLD is a temporary feature; it will be
-        removed in future versions of the library. It is only intended for
-        near-term back-compatibility use.
-
-
-   Latest revision history:
+      2.19  (2018-02-11) fix warning
+      2.18  (2018-01-30) fix warnings
+      2.17  (2018-01-29) bugfix, 1-bit BMP, 16-bitness query, fix warnings
+      2.16  (2017-07-23) all functions have 16-bit variants; optimizations; bugfixes
+      2.15  (2017-03-18) fix png-1,2,4; all Imagenet JPGs; no runtime SSE detection on GCC
+      2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
+      2.13  (2016-12-04) experimental 16-bit API, only for PNG so far; fixes
       2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
       2.11  (2016-04-02) 16-bit PNGS; enable SSE2 in non-gcc x64
                          RGB-format JPEG; remove white matting in PSD;
@@ -153,25 +62,6 @@
                          correct channel count for PNG & BMP
       2.10  (2016-01-22) avoid warning introduced in 2.09
       2.09  (2016-01-16) 16-bit TGA; comments in PNM files; STBI_REALLOC_SIZED
-      2.08  (2015-09-13) fix to 2.07 cleanup, reading RGB PSD as RGBA
-      2.07  (2015-09-13) partial animated GIF support
-                         limited 16-bit PSD support
-                         minor bugs, code cleanup, and compiler warnings
-      2.06  (2015-04-19) fix bug where PSD returns wrong '*comp' value
-      2.05  (2015-04-19) fix bug in progressive JPEG handling, fix warning
-      2.04  (2015-04-15) try to re-enable SIMD on MinGW 64-bit
-      2.03  (2015-04-12) additional corruption checking
-                         stbi_set_flip_vertically_on_load
-                         fix NEON support; fix mingw support
-      2.02  (2015-01-19) fix incorrect assert, fix warning
-      2.01  (2015-01-17) fix various warnings
-      2.00b (2014-12-25) fix STBI_MALLOC in progressive JPEG
-      2.00  (2014-12-25) optimize JPEG, including x86 SSE2 & ARM NEON SIMD
-                         progressive JPEG
-                         PGM/PPM support
-                         STBI_MALLOC,STBI_REALLOC,STBI_FREE
-                         STBI_NO_*, STBI_ONLY_*
-                         GIF bugfix
 
    See end of file for full revision history.
 
@@ -186,34 +76,31 @@
     Tom Seddon (pic)                       Omar Cornut (1/2/4-bit PNG)
     Thatcher Ulrich (psd)                  Nicolas Guillemot (vertical flip)
     Ken Miller (pgm, ppm)                  Richard Mitton (16-bit PSD)
-    urraka@github (animated gif)           Junggon Kim (PNM comments)
-                                           Daniel Gibson (16-bit TGA)
-
- Optimizations & bugfixes
-    Fabian "ryg" Giesen
+    github:urraka (animated gif)           Junggon Kim (PNM comments)
+    Christopher Forseth (animated gif)     Daniel Gibson (16-bit TGA)
+                                           socks-the-fox (16-bit PNG)
+                                           Jeremy Sawicki (handle all ImageNet JPGs)
+ Optimizations & bugfixes                  Mikhail Morozov (1-bit BMP)
+    Fabian "ryg" Giesen                    Anael Seghezzi (is-16-bit query)
     Arseny Kapoulkine
+    John-Mark Allen
 
  Bug & warning fixes
     Marc LeBlanc            David Woo          Guillaume George   Martins Mozeiko
-    Christpher Lloyd        Martin Golini      Jerry Jansson      Joseph Thomson
-    Dave Moore              Roy Eltham         Hayaki Saito       Phil Jordan
-    Won Chun                Luke Graham        Johan Duparc       Nathan Reed
-    the Horde3D community   Thomas Ruf         Ronny Chevalier    Nick Verigakis
-    Janez Zemva             John Bartholomew   Michal Cichon      svdijk@github
-    Jonathan Blow           Ken Hamada         Tero Hanninen      Baldur Karlsson
-    Laurent Gomila          Cort Stratton      Sergio Gonzalez    romigrou@github
-    Aruelien Pocheville     Thibault Reuille   Cass Everitt       Matthew Gregan
-    Ryamond Barbiero        Paul Du Bois       Engin Manap        snagar@github
-    Michaelangel007@github  Oriol Ferrer Mesia socks-the-fox
-    Blazej Dariusz Roszkowski
-
-
-LICENSE
-
-This software is dual-licensed to the public domain and under the following
-license: you are granted a perpetual, irrevocable license to copy, modify,
-publish, and distribute this file as you see fit.
-
+    Christpher Lloyd        Jerry Jansson      Joseph Thomson     Phil Jordan
+    Dave Moore              Roy Eltham         Hayaki Saito       Nathan Reed
+    Won Chun                Luke Graham        Johan Duparc       Nick Verigakis
+    the Horde3D community   Thomas Ruf         Ronny Chevalier    github:rlyeh
+    Janez Zemva             John Bartholomew   Michal Cichon      github:romigrou
+    Jonathan Blow           Ken Hamada         Tero Hanninen      github:svdijk
+    Laurent Gomila          Cort Stratton      Sergio Gonzalez    github:snagar
+    Aruelien Pocheville     Thibault Reuille   Cass Everitt       github:Zelex
+    Ryamond Barbiero        Paul Du Bois       Engin Manap        github:grim210
+    Aldo Culquicondor       Philipp Wiesemann  Dale Weiler        github:sammyhw
+    Oriol Ferrer Mesia      Josh Tobin         Matthew Gregan     github:phprus
+    Julian Raschke          Gregory Mullen     Baldur Karlsson    github:poppolopoppo
+    Christian Floisand      Kevin Schmidt                         github:darealshinji
+    Blazej Dariusz Roszkowski                                     github:Michaelangel007
 */
 
 #ifndef STBI_INCLUDE_STB_IMAGE_H
@@ -222,10 +109,8 @@ publish, and distribute this file as you see fit.
 // DOCUMENTATION
 //
 // Limitations:
-//    - no 16-bit-per-channel PNG
 //    - no 12-bit-per-channel JPEG
 //    - no JPEGs with arithmetic coding
-//    - no 1-bit BMP
 //    - GIF always returns *comp=4
 //
 // Basic usage (see HDR discussion below for HDR usage):
@@ -238,10 +123,10 @@ publish, and distribute this file as you see fit.
 //    stbi_image_free(data)
 //
 // Standard parameters:
-//    int *x       -- outputs image width in pixels
-//    int *y       -- outputs image height in pixels
-//    int *comp    -- outputs # of image components in image file
-//    int req_comp -- if non-zero, # of image components requested in result
+//    int *x                 -- outputs image width in pixels
+//    int *y                 -- outputs image height in pixels
+//    int *channels_in_file  -- outputs # of image components in image file
+//    int desired_channels   -- if non-zero, # of image components requested in result
 //
 // The return value from an image loader is an 'unsigned char *' which points
 // to the pixel data, or NULL on an allocation failure or if the image is
@@ -249,11 +134,12 @@ publish, and distribute this file as you see fit.
 // with each pixel consisting of N interleaved 8-bit components; the first
 // pixel pointed to is top-left-most in the image. There is no padding between
 // image scanlines or between pixels, regardless of format. The number of
-// components N is 'req_comp' if req_comp is non-zero, or *comp otherwise.
-// If req_comp is non-zero, *comp has the number of components that _would_
-// have been output otherwise. E.g. if you set req_comp to 4, you will always
-// get RGBA output, but you can check *comp to see if it's trivially opaque
-// because e.g. there were only 3 channels in the source image.
+// components N is 'desired_channels' if desired_channels is non-zero, or
+// *channels_in_file otherwise. If desired_channels is non-zero,
+// *channels_in_file has the number of components that _would_ have been
+// output otherwise. E.g. if you set desired_channels to 4, you will always
+// get RGBA output, but you can check *channels_in_file to see if it's trivially
+// opaque because e.g. there were only 3 channels in the source image.
 //
 // An output image with N components has the following components interleaved
 // in this order in each pixel:
@@ -265,10 +151,10 @@ publish, and distribute this file as you see fit.
 //       4           red, green, blue, alpha
 //
 // If image loading fails for any reason, the return value will be NULL,
-// and *x, *y, *comp will be unchanged. The function stbi_failure_reason()
-// can be queried for an extremely brief, end-user unfriendly explanation
-// of why the load failed. Define STBI_NO_FAILURE_STRINGS to avoid
-// compiling these strings at all, and STBI_FAILURE_USERMSG to get slightly
+// and *x, *y, *channels_in_file will be unchanged. The function
+// stbi_failure_reason() can be queried for an extremely brief, end-user
+// unfriendly explanation of why the load failed. Define STBI_NO_FAILURE_STRINGS
+// to avoid compiling these strings at all, and STBI_FAILURE_USERMSG to get slightly
 // more user-friendly ones.
 //
 // Paletted PNG, BMP, GIF, and PIC images are automatically depalettized.
@@ -287,13 +173,13 @@ publish, and distribute this file as you see fit.
 // and for best performance I may provide less-easy-to-use APIs that give higher
 // performance, in addition to the easy to use ones. Nevertheless, it's important
 // to keep in mind that from the standpoint of you, a client of this library,
-// all you care about is #1 and #3, and stb libraries do not emphasize #3 above all.
+// all you care about is #1 and #3, and stb libraries DO NOT emphasize #3 above all.
 //
 // Some secondary priorities arise directly from the first two, some of which
 // make more explicit reasons why performance can't be emphasized.
 //
 //    - Portable ("ease of use")
-//    - Small footprint ("easy to maintain")
+//    - Small source code footprint ("easy to maintain")
 //    - No dependencies ("ease of use")
 //
 // ===========================================================================
@@ -324,13 +210,6 @@ publish, and distribute this file as you see fit.
 // the typical path is to have separate builds for NEON and non-NEON devices
 // (at least this is true for iOS and Android). Therefore, the NEON support is
 // toggled by a build flag: define STBI_NEON to get NEON loops.
-//
-// The output of the JPEG decoder is slightly different from versions where
-// SIMD support was introduced (that is, for versions before 1.49). The
-// difference is only +-1 in the 8-bit RGB channels, and only on a small
-// fraction of pixels. You can force the pre-1.49 behavior by defining
-// STBI_JPEG_OLD, but this will disable some of the SIMD decoding path
-// and hence cost some performance.
 //
 // If for some reason you do not want to use any of SIMD code, or if
 // you have issues compiling it, you can disable it entirely by
@@ -387,6 +266,41 @@ publish, and distribute this file as you see fit.
 // says there's premultiplied data (currently only happens in iPhone images,
 // and only if iPhone convert-to-rgb processing is on).
 //
+// ===========================================================================
+//
+// ADDITIONAL CONFIGURATION
+//
+//  - You can suppress implementation of any of the decoders to reduce
+//    your code footprint by #defining one or more of the following
+//    symbols before creating the implementation.
+//
+//        STBI_NO_JPEG
+//        STBI_NO_PNG
+//        STBI_NO_BMP
+//        STBI_NO_PSD
+//        STBI_NO_TGA
+//        STBI_NO_GIF
+//        STBI_NO_HDR
+//        STBI_NO_PIC
+//        STBI_NO_PNM   (.ppm and .pgm)
+//
+//  - You can request *only* certain decoders and suppress all other ones
+//    (this will be more forward-compatible, as addition of new decoders
+//    doesn't require you to disable them explicitly):
+//
+//        STBI_ONLY_JPEG
+//        STBI_ONLY_PNG
+//        STBI_ONLY_BMP
+//        STBI_ONLY_PSD
+//        STBI_ONLY_TGA
+//        STBI_ONLY_GIF
+//        STBI_ONLY_HDR
+//        STBI_ONLY_PIC
+//        STBI_ONLY_PNM   (.ppm and .pgm)
+//
+//   - If you use STBI_NO_PNG (or _ONLY_ without PNG), and you still
+//     want the zlib decoder to be available, #define STBI_SUPPORT_ZLIB
+//
 
 
 #ifndef STBI_NO_STDIO
@@ -397,7 +311,7 @@ publish, and distribute this file as you see fit.
 
 enum
 {
-   STBI_default = 0, // only used for req_comp
+   STBI_default = 0, // only used for desired_channels
 
    STBI_grey       = 1,
    STBI_grey_alpha = 2,
@@ -406,6 +320,7 @@ enum
 };
 
 typedef unsigned char stbi_uc;
+typedef unsigned short stbi_us;
 
 #ifdef __cplusplus
 extern "C" {
@@ -433,22 +348,48 @@ typedef struct
    int      (*eof)   (void *user);                       // returns nonzero if we are at end of file/data
 } stbi_io_callbacks;
 
-STBIDEF stbi_uc *stbi_load               (char              const *filename,           int *x, int *y, int *comp, int req_comp);
-STBIDEF stbi_uc *stbi_load_from_memory   (stbi_uc           const *buffer, int len   , int *x, int *y, int *comp, int req_comp);
-STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk  , void *user, int *x, int *y, int *comp, int req_comp);
+////////////////////////////////////
+//
+// 8-bits-per-channel interface
+//
+
+STBIDEF stbi_uc *stbi_load_from_memory   (stbi_uc           const *buffer, int len   , int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk  , void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+#ifndef STBI_NO_GIF
+STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
+#endif
+
 
 #ifndef STBI_NO_STDIO
-STBIDEF stbi_uc *stbi_load_from_file  (FILE *f,                  int *x, int *y, int *comp, int req_comp);
+STBIDEF stbi_uc *stbi_load            (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc *stbi_load_from_file  (FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
 // for stbi_load_from_file, file pointer is left pointing immediately after image
 #endif
 
+////////////////////////////////////
+//
+// 16-bits-per-channel interface
+//
+
+STBIDEF stbi_us *stbi_load_16_from_memory   (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+
+#ifndef STBI_NO_STDIO
+STBIDEF stbi_us *stbi_load_16          (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us *stbi_load_from_file_16(FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+#endif
+
+////////////////////////////////////
+//
+// float-per-channel interface
+//
 #ifndef STBI_NO_LINEAR
-   STBIDEF float *stbi_loadf                 (char const *filename,           int *x, int *y, int *comp, int req_comp);
-   STBIDEF float *stbi_loadf_from_memory     (stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-   STBIDEF float *stbi_loadf_from_callbacks  (stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp);
+   STBIDEF float *stbi_loadf_from_memory     (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
+   STBIDEF float *stbi_loadf_from_callbacks  (stbi_io_callbacks const *clbk, void *user, int *x, int *y,  int *channels_in_file, int desired_channels);
 
    #ifndef STBI_NO_STDIO
-   STBIDEF float *stbi_loadf_from_file  (FILE *f,                int *x, int *y, int *comp, int req_comp);
+   STBIDEF float *stbi_loadf            (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+   STBIDEF float *stbi_loadf_from_file  (FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
    #endif
 #endif
 
@@ -481,11 +422,14 @@ STBIDEF void     stbi_image_free      (void *retval_from_stbi_load);
 // get image dimensions & components without fully decoding
 STBIDEF int      stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
 STBIDEF int      stbi_info_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp);
+STBIDEF int      stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len);
+STBIDEF int      stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *clbk, void *user);
 
 #ifndef STBI_NO_STDIO
-STBIDEF int      stbi_info            (char const *filename,     int *x, int *y, int *comp);
-STBIDEF int      stbi_info_from_file  (FILE *f,                  int *x, int *y, int *comp);
-
+STBIDEF int      stbi_info               (char const *filename,     int *x, int *y, int *comp);
+STBIDEF int      stbi_info_from_file     (FILE *f,                  int *x, int *y, int *comp);
+STBIDEF int      stbi_is_16_bit          (char const *filename);
+STBIDEF int      stbi_is_16_bit_from_file(FILE *f);
 #endif
 
 
@@ -566,9 +510,10 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
 #include <stddef.h> // ptrdiff_t on osx
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
-#include <math.h>  // ldexp
+#include <math.h>  // ldexp, pow
 #endif
 
 #ifndef STBI_NO_STDIO
@@ -649,12 +594,14 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
 #define STBI__X86_TARGET
 #endif
 
-#if defined(__GNUC__) && (defined(STBI__X86_TARGET) || defined(STBI__X64_TARGET)) && !defined(__SSE2__) && !defined(STBI_NO_SIMD)
-// NOTE: not clear do we actually need this for the 64-bit path?
+#if defined(__GNUC__) && defined(STBI__X86_TARGET) && !defined(__SSE2__) && !defined(STBI_NO_SIMD)
 // gcc doesn't support sse2 intrinsics unless you compile with -msse2,
-// (but compiling with -msse2 allows the compiler to use SSE2 everywhere;
-// this is just broken and gcc are jerks for not fixing it properly
-// http://www.virtualdub.org/blog/pivot/entry.php?id=363 )
+// which in turn means it gets to use SSE2 everywhere. This is unfortunate,
+// but previous attempts to provide the SSE2 functions with runtime
+// detection caused numerous issues. The way architecture extensions are
+// exposed in GCC/Clang is, sadly, not really suited for one-file libs.
+// New behavior: if compiled with -msse2, we use SSE2 without any
+// detection; if not, we don't use it at all.
 #define STBI_NO_SIMD
 #endif
 
@@ -702,7 +649,7 @@ static int stbi__cpuid3(void)
 
 #define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
 
-static int stbi__sse2_available()
+static int stbi__sse2_available(void)
 {
    int info3 = stbi__cpuid3();
    return ((info3 >> 26) & 1) != 0;
@@ -710,16 +657,12 @@ static int stbi__sse2_available()
 #else // assume GCC-style if not VC++
 #define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
 
-static int stbi__sse2_available()
+static int stbi__sse2_available(void)
 {
-#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 // GCC 4.8 or later
-   // GCC 4.8+ has a nice way to do this
-   return __builtin_cpu_supports("sse2");
-#else
-   // portable way to do this, preferably without using GCC inline ASM?
-   // just bail for now.
-   return 0;
-#endif
+   // If we're even attempting to compile this on GCC/Clang, that means
+   // -msse2 is on, which means the compiler is allowed to use SSE2
+   // instructions at will, and so are we.
+   return 1;
 }
 #endif
 #endif
@@ -827,57 +770,73 @@ static void stbi__rewind(stbi__context *s)
    s->img_buffer_end = s->img_buffer_original_end;
 }
 
+enum
+{
+   STBI_ORDER_RGB,
+   STBI_ORDER_BGR
+};
+
+typedef struct
+{
+   int bits_per_channel;
+   int num_channels;
+   int channel_order;
+} stbi__result_info;
+
 #ifndef STBI_NO_JPEG
 static int      stbi__jpeg_test(stbi__context *s);
-static stbi_uc *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_PNG
 static int      stbi__png_test(stbi__context *s);
-static stbi_uc *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__png_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__png_is16(stbi__context *s);
 #endif
 
 #ifndef STBI_NO_BMP
 static int      stbi__bmp_test(stbi__context *s);
-static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_TGA
 static int      stbi__tga_test(stbi__context *s);
-static stbi_uc *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__tga_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_PSD
 static int      stbi__psd_test(stbi__context *s);
-static stbi_uc *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc);
 static int      stbi__psd_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__psd_is16(stbi__context *s);
 #endif
 
 #ifndef STBI_NO_HDR
 static int      stbi__hdr_test(stbi__context *s);
-static float   *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static float   *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_PIC
 static int      stbi__pic_test(stbi__context *s);
-static stbi_uc *stbi__pic_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__pic_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__pic_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_GIF
 static int      stbi__gif_test(stbi__context *s);
-static stbi_uc *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static void    *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
 static int      stbi__gif_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_PNM
 static int      stbi__pnm_test(stbi__context *s);
-static stbi_uc *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
@@ -899,6 +858,81 @@ static void *stbi__malloc(size_t size)
 {
     return STBI_MALLOC(size);
 }
+
+// stb_image uses ints pervasively, including for offset calculations.
+// therefore the largest decoded image size we can support with the
+// current code, even on 64-bit targets, is INT_MAX. this is not a
+// significant limitation for the intended use case.
+//
+// we do, however, need to make sure our size calculations don't
+// overflow. hence a few helper functions for size calculations that
+// multiply integers together, making sure that they're non-negative
+// and no overflow occurs.
+
+// return 1 if the sum is valid, 0 on overflow.
+// negative terms are considered invalid.
+static int stbi__addsizes_valid(int a, int b)
+{
+   if (b < 0) return 0;
+   // now 0 <= b <= INT_MAX, hence also
+   // 0 <= INT_MAX - b <= INTMAX.
+   // And "a + b <= INT_MAX" (which might overflow) is the
+   // same as a <= INT_MAX - b (no overflow)
+   return a <= INT_MAX - b;
+}
+
+// returns 1 if the product is valid, 0 on overflow.
+// negative factors are considered invalid.
+static int stbi__mul2sizes_valid(int a, int b)
+{
+   if (a < 0 || b < 0) return 0;
+   if (b == 0) return 1; // mul-by-0 is always safe
+   // portable way to check for no overflows in a*b
+   return a <= INT_MAX/b;
+}
+
+// returns 1 if "a*b + add" has no negative terms/factors and doesn't overflow
+static int stbi__mad2sizes_valid(int a, int b, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__addsizes_valid(a*b, add);
+}
+
+// returns 1 if "a*b*c + add" has no negative terms/factors and doesn't overflow
+static int stbi__mad3sizes_valid(int a, int b, int c, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
+      stbi__addsizes_valid(a*b*c, add);
+}
+
+// returns 1 if "a*b*c*d + add" has no negative terms/factors and doesn't overflow
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
+static int stbi__mad4sizes_valid(int a, int b, int c, int d, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
+      stbi__mul2sizes_valid(a*b*c, d) && stbi__addsizes_valid(a*b*c*d, add);
+}
+#endif
+
+// mallocs with size overflow checking
+static void *stbi__malloc_mad2(int a, int b, int add)
+{
+   if (!stbi__mad2sizes_valid(a, b, add)) return NULL;
+   return stbi__malloc(a*b + add);
+}
+
+static void *stbi__malloc_mad3(int a, int b, int c, int add)
+{
+   if (!stbi__mad3sizes_valid(a, b, c, add)) return NULL;
+   return stbi__malloc(a*b*c + add);
+}
+
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
+static void *stbi__malloc_mad4(int a, int b, int c, int d, int add)
+{
+   if (!stbi__mad4sizes_valid(a, b, c, d, add)) return NULL;
+   return stbi__malloc(a*b*c*d + add);
+}
+#endif
 
 // stbi__err - error
 // stbi__errpf - error returning pointer to float
@@ -935,33 +969,38 @@ STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip)
     stbi__vertically_flip_on_load = flag_true_if_should_flip;
 }
 
-static unsigned char *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
 {
+   memset(ri, 0, sizeof(*ri)); // make sure it's initialized if we add new fields
+   ri->bits_per_channel = 8; // default is 8 so most paths don't have to be changed
+   ri->channel_order = STBI_ORDER_RGB; // all current input & output are this, but this is here so we can add BGR order
+   ri->num_channels = 0;
+
    #ifndef STBI_NO_JPEG
-   if (stbi__jpeg_test(s)) return stbi__jpeg_load(s,x,y,comp,req_comp);
+   if (stbi__jpeg_test(s)) return stbi__jpeg_load(s,x,y,comp,req_comp, ri);
    #endif
    #ifndef STBI_NO_PNG
-   if (stbi__png_test(s))  return stbi__png_load(s,x,y,comp,req_comp);
+   if (stbi__png_test(s))  return stbi__png_load(s,x,y,comp,req_comp, ri);
    #endif
    #ifndef STBI_NO_BMP
-   if (stbi__bmp_test(s))  return stbi__bmp_load(s,x,y,comp,req_comp);
+   if (stbi__bmp_test(s))  return stbi__bmp_load(s,x,y,comp,req_comp, ri);
    #endif
    #ifndef STBI_NO_GIF
-   if (stbi__gif_test(s))  return stbi__gif_load(s,x,y,comp,req_comp);
+   if (stbi__gif_test(s))  return stbi__gif_load(s,x,y,comp,req_comp, ri);
    #endif
    #ifndef STBI_NO_PSD
-   if (stbi__psd_test(s))  return stbi__psd_load(s,x,y,comp,req_comp);
+   if (stbi__psd_test(s))  return stbi__psd_load(s,x,y,comp,req_comp, ri, bpc);
    #endif
    #ifndef STBI_NO_PIC
-   if (stbi__pic_test(s))  return stbi__pic_load(s,x,y,comp,req_comp);
+   if (stbi__pic_test(s))  return stbi__pic_load(s,x,y,comp,req_comp, ri);
    #endif
    #ifndef STBI_NO_PNM
-   if (stbi__pnm_test(s))  return stbi__pnm_load(s,x,y,comp,req_comp);
+   if (stbi__pnm_test(s))  return stbi__pnm_load(s,x,y,comp,req_comp, ri);
    #endif
 
    #ifndef STBI_NO_HDR
    if (stbi__hdr_test(s)) {
-      float *hdr = stbi__hdr_load(s, x,y,comp,req_comp);
+      float *hdr = stbi__hdr_load(s, x,y,comp,req_comp, ri);
       return stbi__hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
    }
    #endif
@@ -969,56 +1008,135 @@ static unsigned char *stbi__load_main(stbi__context *s, int *x, int *y, int *com
    #ifndef STBI_NO_TGA
    // test tga last because it's a crappy test!
    if (stbi__tga_test(s))
-      return stbi__tga_load(s,x,y,comp,req_comp);
+      return stbi__tga_load(s,x,y,comp,req_comp, ri);
    #endif
 
    return stbi__errpuc("unknown image type", "Image not of any known type, or corrupt");
 }
 
-static unsigned char *stbi__load_flip(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static stbi_uc *stbi__convert_16_to_8(stbi__uint16 *orig, int w, int h, int channels)
 {
-   unsigned char *result = stbi__load_main(s, x, y, comp, req_comp);
+   int i;
+   int img_len = w * h * channels;
+   stbi_uc *reduced;
 
-   if (stbi__vertically_flip_on_load && result != NULL) {
-      int w = *x, h = *y;
-      int depth = req_comp ? req_comp : *comp;
-      int row,col,z;
-      stbi_uc temp;
+   reduced = (stbi_uc *) stbi__malloc(img_len);
+   if (reduced == NULL) return stbi__errpuc("outofmem", "Out of memory");
 
-      // @OPTIMIZE: use a bigger temp buffer and memcpy multiple pixels at once
-      for (row = 0; row < (h>>1); row++) {
-         for (col = 0; col < w; col++) {
-            for (z = 0; z < depth; z++) {
-               temp = result[(row * w + col) * depth + z];
-               result[(row * w + col) * depth + z] = result[((h - row - 1) * w + col) * depth + z];
-               result[((h - row - 1) * w + col) * depth + z] = temp;
-            }
-         }
-      }
-   }
+   for (i = 0; i < img_len; ++i)
+      reduced[i] = (stbi_uc)((orig[i] >> 8) & 0xFF); // top half of each byte is sufficient approx of 16->8 bit scaling
 
-   return result;
+   STBI_FREE(orig);
+   return reduced;
 }
 
-#ifndef STBI_NO_HDR
+static stbi__uint16 *stbi__convert_8_to_16(stbi_uc *orig, int w, int h, int channels)
+{
+   int i;
+   int img_len = w * h * channels;
+   stbi__uint16 *enlarged;
+
+   enlarged = (stbi__uint16 *) stbi__malloc(img_len*2);
+   if (enlarged == NULL) return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+
+   for (i = 0; i < img_len; ++i)
+      enlarged[i] = (stbi__uint16)((orig[i] << 8) + orig[i]); // replicate to high and low byte, maps 0->0, 255->0xffff
+
+   STBI_FREE(orig);
+   return enlarged;
+}
+
+static void stbi__vertical_flip(void *image, int w, int h, int bytes_per_pixel)
+{
+   int row;
+   size_t bytes_per_row = (size_t)w * bytes_per_pixel;
+   stbi_uc temp[2048];
+   stbi_uc *bytes = (stbi_uc *)image;
+
+   for (row = 0; row < (h>>1); row++) {
+      stbi_uc *row0 = bytes + row*bytes_per_row;
+      stbi_uc *row1 = bytes + (h - row - 1)*bytes_per_row;
+      // swap row0 with row1
+      size_t bytes_left = bytes_per_row;
+      while (bytes_left) {
+         size_t bytes_copy = (bytes_left < sizeof(temp)) ? bytes_left : sizeof(temp);
+         memcpy(temp, row0, bytes_copy);
+         memcpy(row0, row1, bytes_copy);
+         memcpy(row1, temp, bytes_copy);
+         row0 += bytes_copy;
+         row1 += bytes_copy;
+         bytes_left -= bytes_copy;
+      }
+   }
+}
+
+static void stbi__vertical_flip_slices(void *image, int w, int h, int z, int bytes_per_pixel)
+{
+   int slice;
+   int slice_size = w * h * bytes_per_pixel;
+
+   stbi_uc *bytes = (stbi_uc *)image;
+   for (slice = 0; slice < z; ++slice) {
+      stbi__vertical_flip(bytes, w, h, bytes_per_pixel);
+      bytes += slice_size;
+   }
+}
+
+static unsigned char *stbi__load_and_postprocess_8bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__result_info ri;
+   void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 8);
+
+   if (result == NULL)
+      return NULL;
+
+   if (ri.bits_per_channel != 8) {
+      STBI_ASSERT(ri.bits_per_channel == 16);
+      result = stbi__convert_16_to_8((stbi__uint16 *) result, *x, *y, req_comp == 0 ? *comp : req_comp);
+      ri.bits_per_channel = 8;
+   }
+
+   // @TODO: move stbi__convert_format to here
+
+   if (stbi__vertically_flip_on_load) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi_uc));
+   }
+
+   return (unsigned char *) result;
+}
+
+static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__result_info ri;
+   void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 16);
+
+   if (result == NULL)
+      return NULL;
+
+   if (ri.bits_per_channel != 16) {
+      STBI_ASSERT(ri.bits_per_channel == 8);
+      result = stbi__convert_8_to_16((stbi_uc *) result, *x, *y, req_comp == 0 ? *comp : req_comp);
+      ri.bits_per_channel = 16;
+   }
+
+   // @TODO: move stbi__convert_format16 to here
+   // @TODO: special case RGB-to-Y (and RGBA-to-YA) for 8-bit-to-16-bit case to keep more precision
+
+   if (stbi__vertically_flip_on_load) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi__uint16));
+   }
+
+   return (stbi__uint16 *) result;
+}
+
+#if !defined(STBI_NO_HDR) || !defined(STBI_NO_LINEAR)
 static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, int req_comp)
 {
    if (stbi__vertically_flip_on_load && result != NULL) {
-      int w = *x, h = *y;
-      int depth = req_comp ? req_comp : *comp;
-      int row,col,z;
-      float temp;
-
-      // @OPTIMIZE: use a bigger temp buffer and memcpy multiple pixels at once
-      for (row = 0; row < (h>>1); row++) {
-         for (col = 0; col < w; col++) {
-            for (z = 0; z < depth; z++) {
-               temp = result[(row * w + col) * depth + z];
-               result[(row * w + col) * depth + z] = result[((h - row - 1) * w + col) * depth + z];
-               result[((h - row - 1) * w + col) * depth + z] = temp;
-            }
-         }
-      }
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(float));
    }
 }
 #endif
@@ -1053,28 +1171,83 @@ STBIDEF stbi_uc *stbi_load_from_file(FILE *f, int *x, int *y, int *comp, int req
    unsigned char *result;
    stbi__context s;
    stbi__start_file(&s,f);
-   result = stbi__load_flip(&s,x,y,comp,req_comp);
+   result = stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
    if (result) {
       // need to 'unget' all the characters in the IO buffer
       fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
    }
    return result;
 }
+
+STBIDEF stbi__uint16 *stbi_load_from_file_16(FILE *f, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__uint16 *result;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   result = stbi__load_and_postprocess_16bit(&s,x,y,comp,req_comp);
+   if (result) {
+      // need to 'unget' all the characters in the IO buffer
+      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+   }
+   return result;
+}
+
+STBIDEF stbi_us *stbi_load_16(char const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   FILE *f = stbi__fopen(filename, "rb");
+   stbi__uint16 *result;
+   if (!f) return (stbi_us *) stbi__errpuc("can't fopen", "Unable to open file");
+   result = stbi_load_from_file_16(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+
 #endif //!STBI_NO_STDIO
+
+STBIDEF stbi_us *stbi_load_16_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__load_and_postprocess_16bit(&s,x,y,channels_in_file,desired_channels);
+}
+
+STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
+   return stbi__load_and_postprocess_16bit(&s,x,y,channels_in_file,desired_channels);
+}
 
 STBIDEF stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
 {
    stbi__context s;
    stbi__start_mem(&s,buffer,len);
-   return stbi__load_flip(&s,x,y,comp,req_comp);
+   return stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
 }
 
 STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
 {
    stbi__context s;
    stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
-   return stbi__load_flip(&s,x,y,comp,req_comp);
+   return stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
 }
+
+#ifndef STBI_NO_GIF
+STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
+{
+   unsigned char *result;
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+
+   result = (unsigned char*) stbi__load_gif_main(&s, delays, x, y, z, comp, req_comp);
+   if (stbi__vertically_flip_on_load) {
+      stbi__vertical_flip_slices( result, *x, *y, *z, *comp );
+   }
+
+   return result;
+}
+#endif
 
 #ifndef STBI_NO_LINEAR
 static float *stbi__loadf_main(stbi__context *s, int *x, int *y, int *comp, int req_comp)
@@ -1082,13 +1255,14 @@ static float *stbi__loadf_main(stbi__context *s, int *x, int *y, int *comp, int 
    unsigned char *data;
    #ifndef STBI_NO_HDR
    if (stbi__hdr_test(s)) {
-      float *hdr_data = stbi__hdr_load(s,x,y,comp,req_comp);
+      stbi__result_info ri;
+      float *hdr_data = stbi__hdr_load(s,x,y,comp,req_comp, &ri);
       if (hdr_data)
          stbi__float_postprocess(hdr_data,x,y,comp,req_comp);
       return hdr_data;
    }
    #endif
-   data = stbi__load_flip(s, x, y, comp, req_comp);
+   data = stbi__load_and_postprocess_8bit(s, x, y, comp, req_comp);
    if (data)
       return stbi__ldr_to_hdr(data, *x, *y, req_comp ? req_comp : *comp);
    return stbi__errpf("unknown image type", "Image not of any known type, or corrupt");
@@ -1158,12 +1332,16 @@ STBIDEF int      stbi_is_hdr          (char const *filename)
    return result;
 }
 
-STBIDEF int      stbi_is_hdr_from_file(FILE *f)
+STBIDEF int stbi_is_hdr_from_file(FILE *f)
 {
    #ifndef STBI_NO_HDR
+   long pos = ftell(f);
+   int res;
    stbi__context s;
    stbi__start_file(&s,f);
-   return stbi__hdr_test(&s);
+   res = stbi__hdr_test(&s);
+   fseek(f, pos, SEEK_SET);
+   return res;
    #else
    STBI_NOTUSED(f);
    return 0;
@@ -1346,7 +1524,7 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
    if (req_comp == img_n) return data;
    STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
 
-   good = (unsigned char *) stbi__malloc(req_comp * x * y);
+   good = (unsigned char *) stbi__malloc_mad3(req_comp, x, y, 0);
    if (good == NULL) {
       STBI_FREE(data);
       return stbi__errpuc("outofmem", "Out of memory");
@@ -1356,26 +1534,75 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
       unsigned char *src  = data + j * x * img_n   ;
       unsigned char *dest = good + j * x * req_comp;
 
-      #define COMBO(a,b)  ((a)*8+(b))
-      #define CASE(a,b)   case COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
       // convert source image with img_n components to one with req_comp components;
       // avoid switch per pixel, so use switch per scanline and massive macros
-      switch (COMBO(img_n, req_comp)) {
-          CASE(1,2) { dest[0]=src[0], dest[1]=255; } break;
-          CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0]; } break;
-          CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=255; } break;
-          CASE(2,1) { dest[0]=src[0]; } break;
-          CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0]; } break;
-          CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=src[1]; } break;
-          CASE(3,4) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2],dest[3]=255; } break;
-          CASE(3,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); } break;
-          CASE(3,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]), dest[1] = 255; } break;
-          CASE(4,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); } break;
-          CASE(4,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]), dest[1] = src[3]; } break;
-          CASE(4,3) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2]; } break;
+      switch (STBI__COMBO(img_n, req_comp)) {
+         STBI__CASE(1,2) { dest[0]=src[0], dest[1]=255;                                     } break;
+         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=255;                     } break;
+         STBI__CASE(2,1) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=src[1];                  } break;
+         STBI__CASE(3,4) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2],dest[3]=255;        } break;
+         STBI__CASE(3,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]), dest[1] = 255;    } break;
+         STBI__CASE(4,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]), dest[1] = src[3]; } break;
+         STBI__CASE(4,3) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2];                    } break;
          default: STBI_ASSERT(0);
       }
-      #undef CASE
+      #undef STBI__CASE
+   }
+
+   STBI_FREE(data);
+   return good;
+}
+
+static stbi__uint16 stbi__compute_y_16(int r, int g, int b)
+{
+   return (stbi__uint16) (((r*77) + (g*150) +  (29*b)) >> 8);
+}
+
+static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int req_comp, unsigned int x, unsigned int y)
+{
+   int i,j;
+   stbi__uint16 *good;
+
+   if (req_comp == img_n) return data;
+   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+
+   good = (stbi__uint16 *) stbi__malloc(req_comp * x * y * 2);
+   if (good == NULL) {
+      STBI_FREE(data);
+      return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+   }
+
+   for (j=0; j < (int) y; ++j) {
+      stbi__uint16 *src  = data + j * x * img_n   ;
+      stbi__uint16 *dest = good + j * x * req_comp;
+
+      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      // convert source image with img_n components to one with req_comp components;
+      // avoid switch per pixel, so use switch per scanline and massive macros
+      switch (STBI__COMBO(img_n, req_comp)) {
+         STBI__CASE(1,2) { dest[0]=src[0], dest[1]=0xffff;                                     } break;
+         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
+         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=0xffff;                     } break;
+         STBI__CASE(2,1) { dest[0]=src[0];                                                     } break;
+         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
+         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=src[1];                     } break;
+         STBI__CASE(3,4) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2],dest[3]=0xffff;        } break;
+         STBI__CASE(3,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]), dest[1] = 0xffff; } break;
+         STBI__CASE(4,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]), dest[1] = src[3]; } break;
+         STBI__CASE(4,3) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2];                       } break;
+         default: STBI_ASSERT(0);
+      }
+      #undef STBI__CASE
    }
 
    STBI_FREE(data);
@@ -1386,7 +1613,9 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
 static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
 {
    int i,k,n;
-   float *output = (float *) stbi__malloc(x * y * comp * sizeof(float));
+   float *output;
+   if (!data) return NULL;
+   output = (float *) stbi__malloc_mad4(x, y, comp, sizeof(float), 0);
    if (output == NULL) { STBI_FREE(data); return stbi__errpf("outofmem", "Out of memory"); }
    // compute number of non-alpha components
    if (comp & 1) n = comp; else n = comp-1;
@@ -1406,7 +1635,9 @@ static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
 static stbi_uc *stbi__hdr_to_ldr(float   *data, int x, int y, int comp)
 {
    int i,k,n;
-   stbi_uc *output = (stbi_uc *) stbi__malloc(x * y * comp);
+   stbi_uc *output;
+   if (!data) return NULL;
+   output = (stbi_uc *) stbi__malloc_mad3(x, y, comp, 0);
    if (output == NULL) { STBI_FREE(data); return stbi__errpuc("outofmem", "Out of memory"); }
    // compute number of non-alpha components
    if (comp & 1) n = comp; else n = comp-1;
@@ -1471,7 +1702,7 @@ typedef struct
    stbi__context *s;
    stbi__huffman huff_dc[4];
    stbi__huffman huff_ac[4];
-   stbi_uc dequant[4][64];
+   stbi__uint16 dequant[4][64];
    stbi__int16 fast_ac[4][1 << FAST_BITS];
 
 // sizes for components, interleaved MCUs
@@ -1507,6 +1738,8 @@ typedef struct
    int            succ_high;
    int            succ_low;
    int            eob_run;
+   int            jfif;
+   int            app14_color_transform; // Adobe APP14 tag
    int            rgb;
 
    int scan_n, order[4];
@@ -1520,7 +1753,8 @@ typedef struct
 
 static int stbi__build_huffman(stbi__huffman *h, int *count)
 {
-   int i,j,k=0,code;
+   int i,j,k=0;
+   unsigned int code;
    // build size list for each symbol (from JPEG spec)
    for (i=0; i < 16; ++i)
       for (j=0; j < count[i]; ++j)
@@ -1536,7 +1770,7 @@ static int stbi__build_huffman(stbi__huffman *h, int *count)
       if (h->size[k] == j) {
          while (h->size[k] == j)
             h->code[k++] = (stbi__uint16) (code++);
-         if (code-1 >= (1 << j)) return stbi__err("bad code lengths","Corrupt JPEG");
+         if (code-1 >= (1u << j)) return stbi__err("bad code lengths","Corrupt JPEG");
       }
       // compute largest code + 1 for this size, preshifted as needed later
       h->maxcode[j] = code << (16-j);
@@ -1577,10 +1811,10 @@ static void stbi__build_fast_ac(stbi__int16 *fast_ac, stbi__huffman *h)
             // magnitude code followed by receive_extend code
             int k = ((i << len) & ((1 << FAST_BITS) - 1)) >> (FAST_BITS - magbits);
             int m = 1 << (magbits - 1);
-            if (k < m) k += (-1 << magbits) + 1;
+            if (k < m) k += (~0U << magbits) + 1;
             // if the result is small enough, we can fit it in fast_ac table
             if (k >= -128 && k <= 127)
-               fast_ac[i] = (stbi__int16) ((k << 8) + (run << 4) + (len + magbits));
+               fast_ac[i] = (stbi__int16) ((k * 256) + (run * 16) + (len + magbits));
          }
       }
    }
@@ -1589,9 +1823,10 @@ static void stbi__build_fast_ac(stbi__int16 *fast_ac, stbi__huffman *h)
 static void stbi__grow_buffer_unsafe(stbi__jpeg *j)
 {
    do {
-      int b = j->nomore ? 0 : stbi__get8(j->s);
+      unsigned int b = j->nomore ? 0 : stbi__get8(j->s);
       if (b == 0xff) {
          int c = stbi__get8(j->s);
+         while (c == 0xff) c = stbi__get8(j->s); // consume fill bytes
          if (c != 0) {
             j->marker = (unsigned char) c;
             j->nomore = 1;
@@ -1604,7 +1839,7 @@ static void stbi__grow_buffer_unsafe(stbi__jpeg *j)
 }
 
 // (1 << n) - 1
-static stbi__uint32 stbi__bmask[17]={0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535};
+static const stbi__uint32 stbi__bmask[17]={0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535};
 
 // decode a jpeg huffman value from the bitstream
 stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
@@ -1657,7 +1892,7 @@ stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
 }
 
 // bias[n] = (-1<<n) + 1
-static int const stbi__jbias[16] = {0,-1,-3,-7,-15,-31,-63,-127,-255,-511,-1023,-2047,-4095,-8191,-16383,-32767};
+static const int stbi__jbias[16] = {0,-1,-3,-7,-15,-31,-63,-127,-255,-511,-1023,-2047,-4095,-8191,-16383,-32767};
 
 // combined JPEG 'receive' and JPEG 'extend', since baseline
 // always extends everything it receives.
@@ -1700,7 +1935,7 @@ stbi_inline static int stbi__jpeg_get_bit(stbi__jpeg *j)
 
 // given a value that's at position X in the zigzag stream,
 // where does it appear in the 8x8 matrix coded as row-major?
-static stbi_uc stbi__jpeg_dezigzag[64+15] =
+static const stbi_uc stbi__jpeg_dezigzag[64+15] =
 {
     0,  1,  8, 16,  9,  2,  3, 10,
    17, 24, 32, 25, 18, 11,  4,  5,
@@ -1716,7 +1951,7 @@ static stbi_uc stbi__jpeg_dezigzag[64+15] =
 };
 
 // decode one 64-entry block--
-static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman *hdc, stbi__huffman *hac, stbi__int16 *fac, int b, stbi_uc *dequant)
+static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman *hdc, stbi__huffman *hac, stbi__int16 *fac, int b, stbi__uint16 *dequant)
 {
    int diff,dc,k;
    int t;
@@ -1926,7 +2161,7 @@ stbi_inline static stbi_uc stbi__clamp(int x)
 }
 
 #define stbi__f2f(x)  ((int) (((x) * 4096 + 0.5)))
-#define stbi__fsh(x)  ((x) << 12)
+#define stbi__fsh(x)  ((x) * 4096)
 
 // derived from jidctint -- DCT_ISLOW
 #define STBI__IDCT_1D(s0,s1,s2,s3,s4,s5,s6,s7) \
@@ -1981,7 +2216,7 @@ static void stbi__idct_block(stbi_uc *out, int out_stride, short data[64])
          //    (1|2|3|4|5|6|7)==0          0     seconds
          //    all separate               -0.047 seconds
          //    1 && 2|3 && 4|5 && 6|7:    -0.047 seconds
-         int dcterm = d[0] << 2;
+         int dcterm = d[0]*4;
          v[0] = v[8] = v[16] = v[24] = v[32] = v[40] = v[48] = v[56] = dcterm;
       } else {
          STBI__IDCT_1D(d[ 0],d[ 8],d[16],d[24],d[32],d[40],d[48],d[56])
@@ -2425,7 +2660,7 @@ static stbi_uc stbi__get_marker(stbi__jpeg *j)
    x = stbi__get8(j->s);
    if (x != 0xff) return STBI__MARKER_none;
    while (x == 0xff)
-      x = stbi__get8(j->s);
+      x = stbi__get8(j->s); // consume repeated 0xff fill bytes
    return x;
 }
 
@@ -2440,7 +2675,7 @@ static void stbi__jpeg_reset(stbi__jpeg *j)
    j->code_bits = 0;
    j->code_buffer = 0;
    j->nomore = 0;
-   j->img_comp[0].dc_pred = j->img_comp[1].dc_pred = j->img_comp[2].dc_pred = 0;
+   j->img_comp[0].dc_pred = j->img_comp[1].dc_pred = j->img_comp[2].dc_pred = j->img_comp[3].dc_pred = 0;
    j->marker = STBI__MARKER_none;
    j->todo = j->restart_interval ? j->restart_interval : 0x7fffffff;
    j->eob_run = 0;
@@ -2572,7 +2807,7 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
    }
 }
 
-static void stbi__jpeg_dequantize(short *data, stbi_uc *dequant)
+static void stbi__jpeg_dequantize(short *data, stbi__uint16 *dequant)
 {
    int i;
    for (i=0; i < 64; ++i)
@@ -2614,13 +2849,14 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
          L = stbi__get16be(z->s)-2;
          while (L > 0) {
             int q = stbi__get8(z->s);
-            int p = q >> 4;
+            int p = q >> 4, sixteen = (p != 0);
             int t = q & 15,i;
-            if (p != 0) return stbi__err("bad DQT type","Corrupt JPEG");
+            if (p != 0 && p != 1) return stbi__err("bad DQT type","Corrupt JPEG");
             if (t > 3) return stbi__err("bad DQT table","Corrupt JPEG");
+
             for (i=0; i < 64; ++i)
-               z->dequant[t][stbi__jpeg_dezigzag[i]] = stbi__get8(z->s);
-            L -= 65;
+               z->dequant[t][stbi__jpeg_dezigzag[i]] = (stbi__uint16)(sixteen ? stbi__get16be(z->s) : stbi__get8(z->s));
+            L -= (sixteen ? 129 : 65);
          }
          return L==0;
 
@@ -2653,12 +2889,50 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
          }
          return L==0;
    }
+
    // check for comment block or APP blocks
    if ((m >= 0xE0 && m <= 0xEF) || m == 0xFE) {
-      stbi__skip(z->s, stbi__get16be(z->s)-2);
+      L = stbi__get16be(z->s);
+      if (L < 2) {
+         if (m == 0xFE)
+            return stbi__err("bad COM len","Corrupt JPEG");
+         else
+            return stbi__err("bad APP len","Corrupt JPEG");
+      }
+      L -= 2;
+
+      if (m == 0xE0 && L >= 5) { // JFIF APP0 segment
+         static const unsigned char tag[5] = {'J','F','I','F','\0'};
+         int ok = 1;
+         int i;
+         for (i=0; i < 5; ++i)
+            if (stbi__get8(z->s) != tag[i])
+               ok = 0;
+         L -= 5;
+         if (ok)
+            z->jfif = 1;
+      } else if (m == 0xEE && L >= 12) { // Adobe APP14 segment
+         static const unsigned char tag[6] = {'A','d','o','b','e','\0'};
+         int ok = 1;
+         int i;
+         for (i=0; i < 6; ++i)
+            if (stbi__get8(z->s) != tag[i])
+               ok = 0;
+         L -= 6;
+         if (ok) {
+            stbi__get8(z->s); // version
+            stbi__get16be(z->s); // flags0
+            stbi__get16be(z->s); // flags1
+            z->app14_color_transform = stbi__get8(z->s); // color transform
+            L -= 6;
+         }
+      }
+
+      stbi__skip(z->s, L);
       return 1;
    }
-   return 0;
+
+   return stbi__err("unknown marker","Corrupt JPEG");
 }
 
 // after we see SOS
@@ -2701,6 +2975,28 @@ static int stbi__process_scan_header(stbi__jpeg *z)
    return 1;
 }
 
+static int stbi__free_jpeg_components(stbi__jpeg *z, int ncomp, int why)
+{
+   int i;
+   for (i=0; i < ncomp; ++i) {
+      if (z->img_comp[i].raw_data) {
+         STBI_FREE(z->img_comp[i].raw_data);
+         z->img_comp[i].raw_data = NULL;
+         z->img_comp[i].data = NULL;
+      }
+      if (z->img_comp[i].raw_coeff) {
+         STBI_FREE(z->img_comp[i].raw_coeff);
+         z->img_comp[i].raw_coeff = 0;
+         z->img_comp[i].coeff = 0;
+      }
+      if (z->img_comp[i].linebuf) {
+         STBI_FREE(z->img_comp[i].linebuf);
+         z->img_comp[i].linebuf = NULL;
+      }
+   }
+   return why;
+}
+
 static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 {
    stbi__context *s = z->s;
@@ -2710,7 +3006,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
    s->img_y = stbi__get16be(s);   if (s->img_y == 0) return stbi__err("no header height", "JPEG format not supported: delayed height"); // Legal, but we don't handle it--but neither does IJG
    s->img_x = stbi__get16be(s);   if (s->img_x == 0) return stbi__err("0 width","Corrupt JPEG"); // JPEG requires
    c = stbi__get8(s);
-   if (c != 3 && c != 1) return stbi__err("bad component count","Corrupt JPEG");    // JFIF requires
+   if (c != 3 && c != 1 && c != 4) return stbi__err("bad component count","Corrupt JPEG");
    s->img_n = c;
    for (i=0; i < c; ++i) {
       z->img_comp[i].data = NULL;
@@ -2721,15 +3017,10 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 
    z->rgb = 0;
    for (i=0; i < s->img_n; ++i) {
-      static unsigned char rgb[3] = { 'R', 'G', 'B' };
+      static const unsigned char rgb[3] = { 'R', 'G', 'B' };
       z->img_comp[i].id = stbi__get8(s);
-      if (z->img_comp[i].id != i+1)   // JFIF requires
-         if (z->img_comp[i].id != i) {  // some version of jpegtran outputs non-JFIF-compliant files!
-            // somethings output this (see http://fileformats.archiveteam.org/wiki/JPEG#Color_format)
-            if (z->img_comp[i].id != rgb[i])
-               return stbi__err("bad component ID","Corrupt JPEG");
-            ++z->rgb;
-         }
+      if (s->img_n == 3 && z->img_comp[i].id == rgb[i])
+         ++z->rgb;
       q = stbi__get8(s);
       z->img_comp[i].h = (q >> 4);  if (!z->img_comp[i].h || z->img_comp[i].h > 4) return stbi__err("bad H","Corrupt JPEG");
       z->img_comp[i].v = q & 15;    if (!z->img_comp[i].v || z->img_comp[i].v > 4) return stbi__err("bad V","Corrupt JPEG");
@@ -2738,7 +3029,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 
    if (scan != STBI__SCAN_load) return 1;
 
-   if ((1 << 30) / s->img_x / s->img_n < s->img_y) return stbi__err("too large", "Image too large to decode");
+   if (!stbi__mad3sizes_valid(s->img_x, s->img_y, s->img_n, 0)) return stbi__err("too large", "Image too large to decode");
 
    for (i=0; i < s->img_n; ++i) {
       if (z->img_comp[i].h > h_max) h_max = z->img_comp[i].h;
@@ -2750,6 +3041,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
    z->img_v_max = v_max;
    z->img_mcu_w = h_max * 8;
    z->img_mcu_h = v_max * 8;
+   // these sizes can't be more than 17 bits
    z->img_mcu_x = (s->img_x + z->img_mcu_w-1) / z->img_mcu_w;
    z->img_mcu_y = (s->img_y + z->img_mcu_h-1) / z->img_mcu_h;
 
@@ -2761,28 +3053,27 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
       // the bogus oversized data from using interleaved MCUs and their
       // big blocks (e.g. a 16x16 iMCU on an image of width 33); we won't
       // discard the extra data until colorspace conversion
+      //
+      // img_mcu_x, img_mcu_y: <=17 bits; comp[i].h and .v are <=4 (checked earlier)
+      // so these muls can't overflow with 32-bit ints (which we require)
       z->img_comp[i].w2 = z->img_mcu_x * z->img_comp[i].h * 8;
       z->img_comp[i].h2 = z->img_mcu_y * z->img_comp[i].v * 8;
-      z->img_comp[i].raw_data = stbi__malloc(z->img_comp[i].w2 * z->img_comp[i].h2+15);
-
-      if (z->img_comp[i].raw_data == NULL) {
-         for(--i; i >= 0; --i) {
-            STBI_FREE(z->img_comp[i].raw_data);
-            z->img_comp[i].raw_data = NULL;
-         }
-         return stbi__err("outofmem", "Out of memory");
-      }
+      z->img_comp[i].coeff = 0;
+      z->img_comp[i].raw_coeff = 0;
+      z->img_comp[i].linebuf = NULL;
+      z->img_comp[i].raw_data = stbi__malloc_mad2(z->img_comp[i].w2, z->img_comp[i].h2, 15);
+      if (z->img_comp[i].raw_data == NULL)
+         return stbi__free_jpeg_components(z, i+1, stbi__err("outofmem", "Out of memory"));
       // align blocks for idct using mmx/sse
       z->img_comp[i].data = (stbi_uc*) (((size_t) z->img_comp[i].raw_data + 15) & ~15);
-      z->img_comp[i].linebuf = NULL;
       if (z->progressive) {
-         z->img_comp[i].coeff_w = (z->img_comp[i].w2 + 7) >> 3;
-         z->img_comp[i].coeff_h = (z->img_comp[i].h2 + 7) >> 3;
-         z->img_comp[i].raw_coeff = STBI_MALLOC(z->img_comp[i].coeff_w * z->img_comp[i].coeff_h * 64 * sizeof(short) + 15);
+         // w2, h2 are multiples of 8 (see above)
+         z->img_comp[i].coeff_w = z->img_comp[i].w2 / 8;
+         z->img_comp[i].coeff_h = z->img_comp[i].h2 / 8;
+         z->img_comp[i].raw_coeff = stbi__malloc_mad3(z->img_comp[i].w2, z->img_comp[i].h2, sizeof(short), 15);
+         if (z->img_comp[i].raw_coeff == NULL)
+            return stbi__free_jpeg_components(z, i+1, stbi__err("outofmem", "Out of memory"));
          z->img_comp[i].coeff = (short*) (((size_t) z->img_comp[i].raw_coeff + 15) & ~15);
-      } else {
-         z->img_comp[i].coeff = 0;
-         z->img_comp[i].raw_coeff = 0;
       }
    }
 
@@ -2801,6 +3092,8 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 static int stbi__decode_jpeg_header(stbi__jpeg *z, int scan)
 {
    int m;
+   z->jfif = 0;
+   z->app14_color_transform = -1; // valid values are 0,1,2
    z->marker = STBI__MARKER_none; // initialize cached marker to empty
    m = stbi__get_marker(z);
    if (!stbi__SOI(m)) return stbi__err("no SOI","Corrupt JPEG");
@@ -2842,12 +3135,15 @@ static int stbi__decode_jpeg_image(stbi__jpeg *j)
                if (x == 255) {
                   j->marker = stbi__get8(j->s);
                   break;
-               } else if (x != 0) {
-                  return stbi__err("junk before marker", "Corrupt JPEG");
                }
             }
             // if we reach eof without hitting a marker, stbi__get_marker() below will fail and we'll eventually return 0
          }
+      } else if (stbi__DNL(m)) {
+         int Ld = stbi__get16be(j->s);
+         stbi__uint32 NL = stbi__get16be(j->s);
+         if (Ld != 4) return stbi__err("bad DNL len", "Corrupt JPEG");
+         if (NL != j->s->img_y) return stbi__err("bad DNL height", "Corrupt JPEG");
       } else {
          if (!stbi__process_marker(j, m)) return 0;
       }
@@ -3066,38 +3362,9 @@ static stbi_uc *stbi__resample_row_generic(stbi_uc *out, stbi_uc *in_near, stbi_
    return out;
 }
 
-#ifdef STBI_JPEG_OLD
-// this is the same YCbCr-to-RGB calculation that stb_image has used
-// historically before the algorithm changes in 1.49
-#define float2fixed(x)  ((int) ((x) * 65536 + 0.5))
-static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step)
-{
-   int i;
-   for (i=0; i < count; ++i) {
-      int y_fixed = (y[i] << 16) + 32768; // rounding
-      int r,g,b;
-      int cr = pcr[i] - 128;
-      int cb = pcb[i] - 128;
-      r = y_fixed + cr*float2fixed(1.40200f);
-      g = y_fixed - cr*float2fixed(0.71414f) - cb*float2fixed(0.34414f);
-      b = y_fixed                            + cb*float2fixed(1.77200f);
-      r >>= 16;
-      g >>= 16;
-      b >>= 16;
-      if ((unsigned) r > 255) { if (r < 0) r = 0; else r = 255; }
-      if ((unsigned) g > 255) { if (g < 0) g = 0; else g = 255; }
-      if ((unsigned) b > 255) { if (b < 0) b = 0; else b = 255; }
-      out[0] = (stbi_uc)r;
-      out[1] = (stbi_uc)g;
-      out[2] = (stbi_uc)b;
-      out[3] = 255;
-      out += step;
-   }
-}
-#else
 // this is a reduced-precision calculation of YCbCr-to-RGB introduced
 // to make sure the code produces the same results in both SIMD and scalar
-#define float2fixed(x)  (((int) ((x) * 4096.0f + 0.5f)) << 8)
+#define stbi__float2fixed(x)  (((int) ((x) * 4096.0f + 0.5f)) << 8)
 static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step)
 {
    int i;
@@ -3106,9 +3373,9 @@ static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc
       int r,g,b;
       int cr = pcr[i] - 128;
       int cb = pcb[i] - 128;
-      r = y_fixed +  cr* float2fixed(1.40200f);
-      g = y_fixed + (cr*-float2fixed(0.71414f)) + ((cb*-float2fixed(0.34414f)) & 0xffff0000);
-      b = y_fixed                               +   cb* float2fixed(1.77200f);
+      r = y_fixed +  cr* stbi__float2fixed(1.40200f);
+      g = y_fixed + (cr*-stbi__float2fixed(0.71414f)) + ((cb*-stbi__float2fixed(0.34414f)) & 0xffff0000);
+      b = y_fixed                                     +   cb* stbi__float2fixed(1.77200f);
       r >>= 20;
       g >>= 20;
       b >>= 20;
@@ -3122,7 +3389,6 @@ static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc
       out += step;
    }
 }
-#endif
 
 #if defined(STBI_SSE2) || defined(STBI_NEON)
 static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc const *pcb, stbi_uc const *pcr, int count, int step)
@@ -3241,9 +3507,9 @@ static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc cons
       int r,g,b;
       int cr = pcr[i] - 128;
       int cb = pcb[i] - 128;
-      r = y_fixed + cr* float2fixed(1.40200f);
-      g = y_fixed + cr*-float2fixed(0.71414f) + ((cb*-float2fixed(0.34414f)) & 0xffff0000);
-      b = y_fixed                             +   cb* float2fixed(1.77200f);
+      r = y_fixed + cr* stbi__float2fixed(1.40200f);
+      g = y_fixed + cr*-stbi__float2fixed(0.71414f) + ((cb*-stbi__float2fixed(0.34414f)) & 0xffff0000);
+      b = y_fixed                                   +   cb* stbi__float2fixed(1.77200f);
       r >>= 20;
       g >>= 20;
       b >>= 20;
@@ -3269,18 +3535,14 @@ static void stbi__setup_jpeg(stbi__jpeg *j)
 #ifdef STBI_SSE2
    if (stbi__sse2_available()) {
       j->idct_block_kernel = stbi__idct_simd;
-      #ifndef STBI_JPEG_OLD
       j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
-      #endif
       j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
    }
 #endif
 
 #ifdef STBI_NEON
    j->idct_block_kernel = stbi__idct_simd;
-   #ifndef STBI_JPEG_OLD
    j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
-   #endif
    j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
 #endif
 }
@@ -3288,23 +3550,7 @@ static void stbi__setup_jpeg(stbi__jpeg *j)
 // clean up the temporary component buffers
 static void stbi__cleanup_jpeg(stbi__jpeg *j)
 {
-   int i;
-   for (i=0; i < j->s->img_n; ++i) {
-      if (j->img_comp[i].raw_data) {
-         STBI_FREE(j->img_comp[i].raw_data);
-         j->img_comp[i].raw_data = NULL;
-         j->img_comp[i].data = NULL;
-      }
-      if (j->img_comp[i].raw_coeff) {
-         STBI_FREE(j->img_comp[i].raw_coeff);
-         j->img_comp[i].raw_coeff = 0;
-         j->img_comp[i].coeff = 0;
-      }
-      if (j->img_comp[i].linebuf) {
-         STBI_FREE(j->img_comp[i].linebuf);
-         j->img_comp[i].linebuf = NULL;
-      }
-   }
+   stbi__free_jpeg_components(j, j->s->img_n, 0);
 }
 
 typedef struct
@@ -3317,9 +3563,16 @@ typedef struct
    int ypos;    // which pre-expansion row we're on
 } stbi__resample;
 
+// fast 0..255 * 0..255 => 0..255 rounded multiplication
+static stbi_uc stbi__blinn_8x8(stbi_uc x, stbi_uc y)
+{
+   unsigned int t = x*y + 128;
+   return (stbi_uc) ((t + (t >>8)) >> 8);
+}
+
 static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp, int req_comp)
 {
-   int n, decode_n;
+   int n, decode_n, is_rgb;
    z->s->img_n = 0; // make stbi__cleanup_jpeg safe
 
    // validate req_comp
@@ -3329,9 +3582,11 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
    if (!stbi__decode_jpeg_image(z)) { stbi__cleanup_jpeg(z); return NULL; }
 
    // determine actual number of components to generate
-   n = req_comp ? req_comp : z->s->img_n;
+   n = req_comp ? req_comp : z->s->img_n >= 3 ? 3 : 1;
 
-   if (z->s->img_n == 3 && n < 3)
+   is_rgb = z->s->img_n == 3 && (z->rgb == 3 || (z->app14_color_transform == 0 && !z->jfif));
+
+   if (z->s->img_n == 3 && n < 3 && !is_rgb)
       decode_n = 1;
    else
       decode_n = z->s->img_n;
@@ -3368,7 +3623,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
       }
 
       // can't error after this so, this is safe
-      output = (stbi_uc *) stbi__malloc(n * z->s->img_x * z->s->img_y + 1);
+      output = (stbi_uc *) stbi__malloc_mad3(n, z->s->img_x, z->s->img_y, 1);
       if (!output) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
 
       // now go ahead and resample
@@ -3391,7 +3646,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
          if (n >= 3) {
             stbi_uc *y = coutput[0];
             if (z->s->img_n == 3) {
-               if (z->rgb == 3) {
+               if (is_rgb) {
                   for (i=0; i < z->s->img_x; ++i) {
                      out[0] = y[i];
                      out[1] = coutput[1][i];
@@ -3402,6 +3657,28 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
                } else {
                   z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
                }
+            } else if (z->s->img_n == 4) {
+               if (z->app14_color_transform == 0) { // CMYK
+                  for (i=0; i < z->s->img_x; ++i) {
+                     stbi_uc m = coutput[3][i];
+                     out[0] = stbi__blinn_8x8(coutput[0][i], m);
+                     out[1] = stbi__blinn_8x8(coutput[1][i], m);
+                     out[2] = stbi__blinn_8x8(coutput[2][i], m);
+                     out[3] = 255;
+                     out += n;
+                  }
+               } else if (z->app14_color_transform == 2) { // YCCK
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+                  for (i=0; i < z->s->img_x; ++i) {
+                     stbi_uc m = coutput[3][i];
+                     out[0] = stbi__blinn_8x8(255 - out[0], m);
+                     out[1] = stbi__blinn_8x8(255 - out[1], m);
+                     out[2] = stbi__blinn_8x8(255 - out[2], m);
+                     out += n;
+                  }
+               } else { // YCbCr + alpha?  Ignore the fourth channel for now
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+               }
             } else
                for (i=0; i < z->s->img_x; ++i) {
                   out[0] = out[1] = out[2] = y[i];
@@ -3409,25 +3686,54 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
                   out += n;
                }
          } else {
-            stbi_uc *y = coutput[0];
-            if (n == 1)
-               for (i=0; i < z->s->img_x; ++i) out[i] = y[i];
-            else
-               for (i=0; i < z->s->img_x; ++i) *out++ = y[i], *out++ = 255;
+            if (is_rgb) {
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i)
+                     *out++ = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+               else {
+                  for (i=0; i < z->s->img_x; ++i, out += 2) {
+                     out[0] = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+                     out[1] = 255;
+                  }
+               }
+            } else if (z->s->img_n == 4 && z->app14_color_transform == 0) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  stbi_uc m = coutput[3][i];
+                  stbi_uc r = stbi__blinn_8x8(coutput[0][i], m);
+                  stbi_uc g = stbi__blinn_8x8(coutput[1][i], m);
+                  stbi_uc b = stbi__blinn_8x8(coutput[2][i], m);
+                  out[0] = stbi__compute_y(r, g, b);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else if (z->s->img_n == 4 && z->app14_color_transform == 2) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  out[0] = stbi__blinn_8x8(255 - coutput[0][i], coutput[3][i]);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else {
+               stbi_uc *y = coutput[0];
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i) out[i] = y[i];
+               else
+                  for (i=0; i < z->s->img_x; ++i) *out++ = y[i], *out++ = 255;
+            }
          }
       }
       stbi__cleanup_jpeg(z);
       *out_x = z->s->img_x;
       *out_y = z->s->img_y;
-      if (comp) *comp  = z->s->img_n; // report original components, not output
+      if (comp) *comp = z->s->img_n >= 3 ? 3 : 1; // report original components, not output
       return output;
    }
 }
 
-static unsigned char *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
    unsigned char* result;
    stbi__jpeg* j = (stbi__jpeg*) stbi__malloc(sizeof(stbi__jpeg));
+   STBI_NOTUSED(ri);
    j->s = s;
    stbi__setup_jpeg(j);
    result = load_jpeg_image(j, x,y,comp,req_comp);
@@ -3438,11 +3744,12 @@ static unsigned char *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *com
 static int stbi__jpeg_test(stbi__context *s)
 {
    int r;
-   stbi__jpeg j;
-   j.s = s;
-   stbi__setup_jpeg(&j);
-   r = stbi__decode_jpeg_header(&j, STBI__SCAN_type);
+   stbi__jpeg* j = (stbi__jpeg*)stbi__malloc(sizeof(stbi__jpeg));
+   j->s = s;
+   stbi__setup_jpeg(j);
+   r = stbi__decode_jpeg_header(j, STBI__SCAN_type);
    stbi__rewind(s);
+   STBI_FREE(j);
    return r;
 }
 
@@ -3454,7 +3761,7 @@ static int stbi__jpeg_info_raw(stbi__jpeg *j, int *x, int *y, int *comp)
    }
    if (x) *x = j->s->img_x;
    if (y) *y = j->s->img_y;
-   if (comp) *comp = j->s->img_n;
+   if (comp) *comp = j->s->img_n >= 3 ? 3 : 1;
    return 1;
 }
 
@@ -3511,7 +3818,7 @@ stbi_inline static int stbi__bit_reverse(int v, int bits)
    return stbi__bitreverse16(v) >> (16-bits);
 }
 
-static int stbi__zbuild_huffman(stbi__zhuffman *z, stbi_uc *sizelist, int num)
+static int stbi__zbuild_huffman(stbi__zhuffman *z, const stbi_uc *sizelist, int num)
 {
    int i,k=0;
    int code, next_code[16], sizes[17];
@@ -3654,18 +3961,18 @@ static int stbi__zexpand(stbi__zbuf *z, char *zout, int n)  // need to make room
    return 1;
 }
 
-static int stbi__zlength_base[31] = {
+static const int stbi__zlength_base[31] = {
    3,4,5,6,7,8,9,10,11,13,
    15,17,19,23,27,31,35,43,51,59,
    67,83,99,115,131,163,195,227,258,0,0 };
 
-static int stbi__zlength_extra[31]=
+static const int stbi__zlength_extra[31]=
 { 0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,0,0 };
 
-static int stbi__zdist_base[32] = { 1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,
+static const int stbi__zdist_base[32] = { 1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,
 257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577,0,0};
 
-static int stbi__zdist_extra[32] =
+static const int stbi__zdist_extra[32] =
 { 0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13};
 
 static int stbi__parse_huffman_block(stbi__zbuf *a)
@@ -3712,7 +4019,7 @@ static int stbi__parse_huffman_block(stbi__zbuf *a)
 
 static int stbi__compute_huffman_codes(stbi__zbuf *a)
 {
-   static stbi_uc length_dezigzag[19] = { 16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
+   static const stbi_uc length_dezigzag[19] = { 16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
    stbi__zhuffman z_codelength;
    stbi_uc lencodes[286+32+137];//padding for maximum single op
    stbi_uc codelength_sizes[19];
@@ -3721,6 +4028,7 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a)
    int hlit  = stbi__zreceive(a,5) + 257;
    int hdist = stbi__zreceive(a,5) + 1;
    int hclen = stbi__zreceive(a,4) + 4;
+   int ntot  = hlit + hdist;
 
    memset(codelength_sizes, 0, sizeof(codelength_sizes));
    for (i=0; i < hclen; ++i) {
@@ -3730,27 +4038,29 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a)
    if (!stbi__zbuild_huffman(&z_codelength, codelength_sizes, 19)) return 0;
 
    n = 0;
-   while (n < hlit + hdist) {
+   while (n < ntot) {
       int c = stbi__zhuffman_decode(a, &z_codelength);
       if (c < 0 || c >= 19) return stbi__err("bad codelengths", "Corrupt PNG");
       if (c < 16)
          lencodes[n++] = (stbi_uc) c;
-      else if (c == 16) {
-         c = stbi__zreceive(a,2)+3;
-         memset(lencodes+n, lencodes[n-1], c);
-         n += c;
-      } else if (c == 17) {
-         c = stbi__zreceive(a,3)+3;
-         memset(lencodes+n, 0, c);
-         n += c;
-      } else {
-         STBI_ASSERT(c == 18);
-         c = stbi__zreceive(a,7)+11;
-         memset(lencodes+n, 0, c);
+      else {
+         stbi_uc fill = 0;
+         if (c == 16) {
+            c = stbi__zreceive(a,2)+3;
+            if (n == 0) return stbi__err("bad codelengths", "Corrupt PNG");
+            fill = lencodes[n-1];
+         } else if (c == 17)
+            c = stbi__zreceive(a,3)+3;
+         else {
+            STBI_ASSERT(c == 18);
+            c = stbi__zreceive(a,7)+11;
+         }
+         if (ntot - n < c) return stbi__err("bad codelengths", "Corrupt PNG");
+         memset(lencodes+n, fill, c);
          n += c;
       }
    }
-   if (n != hlit+hdist) return stbi__err("bad codelengths","Corrupt PNG");
+   if (n != ntot) return stbi__err("bad codelengths","Corrupt PNG");
    if (!stbi__zbuild_huffman(&a->z_length, lencodes, hlit)) return 0;
    if (!stbi__zbuild_huffman(&a->z_distance, lencodes+hlit, hdist)) return 0;
    return 1;
@@ -3798,9 +4108,24 @@ static int stbi__parse_zlib_header(stbi__zbuf *a)
    return 1;
 }
 
-// @TODO: should statically initialize these for optimal thread safety
-static stbi_uc stbi__zdefault_length[288], stbi__zdefault_distance[32];
-static void stbi__init_zdefaults(void)
+static const stbi_uc stbi__zdefault_length[288] =
+{
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, 7,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8
+};
+static const stbi_uc stbi__zdefault_distance[32] =
+{
+   5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5
+};
+/*
+Init algorithm:
 {
    int i;   // use <= to match clearly with spec
    for (i=0; i <= 143; ++i)     stbi__zdefault_length[i]   = 8;
@@ -3810,6 +4135,7 @@ static void stbi__init_zdefaults(void)
 
    for (i=0; i <=  31; ++i)     stbi__zdefault_distance[i] = 5;
 }
+*/
 
 static int stbi__parse_zlib(stbi__zbuf *a, int parse_header)
 {
@@ -3828,7 +4154,6 @@ static int stbi__parse_zlib(stbi__zbuf *a, int parse_header)
       } else {
          if (type == 1) {
             // use fixed code lengths
-            if (!stbi__zdefault_distance[31]) stbi__init_zdefaults();
             if (!stbi__zbuild_huffman(&a->z_length  , stbi__zdefault_length  , 288)) return 0;
             if (!stbi__zbuild_huffman(&a->z_distance, stbi__zdefault_distance,  32)) return 0;
          } else {
@@ -3953,7 +4278,7 @@ static stbi__pngchunk stbi__get_chunk_header(stbi__context *s)
 
 static int stbi__check_png_header(stbi__context *s)
 {
-   static stbi_uc png_sig[8] = { 137,80,78,71,13,10,26,10 };
+   static const stbi_uc png_sig[8] = { 137,80,78,71,13,10,26,10 };
    int i;
    for (i=0; i < 8; ++i)
       if (stbi__get8(s) != png_sig[i]) return stbi__err("bad png sig","Not a PNG");
@@ -3999,7 +4324,7 @@ static int stbi__paeth(int a, int b, int c)
    return c;
 }
 
-static stbi_uc stbi__depth_scale_table[9] = { 0, 0xff, 0x55, 0, 0x11, 0,0,0, 0x01 };
+static const stbi_uc stbi__depth_scale_table[9] = { 0, 0xff, 0x55, 0, 0x11, 0,0,0, 0x01 };
 
 // create the png data from post-deflated data
 static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 raw_len, int out_n, stbi__uint32 x, stbi__uint32 y, int depth, int color)
@@ -4016,20 +4341,21 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
    int width = x;
 
    STBI_ASSERT(out_n == s->img_n || out_n == s->img_n+1);
-   a->out = (stbi_uc *) stbi__malloc(x * y * output_bytes); // extra bytes to write off the end into
+   a->out = (stbi_uc *) stbi__malloc_mad3(x, y, output_bytes, 0); // extra bytes to write off the end into
    if (!a->out) return stbi__err("outofmem", "Out of memory");
 
+   if (!stbi__mad3sizes_valid(img_n, x, depth, 7)) return stbi__err("too large", "Corrupt PNG");
    img_width_bytes = (((img_n * x * depth) + 7) >> 3);
    img_len = (img_width_bytes + 1) * y;
-   if (s->img_x == x && s->img_y == y) {
-      if (raw_len != img_len) return stbi__err("not enough pixels","Corrupt PNG");
-   } else { // interlaced:
-      if (raw_len < img_len) return stbi__err("not enough pixels","Corrupt PNG");
-   }
+
+   // we used to check for exact match between raw_len and img_len on non-interlaced PNGs,
+   // but issue #276 reported a PNG in the wild that had extra data at the end (all zeros),
+   // so just check for raw_len < img_len always.
+   if (raw_len < img_len) return stbi__err("not enough pixels","Corrupt PNG");
 
    for (j=0; j < y; ++j) {
       stbi_uc *cur = a->out + stride*j;
-      stbi_uc *prior = cur - stride;
+      stbi_uc *prior;
       int filter = *raw++;
 
       if (filter > 4)
@@ -4041,6 +4367,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
          filter_bytes = 1;
          width = img_width_bytes;
       }
+      prior = cur - stride; // bugfix: need to compute this after 'cur +=' computation above
 
       // if first row, use special filter that doesn't sample previous row
       if (j == 0) filter = first_row_filter[filter];
@@ -4081,37 +4408,37 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
       // this is a little gross, so that we don't switch per-pixel or per-component
       if (depth < 8 || img_n == out_n) {
          int nk = (width - 1)*filter_bytes;
-         #define CASE(f) \
+         #define STBI__CASE(f) \
              case f:     \
                 for (k=0; k < nk; ++k)
          switch (filter) {
             // "none" filter turns into a memcpy here; make that explicit.
             case STBI__F_none:         memcpy(cur, raw, nk); break;
-                CASE(STBI__F_sub)          { cur[k] = STBI__BYTECAST(raw[k] + cur[k-filter_bytes]); } break;
-                CASE(STBI__F_up)           { cur[k] = STBI__BYTECAST(raw[k] + prior[k]); } break;
-                CASE(STBI__F_avg)          { cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k-filter_bytes])>>1)); } break;
-                CASE(STBI__F_paeth)        { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k-filter_bytes],prior[k],prior[k-filter_bytes])); } break;
-                CASE(STBI__F_avg_first)    { cur[k] = STBI__BYTECAST(raw[k] + (cur[k-filter_bytes] >> 1)); } break;
-                CASE(STBI__F_paeth_first)  { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k-filter_bytes],0,0)); } break;
+            STBI__CASE(STBI__F_sub)          { cur[k] = STBI__BYTECAST(raw[k] + cur[k-filter_bytes]); } break;
+            STBI__CASE(STBI__F_up)           { cur[k] = STBI__BYTECAST(raw[k] + prior[k]); } break;
+            STBI__CASE(STBI__F_avg)          { cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k-filter_bytes])>>1)); } break;
+            STBI__CASE(STBI__F_paeth)        { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k-filter_bytes],prior[k],prior[k-filter_bytes])); } break;
+            STBI__CASE(STBI__F_avg_first)    { cur[k] = STBI__BYTECAST(raw[k] + (cur[k-filter_bytes] >> 1)); } break;
+            STBI__CASE(STBI__F_paeth_first)  { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k-filter_bytes],0,0)); } break;
          }
-         #undef CASE
+         #undef STBI__CASE
          raw += nk;
       } else {
          STBI_ASSERT(img_n+1 == out_n);
-         #define CASE(f) \
+         #define STBI__CASE(f) \
              case f:     \
                 for (i=x-1; i >= 1; --i, cur[filter_bytes]=255,raw+=filter_bytes,cur+=output_bytes,prior+=output_bytes) \
                    for (k=0; k < filter_bytes; ++k)
          switch (filter) {
-             CASE(STBI__F_none)         { cur[k] = raw[k]; } break;
-             CASE(STBI__F_sub)          { cur[k] = STBI__BYTECAST(raw[k] + cur[k- output_bytes]); } break;
-             CASE(STBI__F_up)           { cur[k] = STBI__BYTECAST(raw[k] + prior[k]); } break;
-             CASE(STBI__F_avg)          { cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k- output_bytes])>>1)); } break;
-             CASE(STBI__F_paeth)        { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k- output_bytes],prior[k],prior[k- output_bytes])); } break;
-             CASE(STBI__F_avg_first)    { cur[k] = STBI__BYTECAST(raw[k] + (cur[k- output_bytes] >> 1)); } break;
-             CASE(STBI__F_paeth_first)  { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k- output_bytes],0,0)); } break;
+            STBI__CASE(STBI__F_none)         { cur[k] = raw[k]; } break;
+            STBI__CASE(STBI__F_sub)          { cur[k] = STBI__BYTECAST(raw[k] + cur[k- output_bytes]); } break;
+            STBI__CASE(STBI__F_up)           { cur[k] = STBI__BYTECAST(raw[k] + prior[k]); } break;
+            STBI__CASE(STBI__F_avg)          { cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k- output_bytes])>>1)); } break;
+            STBI__CASE(STBI__F_paeth)        { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k- output_bytes],prior[k],prior[k- output_bytes])); } break;
+            STBI__CASE(STBI__F_avg_first)    { cur[k] = STBI__BYTECAST(raw[k] + (cur[k- output_bytes] >> 1)); } break;
+            STBI__CASE(STBI__F_paeth_first)  { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k- output_bytes],0,0)); } break;
          }
-         #undef CASE
+         #undef STBI__CASE
 
          // the loop above sets the high byte of the pixels' alpha, but for
          // 16 bit png files we also need the low byte set. we'll do that here.
@@ -4214,13 +4541,15 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
 
 static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint32 image_data_len, int out_n, int depth, int color, int interlaced)
 {
+   int bytes = (depth == 16 ? 2 : 1);
+   int out_bytes = out_n * bytes;
    stbi_uc *final;
    int p;
    if (!interlaced)
       return stbi__create_png_image_raw(a, image_data, image_data_len, out_n, a->s->img_x, a->s->img_y, depth, color);
 
    // de-interlacing
-   final = (stbi_uc *) stbi__malloc(a->s->img_x * a->s->img_y * out_n);
+   final = (stbi_uc *) stbi__malloc_mad3(a->s->img_x, a->s->img_y, out_bytes, 0);
    for (p=0; p < 7; ++p) {
       int xorig[] = { 0,4,0,2,0,1,0 };
       int yorig[] = { 0,0,4,0,2,0,1 };
@@ -4240,8 +4569,8 @@ static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint3
             for (i=0; i < x; ++i) {
                int out_y = j*yspc[p]+yorig[p];
                int out_x = i*xspc[p]+xorig[p];
-               memcpy(final + out_y*a->s->img_x*out_n + out_x*out_n,
-                      a->out + (j*x+i)*out_n, out_n);
+               memcpy(final + out_y*a->s->img_x*out_bytes + out_x*out_bytes,
+                      a->out + (j*x+i)*out_bytes, out_bytes);
             }
          }
          STBI_FREE(a->out);
@@ -4309,7 +4638,7 @@ static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int
    stbi__uint32 i, pixel_count = a->s->img_x * a->s->img_y;
    stbi_uc *p, *temp_out, *orig = a->out;
 
-   p = (stbi_uc *) stbi__malloc(pixel_count * pal_img_n);
+   p = (stbi_uc *) stbi__malloc_mad2(pixel_count, pal_img_n, 0);
    if (p == NULL) return stbi__err("outofmem", "Out of memory");
 
    // between here and free(out) below, exitting would leak
@@ -4337,26 +4666,6 @@ static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int
    a->out = temp_out;
 
    STBI_NOTUSED(len);
-
-   return 1;
-}
-
-static int stbi__reduce_png(stbi__png *p)
-{
-   int i;
-   int img_len = p->s->img_x * p->s->img_y * p->s->img_out_n;
-   stbi_uc *reduced;
-   stbi__uint16 *orig = (stbi__uint16*)p->out;
-
-   if (p->depth != 16) return 1; // don't need to do anything if not 16-bit data
-
-   reduced = (stbi_uc *)stbi__malloc(img_len);
-   if (p == NULL) return stbi__err("outofmem", "Out of memory");
-
-   for (i = 0; i < img_len; ++i) reduced[i] = (stbi_uc)((orig[i] >> 8) & 0xFF); // top half of each byte is a decent approx of 16->8 bit scaling
-
-   p->out = reduced;
-   STBI_FREE(orig);
 
    return 1;
 }
@@ -4395,9 +4704,10 @@ static void stbi__de_iphone(stbi__png *z)
             stbi_uc a = p[3];
             stbi_uc t = p[0];
             if (a) {
-               p[0] = p[2] * 255 / a;
-               p[1] = p[1] * 255 / a;
-               p[2] =  t   * 255 / a;
+               stbi_uc half = a / 2;
+               p[0] = (p[2] * 255 + half) / a;
+               p[1] = (p[1] * 255 + half) / a;
+               p[2] = ( t   * 255 + half) / a;
             } else {
                p[0] = p[2];
                p[2] = t;
@@ -4416,7 +4726,7 @@ static void stbi__de_iphone(stbi__png *z)
    }
 }
 
-#define STBI__PNG_TYPE(a,b,c,d)  (((a) << 24) + ((b) << 16) + ((c) << 8) + (d))
+#define STBI__PNG_TYPE(a,b,c,d)  (((unsigned) (a) << 24) + ((unsigned) (b) << 16) + ((unsigned) (c) << 8) + (unsigned) (d))
 
 static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
 {
@@ -4451,7 +4761,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             s->img_y = stbi__get32be(s); if (s->img_y > (1 << 24)) return stbi__err("too large","Very large image (corrupt?)");
             z->depth = stbi__get8(s);  if (z->depth != 1 && z->depth != 2 && z->depth != 4 && z->depth != 8 && z->depth != 16)  return stbi__err("1/2/4/8/16-bit only","PNG not supported: 1/2/4/8/16-bit only");
             color = stbi__get8(s);  if (color > 6)         return stbi__err("bad ctype","Corrupt PNG");
-			if (color == 3 && z->depth == 16)                  return stbi__err("bad ctype","Corrupt PNG");
+            if (color == 3 && z->depth == 16)                  return stbi__err("bad ctype","Corrupt PNG");
             if (color == 3) pal_img_n = 3; else if (color & 1) return stbi__err("bad ctype","Corrupt PNG");
             comp  = stbi__get8(s);  if (comp) return stbi__err("bad comp method","Corrupt PNG");
             filter= stbi__get8(s);  if (filter) return stbi__err("bad filter method","Corrupt PNG");
@@ -4500,7 +4810,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                if (c.length != (stbi__uint32) s->img_n*2) return stbi__err("bad tRNS len","Corrupt PNG");
                has_trans = 1;
                if (z->depth == 16) {
-                  for (k = 0; k < s->img_n; ++k) tc16[k] = stbi__get16be(s); // copy the values as-is
+                  for (k = 0; k < s->img_n; ++k) tc16[k] = (stbi__uint16)stbi__get16be(s); // copy the values as-is
                } else {
                   for (k = 0; k < s->img_n; ++k) tc[k] = (stbi_uc)(stbi__get16be(s) & 255) * stbi__depth_scale_table[z->depth]; // non 8-bit images will be larger
                }
@@ -4560,6 +4870,9 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                if (req_comp >= 3) s->img_out_n = req_comp;
                if (!stbi__expand_png_palette(z, palette, pal_len, s->img_out_n))
                   return 0;
+            } else if (has_trans) {
+               // non-paletted image with tRNS -> source image has (constant) alpha
+               ++s->img_n;
             }
             STBI_FREE(z->expanded); z->expanded = NULL;
             return 1;
@@ -4587,20 +4900,22 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
    }
 }
 
-static unsigned char *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp)
+static void *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp, stbi__result_info *ri)
 {
-   unsigned char *result=NULL;
+   void *result=NULL;
    if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
    if (stbi__parse_png_file(p, STBI__SCAN_load, req_comp)) {
-      if (p->depth == 16) {
-         if (!stbi__reduce_png(p)) {
-            return result;
-         }
-      }
+      if (p->depth < 8)
+         ri->bits_per_channel = 8;
+      else
+         ri->bits_per_channel = p->depth;
       result = p->out;
       p->out = NULL;
       if (req_comp && req_comp != p->s->img_out_n) {
-         result = stbi__convert_format(result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         if (ri->bits_per_channel == 8)
+            result = stbi__convert_format((unsigned char *) result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         else
+            result = stbi__convert_format16((stbi__uint16 *) result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
          p->s->img_out_n = req_comp;
          if (result == NULL) return result;
       }
@@ -4615,11 +4930,11 @@ static unsigned char *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req
    return result;
 }
 
-static unsigned char *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
    stbi__png p;
    p.s = s;
-   return stbi__do_png(&p, x,y,comp,req_comp);
+   return stbi__do_png(&p, x,y,comp,req_comp, ri);
 }
 
 static int stbi__png_test(stbi__context *s)
@@ -4647,6 +4962,19 @@ static int stbi__png_info(stbi__context *s, int *x, int *y, int *comp)
    stbi__png p;
    p.s = s;
    return stbi__png_info_raw(&p, x, y, comp);
+}
+
+static int stbi__png_is16(stbi__context *s)
+{
+   stbi__png p;
+   p.s = s;
+   if (!stbi__png_info_raw(&p, NULL, NULL, NULL))
+	   return 0;
+   if (p.depth != 16) {
+      stbi__rewind(p.s);
+      return 0;
+   }
+   return 1;
 }
 #endif
 
@@ -4699,21 +5027,27 @@ static int stbi__bitcount(unsigned int a)
    return a & 0xff;
 }
 
+// extract an arbitrarily-aligned N-bit value (N=bits)
+// from v, and then make it 8-bits long and fractionally
+// extend it to full full range.
 static int stbi__shiftsigned(int v, int shift, int bits)
 {
-   int result;
-   int z=0;
-
-   if (shift < 0) v <<= -shift;
-   else v >>= shift;
-   result = v;
-
-   z = bits;
-   while (z < 8) {
-      result += v >> z;
-      z += bits;
-   }
-   return result;
+   static unsigned int mul_table[9] = {
+      0,
+      0xff/*0b11111111*/, 0x55/*0b01010101*/, 0x49/*0b01001001*/, 0x11/*0b00010001*/,
+      0x21/*0b00100001*/, 0x41/*0b01000001*/, 0x81/*0b10000001*/, 0x01/*0b00000001*/,
+   };
+   static unsigned int shift_table[9] = {
+      0, 0,0,1,0,2,4,6,0,
+   };
+   if (shift < 0)
+      v <<= -shift;
+   else
+      v >>= shift;
+   STBI_ASSERT(v >= 0 && v < 256);
+   v >>= (8-bits);
+   STBI_ASSERT(bits >= 0 && bits <= 8);
+   return (int) ((unsigned) v * mul_table[bits]) >> shift_table[bits];
 }
 
 typedef struct
@@ -4743,7 +5077,6 @@ static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
    }
    if (stbi__get16le(s) != 1) return stbi__errpuc("bad BMP", "bad BMP");
    info->bpp = stbi__get16le(s);
-   if (info->bpp == 1) return stbi__errpuc("monochrome", "BMP type not supported: 1-bit");
    if (hsz != 12) {
       int compress = stbi__get32le(s);
       if (compress == 1 || compress == 2) return stbi__errpuc("BMP RLE", "BMP type not supported: RLE");
@@ -4807,7 +5140,7 @@ static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
 }
 
 
-static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
    stbi_uc *out;
    unsigned int mr=0,mg=0,mb=0,ma=0, all_a;
@@ -4815,6 +5148,7 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
    int psize=0,i,j,width;
    int flip_vertically, pad, target;
    stbi__bmp_data info;
+   STBI_NOTUSED(ri);
 
    info.all_a = 255;
    if (stbi__bmp_parse_header(s, &info) == NULL)
@@ -4843,7 +5177,11 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
    else
       target = s->img_n; // if they want monochrome, we'll post-convert
 
-   out = (stbi_uc *) stbi__malloc(target * s->img_x * s->img_y);
+   // sanity-check size
+   if (!stbi__mad3sizes_valid(target, s->img_x, s->img_y, 0))
+      return stbi__errpuc("too large", "Corrupt BMP");
+
+   out = (stbi_uc *) stbi__malloc_mad3(target, s->img_x, s->img_y, 0);
    if (!out) return stbi__errpuc("outofmem", "Out of memory");
    if (info.bpp < 16) {
       int z=0;
@@ -4856,29 +5194,47 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
          pal[i][3] = 255;
       }
       stbi__skip(s, info.offset - 14 - info.hsz - psize * (info.hsz == 12 ? 3 : 4));
-      if (info.bpp == 4) width = (s->img_x + 1) >> 1;
+      if (info.bpp == 1) width = (s->img_x + 7) >> 3;
+      else if (info.bpp == 4) width = (s->img_x + 1) >> 1;
       else if (info.bpp == 8) width = s->img_x;
       else { STBI_FREE(out); return stbi__errpuc("bad bpp", "Corrupt BMP"); }
       pad = (-width)&3;
-      for (j=0; j < (int) s->img_y; ++j) {
-         for (i=0; i < (int) s->img_x; i += 2) {
-            int v=stbi__get8(s),v2=0;
-            if (info.bpp == 4) {
-               v2 = v & 15;
-               v >>= 4;
+      if (info.bpp == 1) {
+         for (j=0; j < (int) s->img_y; ++j) {
+            int bit_offset = 7, v = stbi__get8(s);
+            for (i=0; i < (int) s->img_x; ++i) {
+               int color = (v>>bit_offset)&0x1;
+               out[z++] = pal[color][0];
+               out[z++] = pal[color][1];
+               out[z++] = pal[color][2];
+               if((--bit_offset) < 0) {
+                  bit_offset = 7;
+                  v = stbi__get8(s);
+               }
             }
-            out[z++] = pal[v][0];
-            out[z++] = pal[v][1];
-            out[z++] = pal[v][2];
-            if (target == 4) out[z++] = 255;
-            if (i+1 == (int) s->img_x) break;
-            v = (info.bpp == 8) ? stbi__get8(s) : v2;
-            out[z++] = pal[v][0];
-            out[z++] = pal[v][1];
-            out[z++] = pal[v][2];
-            if (target == 4) out[z++] = 255;
+            stbi__skip(s, pad);
          }
-         stbi__skip(s, pad);
+      } else {
+         for (j=0; j < (int) s->img_y; ++j) {
+            for (i=0; i < (int) s->img_x; i += 2) {
+               int v=stbi__get8(s),v2=0;
+               if (info.bpp == 4) {
+                  v2 = v & 15;
+                  v >>= 4;
+               }
+               out[z++] = pal[v][0];
+               out[z++] = pal[v][1];
+               out[z++] = pal[v][2];
+               if (target == 4) out[z++] = 255;
+               if (i+1 == (int) s->img_x) break;
+               v = (info.bpp == 8) ? stbi__get8(s) : v2;
+               out[z++] = pal[v][0];
+               out[z++] = pal[v][1];
+               out[z++] = pal[v][2];
+               if (target == 4) out[z++] = 255;
+            }
+            stbi__skip(s, pad);
+         }
       }
    } else {
       int rshift=0,gshift=0,bshift=0,ashift=0,rcount=0,gcount=0,bcount=0,acount=0;
@@ -4919,7 +5275,7 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
             int bpp = info.bpp;
             for (i=0; i < (int) s->img_x; ++i) {
                stbi__uint32 v = (bpp == 16 ? (stbi__uint32) stbi__get16le(s) : stbi__get32le(s));
-               int a;
+               unsigned int a;
                out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mr, rshift, rcount));
                out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mg, gshift, gcount));
                out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mb, bshift, bcount));
@@ -4967,14 +5323,14 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
 static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int* is_rgb16)
 {
    // only RGB or RGBA (incl. 16bit) or grey allowed
-   if(is_rgb16) *is_rgb16 = 0;
+   if (is_rgb16) *is_rgb16 = 0;
    switch(bits_per_pixel) {
       case 8:  return STBI_grey;
       case 16: if(is_grey) return STBI_grey_alpha;
-            // else: fall-through
+               // fallthrough
       case 15: if(is_rgb16) *is_rgb16 = 1;
-            return STBI_rgb;
-      case 24: // fall-through
+               return STBI_rgb;
+      case 24: // fallthrough
       case 32: return bits_per_pixel/8;
       default: return 0;
    }
@@ -5077,18 +5433,18 @@ errorEnd:
 }
 
 // read 16bit value and convert to 24bit RGB
-void stbi__tga_read_rgb16(stbi__context *s, stbi_uc* out)
+static void stbi__tga_read_rgb16(stbi__context *s, stbi_uc* out)
 {
-   stbi__uint16 px = stbi__get16le(s);
+   stbi__uint16 px = (stbi__uint16)stbi__get16le(s);
    stbi__uint16 fiveBitMask = 31;
    // we have 3 channels with 5bits each
    int r = (px >> 10) & fiveBitMask;
    int g = (px >> 5) & fiveBitMask;
    int b = px & fiveBitMask;
    // Note that this saves the data in RGB(A) order, so it doesn't need to be swapped later
-   out[0] = (r * 255)/31;
-   out[1] = (g * 255)/31;
-   out[2] = (b * 255)/31;
+   out[0] = (stbi_uc)((r * 255)/31);
+   out[1] = (stbi_uc)((g * 255)/31);
+   out[2] = (stbi_uc)((b * 255)/31);
 
    // some people claim that the most significant bit might be used for alpha
    // (possibly if an alpha-bit is set in the "image descriptor byte")
@@ -5096,7 +5452,7 @@ void stbi__tga_read_rgb16(stbi__context *s, stbi_uc* out)
    // so let's treat all 15 and 16bit TGAs as RGB with no alpha.
 }
 
-static stbi_uc *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
    //   read in the TGA header stuff
    int tga_offset = stbi__get8(s);
@@ -5118,10 +5474,11 @@ static stbi_uc *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int 
    unsigned char *tga_data;
    unsigned char *tga_palette = NULL;
    int i, j;
-   unsigned char raw_data[4];
+   unsigned char raw_data[4] = {0};
    int RLE_count = 0;
    int RLE_repeating = 0;
    int read_next_pixel = 1;
+   STBI_NOTUSED(ri);
 
    //   do a tiny bit of precessing
    if ( tga_image_type >= 8 )
@@ -5143,7 +5500,10 @@ static stbi_uc *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int 
    *y = tga_height;
    if (comp) *comp = tga_comp;
 
-   tga_data = (unsigned char*)stbi__malloc( (size_t)tga_width * tga_height * tga_comp );
+   if (!stbi__mad3sizes_valid(tga_width, tga_height, tga_comp, 0))
+      return stbi__errpuc("too large", "Corrupt TGA");
+
+   tga_data = (unsigned char*)stbi__malloc_mad3(tga_width, tga_height, tga_comp, 0);
    if (!tga_data) return stbi__errpuc("outofmem", "Out of memory");
 
    // skip to the data's starting position (offset usually = 0)
@@ -5162,7 +5522,7 @@ static stbi_uc *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int 
          //   any data to skip? (offset usually = 0)
          stbi__skip(s, tga_palette_start );
          //   load the palette
-         tga_palette = (unsigned char*)stbi__malloc( tga_palette_len * tga_comp );
+         tga_palette = (unsigned char*)stbi__malloc_mad2(tga_palette_len, tga_comp, 0);
          if (!tga_palette) {
             STBI_FREE(tga_data);
             return stbi__errpuc("outofmem", "Out of memory");
@@ -5298,14 +5658,53 @@ static int stbi__psd_test(stbi__context *s)
    return r;
 }
 
-static stbi_uc *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static int stbi__psd_decode_rle(stbi__context *s, stbi_uc *p, int pixelCount)
 {
-   int   pixelCount;
+   int count, nleft, len;
+
+   count = 0;
+   while ((nleft = pixelCount - count) > 0) {
+      len = stbi__get8(s);
+      if (len == 128) {
+         // No-op.
+      } else if (len < 128) {
+         // Copy next len+1 bytes literally.
+         len++;
+         if (len > nleft) return 0; // corrupt data
+         count += len;
+         while (len) {
+            *p = stbi__get8(s);
+            p += 4;
+            len--;
+         }
+      } else if (len > 128) {
+         stbi_uc   val;
+         // Next -len+1 bytes in the dest are replicated from next source byte.
+         // (Interpret len as a negative 8-bit int.)
+         len = 257 - len;
+         if (len > nleft) return 0; // corrupt data
+         val = stbi__get8(s);
+         count += len;
+         while (len) {
+            *p = val;
+            p += 4;
+            len--;
+         }
+      }
+   }
+
+   return 1;
+}
+
+static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
+{
+   int pixelCount;
    int channelCount, compression;
-   int channel, i, count, len;
+   int channel, i;
    int bitdepth;
    int w,h;
    stbi_uc *out;
+   STBI_NOTUSED(ri);
 
    // Check identifier
    if (stbi__get32be(s) != 0x38425053)   // "8BPS"
@@ -5362,8 +5761,18 @@ static stbi_uc *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int 
    if (compression > 1)
       return stbi__errpuc("bad compression", "PSD has an unknown compression format");
 
+   // Check size
+   if (!stbi__mad3sizes_valid(4, w, h, 0))
+      return stbi__errpuc("too large", "Corrupt PSD");
+
    // Create the destination image.
-   out = (stbi_uc *) stbi__malloc(4 * w*h);
+
+   if (!compression && bitdepth == 16 && bpc == 16) {
+      out = (stbi_uc *) stbi__malloc_mad3(8, w, h, 0);
+      ri->bits_per_channel = 16;
+   } else
+      out = (stbi_uc *) stbi__malloc(4 * w*h);
+
    if (!out) return stbi__errpuc("outofmem", "Out of memory");
    pixelCount = w*h;
 
@@ -5395,82 +5804,86 @@ static stbi_uc *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int 
                *p = (channel == 3 ? 255 : 0);
          } else {
             // Read the RLE data.
-            count = 0;
-            while (count < pixelCount) {
-               len = stbi__get8(s);
-               if (len == 128) {
-                  // No-op.
-               } else if (len < 128) {
-                  // Copy next len+1 bytes literally.
-                  len++;
-                  count += len;
-                  while (len) {
-                     *p = stbi__get8(s);
-                     p += 4;
-                     len--;
-                  }
-               } else if (len > 128) {
-                  stbi_uc   val;
-                  // Next -len+1 bytes in the dest are replicated from next source byte.
-                  // (Interpret len as a negative 8-bit int.)
-                  len ^= 0x0FF;
-                  len += 2;
-                  val = stbi__get8(s);
-                  count += len;
-                  while (len) {
-                     *p = val;
-                     p += 4;
-                     len--;
-                  }
-               }
+            if (!stbi__psd_decode_rle(s, p, pixelCount)) {
+               STBI_FREE(out);
+               return stbi__errpuc("corrupt", "bad RLE data");
             }
          }
       }
 
    } else {
       // We're at the raw image data.  It's each channel in order (Red, Green, Blue, Alpha, ...)
-      // where each channel consists of an 8-bit value for each pixel in the image.
+      // where each channel consists of an 8-bit (or 16-bit) value for each pixel in the image.
 
       // Read the data by channel.
       for (channel = 0; channel < 4; channel++) {
-         stbi_uc *p;
-
-         p = out + channel;
          if (channel >= channelCount) {
             // Fill this channel with default data.
-            stbi_uc val = channel == 3 ? 255 : 0;
-            for (i = 0; i < pixelCount; i++, p += 4)
-               *p = val;
-         } else {
-            // Read the data.
-            if (bitdepth == 16) {
-               for (i = 0; i < pixelCount; i++, p += 4)
-                  *p = (stbi_uc) (stbi__get16be(s) >> 8);
+            if (bitdepth == 16 && bpc == 16) {
+               stbi__uint16 *q = ((stbi__uint16 *) out) + channel;
+               stbi__uint16 val = channel == 3 ? 65535 : 0;
+               for (i = 0; i < pixelCount; i++, q += 4)
+                  *q = val;
             } else {
+               stbi_uc *p = out+channel;
+               stbi_uc val = channel == 3 ? 255 : 0;
                for (i = 0; i < pixelCount; i++, p += 4)
-                  *p = stbi__get8(s);
+                  *p = val;
+            }
+         } else {
+            if (ri->bits_per_channel == 16) {    // output bpc
+               stbi__uint16 *q = ((stbi__uint16 *) out) + channel;
+               for (i = 0; i < pixelCount; i++, q += 4)
+                  *q = (stbi__uint16) stbi__get16be(s);
+            } else {
+               stbi_uc *p = out+channel;
+               if (bitdepth == 16) {  // input bpc
+                  for (i = 0; i < pixelCount; i++, p += 4)
+                     *p = (stbi_uc) (stbi__get16be(s) >> 8);
+               } else {
+                  for (i = 0; i < pixelCount; i++, p += 4)
+                     *p = stbi__get8(s);
+               }
             }
          }
       }
    }
 
+   // remove weird white matte from PSD
    if (channelCount >= 4) {
-      for (i=0; i < w*h; ++i) {
-         unsigned char *pixel = out + 4*i;
-         if (pixel[3] != 0 && pixel[3] != 255) {
-            // remove weird white matte from PSD
-            float a = pixel[3] / 255.0f;
-            float ra = 1.0f / a;
-            float inv_a = 255.0f * (1 - ra);
-            pixel[0] = (unsigned char) (pixel[0]*ra + inv_a);
-            pixel[1] = (unsigned char) (pixel[1]*ra + inv_a);
-            pixel[2] = (unsigned char) (pixel[2]*ra + inv_a);
+      if (ri->bits_per_channel == 16) {
+         for (i=0; i < w*h; ++i) {
+            stbi__uint16 *pixel = (stbi__uint16 *) out + 4*i;
+            if (pixel[3] != 0 && pixel[3] != 65535) {
+               float a = pixel[3] / 65535.0f;
+               float ra = 1.0f / a;
+               float inv_a = 65535.0f * (1 - ra);
+               pixel[0] = (stbi__uint16) (pixel[0]*ra + inv_a);
+               pixel[1] = (stbi__uint16) (pixel[1]*ra + inv_a);
+               pixel[2] = (stbi__uint16) (pixel[2]*ra + inv_a);
+            }
+         }
+      } else {
+         for (i=0; i < w*h; ++i) {
+            unsigned char *pixel = out + 4*i;
+            if (pixel[3] != 0 && pixel[3] != 255) {
+               float a = pixel[3] / 255.0f;
+               float ra = 1.0f / a;
+               float inv_a = 255.0f * (1 - ra);
+               pixel[0] = (unsigned char) (pixel[0]*ra + inv_a);
+               pixel[1] = (unsigned char) (pixel[1]*ra + inv_a);
+               pixel[2] = (unsigned char) (pixel[2]*ra + inv_a);
+            }
          }
       }
    }
 
+   // convert to desired output format
    if (req_comp && req_comp != 4) {
-      out = stbi__convert_format(out, 4, req_comp, w, h);
+      if (ri->bits_per_channel == 16)
+         out = (stbi_uc *) stbi__convert_format16((stbi__uint16 *) out, 4, req_comp, w, h);
+      else
+         out = stbi__convert_format(out, 4, req_comp, w, h);
       if (out == NULL) return out; // stbi__convert_format frees input on failure
    }
 
@@ -5654,10 +6067,13 @@ static stbi_uc *stbi__pic_load_core(stbi__context *s,int width,int height,int *c
    return result;
 }
 
-static stbi_uc *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_comp)
+static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_comp, stbi__result_info *ri)
 {
    stbi_uc *result;
-   int i, x,y;
+   int i, x,y, internal_comp;
+   STBI_NOTUSED(ri);
+
+   if (!comp) comp = &internal_comp;
 
    for (i=0; i<92; ++i)
       stbi__get8(s);
@@ -5665,14 +6081,14 @@ static stbi_uc *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int re
    x = stbi__get16be(s);
    y = stbi__get16be(s);
    if (stbi__at_eof(s))  return stbi__errpuc("bad file","file too short (pic header)");
-   if ((1 << 28) / x < y) return stbi__errpuc("too large", "Image too large to decode");
+   if (!stbi__mad3sizes_valid(x, y, 4, 0)) return stbi__errpuc("too large", "PIC image too large to decode");
 
    stbi__get32be(s); //skip `ratio'
    stbi__get16be(s); //skip `fields'
    stbi__get16be(s); //skip `pad'
 
    // intermediate buffer is RGBA
-   result = (stbi_uc *) stbi__malloc(x*y*4);
+   result = (stbi_uc *) stbi__malloc_mad3(x, y, 4, 0);
    memset(result, 0xff, x*y*4);
 
    if (!stbi__pic_load_core(s,x,y,comp, result)) {
@@ -5709,11 +6125,13 @@ typedef struct
 typedef struct
 {
    int w,h;
-   stbi_uc *out, *old_out;             // output buffer (always 4 components)
-   int flags, bgindex, ratio, transparent, eflags, delay;
+   stbi_uc *out;                 // output buffer (always 4 components)
+   stbi_uc *background;          // The current "background" as far as a gif is concerned
+   stbi_uc *history;
+   int flags, bgindex, ratio, transparent, eflags;
    stbi_uc  pal[256][4];
    stbi_uc lpal[256][4];
-   stbi__gif_lzw codes[4096];
+   stbi__gif_lzw codes[8192];
    stbi_uc *color_table;
    int parse, step;
    int lflags;
@@ -5721,6 +6139,7 @@ typedef struct
    int max_x, max_y;
    int cur_x, cur_y;
    int line_size;
+   int delay;
 } stbi__gif;
 
 static int stbi__gif_test_raw(stbi__context *s)
@@ -5796,6 +6215,7 @@ static int stbi__gif_info_raw(stbi__context *s, int *x, int *y, int *comp)
 static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
 {
    stbi_uc *p, *c;
+   int idx;
 
    // recurse to decode the prefixes, since the linked-list is backwards,
    // and working backwards through an interleaved image would be nasty
@@ -5804,10 +6224,12 @@ static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
 
    if (g->cur_y >= g->max_y) return;
 
-   p = &g->out[g->cur_x + g->cur_y];
-   c = &g->color_table[g->codes[code].suffix * 4];
+   idx = g->cur_x + g->cur_y;
+   p = &g->out[idx];
+   g->history[idx / 4] = 1;
 
-   if (c[3] >= 128) {
+   c = &g->color_table[g->codes[code].suffix * 4];
+   if (c[3] > 128) { // don't render transparent pixels;
       p[0] = c[2];
       p[1] = c[1];
       p[2] = c[0];
@@ -5881,11 +6303,16 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
                stbi__skip(s,len);
             return g->out;
          } else if (code <= avail) {
-            if (first) return stbi__errpuc("no clear code", "Corrupt GIF");
+            if (first) {
+               return stbi__errpuc("no clear code", "Corrupt GIF");
+            }
 
             if (oldcode >= 0) {
                p = &g->codes[avail++];
-               if (avail > 4096)        return stbi__errpuc("too many codes", "Corrupt GIF");
+               if (avail > 8192) {
+                  return stbi__errpuc("too many codes", "Corrupt GIF");
+               }
+
                p->prefix = (stbi__int16) oldcode;
                p->first = g->codes[oldcode].first;
                p->suffix = (code == avail) ? p->first : g->codes[code].first;
@@ -5907,59 +6334,72 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
    }
 }
 
-static void stbi__fill_gif_background(stbi__gif *g, int x0, int y0, int x1, int y1)
-{
-   int x, y;
-   stbi_uc *c = g->pal[g->bgindex];
-   for (y = y0; y < y1; y += 4 * g->w) {
-      for (x = x0; x < x1; x += 4) {
-         stbi_uc *p  = &g->out[y + x];
-         p[0] = c[2];
-         p[1] = c[1];
-         p[2] = c[0];
-         p[3] = 0;
-      }
-   }
-}
-
 // this function is designed to support animated gifs, although stb_image doesn't support it
-static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp)
+// two back is the image from two frames ago, used for a very specific disposal format
+static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
 {
-   int i;
-   stbi_uc *prev_out = 0;
+   int dispose;
+   int first_frame;
+   int pi;
+   int pcount;
 
-   if (g->out == 0 && !stbi__gif_header(s, g, comp,0))
-      return 0; // stbi__g_failure_reason set by stbi__gif_header
+   // on first frame, any non-written pixels get the background colour (non-transparent)
+   first_frame = 0;
+   if (g->out == 0) {
+      if (!stbi__gif_header(s, g, comp,0))     return 0; // stbi__g_failure_reason set by stbi__gif_header
+      g->out = (stbi_uc *) stbi__malloc(4 * g->w * g->h);
+      g->background = (stbi_uc *) stbi__malloc(4 * g->w * g->h);
+      g->history = (stbi_uc *) stbi__malloc(g->w * g->h);
+      if (g->out == 0)                      return stbi__errpuc("outofmem", "Out of memory");
 
-   prev_out = g->out;
-   g->out = (stbi_uc *) stbi__malloc(4 * g->w * g->h);
-   if (g->out == 0) return stbi__errpuc("outofmem", "Out of memory");
+      // image is treated as "tranparent" at the start - ie, nothing overwrites the current background;
+      // background colour is only used for pixels that are not rendered first frame, after that "background"
+      // color refers to teh color that was there the previous frame.
+      memset( g->out, 0x00, 4 * g->w * g->h );
+      memset( g->background, 0x00, 4 * g->w * g->h ); // state of the background (starts transparent)
+      memset( g->history, 0x00, g->w * g->h );        // pixels that were affected previous frame
+      first_frame = 1;
+   } else {
+      // second frame - how do we dispoase of the previous one?
+      dispose = (g->eflags & 0x1C) >> 2;
+      pcount = g->w * g->h;
 
-   switch ((g->eflags & 0x1C) >> 2) {
-      case 0: // unspecified (also always used on 1st frame)
-         stbi__fill_gif_background(g, 0, 0, 4 * g->w, 4 * g->w * g->h);
-         break;
-      case 1: // do not dispose
-         if (prev_out) memcpy(g->out, prev_out, 4 * g->w * g->h);
-         g->old_out = prev_out;
-         break;
-      case 2: // dispose to background
-         if (prev_out) memcpy(g->out, prev_out, 4 * g->w * g->h);
-         stbi__fill_gif_background(g, g->start_x, g->start_y, g->max_x, g->max_y);
-         break;
-      case 3: // dispose to previous
-         if (g->old_out) {
-            for (i = g->start_y; i < g->max_y; i += 4 * g->w)
-               memcpy(&g->out[i + g->start_x], &g->old_out[i + g->start_x], g->max_x - g->start_x);
+      if ((dispose == 3) && (two_back == 0)) {
+         dispose = 2; // if I don't have an image to revert back to, default to the old background
+      }
+
+      if (dispose == 3) { // use previous graphic
+         for (pi = 0; pi < pcount; ++pi) {
+            if (g->history[pi]) {
+               memcpy( &g->out[pi * 4], &two_back[pi * 4], 4 );
+            }
          }
-         break;
+      } else if (dispose == 2) {
+         // restore what was changed last frame to background before that frame;
+         for (pi = 0; pi < pcount; ++pi) {
+            if (g->history[pi]) {
+               memcpy( &g->out[pi * 4], &g->background[pi * 4], 4 );
+            }
+         }
+      } else {
+         // This is a non-disposal case eithe way, so just
+         // leave the pixels as is, and they will become the new background
+         // 1: do not dispose
+         // 0:  not specified.
+      }
+
+      // background is what out is after the undoing of the previou frame;
+      memcpy( g->background, g->out, 4 * g->w * g->h );
    }
+
+   // clear my history;
+   memset( g->history, 0x00, g->w * g->h );        // pixels that were affected previous frame
 
    for (;;) {
-      switch (stbi__get8(s)) {
+      int tag = stbi__get8(s);
+      switch (tag) {
          case 0x2C: /* Image Descriptor */
          {
-            int prev_trans = -1;
             stbi__int32 x, y, w, h;
             stbi_uc *o;
 
@@ -5992,10 +6432,6 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
                stbi__gif_parse_colortable(s,g->lpal, 2 << (g->lflags & 7), g->eflags & 0x01 ? g->transparent : -1);
                g->color_table = (stbi_uc *) g->lpal;
             } else if (g->flags & 0x80) {
-               if (g->transparent >= 0 && (g->eflags & 0x01)) {
-                  prev_trans = g->pal[g->transparent][3];
-                  g->pal[g->transparent][3] = 0;
-               }
                g->color_table = (stbi_uc *) g->pal;
             } else
                return stbi__errpuc("missing color table", "Corrupt GIF");
@@ -6003,8 +6439,17 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
             o = stbi__process_gif_raster(s, g);
             if (o == NULL) return NULL;
 
-            if (prev_trans != -1)
-               g->pal[g->transparent][3] = (stbi_uc) prev_trans;
+            // if this was the first frame,
+            pcount = g->w * g->h;
+            if (first_frame && (g->bgindex > 0)) {
+               // if first frame, any pixel not drawn to gets the background color
+               for (pi = 0; pi < pcount; ++pi) {
+                  if (g->history[pi] == 0) {
+                     g->pal[g->bgindex][3] = 255; // just in case it was made transparent, undo that; It will be reset next frame if need be;
+                     memcpy( &g->out[pi * 4], &g->pal[g->bgindex], 4 );
+                  }
+               }
+            }
 
             return o;
          }
@@ -6012,19 +6457,35 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
          case 0x21: // Comment Extension.
          {
             int len;
-            if (stbi__get8(s) == 0xF9) { // Graphic Control Extension.
+            int ext = stbi__get8(s);
+            if (ext == 0xF9) { // Graphic Control Extension.
                len = stbi__get8(s);
                if (len == 4) {
                   g->eflags = stbi__get8(s);
-                  g->delay = stbi__get16le(s);
-                  g->transparent = stbi__get8(s);
+                  g->delay = 10 * stbi__get16le(s); // delay - 1/100th of a second, saving as 1/1000ths.
+
+                  // unset old transparent
+                  if (g->transparent >= 0) {
+                     g->pal[g->transparent][3] = 255;
+                  }
+                  if (g->eflags & 0x01) {
+                     g->transparent = stbi__get8(s);
+                     if (g->transparent >= 0) {
+                        g->pal[g->transparent][3] = 0;
+                     }
+                  } else {
+                     // don't need transparent
+                     stbi__skip(s, 1);
+                     g->transparent = -1;
+                  }
                } else {
                   stbi__skip(s, len);
                   break;
                }
             }
-            while ((len = stbi__get8(s)) != 0)
+            while ((len = stbi__get8(s)) != 0) {
                stbi__skip(s, len);
+            }
             break;
          }
 
@@ -6035,27 +6496,92 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
             return stbi__errpuc("unknown code", "Corrupt GIF");
       }
    }
-
-   STBI_NOTUSED(req_comp);
 }
 
-static stbi_uc *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
+{
+   if (stbi__gif_test(s)) {
+      int layers = 0;
+      stbi_uc *u = 0;
+      stbi_uc *out = 0;
+      stbi_uc *two_back = 0;
+      stbi__gif g;
+      int stride;
+      memset(&g, 0, sizeof(g));
+      if (delays) {
+         *delays = 0;
+      }
+
+      do {
+         u = stbi__gif_load_next(s, &g, comp, req_comp, two_back);
+         if (u == (stbi_uc *) s) u = 0;  // end of animated gif marker
+
+         if (u) {
+            *x = g.w;
+            *y = g.h;
+            ++layers;
+            stride = g.w * g.h * 4;
+
+            if (out) {
+               out = (stbi_uc*) STBI_REALLOC( out, layers * stride );
+               if (delays) {
+                  *delays = (int*) STBI_REALLOC( *delays, sizeof(int) * layers );
+               }
+            } else {
+               out = (stbi_uc*)stbi__malloc( layers * stride );
+               if (delays) {
+                  *delays = (int*) stbi__malloc( layers * sizeof(int) );
+               }
+            }
+            memcpy( out + ((layers - 1) * stride), u, stride );
+            if (layers >= 2) {
+               two_back = out - 2 * stride;
+            }
+
+            if (delays) {
+               (*delays)[layers - 1U] = g.delay;
+            }
+         }
+      } while (u != 0);
+
+      // free temp buffer;
+      STBI_FREE(g.out);
+      STBI_FREE(g.history);
+      STBI_FREE(g.background);
+
+      // do the final conversion after loading everything;
+      if (req_comp && req_comp != 4)
+         out = stbi__convert_format(out, 4, req_comp, layers * g.w, g.h);
+
+      *z = layers;
+      return out;
+   } else {
+      return stbi__errpuc("not GIF", "Image was not as a gif type.");
+   }
+}
+
+static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
    stbi_uc *u = 0;
-   stbi__gif* g = (stbi__gif*) stbi__malloc(sizeof(stbi__gif));
-   memset(g, 0, sizeof(*g));
+   stbi__gif g;
+   memset(&g, 0, sizeof(g));
 
-   u = stbi__gif_load_next(s, g, comp, req_comp);
+   u = stbi__gif_load_next(s, &g, comp, req_comp, 0);
    if (u == (stbi_uc *) s) u = 0;  // end of animated gif marker
    if (u) {
-      *x = g->w;
-      *y = g->h;
+      *x = g.w;
+      *y = g.h;
+
+      // moved conversion to after successful load so that the same
+      // can be done for multiple frames.
       if (req_comp && req_comp != 4)
-         u = stbi__convert_format(u, 4, req_comp, g->w, g->h);
+         u = stbi__convert_format(u, 4, req_comp, g.w, g.h);
    }
-   else if (g->out)
-      STBI_FREE(g->out);
-   STBI_FREE(g);
+
+   // free buffers needed for multiple frame loading;
+   STBI_FREE(g.history);
+   STBI_FREE(g.background);
+
    return u;
 }
 
@@ -6069,20 +6595,24 @@ static int stbi__gif_info(stbi__context *s, int *x, int *y, int *comp)
 // Radiance RGBE HDR loader
 // originally by Nicolas Schulz
 #ifndef STBI_NO_HDR
-static int stbi__hdr_test_core(stbi__context *s)
+static int stbi__hdr_test_core(stbi__context *s, const char *signature)
 {
-   const char *signature = "#?RADIANCE\n";
    int i;
    for (i=0; signature[i]; ++i)
       if (stbi__get8(s) != signature[i])
-         return 0;
+          return 0;
+   stbi__rewind(s);
    return 1;
 }
 
 static int stbi__hdr_test(stbi__context* s)
 {
-   int r = stbi__hdr_test_core(s);
+   int r = stbi__hdr_test_core(s, "#?RADIANCE\n");
    stbi__rewind(s);
+   if(!r) {
+       r = stbi__hdr_test_core(s, "#?RGBE\n");
+       stbi__rewind(s);
+   }
    return r;
 }
 
@@ -6136,7 +6666,7 @@ static void stbi__hdr_convert(float *output, stbi_uc *input, int req_comp)
    }
 }
 
-static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
    char buffer[STBI__HDR_BUFLEN];
    char *token;
@@ -6147,10 +6677,12 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
    int len;
    unsigned char count, value;
    int i, j, k, c1,c2, z;
-
+   const char *headerToken;
+   STBI_NOTUSED(ri);
 
    // Check identifier
-   if (strcmp(stbi__hdr_gettoken(s,buffer), "#?RADIANCE") != 0)
+   headerToken = stbi__hdr_gettoken(s,buffer);
+   if (strcmp(headerToken, "#?RADIANCE") != 0 && strcmp(headerToken, "#?RGBE") != 0)
       return stbi__errpf("not HDR", "Corrupt HDR image");
 
    // Parse header
@@ -6179,8 +6711,13 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
    if (comp) *comp = 3;
    if (req_comp == 0) req_comp = 3;
 
+   if (!stbi__mad4sizes_valid(width, height, req_comp, sizeof(float), 0))
+      return stbi__errpf("too large", "HDR image is too large");
+
    // Read data
-   hdr_data = (float *) stbi__malloc(height * width * req_comp * sizeof(float));
+   hdr_data = (float *) stbi__malloc_mad4(width, height, req_comp, sizeof(float), 0);
+   if (!hdr_data)
+      return stbi__errpf("outofmem", "Out of memory");
 
    // Load image data
    // image data is stored as some number of sca
@@ -6219,20 +6756,29 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
          len <<= 8;
          len |= stbi__get8(s);
          if (len != width) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("invalid decoded scanline length", "corrupt HDR"); }
-         if (scanline == NULL) scanline = (stbi_uc *) stbi__malloc(width * 4);
+         if (scanline == NULL) {
+            scanline = (stbi_uc *) stbi__malloc_mad2(width, 4, 0);
+            if (!scanline) {
+               STBI_FREE(hdr_data);
+               return stbi__errpf("outofmem", "Out of memory");
+            }
+         }
 
          for (k = 0; k < 4; ++k) {
+            int nleft;
             i = 0;
-            while (i < width) {
+            while ((nleft = width - i) > 0) {
                count = stbi__get8(s);
                if (count > 128) {
                   // Run
                   value = stbi__get8(s);
                   count -= 128;
+                  if (count > nleft) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("corrupt", "bad RLE data in HDR"); }
                   for (z = 0; z < count; ++z)
                      scanline[i++ * 4 + k] = value;
                } else {
                   // Dump
+                  if (count > nleft) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("corrupt", "bad RLE data in HDR"); }
                   for (z = 0; z < count; ++z)
                      scanline[i++ * 4 + k] = stbi__get8(s);
                }
@@ -6241,7 +6787,8 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
          for (i=0; i < width; ++i)
             stbi__hdr_convert(hdr_data+(j*width + i)*req_comp, scanline + i*4, req_comp);
       }
-      STBI_FREE(scanline);
+      if (scanline)
+         STBI_FREE(scanline);
    }
 
    return hdr_data;
@@ -6252,6 +6799,11 @@ static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
    char buffer[STBI__HDR_BUFLEN];
    char *token;
    int valid = 0;
+   int dummy;
+
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
 
    if (stbi__hdr_test(s) == 0) {
        stbi__rewind( s );
@@ -6298,9 +6850,9 @@ static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp)
    stbi__rewind( s );
    if (p == NULL)
       return 0;
-   *x = s->img_x;
-   *y = s->img_y;
-   *comp = info.ma ? 4 : 3;
+   if (x) *x = s->img_x;
+   if (y) *y = s->img_y;
+   if (comp) *comp = info.ma ? 4 : 3;
    return 1;
 }
 #endif
@@ -6308,7 +6860,10 @@ static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp)
 #ifndef STBI_NO_PSD
 static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
 {
-   int channelCount;
+   int channelCount, dummy, depth;
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
    if (stbi__get32be(s) != 0x38425053) {
        stbi__rewind( s );
        return 0;
@@ -6325,7 +6880,8 @@ static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
    }
    *y = stbi__get32be(s);
    *x = stbi__get32be(s);
-   if (stbi__get16be(s) != 8) {
+   depth = stbi__get16be(s);
+   if (depth != 8 && depth != 16) {
        stbi__rewind( s );
        return 0;
    }
@@ -6336,13 +6892,44 @@ static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
    *comp = 4;
    return 1;
 }
+
+static int stbi__psd_is16(stbi__context *s)
+{
+   int channelCount, depth;
+   if (stbi__get32be(s) != 0x38425053) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 1) {
+       stbi__rewind( s );
+       return 0;
+   }
+   stbi__skip(s, 6);
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   (void) stbi__get32be(s);
+   (void) stbi__get32be(s);
+   depth = stbi__get16be(s);
+   if (depth != 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   return 1;
+}
 #endif
 
 #ifndef STBI_NO_PIC
 static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
 {
-   int act_comp=0,num_packets=0,chained;
+   int act_comp=0,num_packets=0,chained,dummy;
    stbi__pic_packet packets[10];
+
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
 
    if (!stbi__pic_is4(s,"\x53\x80\xF6\x34")) {
       stbi__rewind(s);
@@ -6419,16 +7006,22 @@ static int      stbi__pnm_test(stbi__context *s)
    return 1;
 }
 
-static stbi_uc *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
    stbi_uc *out;
+   STBI_NOTUSED(ri);
+
    if (!stbi__pnm_info(s, (int *)&s->img_x, (int *)&s->img_y, (int *)&s->img_n))
       return 0;
+
    *x = s->img_x;
    *y = s->img_y;
-   *comp = s->img_n;
+   if (comp) *comp = s->img_n;
 
-   out = (stbi_uc *) stbi__malloc(s->img_n * s->img_x * s->img_y);
+   if (!stbi__mad3sizes_valid(s->img_n, s->img_x, s->img_y, 0))
+      return stbi__errpuc("too large", "PNM too large");
+
+   out = (stbi_uc *) stbi__malloc_mad3(s->img_n, s->img_x, s->img_y, 0);
    if (!out) return stbi__errpuc("outofmem", "Out of memory");
    stbi__getn(s, out, s->img_n * s->img_x * s->img_y);
 
@@ -6477,16 +7070,20 @@ static int      stbi__pnm_getinteger(stbi__context *s, char *c)
 
 static int      stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp)
 {
-   int maxv;
+   int maxv, dummy;
    char c, p, t;
 
-   stbi__rewind( s );
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+
+   stbi__rewind(s);
 
    // Get identifier
    p = (char) stbi__get8(s);
    t = (char) stbi__get8(s);
    if (p != 'P' || (t != '5' && t != '6')) {
-       stbi__rewind( s );
+       stbi__rewind(s);
        return 0;
    }
 
@@ -6552,6 +7149,19 @@ static int stbi__info_main(stbi__context *s, int *x, int *y, int *comp)
    return stbi__err("unknown image type", "Image not of any known type, or corrupt");
 }
 
+static int stbi__is_16_main(stbi__context *s)
+{
+   #ifndef STBI_NO_PNG
+   if (stbi__png_is16(s))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_is16(s))  return 1;
+   #endif
+
+   return 0;
+}
+
 #ifndef STBI_NO_STDIO
 STBIDEF int stbi_info(char const *filename, int *x, int *y, int *comp)
 {
@@ -6573,6 +7183,27 @@ STBIDEF int stbi_info_from_file(FILE *f, int *x, int *y, int *comp)
    fseek(f,pos,SEEK_SET);
    return r;
 }
+
+STBIDEF int stbi_is_16_bit(char const *filename)
+{
+    FILE *f = stbi__fopen(filename, "rb");
+    int result;
+    if (!f) return stbi__err("can't fopen", "Unable to open file");
+    result = stbi_is_16_bit_from_file(f);
+    fclose(f);
+    return result;
+}
+
+STBIDEF int stbi_is_16_bit_from_file(FILE *f)
+{
+   int r;
+   stbi__context s;
+   long pos = ftell(f);
+   stbi__start_file(&s, f);
+   r = stbi__is_16_main(&s);
+   fseek(f,pos,SEEK_SET);
+   return r;
+}
 #endif // !STBI_NO_STDIO
 
 STBIDEF int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
@@ -6589,10 +7220,43 @@ STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const *c, void *user, int
    return stbi__info_main(&s,x,y,comp);
 }
 
+STBIDEF int stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__is_16_main(&s);
+}
+
+STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) c, user);
+   return stbi__is_16_main(&s);
+}
+
 #endif // STB_IMAGE_IMPLEMENTATION
 
 /*
    revision history:
+      2.19  (2018-02-11) fix warning
+      2.18  (2018-01-30) fix warnings
+      2.17  (2018-01-29) change sbti__shiftsigned to avoid clang -O2 bug
+                         1-bit BMP
+                         *_is_16_bit api
+                         avoid warnings
+      2.16  (2017-07-23) all functions have 16-bit variants;
+                         STBI_NO_STDIO works again;
+                         compilation fixes;
+                         fix rounding in unpremultiply;
+                         optimize vertical flip;
+                         disable raw_len validation;
+                         documentation fixes
+      2.15  (2017-03-18) fix png-1,2,4 bug; now all Imagenet JPGs decode;
+                         warning fixes; disable run-time SSE detection on gcc;
+                         uniform handling of optional "return" values;
+                         thread-safe initialization of zlib tables
+      2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
+      2.13  (2016-11-29) add 16-bit API, only supported for PNG right now
       2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
       2.11  (2016-04-02) allocate large structures on the stack
                          remove white matting for transparent PSD
@@ -6752,4 +7416,47 @@ STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const *c, void *user, int
               on 'test' only check type, not whether we support this variant
       0.50  (2006-11-19)
               first released version
+*/
+
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
 */

--- a/core/include/tangram/data/clientGeoJsonSource.h
+++ b/core/include/tangram/data/clientGeoJsonSource.h
@@ -18,9 +18,9 @@ class ClientGeoJsonSource : public TileSource {
 
 public:
 
-    ClientGeoJsonSource(std::shared_ptr<Platform> _platform, const std::string& _name,
-            const std::string& _url, bool generateCentroids = false,
-            TileSource::ZoomOptions _zoomOptions = {});
+    ClientGeoJsonSource(Platform& _platform, const std::string& _name,
+                        const std::string& _url, bool generateCentroids = false,
+                        TileSource::ZoomOptions _zoomOptions = {});
     ~ClientGeoJsonSource();
 
     // http://www.iana.org/assignments/media-types/application/geo+json
@@ -49,7 +49,7 @@ protected:
     bool m_hasPendingData = false;
     bool m_generateCentroids = false;
 
-    std::shared_ptr<Platform> m_platform;
+    Platform& m_platform;
 
 };
 

--- a/core/include/tangram/data/clientGeoJsonSource.h
+++ b/core/include/tangram/data/clientGeoJsonSource.h
@@ -33,10 +33,10 @@ public:
     void addPoly(const Properties& _tags, const std::vector<Coordinates>& _poly);
     void generateLabelCentroidFeature();
 
-    virtual void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
+    virtual void loadTileTask(std::shared_ptr<TileTask> _task) override;
     std::shared_ptr<TileTask> createTask(Scene& _scene, TileID _tileId, int _subTask) override;
 
-    virtual void cancelLoadingTile(TileTask& _task) override {};
+    virtual void cancelTileTask(TileTask& _task) override {};
     virtual void clearData() override;
 
 protected:

--- a/core/include/tangram/data/clientGeoJsonSource.h
+++ b/core/include/tangram/data/clientGeoJsonSource.h
@@ -34,7 +34,7 @@ public:
     void generateLabelCentroidFeature();
 
     virtual void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
-    std::shared_ptr<TileTask> createTask(TileID _tileId, int _subTask) override;
+    std::shared_ptr<TileTask> createTask(Scene& _scene, TileID _tileId, int _subTask) override;
 
     virtual void cancelLoadingTile(TileTask& _task) override {};
     virtual void clearData() override;

--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -17,7 +17,7 @@ class TileManager;
 struct RawCache;
 class Texture;
 
-class TileSource : public std::enable_shared_from_this<TileSource> {
+class TileSource {
 
 public:
 
@@ -113,7 +113,7 @@ public:
     virtual void clearRasters();
     virtual void clearRaster(const TileID& id);
 
-    virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask = -1);
+    virtual std::shared_ptr<TileTask> createTask(Scene& _scene, TileID _tile, int _subTask = -1);
 
     /* ID of this TileSource instance */
     int32_t id() const { return m_id; }
@@ -133,7 +133,7 @@ public:
     }
 
     /* assign/get raster datasources to this datasource */
-    void addRasterSource(std::shared_ptr<TileSource> _dataSource);
+    void addRasterSource(TileSource* _dataSource);
     auto& rasterSources() { return m_rasterSources; }
     const auto& rasterSources() const { return m_rasterSources; }
 
@@ -147,7 +147,7 @@ public:
 
 protected:
 
-    void createSubTasks(std::shared_ptr<TileTask> _task);
+    void createSubTasks(Scene& _scene, TileTask& _task);
 
     // This datasource is used to generate actual tile geometry
     bool m_generateGeometry = false;
@@ -167,7 +167,7 @@ protected:
     Format m_format = Format::GeoJson;
 
     /* vector of raster sources (as raster samplers) referenced by this datasource */
-    std::vector<std::shared_ptr<TileSource>> m_rasterSources;
+    std::vector<TileSource*> m_rasterSources;
 
     std::unique_ptr<DataSource> m_sources;
 };

--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -53,7 +53,7 @@ public:
     struct DataSource {
         virtual ~DataSource() {}
 
-        virtual bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) = 0;
+        virtual bool loadTileData(std::shared_ptr<TileTask> _task) = 0;
 
         /* Stops any running I/O tasks pertaining to @_tile */
         virtual void cancelLoadingTile(TileTask& _task) {
@@ -97,10 +97,10 @@ public:
      * the I/O task is complete, the tile data is added to a queue in @_tileManager for
      * further processing before it is renderable.
      */
-    virtual void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb);
+    virtual void loadTileTask(std::shared_ptr<TileTask> _task);
 
     /* Stops any running I/O tasks pertaining to @_task */
-    virtual void cancelLoadingTile(TileTask& _task);
+    virtual void cancelTileTask(TileTask& _task);
 
     /* Parse a <TileTask> with data into a <TileData>, returning an empty TileData on failure */
     virtual std::shared_ptr<TileData> parse(const TileTask& _task) const;

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -142,7 +142,7 @@ class Map {
 public:
 
     // Create an empty map object. To display a map, call either loadScene() or loadSceneAsync().
-    Map(std::shared_ptr<Platform> _platform);
+    explicit Map(std::unique_ptr<Platform> _platform);
     ~Map();
 
     // Load the scene at the given absolute file path asynchronously.
@@ -418,22 +418,22 @@ public:
     // r, g, b must be between 0.0 and 1.0
     void setDefaultBackgroundColor(float r, float g, float b);
 
-    std::shared_ptr<Platform>& getPlatform();
+    Platform& getPlatform();
+
+protected:
+
+    std::unique_ptr<Platform> platform;
+
+    SceneID loadSceneAsync(std::shared_ptr<Scene> _scene,
+                           const std::vector<SceneUpdate>& _sceneUpdates = {});
+
+    SceneID loadScene(std::shared_ptr<Scene> _scene,
+                      const std::vector<SceneUpdate>& _sceneUpdates = {});
 
 private:
 
     class Impl;
     std::unique_ptr<Impl> impl;
-
-protected:
-
-    std::shared_ptr<Platform> platform;
-
-    SceneID loadSceneAsync(std::shared_ptr<Scene> _scene,
-                       const std::vector<SceneUpdate>& _sceneUpdates = {});
-
-    SceneID loadScene(std::shared_ptr<Scene> _scene,
-                  const std::vector<SceneUpdate>& _sceneUpdates = {});
 
 };
 

--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -14,6 +14,7 @@ namespace Tangram {
 class Platform;
 class TileSource;
 class Scene;
+class SceneOptions;
 
 enum LabelType {
     icon,
@@ -424,11 +425,9 @@ protected:
 
     std::unique_ptr<Platform> platform;
 
-    SceneID loadSceneAsync(std::shared_ptr<Scene> _scene,
-                           const std::vector<SceneUpdate>& _sceneUpdates = {});
+    SceneID loadSceneAsync(std::unique_ptr<SceneOptions> _sceneOptions);
 
-    SceneID loadScene(std::shared_ptr<Scene> _scene,
-                      const std::vector<SceneUpdate>& _sceneUpdates = {});
+    SceneID loadScene(std::unique_ptr<SceneOptions> _sceneOptions);
 
 private:
 

--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -61,6 +61,7 @@ public:
     Platform();
     virtual ~Platform();
 
+    virtual void shutdown() = 0;
     // Request that a new frame be rendered by the windowing system
     virtual void requestRender() const = 0;
 

--- a/core/include/tangram/tile/tileTask.h
+++ b/core/include/tangram/tile/tileTask.h
@@ -10,6 +10,7 @@
 
 namespace Tangram {
 
+class Scene;
 class TileManager;
 class TileBuilder;
 class TileSource;
@@ -22,7 +23,7 @@ class TileTask {
 
 public:
 
-    TileTask(TileID& _tileId, std::shared_ptr<TileSource> _source, int _subTask);
+    TileTask(TileID& _tileId, Scene& _scene, TileSource& _source, int _subTask);
 
     // No copies
     TileTask(const TileTask& _other) = delete;
@@ -43,7 +44,8 @@ public:
     std::unique_ptr<Tile> getTile();
     void setTile(std::unique_ptr<Tile>&& _tile);
 
-    std::shared_ptr<TileSource> source() { return m_source.lock(); }
+    std::shared_ptr<Scene> scene() { return m_scene.lock(); }
+    TileSource& source();
     int64_t sourceId() { return m_sourceId; }
     int64_t sourceGeneration() const { return m_sourceGeneration; }
 
@@ -93,8 +95,8 @@ protected:
 
     const int m_subTaskId;
 
-    // Save shared reference to Datasource while building tile
-    std::weak_ptr<TileSource> m_source;
+    // Save shared reference to Scene while building tile
+    std::weak_ptr<Scene> m_scene;
 
     // Vector of tasks to download raster samplers
     std::vector<std::shared_ptr<TileTask>> m_subTasks;
@@ -115,8 +117,8 @@ protected:
 
 class BinaryTileTask : public TileTask {
 public:
-    BinaryTileTask(TileID& _tileId, std::shared_ptr<TileSource> _source, int _subTask)
-        : TileTask(_tileId, _source, _subTask) {}
+    BinaryTileTask(TileID& _tileId, Scene& _scene, TileSource& _source, int _subTask)
+        : TileTask(_tileId, _scene, _source, _subTask) {}
 
     virtual bool hasData() const override {
         return rawTileData && !rawTileData->empty();

--- a/core/include/tangram/tile/tileTask.h
+++ b/core/include/tangram/tile/tileTask.h
@@ -17,9 +17,11 @@ class TileSource;
 class Tile;
 class MapProjection;
 struct TileData;
+class TileTask;
 
+using TileTaskCb = std::function<void(std::shared_ptr<TileTask>)>;
 
-class TileTask {
+class TileTask : public std::enable_shared_from_this<TileTask> {
 
 public:
 
@@ -89,6 +91,10 @@ public:
 
     void startedLoading() { m_needsLoading = false; }
 
+    TileTaskCb cb;
+
+    void done() { cb(shared_from_this()); }
+
 protected:
 
     const TileID m_tileId;
@@ -113,6 +119,7 @@ protected:
 
     std::atomic<float> m_priority;
     std::atomic<bool> m_proxyState;
+
 };
 
 class BinaryTileTask : public TileTask {
@@ -136,8 +143,5 @@ struct TileTaskQueue {
     virtual void enqueue(std::shared_ptr<TileTask> task) = 0;
 };
 
-struct TileTaskCb {
-    std::function<void(std::shared_ptr<TileTask>)> func;
-};
 
 }

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -46,9 +46,8 @@ std::shared_ptr<TileTask> ClientGeoJsonSource::createTask(TileID _tileId, int _s
 
 
 // TODO: pass scene's resourcePath to constructor to be used with `stringFromFile`
-ClientGeoJsonSource::ClientGeoJsonSource(std::shared_ptr<Platform> _platform,
-                                         const std::string& _name, const std::string& _url,
-                                         bool _generateCentroids,
+ClientGeoJsonSource::ClientGeoJsonSource(Platform& _platform, const std::string& _name,
+                                         const std::string& _url, bool _generateCentroids,
                                          TileSource::ZoomOptions _zoomOptions)
 
     : TileSource(_name, nullptr, _zoomOptions),
@@ -67,7 +66,7 @@ ClientGeoJsonSource::ClientGeoJsonSource(std::shared_ptr<Platform> _platform,
             }
             m_hasPendingData = false;
         };
-        m_platform->startUrlRequest(_url, onUrlFinished);
+        m_platform.startUrlRequest(_url, onUrlFinished);
         m_hasPendingData = true;
     }
 

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -40,8 +40,8 @@ struct ClientGeoJsonData {
     std::vector<Properties> properties;
 };
 
-std::shared_ptr<TileTask> ClientGeoJsonSource::createTask(TileID _tileId, int _subTask) {
-    return std::make_shared<TileTask>(_tileId, shared_from_this(), _subTask);
+std::shared_ptr<TileTask> ClientGeoJsonSource::createTask(Scene& _scene, TileID _tileId, int _subTask) {
+    return std::make_shared<TileTask>(_tileId, _scene, *this, _subTask);
 }
 
 

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -183,20 +183,21 @@ void ClientGeoJsonSource::addData(const std::string& _data) {
     m_generation++;
 }
 
-void ClientGeoJsonSource::loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) {
+void ClientGeoJsonSource::loadTileTask(std::shared_ptr<TileTask> _task) {
 
     if (m_hasPendingData) {
         return;
     }
 
     if (_task->needsLoading()) {
+        // Pass directly to TileWorker
         _task->startedLoading();
 
-        _cb.func(_task);
+        _task->done();
     }
 
     // Load subsources
-    TileSource::loadTileData(_task, _cb);
+    TileSource::loadTileTask(_task);
 }
 
 void ClientGeoJsonSource::clearData() {

--- a/core/src/data/formats/mvt.cpp
+++ b/core/src/data/formats/mvt.cpp
@@ -9,6 +9,8 @@
 #include <algorithm>
 #include <iterator>
 
+#define LAYER 3
+
 #define FEATURE_ID 1
 #define FEATURE_TAGS 2
 #define FEATURE_TYPE 3
@@ -330,9 +332,10 @@ std::shared_ptr<TileData> Mvt::parseTile(const TileTask& _task, int32_t _sourceI
 
     try {
         while(item.next()) {
-            if(item.tag == 3) {
+            if(item.tag == LAYER) {
                 tileData->layers.push_back(getLayer(ctx, item.getMessage()));
             } else {
+                LOG("skip %d", (item.value & 0x7));
                 item.skip();
             }
         }

--- a/core/src/data/mbtilesDataSource.cpp
+++ b/core/src/data/mbtilesDataSource.cpp
@@ -115,8 +115,8 @@ struct MBTilesQueries {
 
 };
 
-MBTilesDataSource::MBTilesDataSource(std::shared_ptr<Platform> _platform, std::string _name,
-                                     std::string _path, std::string _mime, bool _cache, bool _offlineFallback)
+MBTilesDataSource::MBTilesDataSource(Platform& _platform, std::string _name, std::string _path,
+                                     std::string _mime, bool _cache, bool _offlineFallback)
     : m_name(_name),
       m_path(_path),
       m_mime(_mime),
@@ -169,7 +169,7 @@ bool MBTilesDataSource::loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb
                     // Trigger TileManager update so that tile will be
                     // downloaded next time.
                     _task->setNeedsLoading(true);
-                    m_platform->requestRender();
+                    m_platform.requestRender();
                 }
             } else {
                 LOGW("missing tile: %s, %d", _task->tileId().toString().c_str());

--- a/core/src/data/mbtilesDataSource.h
+++ b/core/src/data/mbtilesDataSource.h
@@ -17,7 +17,7 @@ class AsyncWorker;
 class MBTilesDataSource : public TileSource::DataSource {
 public:
 
-    MBTilesDataSource(std::shared_ptr<Platform> _platform, std::string _name, std::string _path, std::string _mime,
+    MBTilesDataSource(Platform& _platform, std::string _name, std::string _path, std::string _mime,
                       bool _cache = false, bool _offlineFallback = false);
 
     ~MBTilesDataSource();
@@ -53,7 +53,7 @@ private:
     std::unique_ptr<AsyncWorker> m_worker;
 
     // Platform reference
-    std::shared_ptr<Platform> m_platform;
+    Platform& m_platform;
 
     enum class Compression {
         undefined,

--- a/core/src/data/mbtilesDataSource.h
+++ b/core/src/data/mbtilesDataSource.h
@@ -22,14 +22,14 @@ public:
 
     ~MBTilesDataSource();
 
-    bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
+    bool loadTileData(std::shared_ptr<TileTask> _task) override;
 
     void clear() override {}
 
 private:
     bool getTileData(const TileID& _tileId, std::vector<char>& _data);
     void storeTileData(const TileID& _tileId, const std::vector<char>& _data);
-    bool loadNextSource(std::shared_ptr<TileTask> _task, TileTaskCb _cb);
+    bool loadNextSource(std::shared_ptr<TileTask> _task);
 
     void openMBTiles();
     bool testSchema(SQLite::Database& db);

--- a/core/src/data/memoryCacheDataSource.h
+++ b/core/src/data/memoryCacheDataSource.h
@@ -10,7 +10,7 @@ public:
     MemoryCacheDataSource();
     ~MemoryCacheDataSource();
 
-    bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
+    bool loadTileData(std::shared_ptr<TileTask> _task) override;
 
     void clear() override;
 

--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -5,8 +5,8 @@
 
 namespace Tangram {
 
-NetworkDataSource::NetworkDataSource(std::shared_ptr<Platform> _platform, const std::string& _urlTemplate,
-        std::vector<std::string>&& _urlSubdomains, bool isTms) :
+NetworkDataSource::NetworkDataSource(Platform& _platform, const std::string& _urlTemplate,
+                                     std::vector<std::string>&& _urlSubdomains, bool isTms) :
     m_platform(_platform),
     m_urlTemplate(_urlTemplate),
     m_urlSubdomains(std::move(_urlSubdomains)),
@@ -81,7 +81,7 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
     };
 
     auto& dlTask = static_cast<BinaryTileTask&>(*task);
-    dlTask.urlRequestHandle = m_platform->startUrlRequest(url, onRequestFinish);
+    dlTask.urlRequestHandle = m_platform.startUrlRequest(url, onRequestFinish);
     dlTask.urlRequestStarted = true;
 
     return true;
@@ -92,7 +92,7 @@ void NetworkDataSource::cancelLoadingTile(TileTask& task) {
     if (dlTask.urlRequestStarted) {
         dlTask.urlRequestStarted = false;
 
-        m_platform->cancelUrlRequest(dlTask.urlRequestHandle);
+        m_platform.cancelUrlRequest(dlTask.urlRequestHandle);
     }
 }
 

--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -43,7 +43,7 @@ std::string NetworkDataSource::buildUrlForTile(const TileID& tile, size_t subdom
     return url;
 }
 
-bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb callback) {
+bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task) {
 
     if (task->rawSource != this->level) {
         LOGE("NetworkDataSource must be last!");
@@ -58,7 +58,7 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
         m_urlSubdomainIndex = (m_urlSubdomainIndex + 1) % m_urlSubdomains.size();
     }
 
-    UrlCallback onRequestFinish = [callback, task, url](UrlResponse&& response) {
+    UrlCallback onRequestFinish = [task, url](UrlResponse&& response) {
 
         auto scene = task->scene();
         if (!scene) {
@@ -77,7 +77,8 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
             auto& dlTask = static_cast<BinaryTileTask&>(*task);
             dlTask.rawTileData = std::make_shared<std::vector<char>>(std::move(response.content));
         }
-        callback.func(task);
+        LOGD("DONE %p", task.get());
+        task->done();
     };
 
     auto& dlTask = static_cast<BinaryTileTask&>(*task);

--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -60,9 +60,9 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
 
     UrlCallback onRequestFinish = [callback, task, url](UrlResponse&& response) {
 
-        auto source = task->source();
-        if (!source) {
-            LOGW("URL Callback for deleted TileSource '%s'", url.string().c_str());
+        auto scene = task->scene();
+        if (!scene) {
+            LOGW("URL Callback for deleted Scene '%s'", url.string().c_str());
             return;
         }
         if (task->isCanceled()) {

--- a/core/src/data/networkDataSource.h
+++ b/core/src/data/networkDataSource.h
@@ -12,7 +12,7 @@ class Platform;
 class NetworkDataSource : public TileSource::DataSource {
 public:
 
-    NetworkDataSource(std::shared_ptr<Platform> _platform, const std::string& _urlTemplate,
+    NetworkDataSource(Platform& _platform, const std::string& _urlTemplate,
                       std::vector<std::string>&& _urlSubdomains, bool _isTms);
 
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
@@ -23,7 +23,7 @@ private:
     // Build the URL of a tile using our URL template.
     std::string buildUrlForTile(const TileID& _tile, size_t _subdomainIndex) const;
 
-    std::shared_ptr<Platform> m_platform;
+    Platform& m_platform;
 
     // URL template for requesting tiles from a network or filesystem
     std::string m_urlTemplate;

--- a/core/src/data/networkDataSource.h
+++ b/core/src/data/networkDataSource.h
@@ -15,7 +15,7 @@ public:
     NetworkDataSource(Platform& _platform, const std::string& _urlTemplate,
                       std::vector<std::string>&& _urlSubdomains, bool _isTms);
 
-    bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
+    bool loadTileData(std::shared_ptr<TileTask> _task) override;
 
     void cancelLoadingTile(TileTask& _task) override;
 

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -34,7 +34,7 @@ public:
 
     void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
-    virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask) override;
+    virtual std::shared_ptr<TileTask> createTask(Scene& _scene, TileID _tile, int _subTask) override;
 
     virtual void clearRasters() override;
     virtual void clearRaster(const TileID& id) override;

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -32,8 +32,6 @@ public:
     // TODO Is this always PNG or can it also be JPEG?
     virtual const char* mimeType() const override { return "image/png"; };
 
-    void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
-
     virtual std::shared_ptr<TileTask> createTask(Scene& _scene, TileID _tile, int _subTask) override;
 
     virtual void clearRasters() override;

--- a/core/src/debug/textDisplay.h
+++ b/core/src/debug/textDisplay.h
@@ -60,7 +60,7 @@ private:
     std::unique_ptr<ShaderProgram> m_shader;
     std::string m_log[LOG_CAPACITY];
     std::mutex m_mutex;
-    char* m_vertexBuffer;
+    char* m_vertexBuffer = nullptr;
 
     UniformLocation m_uOrthoProj{"u_orthoProj"};
     UniformLocation m_uColor{"u_color"};

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -38,17 +38,17 @@ Texture::~Texture() {
 }
 
 bool Texture::loadImageFromMemory(const uint8_t* data, size_t length) {
-    unsigned char* pixels = nullptr;
+    // stbi_load_from_memory loads the image as a series of scanlines starting from
+    // the top-left corner of the image. This flips the output such that the data
+    // begins at the bottom-left corner, as required for our OpenGL texture coordinates.
+    stbi_set_flip_vertically_on_load(true);
+
     int width = 0, height = 0, comp = 0;
-    pixels = stbi_load_from_memory(data, static_cast<int>(length), &width, &height, &comp, STBI_rgb_alpha);
+    unsigned char* pixels = stbi_load_from_memory(data, static_cast<int>(length),
+                                                  &width, &height, &comp, STBI_rgb_alpha);
 
     if (pixels) {
-        // stbi_load_from_memory loads the image as a series of scanlines starting from
-        // the top-left corner of the image. This call flips the output such that the data
-        // begins at the bottom-left corner, as required for our OpenGL texture coordinates.
         auto* rgbaPixels = reinterpret_cast<GLuint*>(pixels);
-
-        Texture::flipImageData(rgbaPixels, width, height);
 
         resize(width, height);
 
@@ -265,35 +265,6 @@ size_t Texture::getBytesPerPixel() const {
             return 3;
         default:
             return 4;
-    }
-}
-
-void Texture::flipImageData(GLuint *result, int w, int h) {
-
-    assert(w > 0 && h > 0 && bool(result));
-
-    const int step = 512;
-    GLuint temp[step];
-
-    const int stride = w;
-    const int end = stride % step;
-
-    for (int row = 0; row < h/2; row++) {
-        GLuint* upper = result + row * stride;
-        GLuint* lower = result + (h - row - 1) * stride;
-
-        for (int col = 0; col + step <= stride; col += step) {
-            std::copy(upper, upper + step, temp);
-            std::copy(lower, lower + step, upper);
-            std::copy(temp, temp + step, lower);
-            upper += step;
-            lower += step;
-        }
-        if (end != 0) {
-            std::copy(upper, upper + end, temp);
-            std::copy(lower, lower + end, upper);
-            std::copy(temp, temp + end, lower);
-        }
     }
 }
 

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -97,8 +97,6 @@ public:
 
     size_t getBufferSize() const;
 
-    static void flipImageData(GLuint* result, int width, int height);
-
 protected:
 
     struct DirtyRowRange {

--- a/core/src/labels/labelManager.cpp
+++ b/core/src/labels/labelManager.cpp
@@ -221,12 +221,7 @@ void LabelManager::skipTransitions(Scene& _scene, const std::vector<std::shared_
         std::shared_ptr<Tile> proxy;
 
         auto source = _scene.getTileSource(tile->sourceID());
-        if (!source) {
-            source = _tileManager.getClientTileSource(tile->sourceID());
-            // If tiles for this source exist, this source must exist (either tile or client source)
-            assert(source);
-            continue;
-        }
+        if (!source) { continue; }
 
         if (m_lastZoom < _currentZoom) {
             // zooming in, add the one cached parent tile

--- a/core/src/labels/labelManager.cpp
+++ b/core/src/labels/labelManager.cpp
@@ -1,4 +1,4 @@
-#include "labels/labels.h"
+#include "labels/labelManager.h"
 
 #include "data/tileSource.h"
 #include "gl/primitives.h"
@@ -28,13 +28,13 @@
 
 namespace Tangram {
 
-Labels::Labels()
+LabelManager::LabelManager()
     : m_needUpdate(false),
       m_lastZoom(0.0f) {}
 
-Labels::~Labels() {}
+LabelManager::~LabelManager() {}
 
-void Labels::processLabelUpdate(const ViewState& _viewState, const LabelSet* _labelSet, Style* _style,
+void LabelManager::processLabelUpdate(const ViewState& _viewState, const LabelSet* _labelSet, Style* _style,
                                 const Tile* _tile, const Marker* _marker, const glm::mat4& _mvp,
                                 float _dt, bool _drawAll, bool _onlyRender, bool _isProxy) {
 
@@ -85,7 +85,7 @@ void Labels::processLabelUpdate(const ViewState& _viewState, const LabelSet* _la
     }
 }
 
-std::pair<Label*, const Tile*> Labels::getLabel(uint32_t _selectionColor) const {
+std::pair<Label*, const Tile*> LabelManager::getLabel(uint32_t _selectionColor) const {
 
     for (auto& entry : m_selectionLabels) {
 
@@ -98,7 +98,7 @@ std::pair<Label*, const Tile*> Labels::getLabel(uint32_t _selectionColor) const 
     return {nullptr, nullptr};
 }
 
-void Labels::updateLabels(const ViewState& _viewState, float _dt,
+void LabelManager::updateLabels(const ViewState& _viewState, float _dt,
                           const std::vector<std::unique_ptr<Style>>& _styles,
                           const std::vector<std::shared_ptr<Tile>>& _tiles,
                           const std::vector<std::unique_ptr<Marker>>& _markers,
@@ -156,7 +156,7 @@ void Labels::updateLabels(const ViewState& _viewState, float _dt,
     }
 }
 
-void Labels::skipTransitions(const std::vector<const Style*>& _styles, Tile& _tile, Tile& _proxy) const {
+void LabelManager::skipTransitions(const std::vector<const Style*>& _styles, Tile& _tile, Tile& _proxy) const {
 
     for (const auto& style : _styles) {
 
@@ -204,7 +204,7 @@ std::shared_ptr<Tile> findProxy(int32_t _sourceID, const TileID& _proxyID,
     return nullptr;
 }
 
-void Labels::skipTransitions(Scene& _scene, const std::vector<std::shared_ptr<Tile>>& _tiles,
+void LabelManager::skipTransitions(Scene& _scene, const std::vector<std::shared_ptr<Tile>>& _tiles,
                              TileManager& _tileManager, float _currentZoom) const {
 
     std::vector<const Style*> styles;
@@ -244,7 +244,7 @@ void Labels::skipTransitions(Scene& _scene, const std::vector<std::shared_ptr<Ti
     }
 }
 
-bool Labels::priorityComparator(const LabelEntry& _a, const LabelEntry& _b) {
+bool LabelManager::priorityComparator(const LabelEntry& _a, const LabelEntry& _b) {
     if (_a.proxy != _b.proxy) {
         return _b.proxy;
     }
@@ -287,7 +287,7 @@ bool Labels::priorityComparator(const LabelEntry& _a, const LabelEntry& _b) {
     return l1 < l2;
 }
 
-bool Labels::zOrderComparator(const LabelEntry& _a, const LabelEntry& _b) {
+bool LabelManager::zOrderComparator(const LabelEntry& _a, const LabelEntry& _b) {
 
     if (_a.style != _b.style) {
         return _a.style < _b.style;
@@ -318,7 +318,7 @@ bool Labels::zOrderComparator(const LabelEntry& _a, const LabelEntry& _b) {
     return bool(_a.tile);
 }
 
-void Labels::handleOcclusions(const ViewState& _viewState) {
+void LabelManager::handleOcclusions(const ViewState& _viewState) {
 
     m_isect2d.clear();
     m_repeatGroups.clear();
@@ -428,7 +428,7 @@ void Labels::handleOcclusions(const ViewState& _viewState) {
     }
 }
 
-bool Labels::withinRepeatDistance(Label *_label) {
+bool LabelManager::withinRepeatDistance(Label *_label) {
     float threshold2 = pow(_label->options().repeatDistance, 2);
 
     auto it = m_repeatGroups.find(_label->options().repeatGroup);
@@ -443,7 +443,7 @@ bool Labels::withinRepeatDistance(Label *_label) {
     return false;
 }
 
-void Labels::updateLabelSet(const ViewState& _viewState, float _dt, Scene& _scene,
+void LabelManager::updateLabelSet(const ViewState& _viewState, float _dt, Scene& _scene,
                             const std::vector<std::shared_ptr<Tile>>& _tiles,
                             const std::vector<std::unique_ptr<Marker>>& _markers,
                             TileManager& _tileManager) {
@@ -454,7 +454,7 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt, Scene& _scen
     /// Collect and update labels from visible tiles
     updateLabels(_viewState, _dt, _scene.styles(), _tiles, _markers, false);
 
-    std::sort(m_labels.begin(), m_labels.end(), Labels::priorityComparator);
+    std::sort(m_labels.begin(), m_labels.end(), LabelManager::priorityComparator);
 
     /// Mark labels to skip transitions
 
@@ -473,7 +473,7 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt, Scene& _scen
         m_needUpdate |= entry.label->evalState(_dt);
     }
 
-    std::sort(m_labels.begin(), m_labels.end(), Labels::zOrderComparator);
+    std::sort(m_labels.begin(), m_labels.end(), LabelManager::zOrderComparator);
 
     Label::AABB screenBounds{0, 0, _viewState.viewportSize.x, _viewState.viewportSize.y};
 
@@ -494,7 +494,7 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt, Scene& _scen
     }
 }
 
-void Labels::drawDebug(RenderState& rs, const View& _view) {
+void LabelManager::drawDebug(RenderState& rs, const View& _view) {
 
     if (!Tangram::getDebugFlag(Tangram::DebugFlags::labels)) {
         return;

--- a/core/src/labels/labelManager.h
+++ b/core/src/labels/labelManager.h
@@ -26,12 +26,12 @@ class Style;
 class Scene;
 class TileManager;
 
-class Labels {
+class LabelManager {
 
 public:
-    Labels();
+    LabelManager();
 
-    virtual ~Labels();
+    virtual ~LabelManager();
 
     void drawDebug(RenderState& rs, const View& _view);
 

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -204,13 +204,12 @@ std::shared_ptr<Tile> findProxy(int32_t _sourceID, const TileID& _proxyID,
     return nullptr;
 }
 
-void Labels::skipTransitions(const std::shared_ptr<Scene>& _scene,
-                             const std::vector<std::shared_ptr<Tile>>& _tiles,
+void Labels::skipTransitions(Scene& _scene, const std::vector<std::shared_ptr<Tile>>& _tiles,
                              TileManager& _tileManager, float _currentZoom) const {
 
     std::vector<const Style*> styles;
 
-    for (const auto& style : _scene->styles()) {
+    for (const auto& style : _scene.styles()) {
         if (dynamic_cast<const TextStyle*>(style.get()) ||
             dynamic_cast<const PointStyle*>(style.get())) {
             styles.push_back(style.get());
@@ -221,7 +220,7 @@ void Labels::skipTransitions(const std::shared_ptr<Scene>& _scene,
         TileID tileID = tile->getID();
         std::shared_ptr<Tile> proxy;
 
-        auto source = _scene->getTileSource(tile->sourceID());
+        auto source = _scene.getTileSource(tile->sourceID());
         if (!source) {
             source = _tileManager.getClientTileSource(tile->sourceID());
             // If tiles for this source exist, this source must exist (either tile or client source)
@@ -444,8 +443,7 @@ bool Labels::withinRepeatDistance(Label *_label) {
     return false;
 }
 
-void Labels::updateLabelSet(const ViewState& _viewState, float _dt,
-                            const std::shared_ptr<Scene>& _scene,
+void Labels::updateLabelSet(const ViewState& _viewState, float _dt, Scene& _scene,
                             const std::vector<std::shared_ptr<Tile>>& _tiles,
                             const std::vector<std::unique_ptr<Marker>>& _markers,
                             TileManager& _tileManager) {
@@ -454,7 +452,7 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt,
     m_obbs.clear();
 
     /// Collect and update labels from visible tiles
-    updateLabels(_viewState, _dt, _scene->styles(), _tiles, _markers, false);
+    updateLabels(_viewState, _dt, _scene.styles(), _tiles, _markers, false);
 
     std::sort(m_labels.begin(), m_labels.end(), Labels::priorityComparator);
 

--- a/core/src/labels/labels.h
+++ b/core/src/labels/labels.h
@@ -35,8 +35,7 @@ public:
 
     void drawDebug(RenderState& rs, const View& _view);
 
-    void updateLabelSet(const ViewState& _viewState, float _dt,
-                        const std::shared_ptr<Scene>& _scene,
+    void updateLabelSet(const ViewState& _viewState, float _dt, Scene& _scene,
                         const std::vector<std::shared_ptr<Tile>>& _tiles,
                         const std::vector<std::unique_ptr<Marker>>& _markers,
                         TileManager& tileManager);
@@ -61,8 +60,7 @@ protected:
     using CollisionPairs = std::vector<isect2d::ISect2D<glm::vec2>::Pair>;
 
 
-    void skipTransitions(const std::shared_ptr<Scene>& _scene,
-                         const std::vector<std::shared_ptr<Tile>>& _tiles,
+    void skipTransitions(Scene& _scene, const std::vector<std::shared_ptr<Tile>>& _tiles,
                          TileManager& _tileManager, float _currentZoom) const;
 
     void skipTransitions(const std::vector<const Style*>& _styles, Tile& _tile, Tile& _proxy) const;

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -361,6 +361,10 @@ bool Map::update(float _dt) {
         impl->scene->pendingFonts > 0 ||
         impl->scene->pendingTextures > 0) {
         platform->requestRender();
+        LOG("Waiting for scene:%d fonts:%d textures:%d",
+            bool(impl->scene->markerManager()),
+            bool(impl->scene->pendingFonts > 0),
+            bool(impl->scene->pendingTextures > 0));
         return false;
     }
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -52,7 +52,7 @@ class Map::Impl {
 public:
     explicit Impl(std::shared_ptr<Platform> _platform) :
         platform(_platform),
-        inputHandler(_platform, view),
+        inputHandler(view),
         scene(std::make_shared<Scene>(_platform, Url(), std::make_unique<View>())) {}
 
 
@@ -406,7 +406,7 @@ bool Map::update(float _dt) {
     }
 
     // Request render if labels are in fading states or markers are easing.
-    if (impl->isCameraEasing || labelsNeedUpdate || markersNeedUpdate) {
+    if (isFlinging || impl->isCameraEasing || labelsNeedUpdate || markersNeedUpdate) {
         platform->requestRender();
     }
 
@@ -956,36 +956,43 @@ void Map::markerRemoveAll() {
 void Map::handleTapGesture(float _posX, float _posY) {
     cancelCameraAnimation();
     impl->inputHandler.handleTapGesture(_posX, _posY);
+    impl->platform->requestRender();
 }
 
 void Map::handleDoubleTapGesture(float _posX, float _posY) {
     cancelCameraAnimation();
     impl->inputHandler.handleDoubleTapGesture(_posX, _posY);
+    impl->platform->requestRender();
 }
 
 void Map::handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
     cancelCameraAnimation();
     impl->inputHandler.handlePanGesture(_startX, _startY, _endX, _endY);
+    impl->platform->requestRender();
 }
 
 void Map::handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY) {
     cancelCameraAnimation();
     impl->inputHandler.handleFlingGesture(_posX, _posY, _velocityX, _velocityY);
+    impl->platform->requestRender();
 }
 
 void Map::handlePinchGesture(float _posX, float _posY, float _scale, float _velocity) {
     cancelCameraAnimation();
     impl->inputHandler.handlePinchGesture(_posX, _posY, _scale, _velocity);
+    impl->platform->requestRender();
 }
 
 void Map::handleRotateGesture(float _posX, float _posY, float _radians) {
     cancelCameraAnimation();
     impl->inputHandler.handleRotateGesture(_posX, _posY, _radians);
+    impl->platform->requestRender();
 }
 
 void Map::handleShoveGesture(float _distance) {
     cancelCameraAnimation();
     impl->inputHandler.handleShoveGesture(_distance);
+    impl->platform->requestRender();
 }
 
 void Map::setupGL() {

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -50,7 +50,7 @@ using CameraAnimator = std::function<uint32_t(float dt)>;
 class Map::Impl {
 
 public:
-    explicit Impl(std::shared_ptr<Platform> _platform) :
+    explicit Impl(Platform& _platform) :
         platform(_platform),
         inputHandler(view),
         scene(std::make_shared<Scene>(_platform, Url(), std::make_unique<View>())) {}
@@ -63,12 +63,12 @@ public:
     std::mutex tilesMutex;
     std::mutex sceneMutex;
 
+    Platform& platform;
     RenderState renderState;
     JobQueue jobQueue;
     // Current interactive view
     View view;
     std::unique_ptr<AsyncWorker> asyncWorker = std::make_unique<AsyncWorker>();
-    std::shared_ptr<Platform> platform;
     InputHandler inputHandler;
 
     std::unique_ptr<Ease> ease;
@@ -109,8 +109,8 @@ public:
 
 static std::bitset<9> g_flags = 0;
 
-Map::Map(std::shared_ptr<Platform> _platform) : platform(_platform) {
-    impl.reset(new Impl(_platform));
+Map::Map(std::unique_ptr<Platform> _platform) : platform(std::move(_platform)) {
+    impl.reset(new Impl(*platform));
 }
 
 Map::~Map() {
@@ -140,8 +140,8 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
 
     bool animated = scene->animated() == Scene::animate::yes;
 
-    if (animated != platform->isContinuousRendering()) {
-        platform->setContinuousRendering(animated);
+    if (animated != platform.isContinuousRendering()) {
+        platform.setContinuousRendering(animated);
     }
 
     {
@@ -165,7 +165,7 @@ SceneID Map::loadScene(std::shared_ptr<Scene> scene,
         impl->lastValidScene.reset();
     }
 
-    if (SceneLoader::loadScene(platform, scene, _sceneUpdates)) {
+    if (SceneLoader::loadScene(*platform, scene, _sceneUpdates)) {
         impl->setScene(scene);
 
         {
@@ -188,7 +188,7 @@ SceneID Map::loadScene(const std::string& _scenePath, bool _useScenePosition,
                        const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene file: %s", _scenePath.c_str());
-    auto scene = std::make_shared<Scene>(platform, _scenePath, std::make_unique<View>(impl->view));
+    auto scene = std::make_shared<Scene>(*platform, _scenePath, std::make_unique<View>(impl->view));
     scene->useScenePosition = _useScenePosition;
     return loadScene(scene, _sceneUpdates);
 }
@@ -197,7 +197,7 @@ SceneID Map::loadSceneYaml(const std::string& _yaml, const std::string& _resourc
                            bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene string");
-    auto scene = std::make_shared<Scene>(platform, _yaml, _resourceRoot, std::make_unique<View>(impl->view));
+    auto scene = std::make_shared<Scene>(*platform, _yaml, _resourceRoot, std::make_unique<View>(impl->view));
     scene->useScenePosition = _useScenePosition;
     return loadScene(scene, _sceneUpdates);
 }
@@ -206,7 +206,7 @@ SceneID Map::loadSceneAsync(const std::string& _scenePath, bool _useScenePositio
                             const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene file (async): %s", _scenePath.c_str());
-    auto scene = std::make_shared<Scene>(platform, _scenePath, std::make_unique<View>(impl->view));
+    auto scene = std::make_shared<Scene>(*platform, _scenePath, std::make_unique<View>(impl->view));
     scene->useScenePosition = _useScenePosition;
     return loadSceneAsync(scene, _sceneUpdates);
 }
@@ -215,7 +215,7 @@ SceneID Map::loadSceneYamlAsync(const std::string& _yaml, const std::string& _re
                                 bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene string (async)");
-    auto scene = std::make_shared<Scene>(platform, _yaml, _resourceRoot, std::make_unique<View>(impl->view));
+    auto scene = std::make_shared<Scene>(*platform, _yaml, _resourceRoot, std::make_unique<View>(impl->view));
     scene->useScenePosition = _useScenePosition;
     return loadSceneAsync(scene, _sceneUpdates);
 }
@@ -227,7 +227,7 @@ SceneID Map::loadSceneAsync(std::shared_ptr<Scene> nextScene,
 
     runAsyncTask([nextScene, _sceneUpdates, this](){
 
-            bool newSceneLoaded = SceneLoader::loadScene(platform, nextScene, _sceneUpdates);
+            bool newSceneLoaded = SceneLoader::loadScene(*platform, nextScene, _sceneUpdates);
             if (!newSceneLoaded) {
 
                 if (impl->onSceneReady) {
@@ -269,8 +269,8 @@ void Map::setCameraAnimationListener(CameraAnimationCallback _cb) {
     impl->cameraAnimationListener = _cb;
 }
 
-std::shared_ptr<Platform>& Map::getPlatform() {
-    return platform;
+Platform& Map::getPlatform() {
+    return *platform;
 }
 
 SceneID Map::updateSceneAsync(const std::vector<SceneUpdate>& _sceneUpdates) {
@@ -554,7 +554,7 @@ void Map::setCameraPosition(const CameraPosition& _camera) {
     impl->view.setRoll(_camera.rotation);
     impl->view.setPitch(_camera.tilt);
 
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::setCameraPositionEased(const CameraPosition& _camera, float _duration, EaseType _e) {
@@ -653,7 +653,7 @@ void Map::setPosition(double _lon, double _lat) {
     glm::dvec2 meters = MapProjection::lngLatToProjectedMeters({_lon, _lat});
     impl->view.setPosition(meters.x, meters.y);
     impl->inputHandler.cancelFling();
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::getPosition(double& _lon, double& _lat) {
@@ -667,7 +667,7 @@ void Map::setZoom(float _z) {
 
     impl->view.setZoom(_z);
     impl->inputHandler.cancelFling();
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 float Map::getZoom() {
@@ -694,7 +694,7 @@ void Map::setRotation(float _radians) {
     cancelCameraAnimation();
 
     impl->view.setRoll(_radians);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 float Map::getRotation() {
@@ -705,7 +705,7 @@ void Map::setTilt(float _radians) {
     cancelCameraAnimation();
 
     impl->view.setPitch(_radians);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 float Map::getTilt() {
@@ -781,7 +781,7 @@ void Map::flyTo(const CameraPosition& _camera, float _duration, float _speed) {
             impl->view.setZoom(pos.z);
             impl->view.setRoll(ease(rStart, rEnd, t, e));
             impl->view.setPitch(ease(tStart, _camera.tilt, t, e));
-            impl->platform->requestRender();
+            impl->platform.requestRender();
         };
 
     if (_speed <= 0.f) { _speed = 1.f; }
@@ -956,43 +956,43 @@ void Map::markerRemoveAll() {
 void Map::handleTapGesture(float _posX, float _posY) {
     cancelCameraAnimation();
     impl->inputHandler.handleTapGesture(_posX, _posY);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::handleDoubleTapGesture(float _posX, float _posY) {
     cancelCameraAnimation();
     impl->inputHandler.handleDoubleTapGesture(_posX, _posY);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
     cancelCameraAnimation();
     impl->inputHandler.handlePanGesture(_startX, _startY, _endX, _endY);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY) {
     cancelCameraAnimation();
     impl->inputHandler.handleFlingGesture(_posX, _posY, _velocityX, _velocityY);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::handlePinchGesture(float _posX, float _posY, float _scale, float _velocity) {
     cancelCameraAnimation();
     impl->inputHandler.handlePinchGesture(_posX, _posY, _scale, _velocity);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::handleRotateGesture(float _posX, float _posY, float _radians) {
     cancelCameraAnimation();
     impl->inputHandler.handleRotateGesture(_posX, _posY, _radians);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::handleShoveGesture(float _distance) {
     cancelCameraAnimation();
     impl->inputHandler.handleShoveGesture(_distance);
-    impl->platform->requestRender();
+    impl->platform.requestRender();
 }
 
 void Map::setupGL() {

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -131,7 +131,7 @@ Map::~Map() {
 void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
 
     scene = _scene;
-
+    scene->setPixelScale(view.pixelScale());
     scene->view()->setSize(view.getWidth(), view.getHeight());
 
     view = *_scene->view();
@@ -347,13 +347,9 @@ void Map::resize(int _newWidth, int _newHeight) {
     LOGS("resize: %d x %d", _newWidth, _newHeight);
     LOG("resize: %d x %d", _newWidth, _newHeight);
 
-    // FIXME not needed?? impl->renderState.viewport(0, 0, _newWidth, _newHeight);
-
     impl->view.setSize(_newWidth, _newHeight);
 
     impl->selectionBuffer = std::make_unique<FrameBuffer>(_newWidth/2, _newHeight/2);
-
-    Primitives::setResolution(impl->renderState, _newWidth, _newHeight);
 }
 
 bool Map::update(float _dt) {
@@ -451,6 +447,8 @@ bool Map::render() {
 
     // Cache default framebuffer handle used for rendering
     impl->renderState.cacheDefaultFramebuffer();
+
+    Primitives::setResolution(impl->renderState, impl->view.getWidth(), impl->view.getHeight());
 
     FrameInfo::beginFrame();
 
@@ -823,9 +821,7 @@ bool Map::lngLatToScreenPosition(double _lng, double _lat, double* _x, double* _
 }
 
 void Map::setPixelScale(float _pixelsPerPoint) {
-
     impl->setPixelScale(_pixelsPerPoint);
-
 }
 
 void Map::Impl::setPixelScale(float _pixelsPerPoint) {
@@ -841,16 +837,12 @@ void Map::Impl::setPixelScale(float _pixelsPerPoint) {
 }
 
 void Map::setCameraType(int _type) {
-
     impl->view.setCameraType(static_cast<CameraType>(_type));
     platform->requestRender();
-
 }
 
 int Map::getCameraType() {
-
     return static_cast<int>(impl->view.cameraType());
-
 }
 
 void Map::addTileSource(std::shared_ptr<TileSource> _source) {
@@ -1002,7 +994,7 @@ void Map::setupGL() {
 
     impl->renderState.invalidate();
 
-    impl->scene->tileManager()->clearTileSets();
+    //impl->scene->tileManager()->clearTileSets();
     //impl->scene->markerManager()->rebuildAll();
 
     if (impl->selectionBuffer->valid()) {

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -9,7 +9,7 @@
 #include "gl/primitives.h"
 #include "gl/renderState.h"
 #include "gl/shaderProgram.h"
-#include "labels/labels.h"
+#include "labels/labelManager.h"
 #include "marker/marker.h"
 #include "marker/markerManager.h"
 #include "platform.h"

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -506,10 +506,7 @@ bool Map::render() {
     }
 
     // Get background color for frame based on zoom level, if there are stops
-    auto background = impl->scene->background();
-    if (impl->scene->backgroundStops().frames.size() > 0) {
-        background = impl->scene->backgroundStops().evalColor(impl->view.getIntegerZoom());
-    }
+    Color background = impl->scene->background(impl->view.getIntegerZoom());
 
     // Setup default framebuffer for a new frame
     glm::vec2 viewport(impl->view.getWidth(), impl->view.getHeight());

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -373,15 +373,7 @@ bool Map::update(float _dt) {
 
     impl->jobQueue.runJobs();
 
-    // Wait until font and texture resources are fully loaded
-    if (!impl->scene->markerManager() ||
-        impl->scene->pendingFonts > 0 ||
-        impl->scene->pendingTextures > 0) {
-        platform->requestRender();
-        LOG("Waiting for scene:%d fonts:%d textures:%d",
-            bool(impl->scene->markerManager()),
-            bool(impl->scene->pendingFonts > 0),
-            bool(impl->scene->pendingTextures > 0));
+    if (!impl->scene->complete()) {
         return false;
     }
 
@@ -409,7 +401,6 @@ bool Map::update(float _dt) {
     bool isFlinging = impl->inputHandler.update(_dt);
     impl->isCameraEasing = (isEasing || isFlinging);
     impl->view.update();
-
 
     bool tilesChanging;
     {
@@ -459,9 +450,8 @@ void Map::pickMarkerAt(float _x, float _y, MarkerPickCallback _onMarkerPickCallb
 bool Map::render() {
 
     // Do not render if any texture resources are in process of being downloaded
-    if (!impl->scene->markerManager() ||
-        impl->scene->pendingTextures > 0) {
-        return impl->isCameraEasing;
+    if (!impl->scene->complete()) {
+        return impl->isCameraEasing; // ?????
     }
 
     bool drawSelectionBuffer = getDebugFlag(DebugFlags::selection_buffer);

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -80,7 +80,6 @@ public:
     // NB: Destruction of (managed and loading) tiles must happen
     // before implicit destruction of 'scene' above!
     // In particular any references of Labels and Markers to FontContext
-    MarkerManager markerManager;
     std::unique_ptr<FrameBuffer> selectionBuffer = std::make_unique<FrameBuffer>(0, 0);
 
     bool cacheGlState = false;
@@ -167,8 +166,6 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
     }
 
     inputHandler.setView(view);
-
-    markerManager.setScene(_scene);
 
     bool animated = scene->animated() == Scene::animate::yes;
 
@@ -393,7 +390,9 @@ bool Map::update(float _dt) {
     impl->jobQueue.runJobs();
 
     // Wait until font and texture resources are fully loaded
-    if (impl->scene->pendingFonts > 0 || impl->scene->pendingTextures > 0) {
+    if (!impl->scene->markerManager() ||
+        impl->scene->pendingFonts > 0 ||
+        impl->scene->pendingTextures > 0) {
         platform->requestRender();
         return false;
     }
@@ -426,7 +425,7 @@ bool Map::update(float _dt) {
 
     impl->view.update();
 
-    bool markersChanged = impl->markerManager.update(impl->view, _dt);
+    bool markersChanged = impl->scene->markerManager()->update(impl->view, _dt);
 
     for (const auto& style : impl->scene->styles()) {
         style->onBeginUpdate();
@@ -440,7 +439,7 @@ bool Map::update(float _dt) {
         impl->scene->tileManager()->updateTileSets(impl->view);
 
         auto& tiles = impl->scene->tileManager()->getVisibleTiles();
-        auto& markers = impl->markerManager.markers();
+        auto& markers = impl->scene->markerManager()->markers();
 
         if (impl->view.changedOnLastUpdate() ||
             impl->scene->tileManager()->hasTileSetChanged() ||
@@ -500,7 +499,8 @@ void Map::pickMarkerAt(float _x, float _y, MarkerPickCallback _onMarkerPickCallb
 bool Map::render() {
 
     // Do not render if any texture resources are in process of being downloaded
-    if (impl->scene->pendingTextures > 0) {
+    if (!impl->scene->markerManager() ||
+        impl->scene->pendingTextures > 0) {
         return impl->isCameraEasing;
     }
 
@@ -533,13 +533,13 @@ bool Map::render() {
 
             style->drawSelectionFrame(impl->renderState, impl->view, *(impl->scene),
                                       impl->scene->tileManager()->getVisibleTiles(),
-                                      impl->markerManager.markers());
+                                      impl->scene->markerManager()->markers());
         }
 
         std::vector<SelectionColorRead> colorCache;
         // Resolve feature selection queries
         for (const auto& selectionQuery : impl->selectionQueries) {
-            selectionQuery.process(impl->view, *impl->selectionBuffer, impl->markerManager,
+            selectionQuery.process(impl->view, *impl->selectionBuffer, *impl->scene->markerManager(),
                                    *impl->scene->tileManager(), impl->labels, colorCache);
         }
 
@@ -574,7 +574,7 @@ bool Map::render() {
             bool styleDrawn = style->draw(impl->renderState,
                                           impl->view, *(impl->scene),
                                           impl->scene->tileManager()->getVisibleTiles(),
-                                                                   impl->markerManager.markers());
+                                          impl->scene->markerManager()->markers());
 
             drawnAnimatedStyle |= (styleDrawn && style->isAnimated());
         }
@@ -922,12 +922,6 @@ void Map::Impl::setPixelScale(float _pixelsPerPoint) {
     }
     view.setPixelScale(_pixelsPerPoint);
     scene->setPixelScale(_pixelsPerPoint);
-
-    // Tiles must be rebuilt to apply the new pixel scale to labels.
-    scene->tileManager()->clearTileSets();
-
-    // Markers must be rebuilt to apply the new pixel scale.
-    markerManager.rebuildAll();
 }
 
 void Map::setCameraType(int _type) {
@@ -971,71 +965,83 @@ void Map::clearTileSource(TileSource& _source, bool _data, bool _tiles) {
 }
 
 MarkerID Map::markerAdd() {
-    return impl->markerManager.add();
+    if (!impl->scene->markerManager()) { return false; }
+    return impl->scene->markerManager()->add();
 }
 
 bool Map::markerRemove(MarkerID _marker) {
-    bool success = impl->markerManager.remove(_marker);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->remove(_marker);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetPoint(MarkerID _marker, LngLat _lngLat) {
-    bool success = impl->markerManager.setPoint(_marker, _lngLat);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setPoint(_marker, _lngLat);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetPointEased(MarkerID _marker, LngLat _lngLat, float _duration, EaseType ease) {
-    bool success = impl->markerManager.setPointEased(_marker, _lngLat, _duration, ease);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setPointEased(_marker, _lngLat, _duration, ease);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetPolyline(MarkerID _marker, LngLat* _coordinates, int _count) {
-    bool success = impl->markerManager.setPolyline(_marker, _coordinates, _count);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setPolyline(_marker, _coordinates, _count);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetPolygon(MarkerID _marker, LngLat* _coordinates, int* _counts, int _rings) {
-    bool success = impl->markerManager.setPolygon(_marker, _coordinates, _counts, _rings);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setPolygon(_marker, _coordinates, _counts, _rings);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetStylingFromString(MarkerID _marker, const char* _styling) {
-    bool success = impl->markerManager.setStylingFromString(_marker, _styling);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setStylingFromString(_marker, _styling);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetStylingFromPath(MarkerID _marker, const char* _path) {
-    bool success = impl->markerManager.setStylingFromPath(_marker, _path);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setStylingFromPath(_marker, _path);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data) {
-    bool success = impl->markerManager.setBitmap(_marker, _width, _height, _data);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setBitmap(_marker, _width, _height, _data);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetVisible(MarkerID _marker, bool _visible) {
-    bool success = impl->markerManager.setVisible(_marker, _visible);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setVisible(_marker, _visible);
     platform->requestRender();
     return success;
 }
 
 bool Map::markerSetDrawOrder(MarkerID _marker, int _drawOrder) {
-    bool success = impl->markerManager.setDrawOrder(_marker, _drawOrder);
+    if (!impl->scene->markerManager()) { return false; }
+    bool success = impl->scene->markerManager()->setDrawOrder(_marker, _drawOrder);
     platform->requestRender();
     return success;
 }
 
 void Map::markerRemoveAll() {
-    impl->markerManager.removeAll();
+    if (!impl->scene->markerManager()) { return; }
+    impl->scene->markerManager()->removeAll();
     platform->requestRender();
 }
 
@@ -1081,8 +1087,7 @@ void Map::setupGL() {
     impl->renderState.invalidate();
 
     impl->scene->tileManager()->clearTileSets();
-
-    impl->markerManager.rebuildAll();
+    //impl->scene->markerManager()->rebuildAll();
 
     if (impl->selectionBuffer->valid()) {
         impl->selectionBuffer = std::make_unique<FrameBuffer>(impl->selectionBuffer->getWidth(),

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -67,7 +67,6 @@ public:
     JobQueue jobQueue;
     // Current interactive view
     View view;
-    Labels labels;
     std::unique_ptr<AsyncWorker> asyncWorker = std::make_unique<AsyncWorker>();
     std::shared_ptr<Platform> platform;
     InputHandler inputHandler;
@@ -398,13 +397,13 @@ bool Map::update(float _dt) {
     bool tilesChanging;
     {
         std::lock_guard<std::mutex> lock(impl->tilesMutex);
-        tilesChanging = impl->scene->update(impl->view, impl->labels, _dt);
+        tilesChanging = impl->scene->update(impl->view, _dt);
     }
 
     FrameInfo::endUpdate();
 
     bool viewChanged = impl->view.changedOnLastUpdate();
-    bool labelsNeedUpdate = impl->labels.needUpdate();
+    bool labelsNeedUpdate = impl->scene->labelManager()->needUpdate();
 
     if (viewChanged || tilesChanging || labelsNeedUpdate || impl->sceneLoadTasks > 0) {
         viewComplete = false;
@@ -471,7 +470,7 @@ bool Map::render() {
 
         std::lock_guard<std::mutex> lock(impl->tilesMutex);
 
-        impl->scene->renderSelection(impl->renderState, impl->view, impl->labels,
+        impl->scene->renderSelection(impl->renderState, impl->view,
                                      *impl->selectionBuffer, impl->selectionQueries);
 
         impl->selectionQueries.clear();
@@ -504,7 +503,6 @@ bool Map::render() {
         platform->setContinuousRendering(drawnAnimatedStyle);
     }
 
-    impl->labels.drawDebug(impl->renderState, impl->view);
 
     FrameInfo::draw(impl->renderState, impl->view, *impl->scene->tileManager());
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -53,7 +53,9 @@ public:
     explicit Impl(Platform& _platform) :
         platform(_platform),
         inputHandler(view),
-        scene(std::make_shared<Scene>(_platform, Url(), std::make_unique<View>())) {}
+        scene(std::make_shared<Scene>(_platform,
+                                      std::make_unique<SceneOptions>(Url()),
+                                      std::make_unique<View>())) {}
 
 
     void setScene(std::shared_ptr<Scene>& _scene);
@@ -152,10 +154,59 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
     }
 }
 
+SceneID Map::loadScene(const std::string& _scenePath, bool _useScenePosition,
+                       const std::vector<SceneUpdate>& _sceneUpdates) {
+
+    LOG("Loading scene file: %s", _scenePath.c_str());
+
+    auto options = std::make_unique<SceneOptions>(Url(_scenePath));
+    options->useScenePosition = _useScenePosition;
+
+    return loadScene(std::move(options));
+}
+
+SceneID Map::loadSceneYaml(const std::string& _yaml, const std::string& _resourceRoot,
+                           bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
+
+    LOG("Loading scene string");
+
+    auto options = std::make_unique<SceneOptions>(_yaml, Url(_resourceRoot));
+    options->updates =  _sceneUpdates;
+    options->useScenePosition = _useScenePosition;
+
+    return loadScene(std::move(options));
+}
+
+SceneID Map::loadSceneAsync(const std::string& _scenePath, bool _useScenePosition,
+                            const std::vector<SceneUpdate>& _sceneUpdates) {
+
+    LOG("Loading scene file (async): %s", _scenePath.c_str());
+
+    auto options = std::make_unique<SceneOptions>(Url(_scenePath));
+    options->updates =  _sceneUpdates;
+    options->useScenePosition = _useScenePosition;
+
+    return loadSceneAsync(std::move(options));
+}
+
+SceneID Map::loadSceneYamlAsync(const std::string& _yaml, const std::string& _resourceRoot,
+                                bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
+
+    LOG("Loading scene string (async)");
+
+    auto options = std::make_unique<SceneOptions>(_yaml, Url(_resourceRoot));
+    options->updates =  _sceneUpdates;
+    options->useScenePosition = _useScenePosition;
+
+    return loadSceneAsync(std::move(options));
+}
+
 // NB: Not thread-safe. Must be called on the main/render thread!
 // (Or externally synchronized with main/render thread)
-SceneID Map::loadScene(std::shared_ptr<Scene> scene,
-                       const std::vector<SceneUpdate>& _sceneUpdates) {
+SceneID Map::loadScene(std::unique_ptr<SceneOptions> _sceneOptions) {
+
+    auto newScene = std::make_shared<Scene>(*platform, std::move(_sceneOptions),
+                                             std::make_unique<View>(impl->view));
 
     {
         std::unique_lock<std::mutex> lock(impl->sceneMutex);
@@ -165,75 +216,41 @@ SceneID Map::loadScene(std::shared_ptr<Scene> scene,
         impl->lastValidScene.reset();
     }
 
-    if (SceneLoader::loadScene(*platform, scene, _sceneUpdates)) {
-        impl->setScene(scene);
+    if (SceneLoader::loadScene(newScene)) {
+        impl->setScene(newScene);
 
         {
             std::lock_guard<std::mutex> lock(impl->sceneMutex);
-            impl->lastValidScene = scene;
+            impl->lastValidScene = newScene;
         }
     }
 
     if (impl->onSceneReady) {
-        if (scene->errors.empty()) {
-            impl->onSceneReady(scene->id, nullptr);
+        if (newScene->errors.empty()) {
+            impl->onSceneReady(newScene->id, nullptr);
         } else {
-            impl->onSceneReady(scene->id, &(scene->errors.front()));
+            impl->onSceneReady(newScene->id, &(newScene->errors.front()));
         }
     }
-    return scene->id;
+    return newScene->id;
 }
 
-SceneID Map::loadScene(const std::string& _scenePath, bool _useScenePosition,
-                       const std::vector<SceneUpdate>& _sceneUpdates) {
+SceneID Map::loadSceneAsync(std::unique_ptr<SceneOptions> _sceneOptions) {
 
-    LOG("Loading scene file: %s", _scenePath.c_str());
-    auto scene = std::make_shared<Scene>(*platform, _scenePath, std::make_unique<View>(impl->view));
-    scene->useScenePosition = _useScenePosition;
-    return loadScene(scene, _sceneUpdates);
-}
-
-SceneID Map::loadSceneYaml(const std::string& _yaml, const std::string& _resourceRoot,
-                           bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
-
-    LOG("Loading scene string");
-    auto scene = std::make_shared<Scene>(*platform, _yaml, _resourceRoot, std::make_unique<View>(impl->view));
-    scene->useScenePosition = _useScenePosition;
-    return loadScene(scene, _sceneUpdates);
-}
-
-SceneID Map::loadSceneAsync(const std::string& _scenePath, bool _useScenePosition,
-                            const std::vector<SceneUpdate>& _sceneUpdates) {
-
-    LOG("Loading scene file (async): %s", _scenePath.c_str());
-    auto scene = std::make_shared<Scene>(*platform, _scenePath, std::make_unique<View>(impl->view));
-    scene->useScenePosition = _useScenePosition;
-    return loadSceneAsync(scene, _sceneUpdates);
-}
-
-SceneID Map::loadSceneYamlAsync(const std::string& _yaml, const std::string& _resourceRoot,
-                                bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
-
-    LOG("Loading scene string (async)");
-    auto scene = std::make_shared<Scene>(*platform, _yaml, _resourceRoot, std::make_unique<View>(impl->view));
-    scene->useScenePosition = _useScenePosition;
-    return loadSceneAsync(scene, _sceneUpdates);
-}
-
-SceneID Map::loadSceneAsync(std::shared_ptr<Scene> nextScene,
-                            const std::vector<SceneUpdate>& _sceneUpdates) {
+    auto newScene = std::make_shared<Scene>(*platform, std::move(_sceneOptions),
+                                             std::make_unique<View>(impl->view));
 
     impl->sceneLoadBegin();
 
-    runAsyncTask([nextScene, _sceneUpdates, this](){
+    runAsyncTask([newScene, this](){
 
-            bool newSceneLoaded = SceneLoader::loadScene(*platform, nextScene, _sceneUpdates);
+            bool newSceneLoaded = SceneLoader::loadScene(newScene);
             if (!newSceneLoaded) {
 
                 if (impl->onSceneReady) {
                     SceneError err;
-                    if (!nextScene->errors.empty()) { err = nextScene->errors.front(); }
-                    impl->onSceneReady(nextScene->id, &err);
+                    if (!newScene->errors.empty()) { err = newScene->errors.front(); }
+                    impl->onSceneReady(newScene->id, &err);
                 }
                 impl->sceneLoadEnd();
                 return;
@@ -243,22 +260,22 @@ SceneID Map::loadSceneAsync(std::shared_ptr<Scene> nextScene,
                 std::lock_guard<std::mutex> lock(impl->sceneMutex);
                 // NB: Need to set the scene on the worker thread so that waiting
                 // applyUpdates AsyncTasks can access it to copy the config.
-                impl->lastValidScene = nextScene;
+                impl->lastValidScene = newScene;
             }
 
-            impl->jobQueue.add([nextScene, newSceneLoaded, this]() {
+            impl->jobQueue.add([newScene, newSceneLoaded, this]() {
                     if (newSceneLoaded) {
-                        auto s = nextScene;
+                        auto s = newScene;
                         impl->setScene(s);
                     }
-                    if (impl->onSceneReady) { impl->onSceneReady(nextScene->id, nullptr); }
+                    if (impl->onSceneReady) { impl->onSceneReady(newScene->id, nullptr); }
                 });
 
             impl->sceneLoadEnd();
             platform->requestRender();
         });
 
-    return nextScene->id;
+    return newScene->id;
 }
 
 void Map::setSceneReadyListener(SceneReadyCallback _onSceneReady) {

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -50,10 +50,10 @@ using CameraAnimator = std::function<uint32_t(float dt)>;
 class Map::Impl {
 
 public:
-    Impl(std::shared_ptr<Platform> _platform) :
+    explicit Impl(std::shared_ptr<Platform> _platform) :
         platform(_platform),
         inputHandler(_platform, view),
-        scene(std::make_shared<Scene>(_platform, Url())) {}
+        scene(std::make_shared<Scene>(_platform, Url(), std::make_unique<View>())) {}
 
 
     void setScene(std::shared_ptr<Scene>& _scene);
@@ -65,6 +65,7 @@ public:
 
     RenderState renderState;
     JobQueue jobQueue;
+    // Current interactive view
     View view;
     Labels labels;
     std::unique_ptr<AsyncWorker> asyncWorker = std::make_unique<AsyncWorker>();
@@ -132,40 +133,11 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
 
     scene = _scene;
 
-    scene->setPixelScale(view.pixelScale());
+    scene->view()->setSize(view.getWidth(), view.getHeight());
 
-    auto& camera = scene->camera();
-    view.setCameraType(camera.type);
+    view = *_scene->view();
 
-    switch (camera.type) {
-    case CameraType::perspective:
-        view.setVanishingPoint(camera.vanishingPoint.x, camera.vanishingPoint.y);
-        if (camera.fovStops) {
-            view.setFieldOfViewStops(camera.fovStops);
-        } else {
-            view.setFieldOfView(camera.fieldOfView);
-        }
-        break;
-    case CameraType::isometric:
-        view.setObliqueAxis(camera.obliqueAxis.x, camera.obliqueAxis.y);
-        break;
-    case CameraType::flat:
-        break;
-    }
-
-    if (camera.maxTiltStops) {
-        view.setMaxPitchStops(camera.maxTiltStops);
-    } else {
-        view.setMaxPitch(camera.maxTilt);
-    }
-
-    if (scene->useScenePosition) {
-        auto position = scene->startPosition;
-        view.setCenterCoordinates({position.x, position.y});
-        view.setZoom(scene->startZoom);
-    }
-
-    inputHandler.setView(view);
+    /// FIXME TODO scene->setPixelScale(view.pixelScale());
 
     bool animated = scene->animated() == Scene::animate::yes;
 
@@ -217,7 +189,7 @@ SceneID Map::loadScene(const std::string& _scenePath, bool _useScenePosition,
                        const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene file: %s", _scenePath.c_str());
-    auto scene = std::make_shared<Scene>(platform, _scenePath);
+    auto scene = std::make_shared<Scene>(platform, _scenePath, std::make_unique<View>(impl->view));
     scene->useScenePosition = _useScenePosition;
     return loadScene(scene, _sceneUpdates);
 }
@@ -226,7 +198,7 @@ SceneID Map::loadSceneYaml(const std::string& _yaml, const std::string& _resourc
                            bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene string");
-    auto scene = std::make_shared<Scene>(platform, _yaml, _resourceRoot);
+    auto scene = std::make_shared<Scene>(platform, _yaml, _resourceRoot, std::make_unique<View>(impl->view));
     scene->useScenePosition = _useScenePosition;
     return loadScene(scene, _sceneUpdates);
 }
@@ -235,7 +207,7 @@ SceneID Map::loadSceneAsync(const std::string& _scenePath, bool _useScenePositio
                             const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene file (async): %s", _scenePath.c_str());
-    auto scene = std::make_shared<Scene>(platform, _scenePath);
+    auto scene = std::make_shared<Scene>(platform, _scenePath, std::make_unique<View>(impl->view));
     scene->useScenePosition = _useScenePosition;
     return loadSceneAsync(scene, _sceneUpdates);
 }
@@ -244,7 +216,7 @@ SceneID Map::loadSceneYamlAsync(const std::string& _yaml, const std::string& _re
                                 bool _useScenePosition, const std::vector<SceneUpdate>& _sceneUpdates) {
 
     LOG("Loading scene string (async)");
-    auto scene = std::make_shared<Scene>(platform, _yaml, _resourceRoot);
+    auto scene = std::make_shared<Scene>(platform, _yaml, _resourceRoot, std::make_unique<View>(impl->view));
     scene->useScenePosition = _useScenePosition;
     return loadSceneAsync(scene, _sceneUpdates);
 }
@@ -376,7 +348,7 @@ void Map::resize(int _newWidth, int _newHeight) {
     LOGS("resize: %d x %d", _newWidth, _newHeight);
     LOG("resize: %d x %d", _newWidth, _newHeight);
 
-    impl->renderState.viewport(0, 0, _newWidth, _newHeight);
+    // FIXME not needed?? impl->renderState.viewport(0, 0, _newWidth, _newHeight);
 
     impl->view.setSize(_newWidth, _newHeight);
 
@@ -642,7 +614,7 @@ void Map::setCameraPositionEased(const CameraPosition& _camera, float _duration,
 
 void Map::updateCameraPosition(const CameraUpdate& _update, float _duration, EaseType _e) {
 
-    CameraPosition camera;
+    CameraPosition camera{};
     if ((_update.set & CameraUpdate::SET_CAMERA) != 0) {
         camera = getCameraPosition();
     }
@@ -1076,7 +1048,7 @@ void Map::setDefaultBackgroundColor(float r, float g, float b) {
 void setDebugFlag(DebugFlags _flag, bool _on) {
 
     g_flags.set(_flag, _on);
-    // m_view->setZoom(m_view->getZoom()); // Force the view to refresh
+    // m_view.setZoom(m_view.getZoom()); // Force the view to refresh
 
 }
 
@@ -1089,7 +1061,7 @@ bool getDebugFlag(DebugFlags _flag) {
 void toggleDebugFlag(DebugFlags _flag) {
 
     g_flags.flip(_flag);
-    // m_view->setZoom(m_view->getZoom()); // Force the view to refresh
+    // m_view.setZoom(m_view.getZoom()); // Force the view to refresh
 
     // Rebuild tiles for debug modes that needs it
     // if (_flag == DebugFlags::proxy_colors

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -1,6 +1,5 @@
 #include "map.h"
 
-#include "data/clientGeoJsonSource.h"
 #include "debug/textDisplay.h"
 #include "debug/frameInfo.h"
 #include "gl.h"
@@ -22,7 +21,6 @@
 #include "text/fontContext.h"
 #include "tile/tile.h"
 #include "tile/tileCache.h"
-#include "tile/tileManager.h"
 #include "util/asyncWorker.h"
 #include "util/fastmap.h"
 #include "util/inputHandler.h"
@@ -36,7 +34,7 @@
 
 namespace Tangram {
 
-const static size_t MAX_WORKERS = 2;
+//const static size_t MAX_WORKERS = 2;
 
 struct CameraEase {
     struct {
@@ -55,9 +53,8 @@ public:
     Impl(std::shared_ptr<Platform> _platform) :
         platform(_platform),
         inputHandler(_platform, view),
-        scene(std::make_shared<Scene>(_platform, Url())),
-        tileWorker(_platform, MAX_WORKERS),
-        tileManager(_platform, tileWorker) {}
+        scene(std::make_shared<Scene>(_platform, Url())) {}
+
 
     void setScene(std::shared_ptr<Scene>& _scene);
 
@@ -83,8 +80,6 @@ public:
     // NB: Destruction of (managed and loading) tiles must happen
     // before implicit destruction of 'scene' above!
     // In particular any references of Labels and Markers to FontContext
-    TileWorker tileWorker;
-    TileManager tileManager;
     MarkerManager markerManager;
     std::unique_ptr<FrameBuffer> selectionBuffer = std::make_unique<FrameBuffer>(0, 0);
 
@@ -96,6 +91,8 @@ public:
 
     SceneReadyCallback onSceneReady = nullptr;
     CameraAnimationCallback cameraAnimationListener = nullptr;
+
+    std::vector<std::shared_ptr<TileSource>> clientTileSources;
 
     void sceneLoadBegin() {
         sceneLoadTasks++;
@@ -119,7 +116,9 @@ Map::Map(std::shared_ptr<Platform> _platform) : platform(_platform) {
 
 Map::~Map() {
     // The unique_ptr to Impl will be automatically destroyed when Map is destroyed.
-    impl->tileWorker.stop();
+    //impl->tileWorker.stop();
+    impl->scene.reset();
+
     impl->asyncWorker.reset();
 
     // Make sure other threads are stopped before calling stop()!
@@ -168,14 +167,20 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
     }
 
     inputHandler.setView(view);
-    tileManager.setTileSources(_scene->tileSources());
-    tileWorker.setScene(_scene);
+
     markerManager.setScene(_scene);
 
     bool animated = scene->animated() == Scene::animate::yes;
 
     if (animated != platform->isContinuousRendering()) {
         platform->setContinuousRendering(animated);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(tilesMutex);
+        for (auto& source : clientTileSources) {
+            scene->tileManager()->addClientTileSource(source);
+        }
     }
 }
 
@@ -301,7 +306,7 @@ std::shared_ptr<Platform>& Map::getPlatform() {
 }
 
 SceneID Map::updateSceneAsync(const std::vector<SceneUpdate>& _sceneUpdates) {
-
+#if 0
     impl->sceneLoadBegin();
 
     std::vector<SceneUpdate> updates = _sceneUpdates;
@@ -360,6 +365,8 @@ SceneID Map::updateSceneAsync(const std::vector<SceneUpdate>& _sceneUpdates) {
         });
 
     return nextScene->id;
+#endif
+    return 0;
 }
 
 void Map::setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath) {
@@ -425,23 +432,25 @@ bool Map::update(float _dt) {
         style->onBeginUpdate();
     }
 
+    impl->scene->updateTiles(_dt);
+
     {
         std::lock_guard<std::mutex> lock(impl->tilesMutex);
 
-        impl->tileManager.updateTileSets(impl->view);
+        impl->scene->tileManager()->updateTileSets(impl->view);
 
-        auto& tiles = impl->tileManager.getVisibleTiles();
+        auto& tiles = impl->scene->tileManager()->getVisibleTiles();
         auto& markers = impl->markerManager.markers();
 
         if (impl->view.changedOnLastUpdate() ||
-            impl->tileManager.hasTileSetChanged() ||
+            impl->scene->tileManager()->hasTileSetChanged() ||
             markersChanged) {
 
             for (const auto& tile : tiles) {
                 tile->update(_dt, impl->view);
             }
             impl->labels.updateLabelSet(impl->view.state(), _dt, impl->scene, tiles, markers,
-                                        impl->tileManager);
+                                        *impl->scene->tileManager());
         } else {
             impl->labels.updateLabels(impl->view.state(), _dt, impl->scene->styles(), tiles, markers);
         }
@@ -450,8 +459,8 @@ bool Map::update(float _dt) {
     FrameInfo::endUpdate();
 
     bool viewChanged = impl->view.changedOnLastUpdate();
-    bool tilesChanged = impl->tileManager.hasTileSetChanged();
-    bool tilesLoading = impl->tileManager.hasLoadingTiles();
+    bool tilesChanged = impl->scene->tileManager()->hasTileSetChanged();
+    bool tilesLoading = impl->scene->tileManager()->hasLoadingTiles();
     bool labelsNeedUpdate = impl->labels.needUpdate();
 
     if (viewChanged || tilesChanged || tilesLoading || labelsNeedUpdate || impl->sceneLoadTasks > 0) {
@@ -523,7 +532,7 @@ bool Map::render() {
         for (const auto& style : impl->scene->styles()) {
 
             style->drawSelectionFrame(impl->renderState, impl->view, *(impl->scene),
-                                      impl->tileManager.getVisibleTiles(),
+                                      impl->scene->tileManager()->getVisibleTiles(),
                                       impl->markerManager.markers());
         }
 
@@ -531,7 +540,7 @@ bool Map::render() {
         // Resolve feature selection queries
         for (const auto& selectionQuery : impl->selectionQueries) {
             selectionQuery.process(impl->view, *impl->selectionBuffer, impl->markerManager,
-                                   impl->tileManager, impl->labels, colorCache);
+                                   *impl->scene->tileManager(), impl->labels, colorCache);
         }
 
         impl->selectionQueries.clear();
@@ -551,7 +560,7 @@ bool Map::render() {
 
     if (drawSelectionBuffer) {
         impl->selectionBuffer->drawDebug(impl->renderState, viewport);
-        FrameInfo::draw(impl->renderState, impl->view, impl->tileManager);
+        FrameInfo::draw(impl->renderState, impl->view, *impl->scene->tileManager());
         return impl->isCameraEasing;
     }
 
@@ -563,9 +572,9 @@ bool Map::render() {
         for (const auto& style : impl->scene->styles()) {
 
             bool styleDrawn = style->draw(impl->renderState,
-                                impl->view, *(impl->scene),
-                                impl->tileManager.getVisibleTiles(),
-                                impl->markerManager.markers());
+                                          impl->view, *(impl->scene),
+                                          impl->scene->tileManager()->getVisibleTiles(),
+                                                                   impl->markerManager.markers());
 
             drawnAnimatedStyle |= (styleDrawn && style->isAnimated());
         }
@@ -579,7 +588,7 @@ bool Map::render() {
 
     impl->labels.drawDebug(impl->renderState, impl->view);
 
-    FrameInfo::draw(impl->renderState, impl->view, impl->tileManager);
+    FrameInfo::draw(impl->renderState, impl->view, *impl->scene->tileManager());
 
     return impl->isCameraEasing;
 }
@@ -915,7 +924,7 @@ void Map::Impl::setPixelScale(float _pixelsPerPoint) {
     scene->setPixelScale(_pixelsPerPoint);
 
     // Tiles must be rebuilt to apply the new pixel scale to labels.
-    tileManager.clearTileSets();
+    scene->tileManager()->clearTileSets();
 
     // Markers must be rebuilt to apply the new pixel scale.
     markerManager.rebuildAll();
@@ -935,19 +944,27 @@ int Map::getCameraType() {
 }
 
 void Map::addTileSource(std::shared_ptr<TileSource> _source) {
+    impl->clientTileSources.push_back(_source);
+
     std::lock_guard<std::mutex> lock(impl->tilesMutex);
-    impl->tileManager.addClientTileSource(_source);
+    impl->scene->tileManager()->addClientTileSource(_source);
 }
 
 bool Map::removeTileSource(TileSource& source) {
+    for (auto it = impl->clientTileSources.begin(); it != impl->clientTileSources.end(); ++it) {
+        if (it->get() == &source) {
+            impl->clientTileSources.erase(it);
+            break;
+        }
+    }
     std::lock_guard<std::mutex> lock(impl->tilesMutex);
-    return impl->tileManager.removeClientTileSource(source);
+    return impl->scene->tileManager()->removeClientTileSource(source);
 }
 
 void Map::clearTileSource(TileSource& _source, bool _data, bool _tiles) {
     std::lock_guard<std::mutex> lock(impl->tilesMutex);
 
-    if (_tiles) { impl->tileManager.clearTileSet(_source.id()); }
+    if (_tiles) { impl->scene->tileManager()->clearTileSet(_source.id()); }
     if (_data) { _source.clearData(); }
 
     platform->requestRender();
@@ -1063,7 +1080,7 @@ void Map::setupGL() {
 
     impl->renderState.invalidate();
 
-    impl->tileManager.clearTileSets();
+    impl->scene->tileManager()->clearTileSets();
 
     impl->markerManager.rebuildAll();
 
@@ -1094,7 +1111,7 @@ void Map::runAsyncTask(std::function<void()> _task) {
 
 void Map::onMemoryWarning() {
 
-    impl->tileManager.clearTileSets(true);
+    impl->scene->tileManager()->clearTileSets(true);
 
     if (impl->scene && impl->scene->fontContext()) {
         impl->scene->fontContext()->releaseFonts();

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -491,9 +491,7 @@ bool Map::render() {
     // Delete batch of gl resources
     impl->renderState.flushResourceDeletion();
 
-    for (const auto& style : impl->scene->styles()) {
-        style->onBeginFrame(impl->renderState);
-    }
+    impl->scene->renderBeginFrame(impl->renderState);
 
     // Render feature selection pass to offscreen framebuffer
     if (impl->selectionQueries.size() > 0 || drawSelectionBuffer) {
@@ -501,19 +499,8 @@ bool Map::render() {
 
         std::lock_guard<std::mutex> lock(impl->tilesMutex);
 
-        for (const auto& style : impl->scene->styles()) {
-
-            style->drawSelectionFrame(impl->renderState, impl->view, *(impl->scene),
-                                      impl->scene->tileManager()->getVisibleTiles(),
-                                      impl->scene->markerManager()->markers());
-        }
-
-        std::vector<SelectionColorRead> colorCache;
-        // Resolve feature selection queries
-        for (const auto& selectionQuery : impl->selectionQueries) {
-            selectionQuery.process(impl->view, *impl->selectionBuffer, *impl->scene->markerManager(),
-                                   *impl->scene->tileManager(), impl->labels, colorCache);
-        }
+        impl->scene->renderSelection(impl->renderState, impl->view, impl->labels,
+                                     *impl->selectionBuffer, impl->selectionQueries);
 
         impl->selectionQueries.clear();
     }
@@ -539,17 +526,7 @@ bool Map::render() {
     bool drawnAnimatedStyle = false;
     {
         std::lock_guard<std::mutex> lock(impl->tilesMutex);
-
-        // Loop over all styles
-        for (const auto& style : impl->scene->styles()) {
-
-            bool styleDrawn = style->draw(impl->renderState,
-                                          impl->view, *(impl->scene),
-                                          impl->scene->tileManager()->getVisibleTiles(),
-                                          impl->scene->markerManager()->markers());
-
-            drawnAnimatedStyle |= (styleDrawn && style->isAnimated());
-        }
+        drawnAnimatedStyle = impl->scene->render(impl->renderState, impl->view);
     }
 
     if (impl->scene->animated() != Scene::animate::no &&

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -16,25 +16,18 @@
 
 namespace Tangram {
 
-MarkerManager::MarkerManager() {}
-
-MarkerManager::~MarkerManager() {}
-
-void MarkerManager::setScene(std::shared_ptr<Scene> scene) {
-
-    m_scene = scene;
-
+MarkerManager::MarkerManager(Scene& _scene) : m_scene(_scene){
     m_styleContext = std::make_unique<StyleContext>();
-    m_styleContext->initFunctions(*scene);
+    m_styleContext->initFunctions(m_scene);
 
     // Initialize StyleBuilders.
     m_styleBuilders.clear();
-    for (auto& style : scene->styles()) {
+    for (auto& style : m_scene.styles()) {
         m_styleBuilders[style->getName()] = style->createBuilder();
     }
-
-    removeAll();
 }
+
+MarkerManager::~MarkerManager() {}
 
 MarkerID MarkerManager::add() {
     m_dirty = true;
@@ -125,8 +118,6 @@ bool MarkerManager::setDrawOrder(MarkerID markerID, int drawOrder) {
 
 bool MarkerManager::setPoint(MarkerID markerID, LngLat lngLat) {
 
-    if (!m_scene) { return false; }
-
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
 
@@ -152,8 +143,6 @@ bool MarkerManager::setPoint(MarkerID markerID, LngLat lngLat) {
 
 bool MarkerManager::setPointEased(MarkerID markerID, LngLat lngLat, float duration, EaseType ease) {
 
-    if (!m_scene) { return false; }
-
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
 
@@ -171,8 +160,6 @@ bool MarkerManager::setPointEased(MarkerID markerID, LngLat lngLat, float durati
 }
 
 bool MarkerManager::setPolyline(MarkerID markerID, LngLat* coordinates, int count) {
-
-    if (!m_scene) { return false; }
 
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
@@ -222,8 +209,6 @@ bool MarkerManager::setPolyline(MarkerID markerID, LngLat* coordinates, int coun
 }
 
 bool MarkerManager::setPolygon(MarkerID markerID, LngLat* coordinates, int* counts, int rings) {
-
-    if (!m_scene) { return false; }
 
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
@@ -332,8 +317,6 @@ const std::vector<std::unique_ptr<Marker>>& MarkerManager::markers() const {
 
 bool MarkerManager::buildStyling(Marker& marker) {
 
-    if (!m_scene) { return false; }
-
     const auto& markerStyling = marker.styling();
 
     // If the Marker styling is a path, find the layers it specifies.
@@ -353,7 +336,7 @@ bool MarkerManager::buildStyling(Marker& marker) {
         size_t layerStart = end + 1;
         start = end + 1;
         end = path.find(DELIMITER[0], start);
-        for (const auto& layer : m_scene->layers()) {
+        for (const auto& layer : m_scene.layers()) {
             if (path.compare(layerStart, end - layerStart, layer.name()) == 0) {
                 currentLayer = &layer;
                 marker.mergeRules(layer);
@@ -388,7 +371,7 @@ bool MarkerManager::buildStyling(Marker& marker) {
     std::vector<StyleParam> params;
 
     // If the styling is not a path, try to load it as a string of YAML.
-    const auto& sceneJsFnList = m_scene->functions();
+    const auto& sceneJsFnList = m_scene.functions();
     auto jsFnIndex = sceneJsFnList.size();
 
     try {
@@ -444,7 +427,7 @@ bool MarkerManager::buildMesh(Marker& marker, int zoom) {
     bool interactive = false;
     if (rule->get(StyleParamKey::interactive, interactive) && interactive) {
         if (selectionColor == 0) {
-            selectionColor = m_scene->featureSelection()->nextColorIdentifier();
+            selectionColor = m_scene.featureSelection()->nextColorIdentifier();
         }
         rule->selectionColor = selectionColor;
     } else {

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -377,7 +377,7 @@ bool MarkerManager::buildStyling(Marker& marker) {
     try {
         YAML::Node node = YAML::Load(markerStyling.string);
         // Parse style parameters from the YAML node.
-        SceneLoader::parseStyleParams(node, m_scene, "", params);
+        SceneLoader::parseStyleParams(m_scene, node, "", params);
     } catch (const YAML::Exception& e) {
         LOG("Invalid marker styling '%s', %s", markerStyling.string.c_str(), e.what());
         return false;

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -21,10 +21,8 @@ class MarkerManager {
 
 public:
 
-    MarkerManager();
+    explicit MarkerManager(Scene& scene);
     ~MarkerManager();
-    // Set the Scene object whose styling information will be used to build markers.
-    void setScene(std::shared_ptr<Scene> scene);
 
     // Create a new, empty marker and return its ID. An ID of 0 indicates an invalid marker.
     MarkerID add();
@@ -87,8 +85,9 @@ private:
     bool buildStyling(Marker& marker);
     bool buildMesh(Marker& marker, int zoom);
 
+    Scene& m_scene;
+
     std::unique_ptr<StyleContext> m_styleContext;
-    std::shared_ptr<Scene> m_scene;
     std::vector<std::unique_ptr<Marker>> m_markers;
     std::vector<std::string> m_jsFnList;
     fastmap<std::string, std::unique_ptr<StyleBuilder>> m_styleBuilders;

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -19,7 +19,7 @@ Importer::Importer(std::shared_ptr<Scene> scene)
     : m_scene(scene) {
 }
 
-Node Importer::applySceneImports(std::shared_ptr<Platform> platform) {
+Node Importer::applySceneImports(Platform& platform) {
 
     Url sceneUrl = m_scene->url();
 

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -21,13 +21,13 @@ Importer::Importer(std::shared_ptr<Scene> scene)
 
 Node Importer::applySceneImports(Platform& platform) {
 
-    Url sceneUrl = m_scene->url();
+    Url sceneUrl = m_scene->options().url;
 
     Url nextUrlToImport;
 
-    if (!m_scene->yaml().empty()) {
+    if (!m_scene->options().yaml.empty()) {
         // Load scene from yaml string.
-        addSceneString(sceneUrl, m_scene->yaml());
+        addSceneString(sceneUrl, m_scene->options().yaml);
     } else {
         // Load scene from yaml file.
         m_sceneQueue.push_back(sceneUrl);
@@ -62,7 +62,7 @@ Node Importer::applySceneImports(Platform& platform) {
         }
 
         activeDownloads++;
-        m_scene->startUrlRequest(platform, nextUrlToImport, [&, nextUrlToImport](UrlResponse&& response) {
+        m_scene->startUrlRequest(nextUrlToImport, [&, nextUrlToImport](UrlResponse&& response) {
             std::unique_lock<std::mutex> lock(sceneMutex);
             if (response.error) {
                 LOGE("Unable to retrieve '%s': %s", nextUrlToImport.string().c_str(), response.error);

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -24,7 +24,7 @@ public:
     Importer(std::shared_ptr<Scene> scene);
 
     // Loads the main scene with deep merging dependent imported scenes.
-    Node applySceneImports(std::shared_ptr<Platform> platform);
+    Node applySceneImports(Platform& platform);
 
     static bool isZipArchiveUrl(const Url& url);
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -3,7 +3,7 @@
 #include "data/tileSource.h"
 #include "gl/framebuffer.h"
 #include "gl/shaderProgram.h"
-#include "labels/labels.h"
+#include "labels/labelManager.h"
 #include "scene/dataLayer.h"
 #include "scene/importer.h"
 #include "scene/light.h"
@@ -33,7 +33,7 @@ Scene::Scene(std::shared_ptr<Platform> _platform, const Url& _url, std::unique_p
       m_featureSelection(std::make_unique<FeatureSelection>()),
       m_tileWorker(std::make_unique<TileWorker>(_platform, 2)),
       m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)),
-      m_labelManager(std::make_unique<Labels>()),
+      m_labelManager(std::make_unique<LabelManager>()),
       m_view(std::move(_view)) {
 
 }
@@ -46,7 +46,7 @@ Scene::Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, cons
       m_featureSelection(std::make_unique<FeatureSelection>()),
       m_tileWorker(std::make_unique<TileWorker>(_platform, 2)),
       m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)),
-      m_labelManager(std::make_unique<Labels>()),
+      m_labelManager(std::make_unique<LabelManager>()),
       m_view(std::move(_view)) {}
 
 void Scene::copyConfig(const Scene& _other) {

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -26,24 +26,26 @@ static std::atomic<int32_t> s_serial;
 
 //Scene::Scene() : id(s_serial++) {}
 
-Scene::Scene(std::shared_ptr<Platform> _platform, const Url& _url)
+Scene::Scene(std::shared_ptr<Platform> _platform, const Url& _url, std::unique_ptr<View> _view)
     : id(s_serial++),
       m_url(_url),
       m_fontContext(std::make_shared<FontContext>(_platform)),
       m_featureSelection(std::make_unique<FeatureSelection>()),
       m_tileWorker(std::make_unique<TileWorker>(_platform, 2)),
-      m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)) {}
+      m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)),
+      m_view(std::move(_view)) {
 
-Scene::Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url)
+}
+
+Scene::Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url, std::unique_ptr<View> _view)
     : id(s_serial++),
       m_fontContext(std::make_shared<FontContext>(_platform)),
       m_featureSelection(std::make_unique<FeatureSelection>()),
       m_tileWorker(std::make_unique<TileWorker>(_platform, 2)),
-      m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)) {
-
-    m_url = _url;
-    m_yaml = _yaml;
-}
+      m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)),
+      m_url(_url),
+      m_yaml(_yaml),
+      m_view(std::move(_view)) {}
 
 void Scene::copyConfig(const Scene& _other) {
 
@@ -184,7 +186,7 @@ void Scene::setPixelScale(float _scale) {
     m_fontContext->setPixelScale(_scale);
 
     // Tiles must be rebuilt to apply the new pixel scale to labels.
-    m_tileManager->clearTileSets();
+    // FIXME m_tileManager->clearTileSets();
 
     // Markers must be rebuilt to apply the new pixel scale.
     if (m_markerManager) {
@@ -193,7 +195,7 @@ void Scene::setPixelScale(float _scale) {
 
 }
 
-bool Scene::update(View& _view, Labels& _labels, float _dt) {
+bool Scene::update(const View& _view, Labels& _labels, float _dt) {
 
     m_time += _dt;
 

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -21,19 +21,22 @@ namespace Tangram {
 
 static std::atomic<int32_t> s_serial;
 
-Scene::Scene() : id(s_serial++) {}
+//Scene::Scene() : id(s_serial++) {}
 
-Scene::Scene(std::shared_ptr<const Platform> _platform, const Url& _url)
+Scene::Scene(std::shared_ptr<Platform> _platform, const Url& _url)
     : id(s_serial++),
       m_url(_url),
       m_fontContext(std::make_shared<FontContext>(_platform)),
-      m_featureSelection(std::make_unique<FeatureSelection>()) {
-}
+      m_featureSelection(std::make_unique<FeatureSelection>()),
+      m_tileWorker(std::make_unique<TileWorker>(_platform, 2)),
+      m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)) {}
 
-Scene::Scene(std::shared_ptr<const Platform> _platform, const std::string& _yaml, const Url& _url)
+Scene::Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url)
     : id(s_serial++),
       m_fontContext(std::make_shared<FontContext>(_platform)),
-      m_featureSelection(std::make_unique<FeatureSelection>()) {
+      m_featureSelection(std::make_unique<FeatureSelection>()),
+      m_tileWorker(std::make_unique<TileWorker>(_platform, 2)),
+      m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)) {
 
     m_url = _url;
     m_yaml = _yaml;
@@ -54,7 +57,9 @@ void Scene::copyConfig(const Scene& _other) {
     m_zipArchives = _other.m_zipArchives;
 }
 
-Scene::~Scene() {}
+Scene::~Scene() {
+    //m_tileWorker->stop();
+}
 
 const Style* Scene::findStyle(const std::string& _name) const {
 
@@ -174,6 +179,10 @@ void Scene::setPixelScale(float _scale) {
         style->setPixelScale(_scale);
     }
     m_fontContext->setPixelScale(_scale);
+}
+
+void Scene::updateTiles(float dt) {
+
 }
 
 }

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -27,7 +27,7 @@ static std::atomic<int32_t> s_serial;
 
 //Scene::Scene() : id(s_serial++) {}
 
-Scene::Scene(std::shared_ptr<Platform> _platform, const Url& _url, std::unique_ptr<View> _view)
+Scene::Scene(Platform& _platform, const Url& _url, std::unique_ptr<View> _view)
     : id(s_serial++),
       m_url(_url),
       m_fontContext(std::make_shared<FontContext>(_platform)),
@@ -40,7 +40,7 @@ Scene::Scene(std::shared_ptr<Platform> _platform, const Url& _url, std::unique_p
     m_fontContext->setPixelScale(m_pixelScale);
 }
 
-Scene::Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url, std::unique_ptr<View> _view)
+Scene::Scene(Platform& _platform, const std::string& _yaml, const Url& _url, std::unique_ptr<View> _view)
     : id(s_serial++),
       m_url(_url),
       m_yaml(_yaml),
@@ -90,7 +90,7 @@ Style* Scene::findStyle(const std::string& _name) {
     return nullptr;
 }
 
-UrlRequestHandle Scene::startUrlRequest(std::shared_ptr<Platform> platform, Url url, UrlCallback callback) {
+UrlRequestHandle Scene::startUrlRequest(Platform& platform, Url url, UrlCallback callback) {
     if (url.scheme() == "zip") {
         UrlResponse response;
         // URL for a file in a zip archive, get the encoded source URL.
@@ -119,7 +119,7 @@ UrlRequestHandle Scene::startUrlRequest(std::shared_ptr<Platform> platform, Url 
     }
 
     // For non-zip URLs, send it to the platform.
-    return platform->startUrlRequest(url, callback);
+    return platform.startUrlRequest(url, callback);
 }
 
 void Scene::addZipArchive(Url url, std::shared_ptr<ZipArchive> zipArchive) {

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -26,6 +26,8 @@ namespace Tangram {
 static std::atomic<int32_t> s_serial;
 
 
+Scene::Scene(Platform& _platform) : id(s_serial++), m_platform(_platform) {}
+
 Scene::Scene(Platform& _platform, std::unique_ptr<SceneOptions> _sceneOptions, std::unique_ptr<View> _view)
     : id(s_serial++),
       m_platform(_platform),

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -179,6 +179,15 @@ void Scene::setPixelScale(float _scale) {
         style->setPixelScale(_scale);
     }
     m_fontContext->setPixelScale(_scale);
+
+    // Tiles must be rebuilt to apply the new pixel scale to labels.
+    m_tileManager->clearTileSets();
+
+    // Markers must be rebuilt to apply the new pixel scale.
+    if (m_markerManager) {
+        m_markerManager->rebuildAll();
+    }
+
 }
 
 void Scene::updateTiles(float dt) {

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -14,6 +14,7 @@
 #include "style/material.h"
 #include "style/style.h"
 #include "text/fontContext.h"
+#include "util/base64.h"
 #include "util/mapProjection.h"
 #include "util/util.h"
 #include "util/zipArchive.h"
@@ -40,6 +41,7 @@ Scene::Scene(Platform& _platform, std::unique_ptr<SceneOptions> _sceneOptions, s
       m_view(std::move(_view)) {
     m_pixelScale = m_view->pixelScale();
     m_fontContext->setPixelScale(m_pixelScale);
+    m_loading = true;
 }
 
 #if 0
@@ -59,17 +61,13 @@ void Scene::copyConfig(const Scene& _other) {
 }
 #endif
 
-Scene::~Scene() {
-    //m_tileWorker->stop();
-}
+Scene::~Scene() {}
 
 const Style* Scene::findStyle(const std::string& _name) const {
-
     for (auto& style : m_styles) {
         if (style->getName() == _name) { return style.get(); }
     }
     return nullptr;
-
 }
 
 Style* Scene::findStyle(const std::string& _name) {
@@ -78,38 +76,6 @@ Style* Scene::findStyle(const std::string& _name) {
         if (style->getName() == _name) { return style.get(); }
     }
     return nullptr;
-}
-
-UrlRequestHandle Scene::startUrlRequest(const Url& url, UrlCallback callback) {
-    if (url.scheme() == "zip") {
-        UrlResponse response;
-        // URL for a file in a zip archive, get the encoded source URL.
-        auto source = Importer::getArchiveUrlForZipEntry(url);
-        // Search for the source URL in our archive map.
-        auto it = m_zipArchives.find(source);
-        if (it != m_zipArchives.end()) {
-            auto& archive = it->second;
-            // Found the archive! Now create a response for the request.
-            auto zipEntryPath = url.path().substr(1);
-            auto entry = archive->findEntry(zipEntryPath);
-            if (entry) {
-                response.content.resize(entry->uncompressedSize);
-                bool success = archive->decompressEntry(entry, response.content.data());
-                if (!success) {
-                    response.error = "Unable to decompress zip archive file.";
-                }
-            } else {
-                response.error = "Did not find zip archive entry.";
-            }
-        } else {
-            response.error = "Could not find zip archive.";
-        }
-        callback(std::move(response));
-        return 0;
-    }
-
-    // For non-zip URLs, send it to the platform.
-    return m_platform.startUrlRequest(url, callback);
 }
 
 void Scene::addZipArchive(Url url, std::shared_ptr<ZipArchive> zipArchive) {
@@ -193,7 +159,172 @@ void Scene::setPixelScale(float _scale) {
     if (m_markerManager) {
         m_markerManager->rebuildAll();
     }
+}
 
+UrlRequestHandle Scene::startUrlRequest(const Url& url, UrlCallback callback) {
+    if (url.scheme() == "zip") {
+        UrlResponse response;
+        // URL for a file in a zip archive, get the encoded source URL.
+        auto source = Importer::getArchiveUrlForZipEntry(url);
+        // Search for the source URL in our archive map.
+        auto it = m_zipArchives.find(source);
+        if (it != m_zipArchives.end()) {
+            auto& archive = it->second;
+            // Found the archive! Now create a response for the request.
+            auto zipEntryPath = url.path().substr(1);
+            auto entry = archive->findEntry(zipEntryPath);
+            if (entry) {
+                response.content.resize(entry->uncompressedSize);
+                bool success = archive->decompressEntry(entry, response.content.data());
+                if (!success) {
+                    response.error = "Unable to decompress zip archive file.";
+                }
+            } else {
+                response.error = "Did not find zip archive entry.";
+            }
+        } else {
+            response.error = "Could not find zip archive.";
+        }
+        callback(std::move(response));
+        return 0;
+    }
+
+    // For non-zip URLs, send it to the platform.
+    return m_platform.startUrlRequest(url, callback);
+}
+
+std::shared_ptr<Texture> Scene::fetchTexture(const std::string& _name, const Url& _url,
+                                             const TextureOptions& _options,
+                                             std::unique_ptr<SpriteAtlas> _atlas) {
+
+    std::shared_ptr<Texture> texture = std::make_shared<Texture>(_options);
+    m_textures.emplace(_name, texture);
+
+    if (_url.hasBase64Data() && _url.mediaType() == "image/png") {
+        auto data = _url.data();
+
+        std::vector<unsigned char> blob;
+
+        try {
+            blob = Base64::decode(data);
+        } catch(const std::runtime_error& e) {
+            LOGE("Can't decode Base64 texture '%s'", e.what());
+        }
+
+        if (blob.empty()) {
+            LOGE("Can't decode Base64 texture");
+
+        } else if (!texture->loadImageFromMemory(blob.data(), blob.size())) {
+            LOGE("Invalid Base64 texture");
+        }
+        return texture;
+    }
+
+    texture->setSpriteAtlas(std::move(_atlas));
+
+    LOG("Fetch texture");
+
+    auto task = std::make_shared<TextureTask>(_url, texture);
+
+    {
+        std::lock_guard<std::mutex> lock(m_taskMutex);
+        m_pendingTextures.push_front(task);
+    }
+    startUrlRequest(_url, [t = std::weak_ptr<TextureTask>(task)] (UrlResponse&& response) {
+        auto task = t.lock();
+        if (!task) { return; }
+
+        LOG("Got texture data %s", task->url.string().c_str());
+
+        if (response.error) {
+            LOGE("Error retrieving URL '%s': %s", task->url.string().c_str(), response.error);
+        } else {
+            auto data = reinterpret_cast<const uint8_t*>(response.content.data());
+            auto length = response.content.size();
+            if (!task->texture->loadImageFromMemory(data, length)) {
+                LOGE("Invalid texture data from URL '%s'", task->url.string().c_str());
+            }
+            if (auto& sprites = task->texture->getSpriteAtlas()) {
+                sprites->updateSpriteNodes({task->texture->getWidth(),
+                                            task->texture->getHeight()});
+            }
+        }
+        task->done = true;
+    });
+
+    return texture;
+}
+
+std::shared_ptr<Texture> Scene::loadTexture(const std::string& _name) {
+
+    auto entry = m_textures.find(_name);
+    if (entry != m_textures.end()) {
+        return entry->second;
+    }
+
+    // If texture could not be found by name then interpret name as URL
+    TextureOptions options;
+    return fetchTexture(_name, _name, options);
+}
+
+
+void Scene::loadFont(const std::string& _uri, const std::string& _family,
+                     const std::string& _style, const std::string& _weight) {
+
+    std::string familyNormalized, styleNormalized;
+
+    familyNormalized.resize(_family.size());
+    styleNormalized.resize(_style.size());
+
+    std::transform(_family.begin(), _family.end(), familyNormalized.begin(), ::tolower);
+    std::transform(_style.begin(), _style.end(), styleNormalized.begin(), ::tolower);
+
+    auto task = std::make_shared<FontTask>(FontDescription{familyNormalized,styleNormalized,
+                                                           _weight, _uri}, m_fontContext);
+    {
+        std::lock_guard<std::mutex> lock(m_taskMutex);
+        m_pendingFonts.push_front(task);
+    }
+    startUrlRequest(_uri, [t = std::weak_ptr<FontTask>(task)] (UrlResponse&& response) {
+         auto task = t.lock();
+         if (!task) { return; }
+
+         LOG("Got font: %s", task->ft.uri.c_str());
+
+        if (response.error) {
+            LOGE("Error retrieving font '%s' at %s: ", task->ft.alias.c_str(),
+                 task->ft.uri.c_str(), response.error);
+        } else {
+            task->fontContext->addFont(task->ft, alfons::InputSource(std::move(response.content)));
+        }
+        task->done = true;
+    });
+}
+
+bool Scene::complete() {
+    if (m_ready) { return true; }
+    if (!m_loading) { return false; }
+
+    // Wait until font and texture resources are fully loaded
+    {
+        std::lock_guard<std::mutex> lock(m_taskMutex);
+        int t = 0, f = 0;
+        m_pendingTextures.remove_if([&](auto& task) { t++;  return task->done; });
+        m_pendingFonts.remove_if([&](auto& task) { f++; return task->done; });
+
+        if (!m_pendingTextures.empty() || !m_pendingFonts.empty()) {
+            LOG("Waiting... fonts:%d textures:%d", f, t);
+            return false;
+        }
+    }
+
+    m_markerManager = std::make_unique<MarkerManager>(*this);
+    m_tileWorker->poke();
+
+    m_loading = false;
+    m_ready = true;
+
+    return true;
 }
 
 bool Scene::update(const View& _view, float _dt) {
@@ -218,7 +349,8 @@ bool Scene::update(const View& _view, float _dt) {
         for (const auto& tile : tiles) {
             tile->update(_dt, _view);
         }
-        m_labelManager->updateLabelSet(_view.state(), _dt, *this, tiles, markers, *m_tileManager);
+        m_labelManager->updateLabelSet(_view.state(), _dt, *this, tiles, markers,
+                                       *m_tileManager);
     } else {
         m_labelManager->updateLabels(_view.state(), _dt, m_styles, tiles, markers);
     }

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -25,11 +25,11 @@ namespace Tangram {
 
 static std::atomic<int32_t> s_serial;
 
-//Scene::Scene() : id(s_serial++) {}
 
-Scene::Scene(Platform& _platform, const Url& _url, std::unique_ptr<View> _view)
+Scene::Scene(Platform& _platform, std::unique_ptr<SceneOptions> _sceneOptions, std::unique_ptr<View> _view)
     : id(s_serial++),
-      m_url(_url),
+      m_platform(_platform),
+      m_options(std::move(_sceneOptions)),
       m_fontContext(std::make_shared<FontContext>(_platform)),
       m_featureSelection(std::make_unique<FeatureSelection>()),
       m_tileWorker(std::make_unique<TileWorker>(_platform, 2)),
@@ -40,20 +40,7 @@ Scene::Scene(Platform& _platform, const Url& _url, std::unique_ptr<View> _view)
     m_fontContext->setPixelScale(m_pixelScale);
 }
 
-Scene::Scene(Platform& _platform, const std::string& _yaml, const Url& _url, std::unique_ptr<View> _view)
-    : id(s_serial++),
-      m_url(_url),
-      m_yaml(_yaml),
-      m_fontContext(std::make_shared<FontContext>(_platform)),
-      m_featureSelection(std::make_unique<FeatureSelection>()),
-      m_tileWorker(std::make_unique<TileWorker>(_platform, 2)),
-      m_tileManager(std::make_unique<TileManager>(_platform, *m_tileWorker)),
-      m_labelManager(std::make_unique<LabelManager>()),
-      m_view(std::move(_view)) {
-     m_pixelScale = m_view->pixelScale();
-     m_fontContext->setPixelScale(m_pixelScale);
-}
-
+#if 0
 void Scene::copyConfig(const Scene& _other) {
 
     m_featureSelection.reset(new FeatureSelection());
@@ -68,6 +55,7 @@ void Scene::copyConfig(const Scene& _other) {
 
     m_zipArchives = _other.m_zipArchives;
 }
+#endif
 
 Scene::~Scene() {
     //m_tileWorker->stop();
@@ -90,7 +78,7 @@ Style* Scene::findStyle(const std::string& _name) {
     return nullptr;
 }
 
-UrlRequestHandle Scene::startUrlRequest(Platform& platform, Url url, UrlCallback callback) {
+UrlRequestHandle Scene::startUrlRequest(const Url& url, UrlCallback callback) {
     if (url.scheme() == "zip") {
         UrlResponse response;
         // URL for a file in a zip archive, get the encoded source URL.
@@ -119,7 +107,7 @@ UrlRequestHandle Scene::startUrlRequest(Platform& platform, Url url, UrlCallback
     }
 
     // For non-zip URLs, send it to the platform.
-    return platform.startUrlRequest(url, callback);
+    return m_platform.startUrlRequest(url, callback);
 }
 
 void Scene::addZipArchive(Url url, std::shared_ptr<ZipArchive> zipArchive) {

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -392,6 +392,10 @@ void Scene::renderSelection(RenderState& _rs, View& _view, FrameBuffer& _selecti
                                *m_markerManager, *m_tileManager,
                                *m_labelManager, colorCache);
     }
-
 }
+
+void Scene::requestRender() {
+    if (m_ready) { m_platform.requestRender(); }
+}
+
 }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -41,10 +41,13 @@ class ZipArchive;
 class FrameBuffer;
 class SelectionQuery;
 
+// 16MB default in-memory DataSource cache
+constexpr size_t CACHE_SIZE = 16 * (1024 * 102);
+
 // Delimiter used in sceneloader for style params and layer-sublayer naming
 const std::string DELIMITER = ":";
 
-/* Singleton container of <Style> information
+/* Container of <Style> information
  *
  * Scene is a singleton containing the styles, lighting, and interactions defining a map scene
  */
@@ -66,6 +69,8 @@ public:
     bool useScenePosition = true;
     // Add styles toggled by DebguFlags
     bool debugStyles = false;
+
+    size_t memoryTileCacheSize = CACHE_SIZE;
 };
 
 class Scene {

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -95,7 +95,7 @@ public:
         yes, no, none
     };
 
-    Scene(Platform& _platform);
+    explicit Scene(Platform& _platform);
     Scene(Platform& _platform, std::unique_ptr<SceneOptions> _sceneOptions,
           std::unique_ptr<View> _view = std::make_unique<View>());
 
@@ -105,8 +105,6 @@ public:
     ~Scene();
 
     const int32_t id;
-
-    //void copyConfig(const Scene& _other);
 
     auto& view() { return m_view; }
     auto& camera() { return m_camera; }
@@ -162,9 +160,6 @@ public:
 
     int addJsFunction(const std::string& _function);
 
-    glm::dvec2 startPosition = { 0, 0 };
-    float startZoom = 0;
-
     void animated(bool animated) { m_animated = animated ? yes : no; }
     animate animated() const { return m_animated; }
 
@@ -175,8 +170,6 @@ public:
 
     float pixelScale() { return m_pixelScale; }
     void setPixelScale(float _scale);
-
-    std::vector<SceneError> errors;
 
     bool update(const View& _view, float _dt);
     void renderBeginFrame(RenderState& _rs);
@@ -219,6 +212,9 @@ public:
 
     friend struct SceneLoader;
     friend class Importer;
+
+    std::vector<SceneError> errors;
+
 protected:
     Platform& platform() { return m_platform; }
     const SceneOptions& options() { return *m_options; }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -59,8 +59,12 @@ public:
     std::string yaml;
     // The URL from which this scene was loaded
     Url url;
+    // SceneUpdates to apply to the scene
     std::vector<SceneUpdate> updates;
+    // Set the view to the position provided by the scene
     bool useScenePosition = true;
+    // Add styles toggled by DebguFlags
+    bool debugStyles = false;
 };
 
 class Scene {

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -85,6 +85,7 @@ public:
         yes, no, none
     };
 
+    Scene(Platform& _platform);
     Scene(Platform& _platform, std::unique_ptr<SceneOptions> _sceneOptions,
           std::unique_ptr<View> _view = std::make_unique<View>());
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -70,8 +70,8 @@ public:
     };
 
     //Scene();
-    Scene(std::shared_ptr<Platform> _platform, const Url& _url);
-    Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url);
+    Scene(std::shared_ptr<Platform> _platform, const Url& _url, std::unique_ptr<View> _view);
+    Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url, std::unique_ptr<View> _view);
     Scene(const Scene& _other) = delete;
     Scene(Scene&& _other) = delete;
 
@@ -80,6 +80,8 @@ public:
     const int32_t id;
 
     void copyConfig(const Scene& _other);
+
+    auto& view() { return m_view; }
 
     auto& camera() { return m_camera; }
     auto& config() { return m_config; }
@@ -156,7 +158,7 @@ public:
 
     std::vector<SceneError> errors;
 
-    bool update(View& _view, Labels& _labels, float _dt);
+    bool update(const View& _view, Labels& _labels, float _dt);
     void renderBeginFrame(RenderState& _rs);
     bool render(RenderState& _rs, View& _view);
     void renderSelection(RenderState& _rs, View& _view, Labels& _labels,
@@ -237,6 +239,7 @@ private:
     std::unique_ptr<TileWorker> m_tileWorker;
     std::unique_ptr<TileManager> m_tileManager;
     std::unique_ptr<MarkerManager> m_markerManager;
+    std::unique_ptr<View> m_view;
 
 };
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -36,6 +36,8 @@ class Texture;
 class TileSource;
 class ZipArchive;
 class Labels;
+class FrameBuffer;
+class SelectionQuery;
 
 // Delimiter used in sceneloader for style params and layer-sublayer naming
 const std::string DELIMITER = ":";
@@ -155,6 +157,11 @@ public:
     std::vector<SceneError> errors;
 
     bool update(View& _view, Labels& _labels, float _dt);
+    void renderBeginFrame(RenderState& _rs);
+    bool render(RenderState& _rs, View& _view);
+    void renderSelection(RenderState& _rs, View& _view, Labels& _labels,
+                         FrameBuffer& _selectionBuffer,
+                         std::vector<SelectionQuery>& _selectionQueries);
 
     TileManager* tileManager() { return m_tileManager.get(); }
     MarkerManager* markerManager() { return m_markerManager.get(); }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -27,6 +27,7 @@ namespace Tangram {
 class DataLayer;
 class FeatureSelection;
 class FontContext;
+class LabelManager;
 class Light;
 class MapProjection;
 class Platform;
@@ -35,7 +36,6 @@ class Style;
 class Texture;
 class TileSource;
 class ZipArchive;
-class Labels;
 class FrameBuffer;
 class SelectionQuery;
 
@@ -174,7 +174,7 @@ public:
 
     TileManager* tileManager() { return m_tileManager.get(); }
     MarkerManager* markerManager() { return m_markerManager.get(); }
-    Labels* labelManager() { return m_labelManager.get(); }
+    LabelManager* labelManager() { return m_labelManager.get(); }
 
     void initTileManager() {
         m_tileManager->setTileSources(m_tileSources);
@@ -240,7 +240,7 @@ private:
     std::unique_ptr<TileWorker> m_tileWorker;
     std::unique_ptr<TileManager> m_tileManager;
     std::unique_ptr<MarkerManager> m_markerManager;
-    std::unique_ptr<Labels> m_labelManager;
+    std::unique_ptr<LabelManager> m_labelManager;
     std::unique_ptr<View> m_view;
 
 };

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -70,9 +70,9 @@ public:
     };
 
     //Scene();
-    Scene(std::shared_ptr<Platform> _platform, const Url& _url,
+    Scene(Platform& _platform, const Url& _url,
           std::unique_ptr<View> _view = std::make_unique<View>());
-    Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url,
+    Scene(Platform& _platform, const std::string& _yaml, const Url& _url,
           std::unique_ptr<View> _view = std::make_unique<View>());
     Scene(const Scene& _other) = delete;
     Scene(Scene&& _other) = delete;
@@ -129,7 +129,7 @@ public:
     // as expected within zip archives). This function expects that all required
     // zip archives will be added to the scene with addZipArchive before being
     // requested.
-    UrlRequestHandle startUrlRequest(std::shared_ptr<Platform> platform, Url url, UrlCallback callback);
+    UrlRequestHandle startUrlRequest(Platform& platform, Url url, UrlCallback callback);
 
     void addZipArchive(Url url, std::shared_ptr<ZipArchive> zipArchive);
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -158,10 +158,10 @@ public:
 
     std::vector<SceneError> errors;
 
-    bool update(const View& _view, Labels& _labels, float _dt);
+    bool update(const View& _view, float _dt);
     void renderBeginFrame(RenderState& _rs);
     bool render(RenderState& _rs, View& _view);
-    void renderSelection(RenderState& _rs, View& _view, Labels& _labels,
+    void renderSelection(RenderState& _rs, View& _view,
                          FrameBuffer& _selectionBuffer,
                          std::vector<SelectionQuery>& _selectionQueries);
 
@@ -174,6 +174,7 @@ public:
 
     TileManager* tileManager() { return m_tileManager.get(); }
     MarkerManager* markerManager() { return m_markerManager.get(); }
+    Labels* labelManager() { return m_labelManager.get(); }
 
     void initTileManager() {
         m_tileManager->setTileSources(m_tileSources);
@@ -239,6 +240,7 @@ private:
     std::unique_ptr<TileWorker> m_tileWorker;
     std::unique_ptr<TileManager> m_tileManager;
     std::unique_ptr<MarkerManager> m_markerManager;
+    std::unique_ptr<Labels> m_labelManager;
     std::unique_ptr<View> m_view;
 
 };

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "map.h"
+#include "marker/markerManager.h"
 #include "platform.h"
 #include "stops.h"
 #include "tile/tileManager.h"
@@ -156,6 +157,7 @@ public:
     void updateTiles(float dt);
 
     TileManager* tileManager() { return m_tileManager.get(); }
+    MarkerManager* markerManager() { return m_markerManager.get(); }
 
     void initTileManager() {
         m_tileManager->setTileSources(m_tileSources);
@@ -163,6 +165,7 @@ public:
 
     void startTileWorker() {
         m_tileWorker->setScene(*this);
+        m_markerManager = std::make_unique<MarkerManager>(*this);
     }
 
 private:
@@ -219,6 +222,7 @@ private:
 
     std::unique_ptr<TileWorker> m_tileWorker;
     std::unique_ptr<TileManager> m_tileManager;
+    std::unique_ptr<MarkerManager> m_markerManager;
 
 };
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -35,6 +35,7 @@ class Style;
 class Texture;
 class TileSource;
 class ZipArchive;
+class Labels;
 
 // Delimiter used in sceneloader for style params and layer-sublayer naming
 const std::string DELIMITER = ":";
@@ -126,7 +127,6 @@ public:
 
     void addZipArchive(Url url, std::shared_ptr<ZipArchive> zipArchive);
 
-    void updateTime(float _dt) { m_time += _dt; }
     float time() const { return m_time; }
 
     int addIdForName(const std::string& _name);
@@ -154,7 +154,7 @@ public:
 
     std::vector<SceneError> errors;
 
-    void updateTiles(float dt);
+    bool update(View& _view, Labels& _labels, float _dt);
 
     TileManager* tileManager() { return m_tileManager.get(); }
     MarkerManager* markerManager() { return m_markerManager.get(); }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -163,6 +163,13 @@ public:
                          FrameBuffer& _selectionBuffer,
                          std::vector<SelectionQuery>& _selectionQueries);
 
+    Color background(int _zoom) {
+        if (m_backgroundStops.frames.size() > 0) {
+            return m_backgroundStops.evalColor(_zoom);
+        }
+        return m_background;
+    }
+
     TileManager* tileManager() { return m_tileManager.get(); }
     MarkerManager* markerManager() { return m_markerManager.get(); }
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -70,8 +70,10 @@ public:
     };
 
     //Scene();
-    Scene(std::shared_ptr<Platform> _platform, const Url& _url, std::unique_ptr<View> _view);
-    Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url, std::unique_ptr<View> _view);
+    Scene(std::shared_ptr<Platform> _platform, const Url& _url,
+          std::unique_ptr<View> _view = std::make_unique<View>());
+    Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url,
+          std::unique_ptr<View> _view = std::make_unique<View>());
     Scene(const Scene& _other) = delete;
     Scene(Scene&& _other) = delete;
 

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -232,6 +232,10 @@ public:
 
     std::vector<SceneError> errors;
 
+    void requestRender();
+
+    std::shared_ptr<Texture> emptyTexture() { return nullptr; }
+
 protected:
     Platform& platform() { return m_platform; }
     const SceneOptions& options() { return *m_options; }

--- a/core/src/scene/scene.h
+++ b/core/src/scene/scene.h
@@ -3,6 +3,7 @@
 #include "map.h"
 #include "platform.h"
 #include "stops.h"
+#include "tile/tileManager.h"
 #include "util/color.h"
 #include "util/url.h"
 #include "util/yamlPath.h"
@@ -60,16 +61,15 @@ public:
         glm::vec2 obliqueAxis = {0, 1};
     };
 
-    Camera m_camera;
-
     enum animate {
         yes, no, none
     };
 
-    Scene();
-    Scene(std::shared_ptr<const Platform> _platform, const Url& _url);
-    Scene(std::shared_ptr<const Platform> _platform, const std::string& _yaml, const Url& _url);
+    //Scene();
+    Scene(std::shared_ptr<Platform> _platform, const Url& _url);
+    Scene(std::shared_ptr<Platform> _platform, const std::string& _yaml, const Url& _url);
     Scene(const Scene& _other) = delete;
+    Scene(Scene&& _other) = delete;
 
     ~Scene();
 
@@ -153,7 +153,21 @@ public:
 
     std::vector<SceneError> errors;
 
+    void updateTiles(float dt);
+
+    TileManager* tileManager() { return m_tileManager.get(); }
+
+    void initTileManager() {
+        m_tileManager->setTileSources(m_tileSources);
+    }
+
+    void startTileWorker() {
+        m_tileWorker->setScene(*this);
+    }
+
 private:
+
+    Camera m_camera;
 
     // The URL from which this scene was loaded
     Url m_url;
@@ -201,6 +215,10 @@ private:
     float m_pixelScale = 1.0f;
 
     float m_time = 0.0;
+
+
+    std::unique_ptr<TileWorker> m_tileWorker;
+    std::unique_ptr<TileManager> m_tileManager;
 
 };
 

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -68,7 +68,7 @@ constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
 static const std::string GLOBAL_PREFIX = "global.";
 
-bool SceneLoader::loadScene(const std::shared_ptr<Platform>& _platform, std::shared_ptr<Scene> _scene,
+bool SceneLoader::loadScene(Platform& _platform, std::shared_ptr<Scene> _scene,
                             const std::vector<SceneUpdate>& _updates) {
 
     LOGTimeInit();
@@ -129,7 +129,7 @@ bool SceneLoader::loadScene(const std::shared_ptr<Platform>& _platform, std::sha
     return true;
 }
 
-bool SceneLoader::applyUpdates(const std::shared_ptr<Platform>& platform, Scene& scene,
+bool SceneLoader::applyUpdates(Platform& platform, Scene& scene,
                                const std::vector<SceneUpdate>& updates) {
     auto& root = scene.config();
 
@@ -218,7 +218,7 @@ void SceneLoader::applyGlobals(Scene& _scene) {
     }
 }
 
-void SceneLoader::applySources(const std::shared_ptr<Platform>& _platform, Scene& _scene) {
+void SceneLoader::applySources(Platform& _platform, Scene& _scene) {
 
     const Node& config = _scene.config();
 
@@ -309,7 +309,7 @@ void SceneLoader::applyCameras(Scene& _scene) {
     view->update();
 }
 
-void SceneLoader::applyTextures(const std::shared_ptr<Platform>& _platform, const std::shared_ptr<Scene>& _scene) {
+void SceneLoader::applyTextures(Platform& _platform, const std::shared_ptr<Scene>& _scene) {
     const Node& config = _scene->config();
 
     if (const Node& textures = config["textures"]) {
@@ -322,7 +322,7 @@ void SceneLoader::applyTextures(const std::shared_ptr<Platform>& _platform, cons
     }
 }
 
-void SceneLoader::applyFonts(const std::shared_ptr<Platform>& _platform, const std::shared_ptr<Scene>& _scene) {
+void SceneLoader::applyFonts(Platform& _platform, const std::shared_ptr<Scene>& _scene) {
     const Node& config = _scene->config();
 
     if (const Node& fonts = config["fonts"]) {
@@ -337,7 +337,7 @@ void SceneLoader::applyFonts(const std::shared_ptr<Platform>& _platform, const s
     }
 }
 
-void SceneLoader::applyStyles(const std::shared_ptr<Platform>& _platform, const std::shared_ptr<Scene>& _scene) {
+void SceneLoader::applyStyles(Platform& _platform, const std::shared_ptr<Scene>& _scene) {
     const Node& config = _scene->config();
 
     // Instantiate built-in styles
@@ -425,7 +425,7 @@ void SceneLoader::applyLayers(Scene& _scene) {
 
 }
 
-void SceneLoader::loadShaderConfig(const std::shared_ptr<Platform>& platform, Node shaders, Style& style,
+void SceneLoader::loadShaderConfig(Platform& platform, Node shaders, Style& style,
                                    const std::shared_ptr<Scene>& scene) {
 
     if (!shaders) { return; }
@@ -539,7 +539,7 @@ glm::vec4 parseMaterialVec(const Node& prop) {
     return glm::vec4(0.0);
 }
 
-void SceneLoader::loadMaterial(const std::shared_ptr<Platform>& platform, Node matNode, Material& material,
+void SceneLoader::loadMaterial(Platform& platform, Node matNode, Material& material,
                                const std::shared_ptr<Scene>& scene, Style& style) {
 
     if (!matNode.IsMap()) { return; }
@@ -584,7 +584,7 @@ void SceneLoader::loadMaterial(const std::shared_ptr<Platform>& platform, Node m
     material.setNormal(loadMaterialTexture(platform, matNode["normal"], scene, style));
 }
 
-MaterialTexture SceneLoader::loadMaterialTexture(const std::shared_ptr<Platform>& platform, Node matCompNode,
+MaterialTexture SceneLoader::loadMaterialTexture(Platform& platform, Node matCompNode,
                                                  const std::shared_ptr<Scene>& scene, Style& style) {
 
     if (!matCompNode) { return MaterialTexture{}; }
@@ -670,7 +670,7 @@ bool SceneLoader::parseTexFiltering(Node& filteringNode, TextureOptions& options
 }
 
 
-std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platform>& platform,
+std::shared_ptr<Texture> SceneLoader::fetchTexture(Platform& platform,
                                                    const std::string& name, const std::string& urlString,
                                                    const TextureOptions& options,
                                                    const std::shared_ptr<Scene>& scene,
@@ -721,7 +721,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platfor
                 }
                 scene->pendingTextures--;
                 if (scene->pendingTextures == 0) {
-                    platform->requestRender();
+                    platform.requestRender();
                 }
             });
     }
@@ -729,7 +729,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::shared_ptr<Platfor
     return texture;
 }
 
-std::shared_ptr<Texture> SceneLoader::getOrLoadTexture(const std::shared_ptr<Platform>& platform,
+std::shared_ptr<Texture> SceneLoader::getOrLoadTexture(Platform& platform,
                                                        const std::string& name, const std::shared_ptr<Scene>& scene) {
 
     auto entry = scene->textures().find(name);
@@ -746,7 +746,7 @@ std::shared_ptr<Texture> SceneLoader::getOrLoadTexture(const std::shared_ptr<Pla
     return texture;
 }
 
-void SceneLoader::loadTexture(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& node,
+void SceneLoader::loadTexture(Platform& platform, const std::pair<Node, Node>& node,
                               const std::shared_ptr<Scene>& scene) {
 
     const std::string& name = node.first.Scalar();
@@ -804,7 +804,7 @@ void SceneLoader::loadTexture(const std::shared_ptr<Platform>& platform, const s
     scene->textures().emplace(name, texture);
 }
 
-void loadFontDescription(const std::shared_ptr<Platform>& platform, const Node& node,
+void loadFontDescription(Platform& platform, const Node& node,
                          const std::string& family, const std::shared_ptr<Scene>& scene) {
     if (!node.IsMap()) {
         LOGW("");
@@ -854,7 +854,7 @@ void loadFontDescription(const std::shared_ptr<Platform>& platform, const Node& 
     });
 }
 
-void SceneLoader::loadFont(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& font,
+void SceneLoader::loadFont(Platform& platform, const std::pair<Node, Node>& font,
                            const std::shared_ptr<Scene>& scene) {
     const std::string& family = font.first.Scalar();
 
@@ -867,7 +867,7 @@ void SceneLoader::loadFont(const std::shared_ptr<Platform>& platform, const std:
     }
 }
 
-void SceneLoader::loadStyleProps(const std::shared_ptr<Platform>& platform, Style& style, Node styleNode,
+void SceneLoader::loadStyleProps(Platform& platform, Style& style, Node styleNode,
                                  const std::shared_ptr<Scene>& scene) {
 
     if (!styleNode) {
@@ -986,7 +986,7 @@ void SceneLoader::loadStyleProps(const std::shared_ptr<Platform>& platform, Styl
 
 }
 
-bool SceneLoader::loadStyle(const std::shared_ptr<Platform>& platform, const std::string& name,
+bool SceneLoader::loadStyle(Platform& platform, const std::string& name,
                             Node config, const std::shared_ptr<Scene>& scene) {
 
     const auto& builtIn = Style::builtInStyleNames();
@@ -1039,7 +1039,7 @@ bool SceneLoader::loadStyle(const std::shared_ptr<Platform>& platform, const std
     return true;
 }
 
-void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const std::string& name,
+void SceneLoader::loadSource(Platform& platform, const std::string& name,
                              const Node& source, const Node& sources, Scene& _scene) {
     if (_scene.getTileSource(name)) {
         LOGW("Duplicate TileSource: %s", name.c_str());
@@ -1199,7 +1199,7 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
 
 }
 
-void SceneLoader::loadSourceRasters(const std::shared_ptr<Platform>& platform, std::shared_ptr<TileSource> &source,
+void SceneLoader::loadSourceRasters(Platform& platform, std::shared_ptr<TileSource> &source,
                                     Node rasterNode, const Node& sources, Scene& scene) {
     if (rasterNode.IsSequence()) {
         for (const auto& raster : rasterNode) {
@@ -1711,7 +1711,7 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
     }
 }
 
-bool SceneLoader::parseStyleUniforms(const std::shared_ptr<Platform>& platform, const Node& value,
+bool SceneLoader::parseStyleUniforms(Platform& platform, const Node& value,
                                      const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform) {
     if (value.IsScalar()) { // float, bool or string (texture)
         double fValue;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -704,7 +704,9 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(Platform& platform,
         texture->setSpriteAtlas(std::move(_atlas));
 
         scene->pendingTextures++;
+        LOGTime("Fetch texture");
         scene->startUrlRequest(platform, url, [&, url, scene, texture](UrlResponse&& response) {
+                LOGTime("Got texture data");
                 if (response.error) {
                     LOGE("Error retrieving URL '%s': %s", url.string().c_str(), response.error);
                 } else {
@@ -720,6 +722,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(Platform& platform,
                     }
                 }
                 scene->pendingTextures--;
+                LOGTime("Got texture ready");
                 if (scene->pendingTextures == 0) {
                     platform.requestRender();
                 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -379,7 +379,7 @@ void SceneLoader::applyConfig(const std::shared_ptr<Platform>& _platform, const 
 
     if (const Node& lights = config["lights"]) {
         for (const auto& light : lights) {
-            try { loadLight(light, _scene); }
+            try { loadLight(light, *_scene); }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing light: '%s'", light, e.what());
             }
@@ -396,7 +396,7 @@ void SceneLoader::applyConfig(const std::shared_ptr<Platform>& _platform, const 
     _scene->lightBlocks() = Light::assembleLights(_scene->lights());
     LOGTime("lights");
 
-    loadBackground(config["scene"]["background"], _scene);
+    loadBackground(config["scene"]["background"], *_scene);
 
     Node animated = config["scene"]["animated"];
     if (animated) {
@@ -1214,7 +1214,7 @@ void SceneLoader::parseLightPosition(Node positionNode, PointLight& light) {
     }
 }
 
-void SceneLoader::loadLight(const std::pair<Node, Node>& node, const std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
 
     const Node light = node.second;
     const std::string& name = node.first.Scalar();
@@ -1324,7 +1324,7 @@ void SceneLoader::loadLight(const std::pair<Node, Node>& node, const std::shared
         }
     }
 
-    scene->lights().push_back(std::move(sceneLight));
+    scene.lights().push_back(std::move(sceneLight));
 }
 
 void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
@@ -1897,18 +1897,18 @@ void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
     scene.layers().push_back({ std::move(sublayer), source, collections });
 }
 
-void SceneLoader::loadBackground(Node background, const std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadBackground(Node background, Scene& scene) {
 
     if (!background) { return; }
 
     if (Node colorNode = background["color"]) {
         Color colorResult;
         if (StyleParam::parseColor(colorNode, colorResult)) {
-            scene->background() = colorResult;
+            scene.background() = colorResult;
         } else {
             Stops stopsResult = Stops::Colors(colorNode);
             if (stopsResult.frames.size() > 0) {
-                scene->backgroundStops() = stopsResult;
+                scene.backgroundStops() = stopsResult;
             } else {
                 LOGW("Cannot parse color: %s", Dump(colorNode).c_str());
             }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -91,6 +91,9 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
     applyGlobals(*_scene);
     LOGTime("applyGlobals");
 
+    applyTextures(_scene);
+    LOGTime("textures");
+
     applySources(*_scene);
     LOGTime("applySources");
 
@@ -100,9 +103,6 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
     _scene->initTileManager();
     _scene->tileManager()->updateTileSets(*_scene->view());
     LOGTime("loadTiles");
-
-    applyTextures(_scene);
-    LOGTime("textures");
 
     _scene->fontContext()->loadFonts();
     LOGTime("initFonts");

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -85,7 +85,6 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
         LOGW("Scene updates failed when loading scene");
         return false;
     }
-
     LOGTime("applyUpdates");
 
     applyGlobals(*_scene);
@@ -124,7 +123,6 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
     for (auto& style : _scene->styles()) {
         style->build(*_scene);
     }
-
     LOGTime("built styles");
 
     // Now only waiting for pending fonts and textures:
@@ -168,21 +166,21 @@ bool SceneLoader::applyUpdates(Scene& scene, const std::vector<SceneUpdate>& upd
 void createGlobalRefs(const Node& node, Scene& scene, YamlPathBuffer& path) {
     switch(node.Type()) {
     case NodeType::Scalar: {
-            const auto& value = node.Scalar();
-            if (value.length() > 7 && value.compare(0, 7, GLOBAL_PREFIX) == 0) {
-                scene.globalRefs().emplace_back(path.toYamlPath(),
-                                                YamlPath(value.substr(GLOBAL_PREFIX.length())));
-            }
+        const auto& value = node.Scalar();
+        if (value.length() > 7 && value.compare(0, 7, GLOBAL_PREFIX) == 0) {
+            scene.globalRefs().emplace_back(path.toYamlPath(),
+                                            YamlPath(value.substr(GLOBAL_PREFIX.length())));
         }
+    }
         break;
     case NodeType::Sequence: {
-            path.pushSequence();
-            for (const auto& entry : node) {
-                createGlobalRefs(entry, scene, path);
-                path.increment();
-            }
-            path.pop();
+        path.pushSequence();
+        for (const auto& entry : node) {
+            createGlobalRefs(entry, scene, path);
+            path.increment();
         }
+        path.pop();
+    }
         break;
     case NodeType::Map:
         for (const auto& entry : node) {
@@ -197,7 +195,6 @@ void createGlobalRefs(const Node& node, Scene& scene, YamlPathBuffer& path) {
 }
 
 void SceneLoader::applyGlobals(Scene& _scene) {
-
     const Node& config = _scene.config();
     const Node& globals = config["global"];
     if (!globals) { return; }
@@ -222,44 +219,37 @@ void SceneLoader::applyGlobals(Scene& _scene) {
     }
 }
 
-void SceneLoader::applySources(Scene& _scene) {
-
+void SceneLoader::applyScene(Scene& _scene) {
     const Node& config = _scene.config();
 
-    if (const Node& sources = config["sources"]) {
-        for (const auto& source : sources) {
-            std::string srcName = source.first.Scalar();
-            try { loadSource(srcName, source.second, sources, _scene); }
-            catch (const YAML::RepresentationException& e) {
-                LOGNode("Parsing sources: '%s'", source, e.what());
-            }
-        }
-    } else {
-        LOGW("No source defined in the yaml scene configuration.");
-    }
+    if (const Node& sceneNode = config["scene"]) {
+        loadBackground(sceneNode["background"], _scene);
 
-    if (const Node& layers = config["layers"]) {
-        for (const auto& layer : layers) {
-            if (const Node& data = layer.second["data"]) {
-                if (const Node& data_source = data["source"]) {
-                    if (data_source.IsScalar()) {
-                        auto source = data_source.Scalar();
-                        auto dataSource = _scene.getTileSource(source);
-                        if (dataSource) {
-                            dataSource->generateGeometry(true);
-                        } else {
-                            LOGW("Can't find data source %s for layer %s",
-                                 source.c_str(), layer.first.Scalar().c_str());
-                        }
-                    }
-                }
+        if (Node animated = sceneNode["animated"]) {
+            _scene.animated(YamlUtil::getBoolOrDefault(animated, false));
+        }
+    }
+}
+
+void SceneLoader::loadBackground(const Node& background, Scene& scene) {
+    if (!background) { return; }
+
+    if (const Node& colorNode = background["color"]) {
+        Color colorResult;
+        if (StyleParam::parseColor(colorNode, colorResult)) {
+            scene.background() = colorResult;
+        } else {
+            Stops stopsResult = Stops::Colors(colorNode);
+            if (stopsResult.frames.size() > 0) {
+                scene.backgroundStops() = stopsResult;
+            } else {
+                LOGW("Cannot parse color: %s", Dump(colorNode).c_str());
             }
         }
     }
 }
 
 void SceneLoader::applyCameras(Scene& _scene) {
-
     const Node& config = _scene.config();
 
     if (const Node& camera = config["camera"]) {
@@ -313,79 +303,98 @@ void SceneLoader::applyCameras(Scene& _scene) {
     view->update();
 }
 
-void SceneLoader::applyTextures(Scene& _scene) {
-    const Node& config = _scene.config();
+void SceneLoader::loadCameras(const Node& _cameras, Scene& _scene) {
+    // To correctly match the behavior of the webGL library we'll need a place
+    // to store multiple view instances.  Since we only have one global view
+    // right now, we'll just apply the settings from the first active camera we
+    // find.
 
-    if (const Node& textures = config["textures"]) {
-        for (const auto& texture : textures) {
-            try { loadTexture(texture, _scene); }
-            catch (const YAML::RepresentationException& e) {
-                LOGNode("Parsing texture: '%s'", texture, e.what());
-            }
-        }
+    for (const auto& entry : _cameras) {
+        loadCamera(entry.second, _scene);
     }
 }
 
-void SceneLoader::applyStyles(Scene& _scene) {
+void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
+    auto& camera = _scene.camera();
 
-    // Instantiate built-in styles
-    _scene.styles().emplace_back(new PolygonStyle("polygons"));
-    _scene.styles().emplace_back(new PolylineStyle("lines"));
-    _scene.styles().emplace_back(new TextStyle("text", _scene.fontContext(), true));
-    _scene.styles().emplace_back(new PointStyle("points", _scene.fontContext()));
-    _scene.styles().emplace_back(new RasterStyle("raster"));
-    if (_scene.options().debugStyles) {
-        _scene.styles().emplace_back(new DebugTextStyle("debugtext", _scene.fontContext(), true));
-        _scene.styles().emplace_back(new DebugStyle("debug"));
+    if (const Node& active = _camera["active"]) {
+        if (!YamlUtil::getBoolOrDefault(active, false)) {
+            return;
+        }
     }
 
-    const Node& config = _scene.config();
-    if (const Node& styles = config["styles"]) {
-        StyleMixer mixer;
-        try {
-            mixer.mixStyleNodes(styles);
-        } catch (const YAML::RepresentationException& e) {
-            LOGNode("Mixing styles: '%s'", styles, e.what());
-        }
-        for (const auto& entry : styles) {
-            try {
-                auto name = entry.first.Scalar();
-                loadStyle(name, entry.second, _scene);
+    auto type = _camera["type"].Scalar();
+    if (type == "perspective") {
+        camera.type = CameraType::perspective;
+
+        // Only one of focal length and FOV is applied;
+        // according to docs, focal length takes precedence.
+        if (const Node& focal = _camera["focal_length"]) {
+            float floatValue;
+            if (YamlUtil::getFloat(focal, floatValue)) {
+                camera.fieldOfView = View::focalLengthToFieldOfView(floatValue);
+            } else if (focal.IsSequence()) {
+                camera.fovStops = std::make_shared<Stops>(Stops::Numbers(focal));
+                for (auto& f : camera.fovStops->frames) {
+                    f.value = View::focalLengthToFieldOfView(f.value.get<float>());
+                }
             }
-            catch (const YAML::RepresentationException& e) {
-                LOGNode("Parsing style: '%s'", entry, e.what());
-            }
-        }
-    }
-
-    // Styles that are opaque must be ordered first in the scene so that
-    // they are rendered 'under' styles that require blending
-    std::sort(_scene.styles().begin(), _scene.styles().end(), Style::compare);
-
-    // Post style sorting set their respective IDs=>vector indices
-    // These indices are used for style geometry lookup in tiles
-    auto& styles = _scene.styles();
-    for(uint32_t i = 0; i < styles.size(); i++) {
-        styles[i]->setID(i);
-        styles[i]->setPixelScale(_scene.pixelScale());
-
-        if (auto pointStyle = dynamic_cast<PointStyle*>(styles[i].get())) {
-            pointStyle->setTextures(_scene.textures());
-        }
-    }
-}
-
-void SceneLoader::applyLayers(Scene& _scene) {
-    const Node& config = _scene.config();
-
-    if (const Node& layers = config["layers"]) {
-        for (const auto& layer : layers) {
-            try { loadLayer(layer, _scene); }
-            catch (const YAML::RepresentationException& e) {
-                LOGNode("Parsing layer: '%s'", layer, e.what());
+        } else if (const Node& fov = _camera["fov"]) {
+            if (fov.IsScalar()) {
+                double degrees = YamlUtil::getDoubleOrDefault(fov, camera.fieldOfView * RAD_TO_DEG);
+                camera.fieldOfView = degrees * DEG_TO_RAD;
+            } else if (fov.IsSequence()) {
+                camera.fovStops = std::make_shared<Stops>(Stops::Numbers(fov));
+                for (auto& f : camera.fovStops->frames) {
+                    f.value = float(f.value.get<float>() * DEG_TO_RAD);
+                }
             }
         }
+
+        if (const Node& vanishing = _camera["vanishing_point"]) {
+            if (vanishing.IsSequence() && vanishing.size() >= 2) {
+                // Values are pixels, unit strings are ignored.
+                camera.vanishingPoint.x = YamlUtil::getFloatOrDefault(vanishing[0], 0.f, true);
+                camera.vanishingPoint.y = YamlUtil::getFloatOrDefault(vanishing[1], 0.f, true);
+            }
+        }
+    } else if (type == "isometric") {
+        camera.type = CameraType::isometric;
+
+        if (const Node& axis = _camera["axis"]) {
+            YamlUtil::parseVec(axis, camera.obliqueAxis);
+        }
+    } else if (type == "flat") {
+        camera.type = CameraType::flat;
     }
+
+    // Default is world origin at 0 zoom
+    double x = 0;
+    double y = 0;
+    float z = 0;
+
+    if (const Node& position = _camera["position"]) {
+        x = YamlUtil::getDoubleOrDefault(position[0], x);
+        y = YamlUtil::getDoubleOrDefault(position[1], y);
+        if (position.size() > 2) {
+            z = YamlUtil::getFloatOrDefault(position[2], z);
+        }
+    }
+
+    if (const Node& zoom = _camera["zoom"]) {
+        z = YamlUtil::getFloatOrDefault(zoom, z);
+    }
+
+    if (const Node& maxTilt = _camera["max_tilt"]) {
+        if (maxTilt.IsSequence()) {
+            camera.maxTiltStops = std::make_shared<Stops>(Stops::Numbers(maxTilt));
+        } else if (maxTilt.IsScalar()) {
+            camera.maxTilt = YamlUtil::getFloatOrDefault(maxTilt, PI);
+        }
+    }
+
+    _scene.startPosition = glm::dvec2(x, y);
+    _scene.startZoom = z;
 }
 
 void SceneLoader::applyLights(Scene& _scene) {
@@ -409,262 +418,146 @@ void SceneLoader::applyLights(Scene& _scene) {
     _scene.lightBlocks() = Light::assembleLights(_scene.lights());
 }
 
-void SceneLoader::applyScene(Scene& _scene) {
+void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
+    const Node& light = node.second;
+    const std::string& name = node.first.Scalar();
+    const std::string& type = light["type"].Scalar();
+
+    if (const Node& visible = light["visible"]) {
+        // If 'visible' is false, skip loading this light.
+        if (!YamlUtil::getBoolOrDefault(visible, true)) { return; }
+    }
+
+    std::unique_ptr<Light> sceneLight;
+    if (type == "ambient") {
+        sceneLight = std::make_unique<AmbientLight>(name);
+
+    } else if (type == "directional") {
+        auto dLight(std::make_unique<DirectionalLight>(name));
+
+        if (const Node& directionNode = light["direction"]) {
+            glm::vec3 direction;
+            if (YamlUtil::parseVec<glm::vec3>(directionNode, direction)) {
+                dLight->setDirection(direction);
+            }
+        }
+        sceneLight = std::move(dLight);
+
+    } else if (type == "point") {
+        auto pLight(std::make_unique<PointLight>(name));
+
+        if (const Node& position = light["position"]) {
+            parseLightPosition(position, *pLight);
+        }
+        if (const Node& radius = light["radius"]) {
+            if (radius.size() > 1) {
+                pLight->setRadius(YamlUtil::getFloatOrDefault(radius[0], 0.f),
+                                  YamlUtil::getFloatOrDefault(radius[1], 0.f));
+            } else {
+                pLight->setRadius(YamlUtil::getFloatOrDefault(radius, 0.f));
+            }
+        }
+        if (const Node& att = light["attenuation"]) {
+            float attenuation;
+            if (YamlUtil::getFloat(att, attenuation)) {
+                pLight->setAttenuation(attenuation);
+            }
+        }
+        sceneLight = std::move(pLight);
+
+    } else if (type == "spotlight") {
+        auto sLight(std::make_unique<SpotLight>(name));
+
+        if (const Node& position = light["position"]) {
+            parseLightPosition(position, *sLight);
+        }
+        if (const Node& directionNode = light["direction"]) {
+            glm::vec3 direction;
+            if (YamlUtil::parseVec<glm::vec3>(directionNode, direction)) {
+                sLight->setDirection(direction);
+            }
+        }
+        if (const Node& radius = light["radius"]) {
+            if (radius.size() > 1) {
+                sLight->setRadius(YamlUtil::getFloatOrDefault(radius[0], 0.f),
+                                  YamlUtil::getFloatOrDefault(radius[1], 0.f));
+            } else {
+                sLight->setRadius(YamlUtil::getFloatOrDefault(radius, 0.f));
+            }
+        }
+        if (const Node& angle = light["angle"]) {
+            sLight->setCutoffAngle(YamlUtil::getFloatOrDefault(angle, 0.f));
+        }
+        if (const Node& exponent = light["exponent"]) {
+            sLight->setCutoffExponent(YamlUtil::getFloatOrDefault(exponent, 0.f));
+        }
+        sceneLight = std::move(sLight);
+    }
+    if (const Node& origin = light["origin"]) {
+        const std::string& originStr = origin.Scalar();
+        if (originStr == "world") {
+            sceneLight->setOrigin(LightOrigin::world);
+        } else if (originStr == "camera") {
+            sceneLight->setOrigin(LightOrigin::camera);
+        } else if (originStr == "ground") {
+            sceneLight->setOrigin(LightOrigin::ground);
+        }
+    }
+    if (const Node& ambient = light["ambient"]) {
+        sceneLight->setAmbientColor(YamlUtil::getColorAsVec4(ambient));
+    }
+    if (const Node& diffuse = light["diffuse"]) {
+        sceneLight->setDiffuseColor(YamlUtil::getColorAsVec4(diffuse));
+    }
+    if (const Node& specular = light["specular"]) {
+        sceneLight->setSpecularColor(YamlUtil::getColorAsVec4(specular));
+    }
+
+    // Verify that light position parameters are consistent with the origin type
+    if (sceneLight->getType() == LightType::point || sceneLight->getType() == LightType::spot) {
+        auto pLight = static_cast<PointLight&>(*sceneLight);
+        auto lightPosition = pLight.getPosition();
+        LightOrigin origin = pLight.getOrigin();
+
+        if (origin == LightOrigin::world) {
+            if (lightPosition.units[0] == Unit::pixel || lightPosition.units[1] == Unit::pixel) {
+                LOGW("Light position with attachment %s may not be used with unit of type %s",
+                    lightOriginString(origin).c_str(), unitToString(Unit::pixel).c_str());
+                LOGW("Long/Lat expected in meters");
+            }
+        }
+    }
+    scene.lights().push_back(std::move(sceneLight));
+}
+
+void SceneLoader::parseLightPosition(const Node& positionNode, PointLight& light) {
+    UnitVec<glm::vec3> positionResult;
+    if (StyleParam::parseVec3(positionNode, UnitSet{Unit::none, Unit::pixel, Unit::meter}, positionResult)) {
+        for (auto& unit : positionResult.units) {
+            if (unit == Unit::none) {
+                unit = Unit::meter;
+            }
+        }
+        light.setPosition(positionResult);
+    } else {
+        LOGNode("Invalid light position parameter:", positionNode);
+    }
+}
+
+void SceneLoader::applyTextures(Scene& _scene) {
     const Node& config = _scene.config();
 
-    if (const Node& sceneNode = config["scene"]) {
-        loadBackground(sceneNode["background"], _scene);
-
-        if (Node animated = sceneNode["animated"]) {
-            _scene.animated(YamlUtil::getBoolOrDefault(animated, false));
-        }
-    }
-}
-
-void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, Scene& scene) {
-    if (!shaders) { return; }
-
-    auto& shader = style.getShaderSource();
-
-    if (const Node& extNode = shaders["extensions_mixed"]) {
-        if (extNode.IsScalar()) {
-            shader.addExtensionDeclaration(extNode.Scalar());
-        } else if (extNode.IsSequence()) {
-            for (const auto& e : extNode) {
-                shader.addExtensionDeclaration(e.Scalar());
+    if (const Node& textures = config["textures"]) {
+        for (const auto& texture : textures) {
+            try { loadTexture(texture, _scene); }
+            catch (const YAML::RepresentationException& e) {
+                LOGNode("Parsing texture: '%s'", texture, e.what());
             }
         }
     }
-
-    if (const Node& definesNode = shaders["defines"]) {
-        for (const auto& define : definesNode) {
-            const std::string& name = define.first.Scalar();
-
-            // undefine any previous definitions
-            {
-                auto pos = name.find('(');
-                if (pos == std::string::npos) {
-                    shader.addSourceBlock("defines", "#undef " + name);
-                } else {
-                    shader.addSourceBlock("defines", "#undef " + name.substr(0, pos));
-                }
-            }
-            bool bValue;
-
-            if (YamlUtil::getBool(define.second, bValue)) {
-                // specifying a define to be 'true' means that it is simply
-                // defined and has no value
-                if (bValue) {
-                    shader.addSourceBlock("defines", "#define " + name);
-                }
-            } else {
-                const std::string& value = define.second.Scalar();
-                shader.addSourceBlock("defines", "#define " + name + " " + value);
-            }
-        }
-    }
-
-    if (const Node& uniformsNode = shaders["uniforms"]) {
-        for (const auto& uniform : uniformsNode) {
-            const std::string& name = uniform.first.Scalar();
-            StyleUniform styleUniform;
-
-            if (parseStyleUniforms(uniform.second, scene, styleUniform)) {
-                if (styleUniform.value.is<UniformArray1f>()) {
-                    UniformArray1f& array = styleUniform.value.get<UniformArray1f>();
-                    shader.addSourceBlock("uniforms", "uniform float " + name +
-                        "[" + std::to_string(array.size()) + "];");
-                } else if(styleUniform.value.is<UniformTextureArray>()) {
-                    UniformTextureArray& textureArray = styleUniform.value.get<UniformTextureArray>();
-                    shader.addSourceBlock("uniforms", "uniform " + styleUniform.type + " " + name +
-                        "[" + std::to_string(textureArray.names.size()) + "];");
-                } else {
-                    shader.addSourceBlock("uniforms", "uniform " + styleUniform.type + " " + name + ";");
-                }
-
-                style.styleUniforms().emplace_back(name, styleUniform.value);
-            } else {
-                LOGNode("Style uniform parsing failure", uniform.second);
-            }
-        }
-    }
-
-    if (const Node& blocksNode = shaders["blocks_mixed"]) {
-        for (const auto& block : blocksNode) {
-            const auto& name = block.first.Scalar();
-            const auto& value = block.second;
-            if (value.IsSequence()){
-                for (const auto& it : value) {
-                    shader.addSourceBlock(name, it.Scalar(), false);
-                }
-            } else if (value.IsScalar()) {
-                shader.addSourceBlock(name, value.Scalar(), false);
-            }
-        }
-    }
-}
-
-glm::vec4 parseMaterialVec(const Node& prop) {
-
-    switch (prop.Type()) {
-    case NodeType::Sequence: {
-        glm::vec4 vec;
-        if (YamlUtil::parseVec<glm::vec4>(prop, vec)) {
-            return vec;
-        }
-        break;
-    }
-    case NodeType::Scalar: {
-        double value;
-        if (YamlUtil::getDouble(prop, value, false)) {
-            return glm::vec4(value, value, value, 1.0);
-        } else {
-            return YamlUtil::getColorAsVec4(prop);
-        }
-        break;
-    }
-    case NodeType::Map:
-        // Handled as texture
-        break;
-    default:
-        LOGNode("Invalid 'material'", prop);
-        break;
-    }
-    return glm::vec4(0.0);
-}
-
-void SceneLoader::loadMaterial(const Node& matNode, Material& material,
-                               Scene& scene, Style& style) {
-
-    if (!matNode.IsMap()) { return; }
-
-    if (const Node& n = matNode["emission"]) {
-        if (n.IsMap()) {
-            material.setEmission(loadMaterialTexture(n, scene, style));
-        } else {
-            material.setEmission(parseMaterialVec(n));
-        }
-    }
-    if (const Node& n = matNode["diffuse"]) {
-        if (n.IsMap()) {
-            material.setDiffuse(loadMaterialTexture(n, scene, style));
-        } else {
-            material.setDiffuse(parseMaterialVec(n));
-        }
-    }
-    if (const Node& n = matNode["ambient"]) {
-        if (n.IsMap()) {
-            material.setAmbient(loadMaterialTexture(n, scene, style));
-        } else {
-            material.setAmbient(parseMaterialVec(n));
-        }
-    }
-
-    if (const Node& n = matNode["specular"]) {
-        if (n.IsMap()) {
-            material.setSpecular(loadMaterialTexture(n, scene, style));
-        } else {
-            material.setSpecular(parseMaterialVec(n));
-        }
-    }
-
-    if (const Node& shininess = matNode["shininess"]) {
-        double value;
-        if (YamlUtil::getDouble(shininess, value, false)) {
-            material.setShininess(value);
-        }
-    }
-
-    material.setNormal(loadMaterialTexture(matNode["normal"], scene, style));
-}
-
-MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode,
-                                                 Scene& scene, Style& style) {
-
-    if (!matCompNode) { return MaterialTexture{}; }
-
-    Node textureNode = matCompNode["texture"];
-    if (!textureNode) {
-        LOGNode("Expected a 'texture' parameter", matCompNode);
-
-        return MaterialTexture{};
-    }
-
-    const std::string& name = textureNode.Scalar();
-
-    MaterialTexture matTex;
-    matTex.tex = scene.loadTexture(name);
-
-    if (const Node& mappingNode = matCompNode["mapping"]) {
-        const std::string& mapping = mappingNode.Scalar();
-        if (mapping == "uv") {
-            matTex.mapping = MappingType::uv;
-
-            // Mark the style to generate texture coordinates
-            if (!style.genTexCoords()) {
-                LOGW("Style %s has option `texcoords: false` but material %s has uv mapping",
-                    style.getName().c_str(), name.c_str());
-                LOGW("Defaulting uvs generation to true for style %s",
-                    style.getName().c_str());
-            }
-
-            style.setTexCoordsGeneration(true);
-        } else if (mapping == "spheremap") {
-            matTex.mapping = MappingType::spheremap;
-        } else if (mapping == "planar") {
-            matTex.mapping = MappingType::planar;
-        } else if (mapping == "triplanar") {
-            matTex.mapping = MappingType::triplanar;
-        } else {
-            LOGW("Unrecognized texture mapping '%s'", mapping.c_str());
-        }
-    }
-
-    if (const Node& scaleNode = matCompNode["scale"]) {
-        if (scaleNode.IsSequence() && scaleNode.size() == 2) {
-            matTex.scale.x = YamlUtil::getFloatOrDefault(scaleNode[0], matTex.scale.x);
-            matTex.scale.y = YamlUtil::getFloatOrDefault(scaleNode[1], matTex.scale.y);
-        } else if (scaleNode.IsScalar()) {
-            matTex.scale = glm::vec3(YamlUtil::getFloatOrDefault(scaleNode, 1.f));
-        } else {
-            LOGW("Unrecognized scale parameter in material");
-        }
-    }
-
-    if (const Node& amountNode = matCompNode["amount"]) {
-        if (amountNode.IsScalar()) {
-            matTex.amount = glm::vec3(YamlUtil::getFloatOrDefault(amountNode, 1.f));
-        } else if (!YamlUtil::parseVec(amountNode, matTex.amount)) {
-            LOGW("Unrecognized amount parameter in material");
-        }
-    }
-
-    return matTex;
-}
-
-bool SceneLoader::parseTexFiltering(const Node& filteringNode, TextureOptions& options) {
-    if (!filteringNode.IsScalar()) {
-        return false;
-    }
-    const std::string& filteringString = filteringNode.Scalar();
-    if (filteringString == "linear") {
-        options.minFilter = TextureMinFilter::LINEAR;
-        options.magFilter = TextureMagFilter::LINEAR;
-        return true;
-    } else if (filteringString == "mipmap") {
-        options.minFilter = TextureMinFilter::LINEAR_MIPMAP_LINEAR;
-        options.generateMipmaps = true;
-        return true;
-    } else if (filteringString == "nearest") {
-        options.minFilter = TextureMinFilter::NEAREST;
-        options.magFilter = TextureMagFilter::NEAREST;
-        return true;
-    }
-    return false;
 }
 
 void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
-
     const std::string& name = node.first.Scalar();
     const Node& textureConfig = node.second;
 
@@ -718,6 +611,26 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
     scene.fetchTexture(name, Url(url), options, std::move(atlas));
 }
 
+bool SceneLoader::parseTexFiltering(const Node& filteringNode, TextureOptions& options) {
+    if (!filteringNode.IsScalar()) {
+        return false;
+    }
+    const std::string& filteringString = filteringNode.Scalar();
+    if (filteringString == "linear") {
+        options.minFilter = TextureMinFilter::LINEAR;
+        options.magFilter = TextureMagFilter::LINEAR;
+        return true;
+    } else if (filteringString == "mipmap") {
+        options.minFilter = TextureMinFilter::LINEAR_MIPMAP_LINEAR;
+        options.generateMipmaps = true;
+        return true;
+    } else if (filteringString == "nearest") {
+        options.minFilter = TextureMinFilter::NEAREST;
+        options.magFilter = TextureMagFilter::NEAREST;
+        return true;
+    }
+    return false;
+}
 
 void SceneLoader::applyFonts(Scene& _scene) {
     const Node& config = _scene.config();
@@ -763,7 +676,8 @@ void SceneLoader::loadFontDescription(const Node& node, const std::string& famil
         } else if (key == "url") {
             uri = fontDesc.second.Scalar();
         } else if (key == "external") {
-            LOGW("external: within fonts: is a no-op in native version of tangram (%s)", family.c_str());
+            LOGW("external: within fonts: is a no-op in native" \
+                 " version of tangram (%s)", family.c_str());
         }
     }
 
@@ -773,6 +687,318 @@ void SceneLoader::loadFontDescription(const Node& node, const std::string& famil
     }
 
     scene.loadFont(uri, family, style, weight);
+}
+
+void SceneLoader::applySources(Scene& _scene) {
+    const Node& config = _scene.config();
+    const Node& sources = config["sources"];
+    if (!sources) {
+        LOGW("No source defined in the yaml scene configuration.");
+        return;
+    }
+    for (const auto& source : sources) {
+        std::string srcName = source.first.Scalar();
+        try { loadSource(srcName, source.second, _scene); }
+        catch (const YAML::RepresentationException& e) {
+            LOGNode("Parsing sources: '%s'", source, e.what());
+        }
+    }
+
+    if (const Node& layers = config["layers"]) {
+        for (const auto& layer : layers) {
+            if (const Node& data = layer.second["data"]) {
+                if (const Node& data_source = data["source"]) {
+                    if (data_source.IsScalar()) {
+                        auto source = data_source.Scalar();
+                        auto dataSource = _scene.getTileSource(source);
+                        if (dataSource) {
+                            dataSource->generateGeometry(true);
+                        } else {
+                            LOGW("Can't find data source %s for layer %s",
+                                 source.c_str(), layer.first.Scalar().c_str());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void SceneLoader::loadSource(const std::string& name, const Node& source, Scene& _scene) {
+    if (_scene.getTileSource(name)) {
+        LOGW("Duplicate TileSource: %s", name.c_str());
+        return;
+    }
+
+    std::string type;
+    std::string url;
+    std::string mbtiles;
+    std::vector<std::string> subdomains;
+
+    int32_t minDisplayZoom = -1;
+    int32_t maxDisplayZoom = -1;
+    int32_t maxZoom = 18;
+    int32_t zoomBias = 0;
+    bool generateCentroids = false;
+
+    if (auto typeNode = source["type"]) {
+        type = typeNode.Scalar();
+    }
+    if (auto urlNode = source["url"]) {
+        url = urlNode.Scalar();
+    }
+    if (auto minDisplayZoomNode = source["min_display_zoom"]) {
+        YamlUtil::getInt(minDisplayZoomNode, minDisplayZoom);
+    }
+    if (auto maxDisplayZoomNode = source["max_display_zoom"]) {
+        YamlUtil::getInt(maxDisplayZoomNode, maxDisplayZoom);
+    }
+    if (auto maxZoomNode = source["max_zoom"]) {
+        YamlUtil::getInt(maxZoomNode, maxZoom);
+    }
+    if (auto tileSizeNode = source["tile_size"]) {
+        int tileSize = 0;
+        if (YamlUtil::getInt(tileSizeNode, tileSize)) {
+            zoomBias = TileSource::zoomBiasFromTileSize(tileSize);
+        }
+    }
+
+    // Parse and append any URL parameters.
+    if (auto urlParamsNode = source["url_params"]) {
+        std::stringstream urlStream;
+        // Transform our current URL from "base[?query][#hash]" into "base?params[query][#hash]".
+        auto hashStart = std::min(url.find_first_of("#"), url.size());
+        auto queryStart = std::min(url.find_first_of("?"), url.size());
+        auto baseEnd = std::min(hashStart, queryStart + 1);
+        urlStream << url.substr(0, baseEnd);
+        if (queryStart == url.size()) {
+            urlStream << "?";
+        }
+        if (urlParamsNode.IsMap()) {
+            for (const auto& entry : urlParamsNode) {
+                if (entry.first.IsScalar() && entry.second.IsScalar()) {
+                    urlStream << entry.first.Scalar() << "=" << entry.second.Scalar() << "&";
+                } else {
+                    LOGW("Invalid url_params entry in source '%s', entries" \
+                         " should be strings.", name.c_str());
+                }
+            }
+        } else {
+            LOGW("Expected a map of values for url_params in source '%s'.", name.c_str());
+        }
+        urlStream << url.substr(baseEnd);
+        url = urlStream.str();
+    }
+
+    // Apply URL subdomain configuration.
+    if (const Node& subDomainNode = source["url_subdomains"]) {
+        if (subDomainNode.IsSequence()) {
+            for (const auto& domain : subDomainNode) {
+                if (domain.IsScalar()) {
+                    subdomains.push_back(domain.Scalar());
+                }
+            }
+        }
+    }
+
+    // Check whether the URL template and subdomains make sense together, and warn if not.
+    bool hasSubdomainPlaceholder = (url.find("{s}") != std::string::npos);
+    if (hasSubdomainPlaceholder && subdomains.empty()) {
+        LOGW("The URL for source '%s' includes the subdomain placeholder '{s}'," \
+             " but no subdomains were given.", name.c_str());
+    }
+    if (!hasSubdomainPlaceholder && !subdomains.empty()) {
+        LOGW("The URL for source '%s' has subdomains specified, but does not" \
+             " include the subdomain placeholder '{s}'.", name.c_str());
+    }
+
+    // distinguish tiled and non-tiled sources by url
+    bool tiled = url.size() > 0 &&
+        url.find("{x}") != std::string::npos &&
+        url.find("{y}") != std::string::npos &&
+        url.find("{z}") != std::string::npos;
+
+    bool isMBTilesFile = false;
+    {
+        const char* extStr = ".mbtiles";
+        const size_t extLength = strlen(extStr);
+        const size_t urlLength = url.length();
+        isMBTilesFile = urlLength > extLength && (url.compare(urlLength - extLength, extLength, extStr) == 0);
+    }
+
+    bool isTms = false;
+    if (const Node& tmsNode = source["tms"]) {
+        YamlUtil::getBool(tmsNode, isTms);
+    }
+
+    auto rawSources = std::make_unique<MemoryCacheDataSource>();
+    rawSources->setCacheSize(CACHE_SIZE);
+
+    if (isMBTilesFile) {
+        // If we have MBTiles, we know the source is tiled.
+        tiled = true;
+        // Create an MBTiles data source from the file at the url and add it to the source chain.
+        rawSources->setNext(std::make_unique<MBTilesDataSource>(_scene.platform(), name, url, ""));
+    } else if (tiled) {
+        rawSources->setNext(std::make_unique<NetworkDataSource>(_scene.platform(), url,
+                                                                std::move(subdomains), isTms));
+    }
+
+    std::shared_ptr<TileSource> sourcePtr;
+
+    TileSource::ZoomOptions zoomOptions = { minDisplayZoom, maxDisplayZoom, maxZoom, zoomBias };
+
+    if (type == "GeoJSON" && !tiled) {
+        if (auto genLabelCentroidsNode = source["generate_label_centroids"]) {
+            generateCentroids = true;
+        }
+        sourcePtr = std::make_shared<ClientGeoJsonSource>(_scene.platform(), name, url, generateCentroids,
+                                                          zoomOptions);
+    } else if (type == "Raster") {
+        TextureOptions options;
+        if (const Node& filtering = source["filtering"]) {
+            if (!parseTexFiltering(filtering, options)) {
+                LOGW("Invalid texture filtering: %s", Dump(filtering).c_str());
+            }
+        }
+
+        sourcePtr = std::make_shared<RasterSource>(name, std::move(rawSources), options, zoomOptions);
+    } else {
+        sourcePtr = std::make_shared<TileSource>(name, std::move(rawSources), zoomOptions);
+
+        if (type == "GeoJSON") {
+            sourcePtr->setFormat(TileSource::Format::GeoJson);
+        } else if (type == "TopoJSON") {
+            sourcePtr->setFormat(TileSource::Format::TopoJson);
+        } else if (type == "MVT") {
+            sourcePtr->setFormat(TileSource::Format::Mvt);
+        } else {
+            LOGE("Source '%s' does not have a valid type. " \
+                 "Valid types are 'GeoJSON', 'TopoJSON', and 'MVT'. " \
+                 "This source will be ignored.", name.c_str());
+            return;
+        }
+    }
+
+    _scene.tileSources().push_back(sourcePtr);
+
+    if (const Node& rasters = source["rasters"]) {
+        loadSourceRasters(*sourcePtr, rasters, _scene);
+    }
+}
+
+void SceneLoader::loadSourceRasters(TileSource& source, const Node& rasterNode, Scene& scene) {
+    if (!rasterNode.IsSequence()) { return; }
+    const Node& sources = scene.config()["sources"];
+
+    for (const auto& raster : rasterNode) {
+        std::string srcName = raster.Scalar();
+        try {
+            loadSource(srcName, sources[srcName], scene);
+        } catch (const YAML::RepresentationException& e) {
+            LOGNode("Error parsing sources: '%s'", sources[srcName], e.what());
+            return;
+        }
+        source.addRasterSource(scene.getTileSource(srcName));
+    }
+}
+
+void SceneLoader::applyStyles(Scene& _scene) {
+    // Instantiate built-in styles
+    _scene.styles().emplace_back(new PolygonStyle("polygons"));
+    _scene.styles().emplace_back(new PolylineStyle("lines"));
+    _scene.styles().emplace_back(new TextStyle("text", _scene.fontContext(), true));
+    _scene.styles().emplace_back(new PointStyle("points", _scene.fontContext()));
+    _scene.styles().emplace_back(new RasterStyle("raster"));
+    if (_scene.options().debugStyles) {
+        _scene.styles().emplace_back(new DebugTextStyle("debugtext", _scene.fontContext(), true));
+        _scene.styles().emplace_back(new DebugStyle("debug"));
+    }
+
+    const Node& config = _scene.config();
+    if (const Node& styles = config["styles"]) {
+        StyleMixer mixer;
+        try {
+            mixer.mixStyleNodes(styles);
+        } catch (const YAML::RepresentationException& e) {
+            LOGNode("Mixing styles: '%s'", styles, e.what());
+        }
+        for (const auto& entry : styles) {
+            try {
+                auto name = entry.first.Scalar();
+                loadStyle(name, entry.second, _scene);
+            }
+            catch (const YAML::RepresentationException& e) {
+                LOGNode("Parsing style: '%s'", entry, e.what());
+            }
+        }
+    }
+
+    // Styles that are opaque must be ordered first in the scene so that
+    // they are rendered 'under' styles that require blending
+    std::sort(_scene.styles().begin(), _scene.styles().end(), Style::compare);
+
+    // Post style sorting set their respective IDs=>vector indices
+    // These indices are used for style geometry lookup in tiles
+    auto& styles = _scene.styles();
+    for(uint32_t i = 0; i < styles.size(); i++) {
+        styles[i]->setID(i);
+        styles[i]->setPixelScale(_scene.pixelScale());
+
+        if (auto pointStyle = dynamic_cast<PointStyle*>(styles[i].get())) {
+            pointStyle->setTextures(_scene.textures());
+        }
+    }
+}
+
+bool SceneLoader::loadStyle(const std::string& name, const Node& config, Scene& scene) {
+    const auto& builtIn = Style::builtInStyleNames();
+
+    if (std::find(builtIn.begin(), builtIn.end(), name) != builtIn.end()) {
+        LOGW("Cannot use built-in style name '%s' for new style", name.c_str());
+        return false;
+    }
+
+    const Node& baseNode = config["base"];
+    if (!baseNode) {
+        // No base style, this is an abstract style
+        return true;
+    }
+
+    // Construct style instance using the merged properties
+    std::unique_ptr<Style> style;
+    const auto& baseStyle = baseNode.Scalar();
+    if (baseStyle == "polygons") {
+        style = std::make_unique<PolygonStyle>(name);
+    } else if (baseStyle == "lines") {
+        style = std::make_unique<PolylineStyle>(name);
+    } else if (baseStyle == "text") {
+        style = std::make_unique<TextStyle>(name, scene.fontContext(), true);
+    } else if (baseStyle == "points") {
+        style = std::make_unique<PointStyle>(name, scene.fontContext());
+    } else if (baseStyle == "raster") {
+        style = std::make_unique<RasterStyle>(name);
+    } else {
+        LOGW("Base style '%s' not recognized, cannot instantiate.", baseStyle.c_str());
+        return false;
+    }
+
+    if (const Node& rasterNode = config["raster"]) {
+        const auto& raster = rasterNode.Scalar();
+        if (raster == "normal") {
+            style->setRasterType(RasterType::normal);
+        } else if (raster == "color") {
+            style->setRasterType(RasterType::color);
+        } else if (raster == "custom") {
+            style->setRasterType(RasterType::custom);
+        }
+    }
+
+    loadStyleProps(*style.get(), config, scene);
+
+    scene.styles().push_back(std::move(style));
+
+    return true;
 }
 
 void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, Scene& scene) {
@@ -891,645 +1117,10 @@ void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, Scene& sce
     }
 }
 
-bool SceneLoader::loadStyle(const std::string& name, const Node& config, Scene& scene) {
-
-    const auto& builtIn = Style::builtInStyleNames();
-
-    if (std::find(builtIn.begin(), builtIn.end(), name) != builtIn.end()) {
-        LOGW("Cannot use built-in style name '%s' for new style", name.c_str());
-        return false;
-    }
-
-    const Node& baseNode = config["base"];
-    if (!baseNode) {
-        // No base style, this is an abstract style
-        return true;
-    }
-
-    // Construct style instance using the merged properties
-    std::unique_ptr<Style> style;
-    const auto& baseStyle = baseNode.Scalar();
-    if (baseStyle == "polygons") {
-        style = std::make_unique<PolygonStyle>(name);
-    } else if (baseStyle == "lines") {
-        style = std::make_unique<PolylineStyle>(name);
-    } else if (baseStyle == "text") {
-        style = std::make_unique<TextStyle>(name, scene.fontContext(), true);
-    } else if (baseStyle == "points") {
-        style = std::make_unique<PointStyle>(name, scene.fontContext());
-    } else if (baseStyle == "raster") {
-        style = std::make_unique<RasterStyle>(name);
-    } else {
-        LOGW("Base style '%s' not recognized, cannot instantiate.", baseStyle.c_str());
-        return false;
-    }
-
-    if (const Node& rasterNode = config["raster"]) {
-        const auto& raster = rasterNode.Scalar();
-        if (raster == "normal") {
-            style->setRasterType(RasterType::normal);
-        } else if (raster == "color") {
-            style->setRasterType(RasterType::color);
-        } else if (raster == "custom") {
-            style->setRasterType(RasterType::custom);
-        }
-    }
-
-    loadStyleProps(*style.get(), config, scene);
-
-    scene.styles().push_back(std::move(style));
-
-    return true;
-}
-
-void SceneLoader::loadSource(const std::string& name, const Node& source,
-                             const Node& sources, Scene& _scene) {
-    if (_scene.getTileSource(name)) {
-        LOGW("Duplicate TileSource: %s", name.c_str());
-        return;
-    }
-
-    std::string type;
-    std::string url;
-    std::string mbtiles;
-    std::vector<std::string> subdomains;
-
-    int32_t minDisplayZoom = -1;
-    int32_t maxDisplayZoom = -1;
-    int32_t maxZoom = 18;
-    int32_t zoomBias = 0;
-    bool generateCentroids = false;
-
-    if (auto typeNode = source["type"]) {
-        type = typeNode.Scalar();
-    }
-    if (auto urlNode = source["url"]) {
-        url = urlNode.Scalar();
-    }
-    if (auto minDisplayZoomNode = source["min_display_zoom"]) {
-        YamlUtil::getInt(minDisplayZoomNode, minDisplayZoom);
-    }
-    if (auto maxDisplayZoomNode = source["max_display_zoom"]) {
-        YamlUtil::getInt(maxDisplayZoomNode, maxDisplayZoom);
-    }
-    if (auto maxZoomNode = source["max_zoom"]) {
-        YamlUtil::getInt(maxZoomNode, maxZoom);
-    }
-    if (auto tileSizeNode = source["tile_size"]) {
-        int tileSize = 0;
-        if (YamlUtil::getInt(tileSizeNode, tileSize)) {
-            zoomBias = TileSource::zoomBiasFromTileSize(tileSize);
-        }
-    }
-
-    // Parse and append any URL parameters.
-    if (auto urlParamsNode = source["url_params"]) {
-        std::stringstream urlStream;
-        // Transform our current URL from "base[?query][#hash]" into "base?params[query][#hash]".
-        auto hashStart = std::min(url.find_first_of("#"), url.size());
-        auto queryStart = std::min(url.find_first_of("?"), url.size());
-        auto baseEnd = std::min(hashStart, queryStart + 1);
-        urlStream << url.substr(0, baseEnd);
-        if (queryStart == url.size()) {
-            urlStream << "?";
-        }
-        if (urlParamsNode.IsMap()) {
-            for (const auto& entry : urlParamsNode) {
-                if (entry.first.IsScalar() && entry.second.IsScalar()) {
-                    urlStream << entry.first.Scalar() << "=" << entry.second.Scalar() << "&";
-                } else {
-                    LOGW("Invalid url_params entry in source '%s', entries should be strings.", name.c_str());
-                }
-            }
-        } else {
-            LOGW("Expected a map of values for url_params in source '%s'.", name.c_str());
-        }
-        urlStream << url.substr(baseEnd);
-        url = urlStream.str();
-    }
-
-    // Apply URL subdomain configuration.
-    if (const Node& subDomainNode = source["url_subdomains"]) {
-        if (subDomainNode.IsSequence()) {
-            for (const auto& domain : subDomainNode) {
-                if (domain.IsScalar()) {
-                    subdomains.push_back(domain.Scalar());
-                }
-            }
-        }
-    }
-
-    // Check whether the URL template and subdomains make sense together, and warn if not.
-    bool hasSubdomainPlaceholder = (url.find("{s}") != std::string::npos);
-    if (hasSubdomainPlaceholder && subdomains.empty()) {
-        LOGW("The URL for source '%s' includes the subdomain placeholder '{s}', but no subdomains were given.", name.c_str());
-    }
-    if (!hasSubdomainPlaceholder && !subdomains.empty()) {
-        LOGW("The URL for source '%s' has subdomains specified, but does not include the subdomain placeholder '{s}'.", name.c_str());
-    }
-
-    // distinguish tiled and non-tiled sources by url
-    bool tiled = url.size() > 0 &&
-        url.find("{x}") != std::string::npos &&
-        url.find("{y}") != std::string::npos &&
-        url.find("{z}") != std::string::npos;
-
-    bool isMBTilesFile = false;
-    {
-        const char* extStr = ".mbtiles";
-        const size_t extLength = strlen(extStr);
-        const size_t urlLength = url.length();
-        isMBTilesFile = urlLength > extLength && (url.compare(urlLength - extLength, extLength, extStr) == 0);
-    }
-
-    bool isTms = false;
-    if (const Node& tmsNode = source["tms"]) {
-        YamlUtil::getBool(tmsNode, isTms);
-    }
-
-    auto rawSources = std::make_unique<MemoryCacheDataSource>();
-    rawSources->setCacheSize(CACHE_SIZE);
-
-    if (isMBTilesFile) {
-        // If we have MBTiles, we know the source is tiled.
-        tiled = true;
-        // Create an MBTiles data source from the file at the url and add it to the source chain.
-        rawSources->setNext(std::make_unique<MBTilesDataSource>(_scene.platform(), name, url, ""));
-    } else if (tiled) {
-        rawSources->setNext(std::make_unique<NetworkDataSource>(_scene.platform(), url, std::move(subdomains), isTms));
-    }
-
-    std::shared_ptr<TileSource> sourcePtr;
-
-    TileSource::ZoomOptions zoomOptions = { minDisplayZoom, maxDisplayZoom, maxZoom, zoomBias };
-
-    if (type == "GeoJSON" && !tiled) {
-        if (auto genLabelCentroidsNode = source["generate_label_centroids"]) {
-            generateCentroids = true;
-        }
-        sourcePtr = std::make_shared<ClientGeoJsonSource>(_scene.platform(), name, url, generateCentroids,
-                                                          zoomOptions);
-    } else if (type == "Raster") {
-        TextureOptions options;
-        if (const Node& filtering = source["filtering"]) {
-            if (!parseTexFiltering(filtering, options)) {
-                LOGW("Invalid texture filtering: %s", Dump(filtering).c_str());
-            }
-        }
-
-        sourcePtr = std::make_shared<RasterSource>(name, std::move(rawSources), options, zoomOptions);
-    } else {
-        sourcePtr = std::make_shared<TileSource>(name, std::move(rawSources), zoomOptions);
-
-        if (type == "GeoJSON") {
-            sourcePtr->setFormat(TileSource::Format::GeoJson);
-        } else if (type == "TopoJSON") {
-            sourcePtr->setFormat(TileSource::Format::TopoJson);
-        } else if (type == "MVT") {
-            sourcePtr->setFormat(TileSource::Format::Mvt);
-        } else {
-            LOGE("Source '%s' does not have a valid type. Valid types are 'GeoJSON', 'TopoJSON', and 'MVT'. " \
-                "This source will be ignored.", name.c_str());
-            return;
-        }
-    }
-
-    _scene.tileSources().push_back(sourcePtr);
-
-    if (auto rasters = source["rasters"]) {
-        loadSourceRasters(*sourcePtr, source["rasters"], sources, _scene);
-    }
-
-}
-
-void SceneLoader::loadSourceRasters(TileSource& source, const Node& rasterNode,
-                                    const Node& sources, Scene& scene) {
-    if (rasterNode.IsSequence()) {
-        for (const auto& raster : rasterNode) {
-            std::string srcName = raster.Scalar();
-            try {
-                loadSource(srcName, sources[srcName], sources, scene);
-            } catch (const YAML::RepresentationException& e) {
-                LOGNode("Parsing sources: '%s'", sources[srcName], e.what());
-                return;
-            }
-            source.addRasterSource(scene.getTileSource(srcName));
-        }
-    }
-}
-
-void SceneLoader::parseLightPosition(const Node& positionNode, PointLight& light) {
-    UnitVec<glm::vec3> positionResult;
-    if (StyleParam::parseVec3(positionNode, UnitSet{Unit::none, Unit::pixel, Unit::meter}, positionResult)) {
-        for (auto& unit : positionResult.units) {
-            if (unit == Unit::none) {
-                unit = Unit::meter;
-            }
-        }
-        light.setPosition(positionResult);
-    } else {
-        LOGNode("Invalid light position parameter:", positionNode);
-    }
-}
-
-void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
-
-    const Node& light = node.second;
-    const std::string& name = node.first.Scalar();
-    const std::string& type = light["type"].Scalar();
-
-    if (const Node& visible = light["visible"]) {
-        // If 'visible' is false, skip loading this light.
-        if (!YamlUtil::getBoolOrDefault(visible, true)) { return; }
-    }
-
-    std::unique_ptr<Light> sceneLight;
-
-    if (type == "ambient") {
-        sceneLight = std::make_unique<AmbientLight>(name);
-
-    } else if (type == "directional") {
-        auto dLight(std::make_unique<DirectionalLight>(name));
-
-        if (const Node& directionNode = light["direction"]) {
-            glm::vec3 direction;
-            if (YamlUtil::parseVec<glm::vec3>(directionNode, direction)) {
-                dLight->setDirection(direction);
-            }
-        }
-        sceneLight = std::move(dLight);
-
-    } else if (type == "point") {
-        auto pLight(std::make_unique<PointLight>(name));
-
-        if (const Node& position = light["position"]) {
-            parseLightPosition(position, *pLight);
-        }
-        if (const Node& radius = light["radius"]) {
-            if (radius.size() > 1) {
-                pLight->setRadius(YamlUtil::getFloatOrDefault(radius[0], 0.f), YamlUtil::getFloatOrDefault(radius[1], 0.f));
-            } else {
-                pLight->setRadius(YamlUtil::getFloatOrDefault(radius, 0.f));
-            }
-        }
-        if (const Node& att = light["attenuation"]) {
-            float attenuation;
-            if (YamlUtil::getFloat(att, attenuation)) {
-                pLight->setAttenuation(attenuation);
-            }
-        }
-        sceneLight = std::move(pLight);
-
-    } else if (type == "spotlight") {
-        auto sLight(std::make_unique<SpotLight>(name));
-
-        if (const Node& position = light["position"]) {
-            parseLightPosition(position, *sLight);
-        }
-        if (const Node& directionNode = light["direction"]) {
-            glm::vec3 direction;
-            if (YamlUtil::parseVec<glm::vec3>(directionNode, direction)) {
-                sLight->setDirection(direction);
-            }
-        }
-        if (const Node& radius = light["radius"]) {
-            if (radius.size() > 1) {
-                sLight->setRadius(YamlUtil::getFloatOrDefault(radius[0], 0.f), YamlUtil::getFloatOrDefault(radius[1], 0.f));
-            } else {
-                sLight->setRadius(YamlUtil::getFloatOrDefault(radius, 0.f));
-            }
-        }
-        if (const Node& angle = light["angle"]) {
-            sLight->setCutoffAngle(YamlUtil::getFloatOrDefault(angle, 0.f));
-        }
-        if (const Node& exponent = light["exponent"]) {
-            sLight->setCutoffExponent(YamlUtil::getFloatOrDefault(exponent, 0.f));
-        }
-        sceneLight = std::move(sLight);
-    }
-    if (const Node& origin = light["origin"]) {
-        const std::string& originStr = origin.Scalar();
-        if (originStr == "world") {
-            sceneLight->setOrigin(LightOrigin::world);
-        } else if (originStr == "camera") {
-            sceneLight->setOrigin(LightOrigin::camera);
-        } else if (originStr == "ground") {
-            sceneLight->setOrigin(LightOrigin::ground);
-        }
-    }
-    if (const Node& ambient = light["ambient"]) {
-        sceneLight->setAmbientColor(YamlUtil::getColorAsVec4(ambient));
-    }
-    if (const Node& diffuse = light["diffuse"]) {
-        sceneLight->setDiffuseColor(YamlUtil::getColorAsVec4(diffuse));
-    }
-    if (const Node& specular = light["specular"]) {
-        sceneLight->setSpecularColor(YamlUtil::getColorAsVec4(specular));
-    }
-
-    // Verify that light position parameters are consistent with the origin type
-    if (sceneLight->getType() == LightType::point || sceneLight->getType() == LightType::spot) {
-        auto pLight = static_cast<PointLight&>(*sceneLight);
-        auto lightPosition = pLight.getPosition();
-        LightOrigin origin = pLight.getOrigin();
-
-        if (origin == LightOrigin::world) {
-            if (lightPosition.units[0] == Unit::pixel || lightPosition.units[1] == Unit::pixel) {
-                LOGW("Light position with attachment %s may not be used with unit of type %s",
-                    lightOriginString(origin).c_str(), unitToString(Unit::pixel).c_str());
-                LOGW("Long/Lat expected in meters");
-            }
-        }
-    }
-
-    scene.lights().push_back(std::move(sceneLight));
-}
-
-void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
-
-    auto& camera = _scene.camera();
-
-    if (const Node& active = _camera["active"]) {
-        if (!YamlUtil::getBoolOrDefault(active, false)) {
-            return;
-        }
-    }
-
-    auto type = _camera["type"].Scalar();
-    if (type == "perspective") {
-        camera.type = CameraType::perspective;
-
-        // Only one of focal length and FOV is applied;
-        // according to docs, focal length takes precedence.
-        if (const Node& focal = _camera["focal_length"]) {
-            float floatValue;
-            if (YamlUtil::getFloat(focal, floatValue)) {
-                camera.fieldOfView = View::focalLengthToFieldOfView(floatValue);
-            } else if (focal.IsSequence()) {
-                camera.fovStops = std::make_shared<Stops>(Stops::Numbers(focal));
-                for (auto& f : camera.fovStops->frames) {
-                    f.value = View::focalLengthToFieldOfView(f.value.get<float>());
-                }
-            }
-        } else if (const Node& fov = _camera["fov"]) {
-            if (fov.IsScalar()) {
-                double degrees = YamlUtil::getDoubleOrDefault(fov, camera.fieldOfView * RAD_TO_DEG);
-                camera.fieldOfView = degrees * DEG_TO_RAD;
-            } else if (fov.IsSequence()) {
-                camera.fovStops = std::make_shared<Stops>(Stops::Numbers(fov));
-                for (auto& f : camera.fovStops->frames) {
-                    f.value = float(f.value.get<float>() * DEG_TO_RAD);
-                }
-            }
-        }
-
-        if (const Node& vanishing = _camera["vanishing_point"]) {
-            if (vanishing.IsSequence() && vanishing.size() >= 2) {
-                // Values are pixels, unit strings are ignored.
-                camera.vanishingPoint.x = YamlUtil::getFloatOrDefault(vanishing[0], 0.f, true);
-                camera.vanishingPoint.y = YamlUtil::getFloatOrDefault(vanishing[1], 0.f, true);
-            }
-        }
-    } else if (type == "isometric") {
-        camera.type = CameraType::isometric;
-
-        if (const Node& axis = _camera["axis"]) {
-            YamlUtil::parseVec(axis, camera.obliqueAxis);
-        }
-    } else if (type == "flat") {
-        camera.type = CameraType::flat;
-    }
-
-    // Default is world origin at 0 zoom
-    double x = 0;
-    double y = 0;
-    float z = 0;
-
-    if (const Node& position = _camera["position"]) {
-        x = YamlUtil::getDoubleOrDefault(position[0], x);
-        y = YamlUtil::getDoubleOrDefault(position[1], y);
-        if (position.size() > 2) {
-            z = YamlUtil::getFloatOrDefault(position[2], z);
-        }
-    }
-
-    if (const Node& zoom = _camera["zoom"]) {
-        z = YamlUtil::getFloatOrDefault(zoom, z);
-    }
-
-    if (const Node& maxTilt = _camera["max_tilt"]) {
-        if (maxTilt.IsSequence()) {
-            camera.maxTiltStops = std::make_shared<Stops>(Stops::Numbers(maxTilt));
-        } else if (maxTilt.IsScalar()) {
-            camera.maxTilt = YamlUtil::getFloatOrDefault(maxTilt, PI);
-        }
-    }
-
-    _scene.startPosition = glm::dvec2(x, y);
-    _scene.startZoom = z;
-}
-
-void SceneLoader::loadCameras(const Node& _cameras, Scene& _scene) {
-
-    // To correctly match the behavior of the webGL library we'll need a place
-    // to store multiple view instances.  Since we only have one global view
-    // right now, we'll just apply the settings from the first active camera we
-    // find.
-
-    for (const auto& entry : _cameras) {
-        loadCamera(entry.second, _scene);
-    }
-}
-
-void printFilters(const SceneLayer& layer, int indent){
-    LOG("%*s >>> %s\n", indent, "", layer.name().c_str());
-    layer.filter().print(indent + 2);
-
-    for (auto& l : layer.sublayers()) {
-        printFilters(l, indent + 2);
-    }
-};
-
-Filter SceneLoader::generateFilter(const Node& _filter, Scene& scene) {
-
-    switch (_filter.Type()) {
-    case NodeType::Scalar: {
-
-        const std::string& val = _filter.Scalar();
-        if (val.compare(0, 8, "function") == 0) {
-            return Filter::MatchFunction(scene.addJsFunction(val));
-        }
-        return Filter();
-    }
-    case NodeType::Sequence: {
-        return generateAnyFilter(_filter, scene);
-    }
-    case NodeType::Map: {
-        std::vector<Filter> filters;
-        for (const auto& filtItr : _filter) {
-            const std::string& key = filtItr.first.Scalar();
-            const Node& node = _filter[key];
-            Filter f;
-            if (key == "none") {
-                f = generateNoneFilter(node, scene);
-            } else if (key == "not") {
-                f = generateNoneFilter(node, scene);
-            } else if (key == "any") {
-                f = generateAnyFilter(node, scene);
-            } else if (key == "all") {
-                f = generateAllFilter(node, scene);
-            } else {
-                f = generatePredicate(node, key);
-            }
-
-            if (f.isValid()) { filters.push_back(std::move(f)); }
-        }
-
-        if (!filters.empty()) {
-            if (filters.size() == 1) { return filters.front(); }
-
-            return Filter::MatchAll(std::move(filters));
-        }
-        return Filter();
-    }
-    default:
-        return Filter();
-    }
-}
-
-Filter SceneLoader::generatePredicate(const Node& _node, std::string _key) {
-
-    switch (_node.Type()) {
-    case NodeType::Scalar: {
-        if (_node.Tag() == "tag:yaml.org,2002:str") {
-            // Node was explicitly tagged with '!!str' or the canonical tag
-            // 'tag:yaml.org,2002:str' yaml-cpp normalizes the tag value to the
-            // canonical form
-            return Filter::MatchEquality(_key, { Value(_node.Scalar()) });
-        }
-        double number;
-        if (YamlUtil::getDouble(_node, number, false)) {
-            return Filter::MatchEquality(_key, { Value(number) });
-        }
-        bool existence;
-        if (YamlUtil::getBool(_node, existence)) {
-            return Filter::MatchExistence(_key, existence);
-        }
-        const std::string& value = _node.Scalar();
-        return Filter::MatchEquality(_key, { Value(std::move(value)) });
-    }
-    case NodeType::Sequence: {
-        std::vector<Value> values;
-        for (const auto& valItr : _node) {
-            double number;
-            if (YamlUtil::getDouble(valItr, number, false)) {
-                values.emplace_back(number);
-            } else {
-                const std::string& value = valItr.Scalar();
-                values.emplace_back(std::move(value));
-            }
-        }
-        return Filter::MatchEquality(_key, std::move(values));
-    }
-    case NodeType::Map: {
-        double minVal = -std::numeric_limits<double>::infinity();
-        double maxVal = std::numeric_limits<double>::infinity();
-        bool hasMinPixelArea = false;
-        bool hasMaxPixelArea = false;
-
-        for (const auto& n : _node) {
-            if (n.first.Scalar() == "min") {
-                if(!getFilterRangeValue(n.second, minVal, hasMinPixelArea)) {
-                    return Filter();
-                }
-            } else if (n.first.Scalar() == "max") {
-                if (!getFilterRangeValue(n.second, maxVal, hasMaxPixelArea)) {
-                    return Filter();
-                }
-            }
-        }
-
-        const Node& max = _node["max"];
-        const Node& min = _node["min"];
-        if (max && min && max.IsScalar() && min.IsScalar() &&
-                (hasMinPixelArea != hasMaxPixelArea)) { return Filter(); }
-
-        return Filter::MatchRange(_key, minVal, maxVal, hasMinPixelArea | hasMaxPixelArea);
-    }
-    default:
-        return Filter();
-    }
-}
-
-bool SceneLoader::getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea) {
-    if (!YamlUtil::getDouble(node, val, false)) {
-        auto strVal = node.Scalar();
-        auto n = strVal.find("px2");
-        if (n == std::string::npos) { return false; }
-        try {
-            val = ff::stof(std::string(strVal, 0, n));
-            hasPixelArea = true;
-        } catch (std::invalid_argument) { return false; }
-    }
-    return true;
-}
-
-Filter SceneLoader::generateAnyFilter(const Node& _filter, Scene& scene) {
-
-    if (_filter.IsSequence()) {
-        std::vector<Filter> filters;
-
-        for (const auto& filt : _filter) {
-            if (Filter f = generateFilter(filt, scene)) {
-                filters.push_back(std::move(f));
-            } else { return Filter(); }
-        }
-        return Filter::MatchAny(std::move(filters));
-    }
-    return Filter();
-}
-
-Filter SceneLoader::generateAllFilter(const Node& _filter, Scene& scene) {
-
-    if (_filter.IsSequence()) {
-        std::vector<Filter> filters;
-
-        for (const auto& filt : _filter) {
-            if (Filter f = generateFilter(filt, scene)) {
-                filters.push_back(std::move(f));
-            } else { return Filter(); }
-        }
-        return Filter::MatchAll(std::move(filters));
-    }
-    return Filter();
-}
-
-Filter SceneLoader::generateNoneFilter(const Node& _filter, Scene& scene) {
-
-    if (_filter.IsSequence()) {
-        std::vector<Filter> filters;
-
-        for (const auto& filt : _filter) {
-            if (Filter f = generateFilter(filt, scene)) {
-                filters.push_back(std::move(f));
-            } else { return Filter(); }
-        }
-        return Filter::MatchNone(std::move(filters));
-
-    } else if (_filter.IsMap() || _filter.IsScalar()) {
-        // 'not' case
-        if (Filter f = generateFilter(_filter, scene)) {
-            return Filter::MatchNone({std::move(f)});
-        }
-    }
-    return Filter();
-}
-
 void SceneLoader::parseStyleParams(const Node& params, Scene& scene, const std::string& prefix,
                                    std::vector<StyleParam>& out) {
 
     for (const auto& prop : params) {
-
         std::string key;
         if (!prefix.empty()) {
             key = prefix + DELIMITER + prop.first.Scalar();
@@ -1612,6 +1203,118 @@ void SceneLoader::parseStyleParams(const Node& params, Scene& scene, const std::
         }
         default:
             LOGW("Style parameter %s must be a scalar, sequence, or map.", key.c_str());
+        }
+    }
+}
+
+void SceneLoader::parseTransition(const Node& params, Scene& scene, std::string _prefix,
+                                  std::vector<StyleParam>& out) {
+
+    // First iterate over the mapping of 'events', we currently recognize 'hide', 'selected', and 'show'.
+    for (const auto& event : params) {
+        if (!event.first.IsScalar() || !event.second.IsMap()) {
+            LOGW("Can't parse 'transitions' entry, expected a mapping of strings to mappings at: %s",
+                 _prefix.c_str());
+            continue;
+        }
+
+        // Add the event to our key, so it's now 'transition:event'.
+        std::string transitionEvent = _prefix + DELIMITER + event.first.Scalar();
+
+        // Iterate over the parameters in the 'event', we currently only recognize 'time'.
+        for (const auto& param : event.second) {
+            if (!param.first.IsScalar() || !param.second.IsScalar()) {
+                LOGW("Expected a mapping of strings to strings or numbers in: %s",
+                     transitionEvent.c_str());
+                continue;
+            }
+            // Add the parameter to our key, so it's now 'transition:event:param'.
+            std::string transitionEventParam = transitionEvent + DELIMITER + param.first.Scalar();
+            // Create a style parameter from the key and value.
+            out.push_back(StyleParam{ transitionEventParam, param.second });
+        }
+    }
+}
+
+void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, Scene& scene) {
+    if (!shaders) { return; }
+
+    auto& shader = style.getShaderSource();
+
+    if (const Node& extNode = shaders["extensions_mixed"]) {
+        if (extNode.IsScalar()) {
+            shader.addExtensionDeclaration(extNode.Scalar());
+        } else if (extNode.IsSequence()) {
+            for (const auto& e : extNode) {
+                shader.addExtensionDeclaration(e.Scalar());
+            }
+        }
+    }
+
+    if (const Node& definesNode = shaders["defines"]) {
+        for (const auto& define : definesNode) {
+            const std::string& name = define.first.Scalar();
+
+            // undefine any previous definitions
+            {
+                auto pos = name.find('(');
+                if (pos == std::string::npos) {
+                    shader.addSourceBlock("defines", "#undef " + name);
+                } else {
+                    shader.addSourceBlock("defines", "#undef " + name.substr(0, pos));
+                }
+            }
+            bool bValue;
+
+            if (YamlUtil::getBool(define.second, bValue)) {
+                // specifying a define to be 'true' means that it is simply
+                // defined and has no value
+                if (bValue) {
+                    shader.addSourceBlock("defines", "#define " + name);
+                }
+            } else {
+                const std::string& value = define.second.Scalar();
+                shader.addSourceBlock("defines", "#define " + name + " " + value);
+            }
+        }
+    }
+
+    if (const Node& uniformsNode = shaders["uniforms"]) {
+        for (const auto& uniform : uniformsNode) {
+            const std::string& name = uniform.first.Scalar();
+            StyleUniform styleUniform;
+
+            if (parseStyleUniforms(uniform.second, scene, styleUniform)) {
+                if (styleUniform.value.is<UniformArray1f>()) {
+                    UniformArray1f& array = styleUniform.value.get<UniformArray1f>();
+                    shader.addSourceBlock("uniforms", "uniform float " + name +
+                        "[" + std::to_string(array.size()) + "];");
+                } else if(styleUniform.value.is<UniformTextureArray>()) {
+                    UniformTextureArray& textureArray = styleUniform.value.get<UniformTextureArray>();
+                    shader.addSourceBlock("uniforms", "uniform " + styleUniform.type + " " + name +
+                        "[" + std::to_string(textureArray.names.size()) + "];");
+                } else {
+                    shader.addSourceBlock("uniforms", "uniform " + styleUniform.type + " " + name + ";");
+                }
+
+                style.styleUniforms().emplace_back(name, styleUniform.value);
+            } else {
+                LOGNode("Style uniform parsing failure", uniform.second);
+            }
+        }
+    }
+
+    if (const Node& blocksNode = shaders["blocks_mixed"]) {
+        for (const auto& block : blocksNode) {
+            const auto& name = block.first.Scalar();
+            const auto& value = block.second;
+            if (value.IsSequence()){
+                for (const auto& it : value) {
+                    shader.addSourceBlock(name, it.Scalar(), false);
+                }
+            } else if (value.IsScalar()) {
+                shader.addSourceBlock(name, value.Scalar(), false);
+            }
         }
     }
 }
@@ -1702,41 +1405,192 @@ bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene,
         LOGW("Expected a scalar or sequence value for uniforms");
         return false;
     }
-
     return true;
 }
 
-void SceneLoader::parseTransition(const Node& params, Scene& scene, std::string _prefix,
-                                  std::vector<StyleParam>& out) {
+void SceneLoader::loadMaterial(const Node& matNode, Material& material,
+                               Scene& scene, Style& style) {
 
-    // First iterate over the mapping of 'events', we currently recognize 'hide', 'selected', and 'show'.
-    for (const auto& event : params) {
-        if (!event.first.IsScalar() || !event.second.IsMap()) {
-            LOGW("Can't parse 'transitions' entry, expected a mapping of strings to mappings at: %s",
-                 _prefix.c_str());
-            continue;
-        }
-
-        // Add the event to our key, so it's now 'transition:event'.
-        std::string transitionEvent = _prefix + DELIMITER + event.first.Scalar();
-
-        // Iterate over the parameters in the 'event', we currently only recognize 'time'.
-        for (const auto& param : event.second) {
-            if (!param.first.IsScalar() || !param.second.IsScalar()) {
-                LOGW("Expected a mapping of strings to strings or numbers in: %s",
-                     transitionEvent.c_str());
-                continue;
+    auto parseMaterialVec = [](const Node& prop) -> glm::vec4 {
+        switch (prop.Type()) {
+        case NodeType::Sequence: {
+            glm::vec4 vec;
+            if (YamlUtil::parseVec<glm::vec4>(prop, vec)) {
+                return vec;
             }
-            // Add the parameter to our key, so it's now 'transition:event:param'.
-            std::string transitionEventParam = transitionEvent + DELIMITER + param.first.Scalar();
-            // Create a style parameter from the key and value.
-            out.push_back(StyleParam{ transitionEventParam, param.second });
+            break;
+        }
+        case NodeType::Scalar: {
+            double value;
+            if (YamlUtil::getDouble(prop, value, false)) {
+                return glm::vec4(value, value, value, 1.0);
+            } else {
+                return YamlUtil::getColorAsVec4(prop);
+            }
+            break;
+        }
+        case NodeType::Map:
+            // Handled as texture
+            break;
+        default:
+            LOGNode("Invalid 'material'", prop);
+            break;
+        }
+        return glm::vec4(0.0);
+    };
+
+    if (!matNode.IsMap()) { return; }
+
+    if (const Node& n = matNode["emission"]) {
+        if (n.IsMap()) {
+            material.setEmission(loadMaterialTexture(n, scene, style));
+        } else {
+            material.setEmission(parseMaterialVec(n));
+        }
+    }
+    if (const Node& n = matNode["diffuse"]) {
+        if (n.IsMap()) {
+            material.setDiffuse(loadMaterialTexture(n, scene, style));
+        } else {
+            material.setDiffuse(parseMaterialVec(n));
+        }
+    }
+    if (const Node& n = matNode["ambient"]) {
+        if (n.IsMap()) {
+            material.setAmbient(loadMaterialTexture(n, scene, style));
+        } else {
+            material.setAmbient(parseMaterialVec(n));
+        }
+    }
+
+    if (const Node& n = matNode["specular"]) {
+        if (n.IsMap()) {
+            material.setSpecular(loadMaterialTexture(n, scene, style));
+        } else {
+            material.setSpecular(parseMaterialVec(n));
+        }
+    }
+
+    if (const Node& shininess = matNode["shininess"]) {
+        double value;
+        if (YamlUtil::getDouble(shininess, value, false)) {
+            material.setShininess(value);
+        }
+    }
+    material.setNormal(loadMaterialTexture(matNode["normal"], scene, style));
+}
+
+MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode,
+                                                 Scene& scene, Style& style) {
+
+    if (!matCompNode) { return MaterialTexture{}; }
+
+    Node textureNode = matCompNode["texture"];
+    if (!textureNode) {
+        LOGNode("Expected a 'texture' parameter", matCompNode);
+
+        return MaterialTexture{};
+    }
+
+    const std::string& name = textureNode.Scalar();
+
+    MaterialTexture matTex;
+    matTex.tex = scene.loadTexture(name);
+
+    if (const Node& mappingNode = matCompNode["mapping"]) {
+        const std::string& mapping = mappingNode.Scalar();
+        if (mapping == "uv") {
+            matTex.mapping = MappingType::uv;
+
+            // Mark the style to generate texture coordinates
+            if (!style.genTexCoords()) {
+                LOGW("Style %s has option `texcoords: false` but material %s has uv mapping",
+                    style.getName().c_str(), name.c_str());
+                LOGW("Defaulting uvs generation to true for style %s",
+                    style.getName().c_str());
+            }
+
+            style.setTexCoordsGeneration(true);
+        } else if (mapping == "spheremap") {
+            matTex.mapping = MappingType::spheremap;
+        } else if (mapping == "planar") {
+            matTex.mapping = MappingType::planar;
+        } else if (mapping == "triplanar") {
+            matTex.mapping = MappingType::triplanar;
+        } else {
+            LOGW("Unrecognized texture mapping '%s'", mapping.c_str());
+        }
+    }
+
+    if (const Node& scaleNode = matCompNode["scale"]) {
+        if (scaleNode.IsSequence() && scaleNode.size() == 2) {
+            matTex.scale.x = YamlUtil::getFloatOrDefault(scaleNode[0], matTex.scale.x);
+            matTex.scale.y = YamlUtil::getFloatOrDefault(scaleNode[1], matTex.scale.y);
+        } else if (scaleNode.IsScalar()) {
+            matTex.scale = glm::vec3(YamlUtil::getFloatOrDefault(scaleNode, 1.f));
+        } else {
+            LOGW("Unrecognized scale parameter in material");
+        }
+    }
+
+    if (const Node& amountNode = matCompNode["amount"]) {
+        if (amountNode.IsScalar()) {
+            matTex.amount = glm::vec3(YamlUtil::getFloatOrDefault(amountNode, 1.f));
+        } else if (!YamlUtil::parseVec(amountNode, matTex.amount)) {
+            LOGW("Unrecognized amount parameter in material");
+        }
+    }
+    return matTex;
+}
+
+void SceneLoader::applyLayers(Scene& _scene) {
+    const Node& config = _scene.config();
+
+    if (const Node& layers = config["layers"]) {
+        for (const auto& layer : layers) {
+            try { loadLayer(layer, _scene); }
+            catch (const YAML::RepresentationException& e) {
+                LOGNode("Parsing layer: '%s'", layer, e.what());
+            }
         }
     }
 }
 
-SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layerName, Scene& scene) {
+void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
+    const std::string& name = layer.first.Scalar();
+    std::string source;
+    std::vector<std::string> collections;
 
+    if (const Node& data = layer.second["data"]) {
+
+        if (const Node& data_source = data["source"]) {
+            if (data_source.IsScalar()) {
+                source = data_source.Scalar();
+                // FIXME Log missing source?
+            }
+        }
+
+        if (const Node& data_layer = data["layer"]) {
+            if (data_layer.IsScalar()) {
+                collections.push_back(data_layer.Scalar());
+            } else if (data_layer.IsSequence()) {
+                collections.reserve(data_layer.size());
+                for (const auto& entry : data_layer) {
+                    if (entry.IsScalar()) {
+                        collections.push_back(entry.Scalar());
+                    }
+                }
+            }
+        }
+    }
+    if (collections.empty()) {
+        collections.push_back(name);
+    }
+    auto sublayer = loadSublayer(layer.second, name, scene);
+    scene.layers().push_back({ std::move(sublayer), source, collections });
+}
+
+SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layerName, Scene& scene) {
     std::vector<SceneLayer> sublayers;
     std::vector<DrawRuleData> rules;
     Filter filter;
@@ -1777,66 +1631,187 @@ SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layer
             sublayers.push_back(loadSublayer(member.second, (layerName + DELIMITER + key), scene));
         }
     }
-
     return { layerName, std::move(filter), rules, std::move(sublayers), enabled };
 }
 
-void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
+void printFilters(const SceneLayer& layer, int indent){
+    LOG("%*s >>> %s\n", indent, "", layer.name().c_str());
+    layer.filter().print(indent + 2);
 
-    const std::string& name = layer.first.Scalar();
+    for (auto& l : layer.sublayers()) {
+        printFilters(l, indent + 2);
+    }
+};
 
-    std::string source;
-    std::vector<std::string> collections;
+Filter SceneLoader::generateFilter(const Node& _filter, Scene& scene) {
+    switch (_filter.Type()) {
+    case NodeType::Scalar: {
 
-    if (const Node& data = layer.second["data"]) {
-
-        if (const Node& data_source = data["source"]) {
-            if (data_source.IsScalar()) {
-                source = data_source.Scalar();
-                // FIXME Log missing source?
+        const std::string& val = _filter.Scalar();
+        if (val.compare(0, 8, "function") == 0) {
+            return Filter::MatchFunction(scene.addJsFunction(val));
+        }
+        return Filter();
+    }
+    case NodeType::Sequence: {
+        return generateAnyFilter(_filter, scene);
+    }
+    case NodeType::Map: {
+        std::vector<Filter> filters;
+        for (const auto& filtItr : _filter) {
+            const std::string& key = filtItr.first.Scalar();
+            const Node& node = _filter[key];
+            Filter f;
+            if (key == "none") {
+                f = generateNoneFilter(node, scene);
+            } else if (key == "not") {
+                f = generateNoneFilter(node, scene);
+            } else if (key == "any") {
+                f = generateAnyFilter(node, scene);
+            } else if (key == "all") {
+                f = generateAllFilter(node, scene);
+            } else {
+                f = generatePredicate(node, key);
             }
+
+            if (f.isValid()) { filters.push_back(std::move(f)); }
         }
 
-        if (const Node& data_layer = data["layer"]) {
-            if (data_layer.IsScalar()) {
-                collections.push_back(data_layer.Scalar());
-            } else if (data_layer.IsSequence()) {
-                collections.reserve(data_layer.size());
-                for (const auto& entry : data_layer) {
-                    if (entry.IsScalar()) {
-                        collections.push_back(entry.Scalar());
-                    }
+        if (!filters.empty()) {
+            if (filters.size() == 1) { return filters.front(); }
+
+            return Filter::MatchAll(std::move(filters));
+        }
+        return Filter();
+    }
+    default:
+        return Filter();
+    }
+}
+
+Filter SceneLoader::generateAnyFilter(const Node& _filter, Scene& scene) {
+    if (_filter.IsSequence()) {
+        std::vector<Filter> filters;
+
+        for (const auto& filt : _filter) {
+            if (Filter f = generateFilter(filt, scene)) {
+                filters.push_back(std::move(f));
+            } else { return Filter(); }
+        }
+        return Filter::MatchAny(std::move(filters));
+    }
+    return Filter();
+}
+
+Filter SceneLoader::generateAllFilter(const Node& _filter, Scene& scene) {
+    if (_filter.IsSequence()) {
+        std::vector<Filter> filters;
+
+        for (const auto& filt : _filter) {
+            if (Filter f = generateFilter(filt, scene)) {
+                filters.push_back(std::move(f));
+            } else { return Filter(); }
+        }
+        return Filter::MatchAll(std::move(filters));
+    }
+    return Filter();
+}
+
+Filter SceneLoader::generateNoneFilter(const Node& _filter, Scene& scene) {
+    if (_filter.IsSequence()) {
+        std::vector<Filter> filters;
+
+        for (const auto& filt : _filter) {
+            if (Filter f = generateFilter(filt, scene)) {
+                filters.push_back(std::move(f));
+            } else { return Filter(); }
+        }
+        return Filter::MatchNone(std::move(filters));
+
+    } else if (_filter.IsMap() || _filter.IsScalar()) {
+        // 'not' case
+        if (Filter f = generateFilter(_filter, scene)) {
+            return Filter::MatchNone({std::move(f)});
+        }
+    }
+    return Filter();
+}
+
+Filter SceneLoader::generatePredicate(const Node& _node, std::string _key) {
+    switch (_node.Type()) {
+    case NodeType::Scalar: {
+        if (_node.Tag() == "tag:yaml.org,2002:str") {
+            // Node was explicitly tagged with '!!str' or the canonical tag
+            // 'tag:yaml.org,2002:str' yaml-cpp normalizes the tag value to the
+            // canonical form
+            return Filter::MatchEquality(_key, { Value(_node.Scalar()) });
+        }
+        double number;
+        if (YamlUtil::getDouble(_node, number, false)) {
+            return Filter::MatchEquality(_key, { Value(number) });
+        }
+        bool existence;
+        if (YamlUtil::getBool(_node, existence)) {
+            return Filter::MatchExistence(_key, existence);
+        }
+        const std::string& value = _node.Scalar();
+        return Filter::MatchEquality(_key, { Value(std::move(value)) });
+    }
+    case NodeType::Sequence: {
+        std::vector<Value> values;
+        for (const auto& valItr : _node) {
+            double number;
+            if (YamlUtil::getDouble(valItr, number, false)) {
+                values.emplace_back(number);
+            } else {
+                const std::string& value = valItr.Scalar();
+                values.emplace_back(std::move(value));
+            }
+        }
+        return Filter::MatchEquality(_key, std::move(values));
+    }
+    case NodeType::Map: {
+        double minVal = -std::numeric_limits<double>::infinity();
+        double maxVal = std::numeric_limits<double>::infinity();
+        bool hasMinPixelArea = false;
+        bool hasMaxPixelArea = false;
+
+        for (const auto& n : _node) {
+            if (n.first.Scalar() == "min") {
+                if(!getFilterRangeValue(n.second, minVal, hasMinPixelArea)) {
+                    return Filter();
+                }
+            } else if (n.first.Scalar() == "max") {
+                if (!getFilterRangeValue(n.second, maxVal, hasMaxPixelArea)) {
+                    return Filter();
                 }
             }
         }
+
+        const Node& max = _node["max"];
+        const Node& min = _node["min"];
+        if (max && min && max.IsScalar() && min.IsScalar() &&
+                (hasMinPixelArea != hasMaxPixelArea)) { return Filter(); }
+
+        return Filter::MatchRange(_key, minVal, maxVal, hasMinPixelArea | hasMaxPixelArea);
     }
-
-    if (collections.empty()) {
-        collections.push_back(name);
-    }
-
-    auto sublayer = loadSublayer(layer.second, name, scene);
-
-    scene.layers().push_back({ std::move(sublayer), source, collections });
-}
-
-void SceneLoader::loadBackground(const Node& background, Scene& scene) {
-
-    if (!background) { return; }
-
-    if (const Node& colorNode = background["color"]) {
-        Color colorResult;
-        if (StyleParam::parseColor(colorNode, colorResult)) {
-            scene.background() = colorResult;
-        } else {
-            Stops stopsResult = Stops::Colors(colorNode);
-            if (stopsResult.frames.size() > 0) {
-                scene.backgroundStops() = stopsResult;
-            } else {
-                LOGW("Cannot parse color: %s", Dump(colorNode).c_str());
-            }
-        }
+    default:
+        return Filter();
     }
 }
+
+bool SceneLoader::getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea) {
+    if (!YamlUtil::getDouble(node, val, false)) {
+        auto strVal = node.Scalar();
+        auto n = strVal.find("px2");
+        if (n == std::string::npos) { return false; }
+        try {
+            val = ff::stof(std::string(strVal, 0, n));
+            hasPixelArea = true;
+        } catch (std::invalid_argument) { return false; }
+    }
+    return true;
+}
+
 
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -96,7 +96,7 @@ bool SceneLoader::loadScene(const std::shared_ptr<Platform>& _platform, std::sha
     LOGTime("applySources");
 
     _scene->initTileManager();
-    _scene->updateTiles(0);
+    //_scene->updateTiles(0);
 
     // Load font resources
     _scene->fontContext()->loadFonts();

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -342,11 +342,13 @@ void SceneLoader::applyStyles(std::shared_ptr<Scene>& _scene) {
     // Instantiate built-in styles
     _scene->styles().emplace_back(new PolygonStyle("polygons"));
     _scene->styles().emplace_back(new PolylineStyle("lines"));
-    _scene->styles().emplace_back(new DebugTextStyle("debugtext", _scene->fontContext(), true));
     _scene->styles().emplace_back(new TextStyle("text", _scene->fontContext(), true));
-    _scene->styles().emplace_back(new DebugStyle("debug"));
     _scene->styles().emplace_back(new PointStyle("points", _scene->fontContext()));
     _scene->styles().emplace_back(new RasterStyle("raster"));
+    if (_scene->options().debugStyles) {
+        _scene->styles().emplace_back(new DebugTextStyle("debugtext", _scene->fontContext(), true));
+        _scene->styles().emplace_back(new DebugStyle("debug"));
+    }
 
     if (const Node& styles = config["styles"]) {
         StyleMixer mixer;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -68,22 +68,21 @@ constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
 
 static const std::string GLOBAL_PREFIX = "global.";
 
-bool SceneLoader::loadScene(Platform& _platform, std::shared_ptr<Scene> _scene,
-                            const std::vector<SceneUpdate>& _updates) {
+bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
 
     LOGTimeInit();
 
     Importer sceneImporter(_scene);
     LOGTime("sceneImporter");
 
-    _scene->config() = sceneImporter.applySceneImports(_platform);
+    _scene->config() = sceneImporter.applySceneImports(_scene->platform());
     LOGTime("applyImports");
 
     if (!_scene->config()) {
         return false;
     }
 
-    if (!applyUpdates(_platform, *_scene, _updates)) {
+    if (!applyUpdates(*_scene)) {
         LOGW("Scene updates failed when loading scene");
         return false;
     }
@@ -92,7 +91,7 @@ bool SceneLoader::loadScene(Platform& _platform, std::shared_ptr<Scene> _scene,
     applyGlobals(*_scene);
     LOGTime("applyGlobals");
 
-    applySources(_platform, *_scene);
+    applySources(*_scene);
     LOGTime("applySources");
 
     applyCameras(*_scene);
@@ -102,16 +101,16 @@ bool SceneLoader::loadScene(Platform& _platform, std::shared_ptr<Scene> _scene,
     _scene->tileManager()->updateTileSets(*_scene->view());
     LOGTime("loadTiles");
 
-    applyTextures(_platform, _scene);
+    applyTextures(_scene);
     LOGTime("textures");
 
     _scene->fontContext()->loadFonts();
     LOGTime("initFonts");
 
-    applyFonts(_platform, _scene);
+    applyFonts(_scene);
     LOGTime("fonts");
 
-    applyStyles(_platform, _scene);
+    applyStyles(_scene);
     LOGTime("styles");
 
     applyLayers(*_scene);
@@ -129,11 +128,10 @@ bool SceneLoader::loadScene(Platform& _platform, std::shared_ptr<Scene> _scene,
     return true;
 }
 
-bool SceneLoader::applyUpdates(Platform& platform, Scene& scene,
-                               const std::vector<SceneUpdate>& updates) {
+bool SceneLoader::applyUpdates(Scene& scene) {
     auto& root = scene.config();
 
-    for (const auto& update : updates) {
+    for (const auto& update : scene.options().updates) {
         Node value;
 
         try {
@@ -156,7 +154,7 @@ bool SceneLoader::applyUpdates(Platform& platform, Scene& scene,
         }
     }
 
-    Importer::resolveSceneUrls(root, scene.url());
+    Importer::resolveSceneUrls(root, scene.options().url);
 
     return true;
 }
@@ -218,14 +216,14 @@ void SceneLoader::applyGlobals(Scene& _scene) {
     }
 }
 
-void SceneLoader::applySources(Platform& _platform, Scene& _scene) {
+void SceneLoader::applySources(Scene& _scene) {
 
     const Node& config = _scene.config();
 
     if (const Node& sources = config["sources"]) {
         for (const auto& source : sources) {
             std::string srcName = source.first.Scalar();
-            try { loadSource(_platform, srcName, source.second, sources, _scene); }
+            try { loadSource(srcName, source.second, sources, _scene); }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing sources: '%s'", source, e.what());
             }
@@ -298,7 +296,7 @@ void SceneLoader::applyCameras(Scene& _scene) {
         view->setMaxPitch(camera.maxTilt);
     }
 
-    if (_scene.useScenePosition) {
+    if (_scene.options().useScenePosition) {
         auto position = _scene.startPosition;
         view->setCenterCoordinates({position.x, position.y});
         view->setZoom(_scene.startZoom);
@@ -309,12 +307,12 @@ void SceneLoader::applyCameras(Scene& _scene) {
     view->update();
 }
 
-void SceneLoader::applyTextures(Platform& _platform, const std::shared_ptr<Scene>& _scene) {
+void SceneLoader::applyTextures(std::shared_ptr<Scene>& _scene) {
     const Node& config = _scene->config();
 
     if (const Node& textures = config["textures"]) {
         for (const auto& texture : textures) {
-            try { loadTexture(_platform, texture, _scene); }
+            try { loadTexture(texture, _scene); }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing texture: '%s'", texture, e.what());
             }
@@ -322,13 +320,13 @@ void SceneLoader::applyTextures(Platform& _platform, const std::shared_ptr<Scene
     }
 }
 
-void SceneLoader::applyFonts(Platform& _platform, const std::shared_ptr<Scene>& _scene) {
+void SceneLoader::applyFonts(std::shared_ptr<Scene>& _scene) {
     const Node& config = _scene->config();
 
     if (const Node& fonts = config["fonts"]) {
         if (fonts.IsMap()) {
             for (const auto& font : fonts) {
-                try { loadFont(_platform, font, _scene); }
+                try { loadFont(font, _scene); }
                 catch (const YAML::RepresentationException& e) {
                     LOGNode("Parsing font: '%s'", font, e.what());
                 }
@@ -337,7 +335,7 @@ void SceneLoader::applyFonts(Platform& _platform, const std::shared_ptr<Scene>& 
     }
 }
 
-void SceneLoader::applyStyles(Platform& _platform, const std::shared_ptr<Scene>& _scene) {
+void SceneLoader::applyStyles(std::shared_ptr<Scene>& _scene) {
     const Node& config = _scene->config();
 
     // Instantiate built-in styles
@@ -359,8 +357,7 @@ void SceneLoader::applyStyles(Platform& _platform, const std::shared_ptr<Scene>&
         for (const auto& entry : styles) {
             try {
                 auto name = entry.first.Scalar();
-                auto config = entry.second;
-                loadStyle(_platform, name, config, _scene);
+                loadStyle(name, entry.second, _scene);
             }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing style: '%s'", entry, e.what());
@@ -425,8 +422,7 @@ void SceneLoader::applyLayers(Scene& _scene) {
 
 }
 
-void SceneLoader::loadShaderConfig(Platform& platform, Node shaders, Style& style,
-                                   const std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadShaderConfig(Node shaders, Style& style, std::shared_ptr<Scene>& scene) {
 
     if (!shaders) { return; }
 
@@ -475,7 +471,7 @@ void SceneLoader::loadShaderConfig(Platform& platform, Node shaders, Style& styl
             const std::string& name = uniform.first.Scalar();
             StyleUniform styleUniform;
 
-            if (parseStyleUniforms(platform, uniform.second, scene, styleUniform)) {
+            if (parseStyleUniforms(uniform.second, scene, styleUniform)) {
                 if (styleUniform.value.is<UniformArray1f>()) {
                     UniformArray1f& array = styleUniform.value.get<UniformArray1f>();
                     shader.addSourceBlock("uniforms", "uniform float " + name +
@@ -539,28 +535,28 @@ glm::vec4 parseMaterialVec(const Node& prop) {
     return glm::vec4(0.0);
 }
 
-void SceneLoader::loadMaterial(Platform& platform, Node matNode, Material& material,
-                               const std::shared_ptr<Scene>& scene, Style& style) {
+void SceneLoader::loadMaterial(Node matNode, Material& material,
+                               std::shared_ptr<Scene>& scene, Style& style) {
 
     if (!matNode.IsMap()) { return; }
 
     if (Node n = matNode["emission"]) {
         if (n.IsMap()) {
-            material.setEmission(loadMaterialTexture(platform, n, scene, style));
+            material.setEmission(loadMaterialTexture(n, scene, style));
         } else {
             material.setEmission(parseMaterialVec(n));
         }
     }
     if (Node n = matNode["diffuse"]) {
         if (n.IsMap()) {
-            material.setDiffuse(loadMaterialTexture(platform, n, scene, style));
+            material.setDiffuse(loadMaterialTexture(n, scene, style));
         } else {
             material.setDiffuse(parseMaterialVec(n));
         }
     }
     if (Node n = matNode["ambient"]) {
         if (n.IsMap()) {
-            material.setAmbient(loadMaterialTexture(platform, n, scene, style));
+            material.setAmbient(loadMaterialTexture(n, scene, style));
         } else {
             material.setAmbient(parseMaterialVec(n));
         }
@@ -568,7 +564,7 @@ void SceneLoader::loadMaterial(Platform& platform, Node matNode, Material& mater
 
     if (Node n = matNode["specular"]) {
         if (n.IsMap()) {
-            material.setSpecular(loadMaterialTexture(platform, n, scene, style));
+            material.setSpecular(loadMaterialTexture(n, scene, style));
         } else {
             material.setSpecular(parseMaterialVec(n));
         }
@@ -581,11 +577,10 @@ void SceneLoader::loadMaterial(Platform& platform, Node matNode, Material& mater
         }
     }
 
-    material.setNormal(loadMaterialTexture(platform, matNode["normal"], scene, style));
+    material.setNormal(loadMaterialTexture(matNode["normal"], scene, style));
 }
 
-MaterialTexture SceneLoader::loadMaterialTexture(Platform& platform, Node matCompNode,
-                                                 const std::shared_ptr<Scene>& scene, Style& style) {
+MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, std::shared_ptr<Scene>& scene, Style& style) {
 
     if (!matCompNode) { return MaterialTexture{}; }
 
@@ -599,7 +594,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Platform& platform, Node matCom
     const std::string& name = textureNode.Scalar();
 
     MaterialTexture matTex;
-    matTex.tex = getOrLoadTexture(platform, name, scene);
+    matTex.tex = getOrLoadTexture(name, scene);
 
     if (Node mappingNode = matCompNode["mapping"]) {
         const std::string& mapping = mappingNode.Scalar();
@@ -670,10 +665,8 @@ bool SceneLoader::parseTexFiltering(Node& filteringNode, TextureOptions& options
 }
 
 
-std::shared_ptr<Texture> SceneLoader::fetchTexture(Platform& platform,
-                                                   const std::string& name, const std::string& urlString,
-                                                   const TextureOptions& options,
-                                                   const std::shared_ptr<Scene>& scene,
+std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, const std::string& urlString,
+                                                   const TextureOptions& options, std::shared_ptr<Scene>& scene,
                                                    std::unique_ptr<SpriteAtlas> _atlas) {
     std::shared_ptr<Texture> texture;
 
@@ -705,7 +698,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(Platform& platform,
 
         scene->pendingTextures++;
         LOGTime("Fetch texture");
-        scene->startUrlRequest(platform, url, [&, url, scene, texture](UrlResponse&& response) {
+        scene->startUrlRequest(url, [&, url, scene, texture](UrlResponse&& response) {
                 LOGTime("Got texture data");
                 if (response.error) {
                     LOGE("Error retrieving URL '%s': %s", url.string().c_str(), response.error);
@@ -724,7 +717,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(Platform& platform,
                 scene->pendingTextures--;
                 LOGTime("Got texture ready");
                 if (scene->pendingTextures == 0) {
-                    platform.requestRender();
+                    scene->platform().requestRender();
                 }
             });
     }
@@ -732,8 +725,7 @@ std::shared_ptr<Texture> SceneLoader::fetchTexture(Platform& platform,
     return texture;
 }
 
-std::shared_ptr<Texture> SceneLoader::getOrLoadTexture(Platform& platform,
-                                                       const std::string& name, const std::shared_ptr<Scene>& scene) {
+std::shared_ptr<Texture> SceneLoader::getOrLoadTexture(const std::string& name, std::shared_ptr<Scene>& scene) {
 
     auto entry = scene->textures().find(name);
     if (entry != scene->textures().end()) {
@@ -742,15 +734,14 @@ std::shared_ptr<Texture> SceneLoader::getOrLoadTexture(Platform& platform,
 
     // If texture could not be found by name then interpret name as URL
     TextureOptions options;
-    auto texture = fetchTexture(platform, name, name, options, scene);
+    auto texture = fetchTexture(name, name, options, scene);
 
     scene->textures().emplace(name, texture);
 
     return texture;
 }
 
-void SceneLoader::loadTexture(Platform& platform, const std::pair<Node, Node>& node,
-                              const std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadTexture( const std::pair<Node, Node>& node, std::shared_ptr<Scene>& scene) {
 
     const std::string& name = node.first.Scalar();
     const Node& textureConfig = node.second;
@@ -802,13 +793,13 @@ void SceneLoader::loadTexture(Platform& platform, const std::pair<Node, Node>& n
             }
         }
     }
-    auto texture = fetchTexture(platform, name, url, options, scene, std::move(atlas));
+    auto texture = fetchTexture(name, url, options, scene, std::move(atlas));
 
     scene->textures().emplace(name, texture);
 }
 
-void loadFontDescription(Platform& platform, const Node& node,
-                         const std::string& family, const std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadFontDescription(const Node& node, const std::string& family,
+                                      std::shared_ptr<Scene>& scene) {
     if (!node.IsMap()) {
         LOGW("");
         return;
@@ -847,7 +838,7 @@ void loadFontDescription(Platform& platform, const Node& node,
 
     // Load font file.
     scene->pendingFonts++;
-    scene->startUrlRequest(platform, url, [_ft, scene](UrlResponse&& response) {
+    scene->startUrlRequest(url, [_ft, scene](UrlResponse&& response) {
         if (response.error) {
             LOGE("Error retrieving font '%s' at %s: ", _ft.alias.c_str(), _ft.uri.c_str(), response.error);
         } else {
@@ -857,21 +848,19 @@ void loadFontDescription(Platform& platform, const Node& node,
     });
 }
 
-void SceneLoader::loadFont(Platform& platform, const std::pair<Node, Node>& font,
-                           const std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadFont(const std::pair<Node, Node>& font, std::shared_ptr<Scene>& scene) {
     const std::string& family = font.first.Scalar();
 
     if (font.second.IsMap()) {
-        loadFontDescription(platform, font.second, family, scene);
+        loadFontDescription(font.second, family, scene);
     } else if (font.second.IsSequence()) {
         for (const auto& node : font.second) {
-            loadFontDescription(platform, node, family, scene);
+            loadFontDescription(node, family, scene);
         }
     }
 }
 
-void SceneLoader::loadStyleProps(Platform& platform, Style& style, Node styleNode,
-                                 const std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<Scene>& scene) {
 
     if (!styleNode) {
         LOGW("Can not parse style parameters, bad style YAML Node");
@@ -940,7 +929,7 @@ void SceneLoader::loadStyleProps(Platform& platform, Style& style, Node styleNod
     }
 
     if (Node shadersNode = styleNode["shaders"]) {
-        loadShaderConfig(platform, shadersNode, style, scene);
+        loadShaderConfig(shadersNode, style, scene);
     }
 
     if (Node lightingNode = styleNode["lighting"]) {
@@ -972,7 +961,7 @@ void SceneLoader::loadStyleProps(Platform& platform, Style& style, Node styleNod
     }
 
     if (Node materialNode = styleNode["material"]) {
-        loadMaterial(platform, materialNode, style.getMaterial(), scene, style);
+        loadMaterial(materialNode, style.getMaterial(), scene, style);
     }
 
     if (const Node& drawNode = styleNode["draw"]) {
@@ -989,8 +978,7 @@ void SceneLoader::loadStyleProps(Platform& platform, Style& style, Node styleNod
 
 }
 
-bool SceneLoader::loadStyle(Platform& platform, const std::string& name,
-                            Node config, const std::shared_ptr<Scene>& scene) {
+bool SceneLoader::loadStyle(const std::string& name, Node config, std::shared_ptr<Scene>& scene) {
 
     const auto& builtIn = Style::builtInStyleNames();
 
@@ -1035,15 +1023,15 @@ bool SceneLoader::loadStyle(Platform& platform, const std::string& name,
         }
     }
 
-    loadStyleProps(platform, *style.get(), config, scene);
+    loadStyleProps(*style.get(), config, scene);
 
     scene->styles().push_back(std::move(style));
 
     return true;
 }
 
-void SceneLoader::loadSource(Platform& platform, const std::string& name,
-                             const Node& source, const Node& sources, Scene& _scene) {
+void SceneLoader::loadSource(const std::string& name, const Node& source,
+                             const Node& sources, Scene& _scene) {
     if (_scene.getTileSource(name)) {
         LOGW("Duplicate TileSource: %s", name.c_str());
         return;
@@ -1154,9 +1142,9 @@ void SceneLoader::loadSource(Platform& platform, const std::string& name,
         // If we have MBTiles, we know the source is tiled.
         tiled = true;
         // Create an MBTiles data source from the file at the url and add it to the source chain.
-        rawSources->setNext(std::make_unique<MBTilesDataSource>(platform, name, url, ""));
+        rawSources->setNext(std::make_unique<MBTilesDataSource>(_scene.platform(), name, url, ""));
     } else if (tiled) {
-        rawSources->setNext(std::make_unique<NetworkDataSource>(platform, url, std::move(subdomains), isTms));
+        rawSources->setNext(std::make_unique<NetworkDataSource>(_scene.platform(), url, std::move(subdomains), isTms));
     }
 
     std::shared_ptr<TileSource> sourcePtr;
@@ -1167,7 +1155,7 @@ void SceneLoader::loadSource(Platform& platform, const std::string& name,
         if (auto genLabelCentroidsNode = source["generate_label_centroids"]) {
             generateCentroids = true;
         }
-        sourcePtr = std::make_shared<ClientGeoJsonSource>(platform, name, url, generateCentroids,
+        sourcePtr = std::make_shared<ClientGeoJsonSource>(_scene.platform(), name, url, generateCentroids,
                                                           zoomOptions);
     } else if (type == "Raster") {
         TextureOptions options;
@@ -1197,18 +1185,18 @@ void SceneLoader::loadSource(Platform& platform, const std::string& name,
     _scene.tileSources().push_back(sourcePtr);
 
     if (auto rasters = source["rasters"]) {
-        loadSourceRasters(platform, sourcePtr, source["rasters"], sources, _scene);
+        loadSourceRasters(sourcePtr, source["rasters"], sources, _scene);
     }
 
 }
 
-void SceneLoader::loadSourceRasters(Platform& platform, std::shared_ptr<TileSource> &source,
-                                    Node rasterNode, const Node& sources, Scene& scene) {
+void SceneLoader::loadSourceRasters(std::shared_ptr<TileSource> &source, Node rasterNode,
+                                    const Node& sources, Scene& scene) {
     if (rasterNode.IsSequence()) {
         for (const auto& raster : rasterNode) {
             std::string srcName = raster.Scalar();
             try {
-                loadSource(platform, srcName, sources[srcName], sources, scene);
+                loadSource(srcName, sources[srcName], sources, scene);
             } catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing sources: '%s'", sources[srcName], e.what());
                 return;
@@ -1714,8 +1702,8 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
     }
 }
 
-bool SceneLoader::parseStyleUniforms(Platform& platform, const Node& value,
-                                     const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform) {
+bool SceneLoader::parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& scene,
+                                     StyleUniform& styleUniform) {
     if (value.IsScalar()) { // float, bool or string (texture)
         double fValue;
         bool bValue;
@@ -1731,7 +1719,7 @@ bool SceneLoader::parseStyleUniforms(Platform& platform, const Node& value,
             styleUniform.type = "sampler2D";
             styleUniform.value = strVal;
 
-            getOrLoadTexture(platform, strVal, scene);
+            getOrLoadTexture(strVal, scene);
         }
     } else if (value.IsSequence()) {
         size_t size = value.size();
@@ -1791,7 +1779,7 @@ bool SceneLoader::parseStyleUniforms(Platform& platform, const Node& value,
                 const std::string& textureName = strVal.Scalar();
                 textureArrayUniform.names.push_back(textureName);
 
-                getOrLoadTexture(platform, textureName, scene);
+                getOrLoadTexture(textureName, scene);
             }
 
             styleUniform.value = std::move(textureArrayUniform);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -306,7 +306,7 @@ bool SceneLoader::applyConfig(const std::shared_ptr<Platform>& _platform, const 
 
     if (const Node& layers = config["layers"]) {
         for (const auto& layer : layers) {
-            try { loadLayer(layer, _scene); }
+            try { loadLayer(layer, *_scene); }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing layer: '%s'", layer, e.what());
             }
@@ -912,7 +912,7 @@ void SceneLoader::loadStyleProps(const std::shared_ptr<Platform>& platform, Styl
     if (const Node& drawNode = styleNode["draw"]) {
         std::vector<StyleParam> params;
         int ruleID = scene->addIdForName(style.getName());
-        parseStyleParams(drawNode, scene, "", params);
+        parseStyleParams(drawNode, *scene, "", params);
         /*Note:  ruleID and name is immaterial here, as these are only used for rule merging, but
          * style's default styling rules are applied post rule merging for any style parameter which
          * was not assigned during merging step.
@@ -1557,8 +1557,8 @@ Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
     return Filter();
 }
 
-void SceneLoader::parseStyleParams(Node params, const std::shared_ptr<Scene>& scene,
-                                   const std::string& prefix, std::vector<StyleParam>& out) {
+void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string& prefix,
+                                   std::vector<StyleParam>& out) {
 
     for (const auto& prop : params) {
 
@@ -1591,7 +1591,7 @@ void SceneLoader::parseStyleParams(Node params, const std::shared_ptr<Scene>& sc
 
             if (val.compare(0, 8, "function") == 0) {
                 StyleParam param(key);
-                param.function = scene->addJsFunction(val);
+                param.function = scene.addJsFunction(val);
                 out.push_back(std::move(param));
             } else {
                 out.push_back(StyleParam{ key, value });
@@ -1604,23 +1604,23 @@ void SceneLoader::parseStyleParams(Node params, const std::shared_ptr<Scene>& sc
                 if (styleKey != StyleParamKey::none) {
 
                     if (StyleParam::isColor(styleKey)) {
-                        scene->stops().push_back(Stops::Colors(value));
-                        out.push_back(StyleParam{ styleKey, &(scene->stops().back()) });
+                        scene.stops().push_back(Stops::Colors(value));
+                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                     } else if (StyleParam::isSize(styleKey)) {
-                        scene->stops().push_back(Stops::Sizes(value, StyleParam::unitSetForStyleParam(styleKey)));
-                        out.push_back(StyleParam{ styleKey, &(scene->stops().back()) });
+                        scene.stops().push_back(Stops::Sizes(value, StyleParam::unitSetForStyleParam(styleKey)));
+                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                     } else if (StyleParam::isWidth(styleKey)) {
-                        scene->stops().push_back(Stops::Widths(value, StyleParam::unitSetForStyleParam(styleKey)));
-                        out.push_back(StyleParam{ styleKey, &(scene->stops().back()) });
+                        scene.stops().push_back(Stops::Widths(value, StyleParam::unitSetForStyleParam(styleKey)));
+                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                     } else if (StyleParam::isOffsets(styleKey)) {
-                        scene->stops().push_back(Stops::Offsets(value, StyleParam::unitSetForStyleParam(styleKey)));
-                        out.push_back(StyleParam{ styleKey, &(scene->stops().back()) });
+                        scene.stops().push_back(Stops::Offsets(value, StyleParam::unitSetForStyleParam(styleKey)));
+                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                     } else if (StyleParam::isFontSize(styleKey)) {
-                        scene->stops().push_back(Stops::FontSize(value));
-                        out.push_back(StyleParam{ styleKey, &(scene->stops().back()) });
+                        scene.stops().push_back(Stops::FontSize(value));
+                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                     } else if (StyleParam::isNumberType(styleKey)) {
-                        scene->stops().push_back(Stops::Numbers(value));
-                        out.push_back(StyleParam{ styleKey, &(scene->stops().back()) });
+                        scene.stops().push_back(Stops::Numbers(value));
+                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
                     }
                 } else {
                     LOGW("Unknown style parameter %s", key.c_str());
@@ -1738,8 +1738,7 @@ bool SceneLoader::parseStyleUniforms(const std::shared_ptr<Platform>& platform, 
     return true;
 }
 
-void SceneLoader::parseTransition(Node params, const std::shared_ptr<Scene>& scene, std::string _prefix,
-                                  std::vector<StyleParam>& out) {
+void SceneLoader::parseTransition(Node params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out) {
 
     // First iterate over the mapping of 'events', we currently recognize 'hide', 'selected', and 'show'.
     for (const auto& event : params) {
@@ -1765,8 +1764,7 @@ void SceneLoader::parseTransition(Node params, const std::shared_ptr<Scene>& sce
     }
 }
 
-SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layerName,
-                                     const std::shared_ptr<Scene>& scene) {
+SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layerName, Scene& scene) {
 
     std::vector<SceneLayer> sublayers;
     std::vector<DrawRuleData> rules;
@@ -1787,12 +1785,12 @@ SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layer
                 parseStyleParams(ruleNode.second, scene, "", params);
 
                 const std::string& ruleName = ruleNode.first.Scalar();
-                int ruleId = scene->addIdForName(ruleName);
+                int ruleId = scene.addIdForName(ruleName);
 
                 rules.push_back({ ruleName, ruleId, std::move(params) });
             }
         } else if (key == "filter") {
-            filter = generateFilter(member.second, *scene);
+            filter = generateFilter(member.second, scene);
             if (!filter.isValid()) {
                 LOGNode("Invalid 'filter' in layer '%s'", member.second, layerName.c_str());
                 return { layerName, {}, {}, {}, false };
@@ -1812,7 +1810,7 @@ SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layer
     return { layerName, std::move(filter), rules, std::move(sublayers), enabled };
 }
 
-void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, const std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
 
     const std::string& name = layer.first.Scalar();
 
@@ -1848,7 +1846,7 @@ void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, const std::share
 
     auto sublayer = loadSublayer(layer.second, name, scene);
 
-    scene->layers().push_back({ std::move(sublayer), source, collections });
+    scene.layers().push_back({ std::move(sublayer), source, collections });
 }
 
 void SceneLoader::loadBackground(Node background, const std::shared_ptr<Scene>& scene) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -289,12 +289,6 @@ void SceneLoader::applyCameras(Scene& _scene) {
         view->setMaxPitch(camera.maxTilt);
     }
 
-    if (_scene.options().useScenePosition) {
-        auto position = _scene.startPosition;
-        view->setCenterCoordinates({position.x, position.y});
-        view->setZoom(_scene.startZoom);
-    }
-
     LOGE("UPDATE VIEW %fx%f - %f %f %f", view->getWidth(), view->getHeight(), view->getZoom(),
          view->getCenterCoordinates().longitude, view->getCenterCoordinates().latitude);
     view->update();
@@ -390,8 +384,10 @@ void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
         }
     }
 
-    _scene.startPosition = glm::dvec2(x, y);
-    _scene.startZoom = z;
+    if (_scene.options().useScenePosition) {
+        _scene.view()->setCenterCoordinates({x, y});
+        _scene.view()->setZoom(z);
+    }
 }
 
 void SceneLoader::applyLights(Scene& _scene) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -194,7 +194,7 @@ void createGlobalRefs(const Node& node, Scene& scene, YamlPathBuffer& path) {
 void SceneLoader::applyGlobals(Scene& _scene) {
 
     const Node& config = _scene.config();
-    const auto& globals = config["global"];
+    const Node& globals = config["global"];
     if (!globals) { return; }
 
     YamlPathBuffer path;
@@ -235,7 +235,7 @@ void SceneLoader::applySources(Scene& _scene) {
 
     if (const Node& layers = config["layers"]) {
         for (const auto& layer : layers) {
-            if (Node data = layer.second["data"]) {
+            if (const Node& data = layer.second["data"]) {
                 if (const Node& data_source = data["source"]) {
                     if (data_source.IsScalar()) {
                         auto source = data_source.Scalar();
@@ -414,22 +414,22 @@ void SceneLoader::applyLayers(Scene& _scene) {
     _scene.lightBlocks() = Light::assembleLights(_scene.lights());
     LOGTime("lights");
 
-    loadBackground(config["scene"]["background"], _scene);
+    if (const Node& sceneNode = config["scene"]) {
+        loadBackground(sceneNode["background"], _scene);
 
-    Node animated = config["scene"]["animated"];
-    if (animated) {
-        _scene.animated(YamlUtil::getBoolOrDefault(animated, false));
+        if (Node animated = sceneNode["animated"]) {
+            _scene.animated(YamlUtil::getBoolOrDefault(animated, false));
+        }
     }
-
 }
 
-void SceneLoader::loadShaderConfig(Node shaders, Style& style, std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, std::shared_ptr<Scene>& scene) {
 
     if (!shaders) { return; }
 
     auto& shader = style.getShaderSource();
 
-    if (Node extNode = shaders["extensions_mixed"]) {
+    if (const Node& extNode = shaders["extensions_mixed"]) {
         if (extNode.IsScalar()) {
             shader.addExtensionDeclaration(extNode.Scalar());
         } else if (extNode.IsSequence()) {
@@ -439,7 +439,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, std::shared_ptr<S
         }
     }
 
-    if (Node definesNode = shaders["defines"]) {
+    if (const Node& definesNode = shaders["defines"]) {
         for (const auto& define : definesNode) {
             const std::string& name = define.first.Scalar();
 
@@ -467,7 +467,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, std::shared_ptr<S
         }
     }
 
-    if (Node uniformsNode = shaders["uniforms"]) {
+    if (const Node& uniformsNode = shaders["uniforms"]) {
         for (const auto& uniform : uniformsNode) {
             const std::string& name = uniform.first.Scalar();
             StyleUniform styleUniform;
@@ -492,7 +492,7 @@ void SceneLoader::loadShaderConfig(Node shaders, Style& style, std::shared_ptr<S
         }
     }
 
-    if (Node blocksNode = shaders["blocks_mixed"]) {
+    if (const Node& blocksNode = shaders["blocks_mixed"]) {
         for (const auto& block : blocksNode) {
             const auto& name = block.first.Scalar();
             const auto& value = block.second;
@@ -536,26 +536,26 @@ glm::vec4 parseMaterialVec(const Node& prop) {
     return glm::vec4(0.0);
 }
 
-void SceneLoader::loadMaterial(Node matNode, Material& material,
+void SceneLoader::loadMaterial(const Node& matNode, Material& material,
                                std::shared_ptr<Scene>& scene, Style& style) {
 
     if (!matNode.IsMap()) { return; }
 
-    if (Node n = matNode["emission"]) {
+    if (const Node& n = matNode["emission"]) {
         if (n.IsMap()) {
             material.setEmission(loadMaterialTexture(n, scene, style));
         } else {
             material.setEmission(parseMaterialVec(n));
         }
     }
-    if (Node n = matNode["diffuse"]) {
+    if (const Node& n = matNode["diffuse"]) {
         if (n.IsMap()) {
             material.setDiffuse(loadMaterialTexture(n, scene, style));
         } else {
             material.setDiffuse(parseMaterialVec(n));
         }
     }
-    if (Node n = matNode["ambient"]) {
+    if (const Node& n = matNode["ambient"]) {
         if (n.IsMap()) {
             material.setAmbient(loadMaterialTexture(n, scene, style));
         } else {
@@ -563,7 +563,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material,
         }
     }
 
-    if (Node n = matNode["specular"]) {
+    if (const Node& n = matNode["specular"]) {
         if (n.IsMap()) {
             material.setSpecular(loadMaterialTexture(n, scene, style));
         } else {
@@ -571,7 +571,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material,
         }
     }
 
-    if (Node shininess = matNode["shininess"]) {
+    if (const Node& shininess = matNode["shininess"]) {
         double value;
         if (YamlUtil::getDouble(shininess, value, false)) {
             material.setShininess(value);
@@ -581,7 +581,7 @@ void SceneLoader::loadMaterial(Node matNode, Material& material,
     material.setNormal(loadMaterialTexture(matNode["normal"], scene, style));
 }
 
-MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, std::shared_ptr<Scene>& scene, Style& style) {
+MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode, std::shared_ptr<Scene>& scene, Style& style) {
 
     if (!matCompNode) { return MaterialTexture{}; }
 
@@ -597,7 +597,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, std::shared_p
     MaterialTexture matTex;
     matTex.tex = getOrLoadTexture(name, scene);
 
-    if (Node mappingNode = matCompNode["mapping"]) {
+    if (const Node& mappingNode = matCompNode["mapping"]) {
         const std::string& mapping = mappingNode.Scalar();
         if (mapping == "uv") {
             matTex.mapping = MappingType::uv;
@@ -622,7 +622,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, std::shared_p
         }
     }
 
-    if (Node scaleNode = matCompNode["scale"]) {
+    if (const Node& scaleNode = matCompNode["scale"]) {
         if (scaleNode.IsSequence() && scaleNode.size() == 2) {
             matTex.scale.x = YamlUtil::getFloatOrDefault(scaleNode[0], matTex.scale.x);
             matTex.scale.y = YamlUtil::getFloatOrDefault(scaleNode[1], matTex.scale.y);
@@ -633,7 +633,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, std::shared_p
         }
     }
 
-    if (Node amountNode = matCompNode["amount"]) {
+    if (const Node& amountNode = matCompNode["amount"]) {
         if (amountNode.IsScalar()) {
             matTex.amount = glm::vec3(YamlUtil::getFloatOrDefault(amountNode, 1.f));
         } else if (!YamlUtil::parseVec(amountNode, matTex.amount)) {
@@ -644,7 +644,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(Node matCompNode, std::shared_p
     return matTex;
 }
 
-bool SceneLoader::parseTexFiltering(Node& filteringNode, TextureOptions& options) {
+bool SceneLoader::parseTexFiltering(const Node& filteringNode, TextureOptions& options) {
     if (!filteringNode.IsScalar()) {
         return false;
     }
@@ -755,7 +755,7 @@ void SceneLoader::loadTexture( const std::pair<Node, Node>& node, std::shared_pt
     std::string url;
     TextureOptions options;
 
-    if (Node urlNode = textureConfig["url"]) {
+    if (const Node& urlNode = textureConfig["url"]) {
         if (urlNode.IsScalar()) {
             url = urlNode.Scalar();
         }
@@ -765,23 +765,23 @@ void SceneLoader::loadTexture( const std::pair<Node, Node>& node, std::shared_pt
         return;
     }
 
-    if (Node filtering = textureConfig["filtering"]) {
+    if (const Node& filtering = textureConfig["filtering"]) {
         if (!parseTexFiltering(filtering, options)) {
             LOGW("Invalid texture filtering: %s", Dump(filtering).c_str());
         }
     }
 
-    if (Node density = textureConfig["density"]) {
+    if (const Node& density = textureConfig["density"]) {
         options.displayScale = 1.f / YamlUtil::getFloatOrDefault(density, 1.f);
     }
 
     std::unique_ptr<SpriteAtlas> atlas;
-    if (Node sprites = textureConfig["sprites"]) {
+    if (const Node& sprites = textureConfig["sprites"]) {
         atlas = std::make_unique<SpriteAtlas>();
 
         for (auto it = sprites.begin(); it != sprites.end(); ++it) {
 
-            const Node sprite = it->second;
+            const Node& sprite = it->second;
             const std::string& spriteName = it->first.Scalar();
 
             if (sprite) {
@@ -861,14 +861,14 @@ void SceneLoader::loadFont(const std::pair<Node, Node>& font, std::shared_ptr<Sc
     }
 }
 
-void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, std::shared_ptr<Scene>& scene) {
 
     if (!styleNode) {
         LOGW("Can not parse style parameters, bad style YAML Node");
         return;
     }
 
-    if (Node animatedNode = styleNode["animated"]) {
+    if (const Node& animatedNode = styleNode["animated"]) {
         if (!animatedNode.IsScalar()) { LOGW("animated flag should be a scalar"); }
         else {
             bool animate;
@@ -878,7 +878,7 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<S
         }
     }
 
-    if (Node blendNode = styleNode["blend"]) {
+    if (const Node& blendNode = styleNode["blend"]) {
         const std::string& blendMode = blendNode.Scalar();
         if      (blendMode == "opaque")      { style.setBlendMode(Blending::opaque); }
         else if (blendMode == "add")         { style.setBlendMode(Blending::add); }
@@ -889,7 +889,7 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<S
         else { LOGW("Invalid blend mode '%s'", blendMode.c_str()); }
     }
 
-    if (Node blendOrderNode = styleNode["blend_order"]) {
+    if (const Node& blendOrderNode = styleNode["blend_order"]) {
         int blendOrderValue;
         if (YamlUtil::getInt(blendOrderNode, blendOrderValue)) {
             style.setBlendOrder(blendOrderValue);
@@ -898,14 +898,14 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<S
         }
     }
 
-    if (Node texcoordsNode = styleNode["texcoords"]) {
+    if (const Node& texcoordsNode = styleNode["texcoords"]) {
         bool boolValue;
         if (YamlUtil::getBool(texcoordsNode, boolValue)) {
             style.setTexCoordsGeneration(boolValue);
         }
     }
 
-    if (Node dashNode = styleNode["dash"]) {
+    if (const Node& dashNode = styleNode["dash"]) {
         if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&style)) {
             if (dashNode.IsSequence()) {
                 std::vector<float> dashValues;
@@ -922,18 +922,18 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<S
         }
     }
 
-    if (Node dashBackgroundColor = styleNode["dash_background_color"]) {
+    if (const Node& dashBackgroundColor = styleNode["dash_background_color"]) {
         if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&style)) {
             glm::vec4 backgroundColor = YamlUtil::getColorAsVec4(dashBackgroundColor);
             polylineStyle->setDashBackgroundColor(backgroundColor);
         }
     }
 
-    if (Node shadersNode = styleNode["shaders"]) {
+    if (const Node& shadersNode = styleNode["shaders"]) {
         loadShaderConfig(shadersNode, style, scene);
     }
 
-    if (Node lightingNode = styleNode["lighting"]) {
+    if (const Node& lightingNode = styleNode["lighting"]) {
         const std::string& lighting = lightingNode.Scalar();
         if (lighting == "fragment") { style.setLightingType(LightingType::fragment); }
         else if (lighting == "vertex") { style.setLightingType(LightingType::vertex); }
@@ -942,7 +942,7 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<S
         else { LOGW("Unrecognized lighting type '%s'", lighting.c_str()); }
     }
 
-    if (Node textureNode = styleNode["texture"]) {
+    if (const Node& textureNode = styleNode["texture"]) {
         if (auto pointStyle = dynamic_cast<PointStyle*>(&style)) {
             const std::string& textureName = textureNode.Scalar();
             auto styleTexture = scene->getTexture(textureName);
@@ -961,7 +961,7 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<S
         }
     }
 
-    if (Node materialNode = styleNode["material"]) {
+    if (const Node& materialNode = styleNode["material"]) {
         loadMaterial(materialNode, style.getMaterial(), scene, style);
     }
 
@@ -976,10 +976,9 @@ void SceneLoader::loadStyleProps(Style& style, Node styleNode, std::shared_ptr<S
         auto rule = std::make_unique<DrawRuleData>(style.getName(), ruleID, std::move(params));
         style.setDefaultDrawRule(std::move(rule));
     }
-
 }
 
-bool SceneLoader::loadStyle(const std::string& name, Node config, std::shared_ptr<Scene>& scene) {
+bool SceneLoader::loadStyle(const std::string& name, const Node& config, std::shared_ptr<Scene>& scene) {
 
     const auto& builtIn = Style::builtInStyleNames();
 
@@ -988,7 +987,7 @@ bool SceneLoader::loadStyle(const std::string& name, Node config, std::shared_pt
         return false;
     }
 
-    Node baseNode = config["base"];
+    const Node& baseNode = config["base"];
     if (!baseNode) {
         // No base style, this is an abstract style
         return true;
@@ -996,7 +995,7 @@ bool SceneLoader::loadStyle(const std::string& name, Node config, std::shared_pt
 
     // Construct style instance using the merged properties
     std::unique_ptr<Style> style;
-    auto baseStyle = baseNode.Scalar();
+    const auto& baseStyle = baseNode.Scalar();
     if (baseStyle == "polygons") {
         style = std::make_unique<PolygonStyle>(name);
     } else if (baseStyle == "lines") {
@@ -1012,8 +1011,7 @@ bool SceneLoader::loadStyle(const std::string& name, Node config, std::shared_pt
         return false;
     }
 
-    Node rasterNode = config["raster"];
-    if (rasterNode) {
+    if (const Node& rasterNode = config["raster"]) {
         const auto& raster = rasterNode.Scalar();
         if (raster == "normal") {
             style->setRasterType(RasterType::normal);
@@ -1098,7 +1096,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source,
     }
 
     // Apply URL subdomain configuration.
-    if (Node subDomainNode = source["url_subdomains"]) {
+    if (const Node& subDomainNode = source["url_subdomains"]) {
         if (subDomainNode.IsSequence()) {
             for (const auto& domain : subDomainNode) {
                 if (domain.IsScalar()) {
@@ -1132,7 +1130,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source,
     }
 
     bool isTms = false;
-    if (auto tmsNode = source["tms"]) {
+    if (const Node& tmsNode = source["tms"]) {
         YamlUtil::getBool(tmsNode, isTms);
     }
 
@@ -1160,7 +1158,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source,
                                                           zoomOptions);
     } else if (type == "Raster") {
         TextureOptions options;
-        if (Node filtering = source["filtering"]) {
+        if (const Node& filtering = source["filtering"]) {
             if (!parseTexFiltering(filtering, options)) {
                 LOGW("Invalid texture filtering: %s", Dump(filtering).c_str());
             }
@@ -1191,7 +1189,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source,
 
 }
 
-void SceneLoader::loadSourceRasters(std::shared_ptr<TileSource> &source, Node rasterNode,
+void SceneLoader::loadSourceRasters(std::shared_ptr<TileSource> &source, const Node& rasterNode,
                                     const Node& sources, Scene& scene) {
     if (rasterNode.IsSequence()) {
         for (const auto& raster : rasterNode) {
@@ -1207,7 +1205,7 @@ void SceneLoader::loadSourceRasters(std::shared_ptr<TileSource> &source, Node ra
     }
 }
 
-void SceneLoader::parseLightPosition(Node positionNode, PointLight& light) {
+void SceneLoader::parseLightPosition(const Node& positionNode, PointLight& light) {
     UnitVec<glm::vec3> positionResult;
     if (StyleParam::parseVec3(positionNode, UnitSet{Unit::none, Unit::pixel, Unit::meter}, positionResult)) {
         for (auto& unit : positionResult.units) {
@@ -1223,11 +1221,11 @@ void SceneLoader::parseLightPosition(Node positionNode, PointLight& light) {
 
 void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
 
-    const Node light = node.second;
+    const Node& light = node.second;
     const std::string& name = node.first.Scalar();
     const std::string& type = light["type"].Scalar();
 
-    if (Node visible = light["visible"]) {
+    if (const Node& visible = light["visible"]) {
         // If 'visible' is false, skip loading this light.
         if (!YamlUtil::getBoolOrDefault(visible, true)) { return; }
     }
@@ -1240,7 +1238,7 @@ void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
     } else if (type == "directional") {
         auto dLight(std::make_unique<DirectionalLight>(name));
 
-        if (Node directionNode = light["direction"]) {
+        if (const Node& directionNode = light["direction"]) {
             glm::vec3 direction;
             if (YamlUtil::parseVec<glm::vec3>(directionNode, direction)) {
                 dLight->setDirection(direction);
@@ -1251,17 +1249,17 @@ void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
     } else if (type == "point") {
         auto pLight(std::make_unique<PointLight>(name));
 
-        if (Node position = light["position"]) {
+        if (const Node& position = light["position"]) {
             parseLightPosition(position, *pLight);
         }
-        if (Node radius = light["radius"]) {
+        if (const Node& radius = light["radius"]) {
             if (radius.size() > 1) {
                 pLight->setRadius(YamlUtil::getFloatOrDefault(radius[0], 0.f), YamlUtil::getFloatOrDefault(radius[1], 0.f));
             } else {
                 pLight->setRadius(YamlUtil::getFloatOrDefault(radius, 0.f));
             }
         }
-        if (Node att = light["attenuation"]) {
+        if (const Node& att = light["attenuation"]) {
             float attenuation;
             if (YamlUtil::getFloat(att, attenuation)) {
                 pLight->setAttenuation(attenuation);
@@ -1272,31 +1270,31 @@ void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
     } else if (type == "spotlight") {
         auto sLight(std::make_unique<SpotLight>(name));
 
-        if (Node position = light["position"]) {
+        if (const Node& position = light["position"]) {
             parseLightPosition(position, *sLight);
         }
-        if (Node directionNode = light["direction"]) {
+        if (const Node& directionNode = light["direction"]) {
             glm::vec3 direction;
             if (YamlUtil::parseVec<glm::vec3>(directionNode, direction)) {
                 sLight->setDirection(direction);
             }
         }
-        if (Node radius = light["radius"]) {
+        if (const Node& radius = light["radius"]) {
             if (radius.size() > 1) {
                 sLight->setRadius(YamlUtil::getFloatOrDefault(radius[0], 0.f), YamlUtil::getFloatOrDefault(radius[1], 0.f));
             } else {
                 sLight->setRadius(YamlUtil::getFloatOrDefault(radius, 0.f));
             }
         }
-        if (Node angle = light["angle"]) {
+        if (const Node& angle = light["angle"]) {
             sLight->setCutoffAngle(YamlUtil::getFloatOrDefault(angle, 0.f));
         }
-        if (Node exponent = light["exponent"]) {
+        if (const Node& exponent = light["exponent"]) {
             sLight->setCutoffExponent(YamlUtil::getFloatOrDefault(exponent, 0.f));
         }
         sceneLight = std::move(sLight);
     }
-    if (Node origin = light["origin"]) {
+    if (const Node& origin = light["origin"]) {
         const std::string& originStr = origin.Scalar();
         if (originStr == "world") {
             sceneLight->setOrigin(LightOrigin::world);
@@ -1306,13 +1304,13 @@ void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
             sceneLight->setOrigin(LightOrigin::ground);
         }
     }
-    if (Node ambient = light["ambient"]) {
+    if (const Node& ambient = light["ambient"]) {
         sceneLight->setAmbientColor(YamlUtil::getColorAsVec4(ambient));
     }
-    if (Node diffuse = light["diffuse"]) {
+    if (const Node& diffuse = light["diffuse"]) {
         sceneLight->setDiffuseColor(YamlUtil::getColorAsVec4(diffuse));
     }
-    if (Node specular = light["specular"]) {
+    if (const Node& specular = light["specular"]) {
         sceneLight->setSpecularColor(YamlUtil::getColorAsVec4(specular));
     }
 
@@ -1338,7 +1336,7 @@ void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
 
     auto& camera = _scene.camera();
 
-    if (Node active = _camera["active"]) {
+    if (const Node& active = _camera["active"]) {
         if (!YamlUtil::getBoolOrDefault(active, false)) {
             return;
         }
@@ -1350,7 +1348,7 @@ void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
 
         // Only one of focal length and FOV is applied;
         // according to docs, focal length takes precedence.
-        if (Node focal = _camera["focal_length"]) {
+        if (const Node& focal = _camera["focal_length"]) {
             float floatValue;
             if (YamlUtil::getFloat(focal, floatValue)) {
                 camera.fieldOfView = View::focalLengthToFieldOfView(floatValue);
@@ -1360,7 +1358,7 @@ void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
                     f.value = View::focalLengthToFieldOfView(f.value.get<float>());
                 }
             }
-        } else if (Node fov = _camera["fov"]) {
+        } else if (const Node& fov = _camera["fov"]) {
             if (fov.IsScalar()) {
                 double degrees = YamlUtil::getDoubleOrDefault(fov, camera.fieldOfView * RAD_TO_DEG);
                 camera.fieldOfView = degrees * DEG_TO_RAD;
@@ -1372,7 +1370,7 @@ void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
             }
         }
 
-        if (Node vanishing = _camera["vanishing_point"]) {
+        if (const Node& vanishing = _camera["vanishing_point"]) {
             if (vanishing.IsSequence() && vanishing.size() >= 2) {
                 // Values are pixels, unit strings are ignored.
                 camera.vanishingPoint.x = YamlUtil::getFloatOrDefault(vanishing[0], 0.f, true);
@@ -1382,7 +1380,7 @@ void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
     } else if (type == "isometric") {
         camera.type = CameraType::isometric;
 
-        if (Node axis = _camera["axis"]) {
+        if (const Node& axis = _camera["axis"]) {
             YamlUtil::parseVec(axis, camera.obliqueAxis);
         }
     } else if (type == "flat") {
@@ -1394,7 +1392,7 @@ void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
     double y = 0;
     float z = 0;
 
-    if (Node position = _camera["position"]) {
+    if (const Node& position = _camera["position"]) {
         x = YamlUtil::getDoubleOrDefault(position[0], x);
         y = YamlUtil::getDoubleOrDefault(position[1], y);
         if (position.size() > 2) {
@@ -1402,11 +1400,11 @@ void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
         }
     }
 
-    if (Node zoom = _camera["zoom"]) {
+    if (const Node& zoom = _camera["zoom"]) {
         z = YamlUtil::getFloatOrDefault(zoom, z);
     }
 
-    if (Node maxTilt = _camera["max_tilt"]) {
+    if (const Node& maxTilt = _camera["max_tilt"]) {
         if (maxTilt.IsSequence()) {
             camera.maxTiltStops = std::make_shared<Stops>(Stops::Numbers(maxTilt));
         } else if (maxTilt.IsScalar()) {
@@ -1439,7 +1437,7 @@ void printFilters(const SceneLayer& layer, int indent){
     }
 };
 
-Filter SceneLoader::generateFilter(Node _filter, Scene& scene) {
+Filter SceneLoader::generateFilter(const Node& _filter, Scene& scene) {
 
     switch (_filter.Type()) {
     case NodeType::Scalar: {
@@ -1457,7 +1455,7 @@ Filter SceneLoader::generateFilter(Node _filter, Scene& scene) {
         std::vector<Filter> filters;
         for (const auto& filtItr : _filter) {
             const std::string& key = filtItr.first.Scalar();
-            Node node = _filter[key];
+            const Node& node = _filter[key];
             Filter f;
             if (key == "none") {
                 f = generateNoneFilter(node, scene);
@@ -1486,7 +1484,7 @@ Filter SceneLoader::generateFilter(Node _filter, Scene& scene) {
     }
 }
 
-Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
+Filter SceneLoader::generatePredicate(const Node& _node, std::string _key) {
 
     switch (_node.Type()) {
     case NodeType::Scalar: {
@@ -1538,7 +1536,9 @@ Filter SceneLoader::generatePredicate(Node _node, std::string _key) {
             }
         }
 
-        if (_node["max"].IsScalar() && _node["min"].IsScalar() &&
+        const Node& max = _node["max"];
+        const Node& min = _node["min"];
+        if (max && min && max.IsScalar() && min.IsScalar() &&
                 (hasMinPixelArea != hasMaxPixelArea)) { return Filter(); }
 
         return Filter::MatchRange(_key, minVal, maxVal, hasMinPixelArea | hasMaxPixelArea);
@@ -1561,7 +1561,7 @@ bool SceneLoader::getFilterRangeValue(const Node& node, double& val, bool& hasPi
     return true;
 }
 
-Filter SceneLoader::generateAnyFilter(Node _filter, Scene& scene) {
+Filter SceneLoader::generateAnyFilter(const Node& _filter, Scene& scene) {
 
     if (_filter.IsSequence()) {
         std::vector<Filter> filters;
@@ -1576,7 +1576,7 @@ Filter SceneLoader::generateAnyFilter(Node _filter, Scene& scene) {
     return Filter();
 }
 
-Filter SceneLoader::generateAllFilter(Node _filter, Scene& scene) {
+Filter SceneLoader::generateAllFilter(const Node& _filter, Scene& scene) {
 
     if (_filter.IsSequence()) {
         std::vector<Filter> filters;
@@ -1591,7 +1591,7 @@ Filter SceneLoader::generateAllFilter(Node _filter, Scene& scene) {
     return Filter();
 }
 
-Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
+Filter SceneLoader::generateNoneFilter(const Node& _filter, Scene& scene) {
 
     if (_filter.IsSequence()) {
         std::vector<Filter> filters;
@@ -1612,7 +1612,7 @@ Filter SceneLoader::generateNoneFilter(Node _filter, Scene& scene) {
     return Filter();
 }
 
-void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string& prefix,
+void SceneLoader::parseStyleParams(const Node& params, Scene& scene, const std::string& prefix,
                                    std::vector<StyleParam>& out) {
 
     for (const auto& prop : params) {
@@ -1623,7 +1623,7 @@ void SceneLoader::parseStyleParams(Node params, Scene& scene, const std::string&
         } else {
             key = prop.first.Scalar();
         }
-        Node value = prop.second;
+        const Node& value = prop.second;
 
         if (key == "transition" || key == "text:transition") {
             parseTransition(prop.second, scene, key, out);
@@ -1793,7 +1793,7 @@ bool SceneLoader::parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& 
     return true;
 }
 
-void SceneLoader::parseTransition(Node params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out) {
+void SceneLoader::parseTransition(const Node& params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out) {
 
     // First iterate over the mapping of 'events', we currently recognize 'hide', 'selected', and 'show'.
     for (const auto& event : params) {
@@ -1872,7 +1872,7 @@ void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
     std::string source;
     std::vector<std::string> collections;
 
-    if (Node data = layer.second["data"]) {
+    if (const Node& data = layer.second["data"]) {
 
         if (const Node& data_source = data["source"]) {
             if (data_source.IsScalar()) {
@@ -1881,7 +1881,7 @@ void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
             }
         }
 
-        if (Node data_layer = data["layer"]) {
+        if (const Node& data_layer = data["layer"]) {
             if (data_layer.IsScalar()) {
                 collections.push_back(data_layer.Scalar());
             } else if (data_layer.IsSequence()) {
@@ -1904,11 +1904,11 @@ void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
     scene.layers().push_back({ std::move(sublayer), source, collections });
 }
 
-void SceneLoader::loadBackground(Node background, Scene& scene) {
+void SceneLoader::loadBackground(const Node& background, Scene& scene) {
 
     if (!background) { return; }
 
-    if (Node colorNode = background["color"]) {
+    if (const Node& colorNode = background["color"]) {
         Color colorResult;
         if (StyleParam::parseColor(colorNode, colorResult)) {
             scene.background() = colorResult;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -129,17 +129,17 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
     return true;
 }
 
-bool SceneLoader::applyUpdates(Scene& scene, const std::vector<SceneUpdate>& updates) {
-    auto& root = scene.config();
+bool SceneLoader::applyUpdates(Scene& _scene, const std::vector<SceneUpdate>& _updates) {
+    auto& root = _scene.config();
 
-    for (const auto& update : updates) {
+    for (const auto& update : _updates) {
         Node value;
 
         try {
             value = YAML::Load(update.value);
         } catch (const YAML::ParserException& e) {
             LOGE("Parsing scene update string failed. '%s'", e.what());
-            scene.errors.push_back({update, Error::scene_update_value_yaml_syntax_error});
+            _scene.errors.push_back({update, Error::scene_update_value_yaml_syntax_error});
             return false;
         }
 
@@ -149,41 +149,41 @@ bool SceneLoader::applyUpdates(Scene& scene, const std::vector<SceneUpdate>& upd
             if (pathIsValid) {
                 node = value;
             } else {
-                scene.errors.push_back({update, Error::scene_update_path_not_found});
+                _scene.errors.push_back({update, Error::scene_update_path_not_found});
                 return false;
             }
         }
     }
 
-    Importer::resolveSceneUrls(root, scene.options().url);
+    Importer::resolveSceneUrls(root, _scene.options().url);
 
     return true;
 }
 
-void createGlobalRefs(const Node& node, Scene& scene, YamlPathBuffer& path) {
-    switch(node.Type()) {
+void createGlobalRefs(Scene& _scene, const Node& _node, YamlPathBuffer& _path) {
+    switch(_node.Type()) {
     case NodeType::Scalar: {
-        const auto& value = node.Scalar();
+        const auto& value = _node.Scalar();
         if (value.length() > 7 && value.compare(0, 7, GLOBAL_PREFIX) == 0) {
-            scene.globalRefs().emplace_back(path.toYamlPath(),
+            _scene.globalRefs().emplace_back(_path.toYamlPath(),
                                             YamlPath(value.substr(GLOBAL_PREFIX.length())));
         }
     }
         break;
     case NodeType::Sequence: {
-        path.pushSequence();
-        for (const auto& entry : node) {
-            createGlobalRefs(entry, scene, path);
-            path.increment();
+        _path.pushSequence();
+        for (const auto& entry : _node) {
+            createGlobalRefs(_scene, entry, _path);
+            _path.increment();
         }
-        path.pop();
+        _path.pop();
     }
         break;
     case NodeType::Map:
-        for (const auto& entry : node) {
-            path.pushMap(&entry.first.Scalar());
-            createGlobalRefs(entry.second, scene, path);
-            path.pop();
+        for (const auto& entry : _node) {
+            _path.pushMap(&entry.first.Scalar());
+            createGlobalRefs(_scene, entry.second, _path);
+            _path.pop();
         }
         break;
     default:
@@ -197,7 +197,7 @@ void SceneLoader::applyGlobals(Scene& _scene) {
     if (!globals) { return; }
 
     YamlPathBuffer path;
-    createGlobalRefs(config, _scene, path);
+    createGlobalRefs(_scene, config, path);
     if (!_scene.globalRefs().empty() && !globals.IsMap()) {
         LOGW("Missing global references");
     }
@@ -220,7 +220,7 @@ void SceneLoader::applyScene(Scene& _scene) {
     const Node& config = _scene.config();
 
     if (const Node& sceneNode = config["scene"]) {
-        loadBackground(sceneNode["background"], _scene);
+        loadBackground(_scene, sceneNode["background"]);
 
         if (Node animated = sceneNode["animated"]) {
             _scene.animated(YamlUtil::getBoolOrDefault(animated, false));
@@ -228,17 +228,17 @@ void SceneLoader::applyScene(Scene& _scene) {
     }
 }
 
-void SceneLoader::loadBackground(const Node& background, Scene& scene) {
-    if (!background) { return; }
+void SceneLoader::loadBackground(Scene& _scene, const Node& _background) {
+    if (!_background) { return; }
 
-    if (const Node& colorNode = background["color"]) {
+    if (const Node& colorNode = _background["color"]) {
         Color colorResult;
         if (StyleParam::parseColor(colorNode, colorResult)) {
-            scene.background() = colorResult;
+            _scene.background() = colorResult;
         } else {
             Stops stopsResult = Stops::Colors(colorNode);
             if (stopsResult.frames.size() > 0) {
-                scene.backgroundStops() = stopsResult;
+                _scene.backgroundStops() = stopsResult;
             } else {
                 LOGW("Cannot parse color: %s", Dump(colorNode).c_str());
             }
@@ -250,13 +250,13 @@ void SceneLoader::applyCameras(Scene& _scene) {
     const Node& config = _scene.config();
 
     if (const Node& camera = config["camera"]) {
-        try { loadCamera(camera, _scene); }
+        try { loadCamera(_scene, camera); }
         catch (const YAML::RepresentationException& e) {
             LOGNode("Parsing camera: '%s'", camera, e.what());
         }
 
     } else if (const Node& cameras = config["cameras"]) {
-        try { loadCameras(cameras, _scene); }
+        try { loadCameras(_scene, cameras); }
         catch (const YAML::RepresentationException& e) {
             LOGNode("Parsing cameras: '%s'", cameras, e.what());
         }
@@ -294,18 +294,18 @@ void SceneLoader::applyCameras(Scene& _scene) {
     view->update();
 }
 
-void SceneLoader::loadCameras(const Node& _cameras, Scene& _scene) {
+void SceneLoader::loadCameras(Scene& _scene, const Node& _cameras) {
     // To correctly match the behavior of the webGL library we'll need a place
     // to store multiple view instances.  Since we only have one global view
     // right now, we'll just apply the settings from the first active camera we
     // find.
 
     for (const auto& entry : _cameras) {
-        loadCamera(entry.second, _scene);
+        loadCamera(_scene, entry.second);
     }
 }
 
-void SceneLoader::loadCamera(const Node& _camera, Scene& _scene) {
+void SceneLoader::loadCamera(Scene& _scene, const Node& _camera) {
     auto& camera = _scene.camera();
 
     if (const Node& active = _camera["active"]) {
@@ -395,7 +395,7 @@ void SceneLoader::applyLights(Scene& _scene) {
 
     if (const Node& lights = config["lights"]) {
         for (const auto& light : lights) {
-            try { loadLight(light, _scene); }
+            try { loadLight(_scene, light); }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing light: '%s'", light, e.what());
             }
@@ -411,9 +411,9 @@ void SceneLoader::applyLights(Scene& _scene) {
     _scene.lightBlocks() = Light::assembleLights(_scene.lights());
 }
 
-void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
-    const Node& light = node.second;
-    const std::string& name = node.first.Scalar();
+void SceneLoader::loadLight(Scene& _scene, const std::pair<Node, Node>& _node) {
+    const Node& light = _node.second;
+    const std::string& name = _node.first.Scalar();
     const std::string& type = light["type"].Scalar();
 
     if (const Node& visible = light["visible"]) {
@@ -520,20 +520,20 @@ void SceneLoader::loadLight(const std::pair<Node, Node>& node, Scene& scene) {
             }
         }
     }
-    scene.lights().push_back(std::move(sceneLight));
+    _scene.lights().push_back(std::move(sceneLight));
 }
 
-void SceneLoader::parseLightPosition(const Node& positionNode, PointLight& light) {
+void SceneLoader::parseLightPosition(const Node& _positionNode, PointLight& _light) {
     UnitVec<glm::vec3> positionResult;
-    if (StyleParam::parseVec3(positionNode, UnitSet{Unit::none, Unit::pixel, Unit::meter}, positionResult)) {
+    if (StyleParam::parseVec3(_positionNode, UnitSet{Unit::none, Unit::pixel, Unit::meter}, positionResult)) {
         for (auto& unit : positionResult.units) {
             if (unit == Unit::none) {
                 unit = Unit::meter;
             }
         }
-        light.setPosition(positionResult);
+        _light.setPosition(positionResult);
     } else {
-        LOGNode("Invalid light position parameter:", positionNode);
+        LOGNode("Invalid light position parameter:", _positionNode);
     }
 }
 
@@ -542,7 +542,7 @@ void SceneLoader::applyTextures(Scene& _scene) {
 
     if (const Node& textures = config["textures"]) {
         for (const auto& texture : textures) {
-            try { loadTexture(texture, _scene); }
+            try { loadTexture(_scene, texture); }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing texture: '%s'", texture, e.what());
             }
@@ -550,9 +550,9 @@ void SceneLoader::applyTextures(Scene& _scene) {
     }
 }
 
-void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
-    const std::string& name = node.first.Scalar();
-    const Node& textureConfig = node.second;
+void SceneLoader::loadTexture(Scene& _scene, const std::pair<Node, Node>& _node) {
+    const std::string& name = _node.first.Scalar();
+    const Node& textureConfig = _node.second;
 
     if (!textureConfig.IsMap()) {
         LOGW("Invalid texture node '%s', skipping.", name.c_str());
@@ -601,25 +601,25 @@ void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
             }
         }
     }
-    scene.fetchTexture(name, Url(url), options, std::move(atlas));
+    _scene.fetchTexture(name, Url(url), options, std::move(atlas));
 }
 
-bool SceneLoader::parseTexFiltering(const Node& filteringNode, TextureOptions& options) {
-    if (!filteringNode.IsScalar()) {
+bool SceneLoader::parseTexFiltering(const Node& _filteringNode, TextureOptions& _options) {
+    if (!_filteringNode.IsScalar()) {
         return false;
     }
-    const std::string& filteringString = filteringNode.Scalar();
+    const std::string& filteringString = _filteringNode.Scalar();
     if (filteringString == "linear") {
-        options.minFilter = TextureMinFilter::LINEAR;
-        options.magFilter = TextureMagFilter::LINEAR;
+        _options.minFilter = TextureMinFilter::LINEAR;
+        _options.magFilter = TextureMagFilter::LINEAR;
         return true;
     } else if (filteringString == "mipmap") {
-        options.minFilter = TextureMinFilter::LINEAR_MIPMAP_LINEAR;
-        options.generateMipmaps = true;
+        _options.minFilter = TextureMinFilter::LINEAR_MIPMAP_LINEAR;
+        _options.generateMipmaps = true;
         return true;
     } else if (filteringString == "nearest") {
-        options.minFilter = TextureMinFilter::NEAREST;
-        options.magFilter = TextureMagFilter::NEAREST;
+        _options.minFilter = TextureMinFilter::NEAREST;
+        _options.magFilter = TextureMagFilter::NEAREST;
         return true;
     }
     return false;
@@ -638,10 +638,10 @@ void SceneLoader::applyFonts(Scene& _scene) {
             const std::string& family = font.first.Scalar();
 
             if (font.second.IsMap()) {
-                loadFontDescription(font.second, family, _scene);
+                loadFontDescription(_scene, font.second, family);
             } else if (font.second.IsSequence()) {
                 for (const auto& node : font.second) {
-                    loadFontDescription(node, family, _scene);
+                    loadFontDescription(_scene, node, family);
                 }
             } else {
                 // LOG
@@ -653,14 +653,14 @@ void SceneLoader::applyFonts(Scene& _scene) {
     }
 }
 
-void SceneLoader::loadFontDescription(const Node& node, const std::string& family, Scene& scene) {
-    if (!node.IsMap()) {
+void SceneLoader::loadFontDescription(Scene& _scene, const Node& _node, const std::string& _family) {
+    if (!_node.IsMap()) {
         LOGW("");
         return;
     }
     std::string style = "regular", weight = "400", uri;
 
-    for (const auto& fontDesc : node) {
+    for (const auto& fontDesc : _node) {
         const std::string& key = fontDesc.first.Scalar();
         if (key == "weight") {
             weight = fontDesc.second.Scalar();
@@ -670,16 +670,16 @@ void SceneLoader::loadFontDescription(const Node& node, const std::string& famil
             uri = fontDesc.second.Scalar();
         } else if (key == "external") {
             LOGW("external: within fonts: is a no-op in native" \
-                 " version of tangram (%s)", family.c_str());
+                 " version of tangram (%s)", _family.c_str());
         }
     }
 
     if (uri.empty()) {
-        LOGW("Empty url: block within fonts: (%s)", family.c_str());
+        LOGW("Empty url: block within fonts: (%s)", _family.c_str());
         return;
     }
 
-    scene.loadFont(uri, family, style, weight);
+    _scene.loadFont(uri, _family, style, weight);
 }
 
 void SceneLoader::applySources(Scene& _scene) {
@@ -691,7 +691,7 @@ void SceneLoader::applySources(Scene& _scene) {
     }
     for (const auto& source : sources) {
         std::string srcName = source.first.Scalar();
-        try { loadSource(srcName, source.second, _scene); }
+        try { loadSource( _scene, srcName, source.second); }
         catch (const YAML::RepresentationException& e) {
             LOGNode("Parsing sources: '%s'", source, e.what());
         }
@@ -717,9 +717,9 @@ void SceneLoader::applySources(Scene& _scene) {
     }
 }
 
-void SceneLoader::loadSource(const std::string& name, const Node& source, Scene& _scene) {
-    if (_scene.getTileSource(name)) {
-        LOGW("Duplicate TileSource: %s", name.c_str());
+void SceneLoader::loadSource(Scene& _scene, const std::string& _name, const Node& _source) {
+    if (_scene.getTileSource(_name)) {
+        LOGW("Duplicate TileSource: %s", _name.c_str());
         return;
     }
 
@@ -734,22 +734,22 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
     int32_t zoomBias = 0;
     bool generateCentroids = false;
 
-    if (auto typeNode = source["type"]) {
+    if (auto typeNode = _source["type"]) {
         type = typeNode.Scalar();
     }
-    if (auto urlNode = source["url"]) {
+    if (auto urlNode = _source["url"]) {
         url = urlNode.Scalar();
     }
-    if (auto minDisplayZoomNode = source["min_display_zoom"]) {
+    if (auto minDisplayZoomNode = _source["min_display_zoom"]) {
         YamlUtil::getInt(minDisplayZoomNode, minDisplayZoom);
     }
-    if (auto maxDisplayZoomNode = source["max_display_zoom"]) {
+    if (auto maxDisplayZoomNode = _source["max_display_zoom"]) {
         YamlUtil::getInt(maxDisplayZoomNode, maxDisplayZoom);
     }
-    if (auto maxZoomNode = source["max_zoom"]) {
+    if (auto maxZoomNode = _source["max_zoom"]) {
         YamlUtil::getInt(maxZoomNode, maxZoom);
     }
-    if (auto tileSizeNode = source["tile_size"]) {
+    if (auto tileSizeNode = _source["tile_size"]) {
         int tileSize = 0;
         if (YamlUtil::getInt(tileSizeNode, tileSize)) {
             zoomBias = TileSource::zoomBiasFromTileSize(tileSize);
@@ -757,7 +757,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
     }
 
     // Parse and append any URL parameters.
-    if (auto urlParamsNode = source["url_params"]) {
+    if (auto urlParamsNode = _source["url_params"]) {
         std::stringstream urlStream;
         // Transform our current URL from "base[?query][#hash]" into "base?params[query][#hash]".
         auto hashStart = std::min(url.find_first_of("#"), url.size());
@@ -773,18 +773,18 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
                     urlStream << entry.first.Scalar() << "=" << entry.second.Scalar() << "&";
                 } else {
                     LOGW("Invalid url_params entry in source '%s', entries" \
-                         " should be strings.", name.c_str());
+                         " should be strings.", _name.c_str());
                 }
             }
         } else {
-            LOGW("Expected a map of values for url_params in source '%s'.", name.c_str());
+            LOGW("Expected a map of values for url_params in source '%s'.", _name.c_str());
         }
         urlStream << url.substr(baseEnd);
         url = urlStream.str();
     }
 
     // Apply URL subdomain configuration.
-    if (const Node& subDomainNode = source["url_subdomains"]) {
+    if (const Node& subDomainNode = _source["url_subdomains"]) {
         if (subDomainNode.IsSequence()) {
             for (const auto& domain : subDomainNode) {
                 if (domain.IsScalar()) {
@@ -798,11 +798,11 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
     bool hasSubdomainPlaceholder = (url.find("{s}") != std::string::npos);
     if (hasSubdomainPlaceholder && subdomains.empty()) {
         LOGW("The URL for source '%s' includes the subdomain placeholder '{s}'," \
-             " but no subdomains were given.", name.c_str());
+             " but no subdomains were given.", _name.c_str());
     }
     if (!hasSubdomainPlaceholder && !subdomains.empty()) {
         LOGW("The URL for source '%s' has subdomains specified, but does not" \
-             " include the subdomain placeholder '{s}'.", name.c_str());
+             " include the subdomain placeholder '{s}'.", _name.c_str());
     }
 
     // distinguish tiled and non-tiled sources by url
@@ -820,7 +820,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
     }
 
     bool isTms = false;
-    if (const Node& tmsNode = source["tms"]) {
+    if (const Node& tmsNode = _source["tms"]) {
         YamlUtil::getBool(tmsNode, isTms);
     }
 
@@ -830,7 +830,7 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
         // If we have MBTiles, we know the source is tiled.
         tiled = true;
         // Create an MBTiles data source from the file at the url and add it to the source chain.
-        rawSources = std::make_unique<MBTilesDataSource>(_scene.platform(), name, url, "");
+        rawSources = std::make_unique<MBTilesDataSource>(_scene.platform(), _name, url, "");
     } else if (tiled) {
         auto cacheSize = _scene.options().memoryTileCacheSize;
         if (cacheSize > 0) {
@@ -852,21 +852,21 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
     TileSource::ZoomOptions zoomOptions = { minDisplayZoom, maxDisplayZoom, maxZoom, zoomBias };
 
     if (type == "GeoJSON" && !tiled) {
-        if (auto genLabelCentroidsNode = source["generate_label_centroids"]) {
+        if (auto genLabelCentroidsNode = _source["generate_label_centroids"]) {
             generateCentroids = true;
         }
-        sourcePtr = std::make_shared<ClientGeoJsonSource>(_scene.platform(), name, url,
+        sourcePtr = std::make_shared<ClientGeoJsonSource>(_scene.platform(), _name, url,
                                                           generateCentroids, zoomOptions);
     } else if (type == "Raster") {
         TextureOptions options;
-        if (const Node& filtering = source["filtering"]) {
+        if (const Node& filtering = _source["filtering"]) {
             if (!parseTexFiltering(filtering, options)) {
                 LOGW("Invalid texture filtering: %s", Dump(filtering).c_str());
             }
         }
-        sourcePtr = std::make_shared<RasterSource>(name, std::move(rawSources), options, zoomOptions);
+        sourcePtr = std::make_shared<RasterSource>(_name, std::move(rawSources), options, zoomOptions);
     } else {
-        sourcePtr = std::make_shared<TileSource>(name, std::move(rawSources), zoomOptions);
+        sourcePtr = std::make_shared<TileSource>(_name, std::move(rawSources), zoomOptions);
 
         if (type == "GeoJSON") {
             sourcePtr->setFormat(TileSource::Format::GeoJson);
@@ -877,31 +877,31 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
         } else {
             LOGE("Source '%s' does not have a valid type. " \
                  "Valid types are 'GeoJSON', 'TopoJSON', and 'MVT'. " \
-                 "This source will be ignored.", name.c_str());
+                 "This source will be ignored.", _name.c_str());
             return;
         }
     }
 
     _scene.tileSources().push_back(sourcePtr);
 
-    if (const Node& rasters = source["rasters"]) {
-        loadSourceRasters(*sourcePtr, rasters, _scene);
+    if (const Node& rasters = _source["rasters"]) {
+        loadSourceRasters(_scene, *sourcePtr, rasters);
     }
 }
 
-void SceneLoader::loadSourceRasters(TileSource& source, const Node& rasterNode, Scene& scene) {
-    if (!rasterNode.IsSequence()) { return; }
-    const Node& sources = scene.config()["sources"];
+void SceneLoader::loadSourceRasters(Scene& _scene, TileSource& _source, const Node& _rasterNode) {
+    if (!_rasterNode.IsSequence()) { return; }
+    const Node& sources = _scene.config()["sources"];
 
-    for (const auto& raster : rasterNode) {
+    for (const auto& raster : _rasterNode) {
         std::string srcName = raster.Scalar();
         try {
-            loadSource(srcName, sources[srcName], scene);
+            loadSource(_scene, srcName, sources[srcName]);
         } catch (const YAML::RepresentationException& e) {
             LOGNode("Error parsing sources: '%s'", sources[srcName], e.what());
             return;
         }
-        source.addRasterSource(scene.getTileSource(srcName));
+        _source.addRasterSource(_scene.getTileSource(srcName));
     }
 }
 
@@ -928,7 +928,7 @@ void SceneLoader::applyStyles(Scene& _scene) {
         for (const auto& entry : styles) {
             try {
                 auto name = entry.first.Scalar();
-                loadStyle(name, entry.second, _scene);
+                loadStyle(_scene, name, entry.second);
             }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing style: '%s'", entry, e.what());
@@ -953,7 +953,7 @@ void SceneLoader::applyStyles(Scene& _scene) {
     }
 }
 
-bool SceneLoader::loadStyle(const std::string& name, const Node& config, Scene& scene) {
+bool SceneLoader::loadStyle(Scene& _scene, const std::string& name, const Node& config) {
     const auto& builtIn = Style::builtInStyleNames();
 
     if (std::find(builtIn.begin(), builtIn.end(), name) != builtIn.end()) {
@@ -975,9 +975,9 @@ bool SceneLoader::loadStyle(const std::string& name, const Node& config, Scene& 
     } else if (baseStyle == "lines") {
         style = std::make_unique<PolylineStyle>(name);
     } else if (baseStyle == "text") {
-        style = std::make_unique<TextStyle>(name, scene.fontContext(), true);
+        style = std::make_unique<TextStyle>(name, _scene.fontContext(), true);
     } else if (baseStyle == "points") {
-        style = std::make_unique<PointStyle>(name, scene.fontContext());
+        style = std::make_unique<PointStyle>(name, _scene.fontContext());
     } else if (baseStyle == "raster") {
         style = std::make_unique<RasterStyle>(name);
     } else {
@@ -996,58 +996,58 @@ bool SceneLoader::loadStyle(const std::string& name, const Node& config, Scene& 
         }
     }
 
-    loadStyleProps(*style.get(), config, scene);
+    loadStyleProps(_scene, *style.get(), config);
 
-    scene.styles().push_back(std::move(style));
+    _scene.styles().push_back(std::move(style));
 
     return true;
 }
 
-void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, Scene& scene) {
-    if (!styleNode) {
+void SceneLoader::loadStyleProps(Scene& _scene, Style& _style, const Node& _styleNode) {
+    if (!_styleNode) {
         LOGW("Can not parse style parameters, bad style YAML Node");
         return;
     }
 
-    if (const Node& animatedNode = styleNode["animated"]) {
+    if (const Node& animatedNode = _styleNode["animated"]) {
         if (!animatedNode.IsScalar()) { LOGW("animated flag should be a scalar"); }
         else {
             bool animate;
             if (YamlUtil::getBool(animatedNode, animate)) {
-                style.setAnimated(animate);
+                _style.setAnimated(animate);
             }
         }
     }
 
-    if (const Node& blendNode = styleNode["blend"]) {
+    if (const Node& blendNode = _styleNode["blend"]) {
         const std::string& blendMode = blendNode.Scalar();
-        if      (blendMode == "opaque")      { style.setBlendMode(Blending::opaque); }
-        else if (blendMode == "add")         { style.setBlendMode(Blending::add); }
-        else if (blendMode == "multiply")    { style.setBlendMode(Blending::multiply); }
-        else if (blendMode == "overlay")     { style.setBlendMode(Blending::overlay); }
-        else if (blendMode == "inlay")       { style.setBlendMode(Blending::inlay); }
-        else if (blendMode == "translucent") { style.setBlendMode(Blending::translucent); }
+        if      (blendMode == "opaque")      { _style.setBlendMode(Blending::opaque); }
+        else if (blendMode == "add")         { _style.setBlendMode(Blending::add); }
+        else if (blendMode == "multiply")    { _style.setBlendMode(Blending::multiply); }
+        else if (blendMode == "overlay")     { _style.setBlendMode(Blending::overlay); }
+        else if (blendMode == "inlay")       { _style.setBlendMode(Blending::inlay); }
+        else if (blendMode == "translucent") { _style.setBlendMode(Blending::translucent); }
         else { LOGW("Invalid blend mode '%s'", blendMode.c_str()); }
     }
 
-    if (const Node& blendOrderNode = styleNode["blend_order"]) {
+    if (const Node& blendOrderNode = _styleNode["blend_order"]) {
         int blendOrderValue;
         if (YamlUtil::getInt(blendOrderNode, blendOrderValue)) {
-            style.setBlendOrder(blendOrderValue);
+            _style.setBlendOrder(blendOrderValue);
         } else {
             LOGE("Integral value expected for blend_order style parameter.\n");
         }
     }
 
-    if (const Node& texcoordsNode = styleNode["texcoords"]) {
+    if (const Node& texcoordsNode = _styleNode["texcoords"]) {
         bool boolValue;
         if (YamlUtil::getBool(texcoordsNode, boolValue)) {
-            style.setTexCoordsGeneration(boolValue);
+            _style.setTexCoordsGeneration(boolValue);
         }
     }
 
-    if (const Node& dashNode = styleNode["dash"]) {
-        if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&style)) {
+    if (const Node& dashNode = _styleNode["dash"]) {
+        if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&_style)) {
             if (dashNode.IsSequence()) {
                 std::vector<float> dashValues;
                 dashValues.reserve(dashNode.size());
@@ -1063,38 +1063,38 @@ void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, Scene& sce
         }
     }
 
-    if (const Node& dashBackgroundColor = styleNode["dash_background_color"]) {
-        if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&style)) {
+    if (const Node& dashBackgroundColor = _styleNode["dash_background_color"]) {
+        if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&_style)) {
             glm::vec4 backgroundColor = YamlUtil::getColorAsVec4(dashBackgroundColor);
             polylineStyle->setDashBackgroundColor(backgroundColor);
         }
     }
 
-    if (const Node& shadersNode = styleNode["shaders"]) {
-        loadShaderConfig(shadersNode, style, scene);
+    if (const Node& shadersNode = _styleNode["shaders"]) {
+        loadShaderConfig(_scene, shadersNode, _style);
     }
 
-    if (const Node& lightingNode = styleNode["lighting"]) {
+    if (const Node& lightingNode = _styleNode["lighting"]) {
         const std::string& lighting = lightingNode.Scalar();
-        if (lighting == "fragment") { style.setLightingType(LightingType::fragment); }
-        else if (lighting == "vertex") { style.setLightingType(LightingType::vertex); }
-        else if (lighting == "false") { style.setLightingType(LightingType::none); }
+        if (lighting == "fragment") { _style.setLightingType(LightingType::fragment); }
+        else if (lighting == "vertex") { _style.setLightingType(LightingType::vertex); }
+        else if (lighting == "false") { _style.setLightingType(LightingType::none); }
         else if (lighting == "true") { } // use default lighting
         else { LOGW("Unrecognized lighting type '%s'", lighting.c_str()); }
     }
 
-    if (const Node& textureNode = styleNode["texture"]) {
-        if (auto pointStyle = dynamic_cast<PointStyle*>(&style)) {
+    if (const Node& textureNode = _styleNode["texture"]) {
+        if (auto pointStyle = dynamic_cast<PointStyle*>(&_style)) {
             const std::string& textureName = textureNode.Scalar();
-            auto styleTexture = scene.getTexture(textureName);
+            auto styleTexture = _scene.getTexture(textureName);
             if (styleTexture) {
                 pointStyle->setDefaultTexture(styleTexture);
             } else {
                 LOGW("U ndefined texture name %s", textureName.c_str());
             }
-        } else if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&style)) {
+        } else if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&_style)) {
             const std::string& textureName = textureNode.Scalar();
-            auto texture = scene.getTexture(textureName);
+            auto texture = _scene.getTexture(textureName);
             if (texture) {
                 polylineStyle->setTexture(texture);
                 polylineStyle->setTexCoordsGeneration(true);
@@ -1102,48 +1102,48 @@ void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, Scene& sce
         }
     }
 
-    if (const Node& materialNode = styleNode["material"]) {
-        loadMaterial(materialNode, style.getMaterial(), scene, style);
+    if (const Node& materialNode = _styleNode["material"]) {
+        loadMaterial(_scene, materialNode, _style.getMaterial(), _style);
     }
 
-    if (const Node& drawNode = styleNode["draw"]) {
+    if (const Node& drawNode = _styleNode["draw"]) {
         std::vector<StyleParam> params;
-        int ruleID = scene.addIdForName(style.getName());
-        parseStyleParams(drawNode, scene, "", params);
+        int ruleID = _scene.addIdForName(_style.getName());
+        parseStyleParams(_scene, drawNode, "", params);
         /*Note:  ruleID and name is immaterial here, as these are only used for rule merging, but
          * style's default styling rules are applied post rule merging for any style parameter which
          * was not assigned during merging step.
          */
-        auto rule = std::make_unique<DrawRuleData>(style.getName(), ruleID, std::move(params));
-        style.setDefaultDrawRule(std::move(rule));
+        auto rule = std::make_unique<DrawRuleData>(_style.getName(), ruleID, std::move(params));
+        _style.setDefaultDrawRule(std::move(rule));
     }
 }
 
-void SceneLoader::parseStyleParams(const Node& params, Scene& scene, const std::string& prefix,
-                                   std::vector<StyleParam>& out) {
+void SceneLoader::parseStyleParams(Scene& _scene, const Node& _params, const std::string& _prefix,
+                                   std::vector<StyleParam>& _out) {
 
-    for (const auto& prop : params) {
+    for (const auto& prop : _params) {
         std::string key;
-        if (!prefix.empty()) {
-            key = prefix + DELIMITER + prop.first.Scalar();
+        if (!_prefix.empty()) {
+            key = _prefix + DELIMITER + prop.first.Scalar();
         } else {
             key = prop.first.Scalar();
         }
         const Node& value = prop.second;
 
         if (key == "transition" || key == "text:transition") {
-            parseTransition(prop.second, scene, key, out);
+            parseTransition(_scene, prop.second, key, _out);
             continue;
         }
 
         if (key == "texture") {
-            out.push_back(StyleParam{ StyleParamKey::texture, value });
+            _out.push_back(StyleParam{ StyleParamKey::texture, value });
             continue;
         }
 
         if (key == "text") {
             // Add StyleParam to signify that icon uses text
-            out.push_back(StyleParam{ StyleParamKey::point_text, "" });
+            _out.push_back(StyleParam{ StyleParamKey::point_text, "" });
         }
 
         switch (value.Type()) {
@@ -1152,10 +1152,10 @@ void SceneLoader::parseStyleParams(const Node& params, Scene& scene, const std::
 
             if (val.compare(0, 8, "function") == 0) {
                 StyleParam param(key);
-                param.function = scene.addJsFunction(val);
-                out.push_back(std::move(param));
+                param.function = _scene.addJsFunction(val);
+                _out.push_back(std::move(param));
             } else {
-                out.push_back(StyleParam{ key, value });
+                _out.push_back(StyleParam{ key, value });
             }
             break;
         }
@@ -1165,42 +1165,42 @@ void SceneLoader::parseStyleParams(const Node& params, Scene& scene, const std::
                 if (styleKey != StyleParamKey::none) {
 
                     if (StyleParam::isColor(styleKey)) {
-                        scene.stops().push_back(Stops::Colors(value));
-                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
+                        _scene.stops().push_back(Stops::Colors(value));
+                        _out.push_back(StyleParam{ styleKey, &(_scene.stops().back()) });
                     } else if (StyleParam::isSize(styleKey)) {
-                        scene.stops().push_back(Stops::Sizes(value, StyleParam::unitSetForStyleParam(styleKey)));
-                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
+                        _scene.stops().push_back(Stops::Sizes(value, StyleParam::unitSetForStyleParam(styleKey)));
+                        _out.push_back(StyleParam{ styleKey, &(_scene.stops().back()) });
                     } else if (StyleParam::isWidth(styleKey)) {
-                        scene.stops().push_back(Stops::Widths(value, StyleParam::unitSetForStyleParam(styleKey)));
-                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
+                        _scene.stops().push_back(Stops::Widths(value, StyleParam::unitSetForStyleParam(styleKey)));
+                        _out.push_back(StyleParam{ styleKey, &(_scene.stops().back()) });
                     } else if (StyleParam::isOffsets(styleKey)) {
-                        scene.stops().push_back(Stops::Offsets(value, StyleParam::unitSetForStyleParam(styleKey)));
-                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
+                        _scene.stops().push_back(Stops::Offsets(value, StyleParam::unitSetForStyleParam(styleKey)));
+                        _out.push_back(StyleParam{ styleKey, &(_scene.stops().back()) });
                     } else if (StyleParam::isFontSize(styleKey)) {
-                        scene.stops().push_back(Stops::FontSize(value));
-                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
+                        _scene.stops().push_back(Stops::FontSize(value));
+                        _out.push_back(StyleParam{ styleKey, &(_scene.stops().back()) });
                     } else if (StyleParam::isNumberType(styleKey)) {
-                        scene.stops().push_back(Stops::Numbers(value));
-                        out.push_back(StyleParam{ styleKey, &(scene.stops().back()) });
+                        _scene.stops().push_back(Stops::Numbers(value));
+                        _out.push_back(StyleParam{ styleKey, &(_scene.stops().back()) });
                     }
                 } else {
                     LOGW("Unknown style parameter %s", key.c_str());
                 }
 
             } else {
-                out.push_back(StyleParam{ key, value });
+                _out.push_back(StyleParam{ key, value });
             }
             break;
         }
         case NodeType::Map: {
             // NB: Flatten parameter map
-            parseStyleParams(value, scene, key, out);
+            parseStyleParams(_scene, value, key, _out);
 
             break;
         }
         case NodeType::Null: {
             // Handles the case, when null style param value is used to unset a merged style param
-            out.emplace_back(StyleParam::getKey(key));
+            _out.emplace_back(StyleParam::getKey(key));
             break;
         }
         default:
@@ -1209,11 +1209,11 @@ void SceneLoader::parseStyleParams(const Node& params, Scene& scene, const std::
     }
 }
 
-void SceneLoader::parseTransition(const Node& params, Scene& scene, std::string _prefix,
-                                  std::vector<StyleParam>& out) {
+void SceneLoader::parseTransition(Scene& _scene, const Node& _params, std::string _prefix,
+                                  std::vector<StyleParam>& _out) {
 
     // First iterate over the mapping of 'events', we currently recognize 'hide', 'selected', and 'show'.
-    for (const auto& event : params) {
+    for (const auto& event : _params) {
         if (!event.first.IsScalar() || !event.second.IsMap()) {
             LOGW("Can't parse 'transitions' entry, expected a mapping of strings to mappings at: %s",
                  _prefix.c_str());
@@ -1233,17 +1233,17 @@ void SceneLoader::parseTransition(const Node& params, Scene& scene, std::string 
             // Add the parameter to our key, so it's now 'transition:event:param'.
             std::string transitionEventParam = transitionEvent + DELIMITER + param.first.Scalar();
             // Create a style parameter from the key and value.
-            out.push_back(StyleParam{ transitionEventParam, param.second });
+            _out.push_back(StyleParam{ transitionEventParam, param.second });
         }
     }
 }
 
-void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, Scene& scene) {
-    if (!shaders) { return; }
+void SceneLoader::loadShaderConfig(Scene& _scene, const Node& _shaders, Style& _style) {
+    if (!_shaders) { return; }
 
-    auto& shader = style.getShaderSource();
+    auto& shader = _style.getShaderSource();
 
-    if (const Node& extNode = shaders["extensions_mixed"]) {
+    if (const Node& extNode = _shaders["extensions_mixed"]) {
         if (extNode.IsScalar()) {
             shader.addExtensionDeclaration(extNode.Scalar());
         } else if (extNode.IsSequence()) {
@@ -1253,7 +1253,7 @@ void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, Scene& sce
         }
     }
 
-    if (const Node& definesNode = shaders["defines"]) {
+    if (const Node& definesNode = _shaders["defines"]) {
         for (const auto& define : definesNode) {
             const std::string& name = define.first.Scalar();
 
@@ -1281,12 +1281,12 @@ void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, Scene& sce
         }
     }
 
-    if (const Node& uniformsNode = shaders["uniforms"]) {
+    if (const Node& uniformsNode = _shaders["uniforms"]) {
         for (const auto& uniform : uniformsNode) {
             const std::string& name = uniform.first.Scalar();
             StyleUniform styleUniform;
 
-            if (parseStyleUniforms(uniform.second, scene, styleUniform)) {
+            if (parseStyleUniforms(_scene, uniform.second, styleUniform)) {
                 if (styleUniform.value.is<UniformArray1f>()) {
                     UniformArray1f& array = styleUniform.value.get<UniformArray1f>();
                     shader.addSourceBlock("uniforms", "uniform float " + name +
@@ -1299,14 +1299,14 @@ void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, Scene& sce
                     shader.addSourceBlock("uniforms", "uniform " + styleUniform.type + " " + name + ";");
                 }
 
-                style.styleUniforms().emplace_back(name, styleUniform.value);
+                _style.styleUniforms().emplace_back(name, styleUniform.value);
             } else {
                 LOGNode("Style uniform parsing failure", uniform.second);
             }
         }
     }
 
-    if (const Node& blocksNode = shaders["blocks_mixed"]) {
+    if (const Node& blocksNode = _shaders["blocks_mixed"]) {
         for (const auto& block : blocksNode) {
             const auto& name = block.first.Scalar();
             const auto& value = block.second;
@@ -1321,59 +1321,58 @@ void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, Scene& sce
     }
 }
 
-bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene,
-                                     StyleUniform& styleUniform) {
-    if (value.IsScalar()) { // float, bool or string (texture)
+bool SceneLoader::parseStyleUniforms(Scene& _scene, const Node& _value, StyleUniform& _styleUniform) {
+    if (_value.IsScalar()) { // float, bool or string (texture)
         double fValue;
         bool bValue;
 
-        if (YamlUtil::getDouble(value, fValue, false)) {
-            styleUniform.type = "float";
-            styleUniform.value = (float)fValue;
-        } else if (YamlUtil::getBool(value, bValue)) {
-            styleUniform.type = "bool";
-            styleUniform.value = (bool)bValue;
+        if (YamlUtil::getDouble(_value, fValue, false)) {
+            _styleUniform.type = "float";
+            _styleUniform.value = (float)fValue;
+        } else if (YamlUtil::getBool(_value, bValue)) {
+            _styleUniform.type = "bool";
+            _styleUniform.value = (bool)bValue;
         } else {
-            const std::string& strVal = value.Scalar();
-            styleUniform.type = "sampler2D";
-            styleUniform.value = strVal;
+            const std::string& strVal = _value.Scalar();
+            _styleUniform.type = "sampler2D";
+            _styleUniform.value = strVal;
 
-            scene.loadTexture(strVal);
+            _scene.loadTexture(strVal);
         }
-    } else if (value.IsSequence()) {
-        size_t size = value.size();
+    } else if (_value.IsSequence()) {
+        size_t size = _value.size();
         bool parsed = false;
         switch (size) {
             case 2: {
                 glm::vec2 vec;
-                if (YamlUtil::parseVec<glm::vec2>(value, vec)) {
-                    styleUniform.value = vec;
-                    styleUniform.type = "vec2";
+                if (YamlUtil::parseVec<glm::vec2>(_value, vec)) {
+                    _styleUniform.value = vec;
+                    _styleUniform.type = "vec2";
                     parsed = true;
                 }
                 break;
             }
             case 3: {
                 glm::vec3 vec;
-                if (YamlUtil::parseVec(value, vec)) {
-                    styleUniform.value = vec;
-                    styleUniform.type = "vec3";
+                if (YamlUtil::parseVec(_value, vec)) {
+                    _styleUniform.value = vec;
+                    _styleUniform.type = "vec3";
                     parsed = true;
                 }
                 break;
             }
             case 4: {
                 glm::vec4 vec;
-                if (YamlUtil::parseVec(value, vec)) {
-                    styleUniform.value = vec;
-                    styleUniform.type = "vec4";
+                if (YamlUtil::parseVec(_value, vec)) {
+                    _styleUniform.value = vec;
+                    _styleUniform.type = "vec4";
                     parsed = true;
                 }
                 break;
             }
             default: {
                 UniformArray1f uniformArray;
-                for (const auto& val : value) {
+                for (const auto& val : _value) {
                     double fValue;
                     if (YamlUtil::getDouble(val, fValue)) {
                         uniformArray.push_back(fValue);
@@ -1381,8 +1380,8 @@ bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene,
                         return false;
                     }
                 }
-                styleUniform.value = std::move(uniformArray);
-                styleUniform.type = "vec" + std::to_string(size);
+                _styleUniform.value = std::move(uniformArray);
+                _styleUniform.type = "vec" + std::to_string(size);
                 parsed = true;
                 break;
             }
@@ -1392,16 +1391,16 @@ bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene,
             // array of strings (textures)
             UniformTextureArray textureArrayUniform;
             textureArrayUniform.names.reserve(size);
-            styleUniform.type = "sampler2D";
+            _styleUniform.type = "sampler2D";
 
-            for (const auto& strVal : value) {
+            for (const auto& strVal : _value) {
                 const std::string& textureName = strVal.Scalar();
                 textureArrayUniform.names.push_back(textureName);
 
-                scene.loadTexture(textureName);
+                _scene.loadTexture(textureName);
             }
 
-            styleUniform.value = std::move(textureArrayUniform);
+            _styleUniform.value = std::move(textureArrayUniform);
         }
     } else {
         LOGW("Expected a scalar or sequence value for uniforms");
@@ -1410,8 +1409,7 @@ bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene,
     return true;
 }
 
-void SceneLoader::loadMaterial(const Node& matNode, Material& material,
-                               Scene& scene, Style& style) {
+void SceneLoader::loadMaterial(Scene& _scene, const Node& _matNode, Material& _material, Style& _style) {
 
     auto parseMaterialVec = [](const Node& prop) -> glm::vec4 {
         switch (prop.Type()) {
@@ -1441,55 +1439,54 @@ void SceneLoader::loadMaterial(const Node& matNode, Material& material,
         return glm::vec4(0.0);
     };
 
-    if (!matNode.IsMap()) { return; }
+    if (!_matNode.IsMap()) { return; }
 
-    if (const Node& n = matNode["emission"]) {
+    if (const Node& n = _matNode["emission"]) {
         if (n.IsMap()) {
-            material.setEmission(loadMaterialTexture(n, scene, style));
+            _material.setEmission(loadMaterialTexture(_scene, n, _style));
         } else {
-            material.setEmission(parseMaterialVec(n));
+            _material.setEmission(parseMaterialVec(n));
         }
     }
-    if (const Node& n = matNode["diffuse"]) {
+    if (const Node& n = _matNode["diffuse"]) {
         if (n.IsMap()) {
-            material.setDiffuse(loadMaterialTexture(n, scene, style));
+            _material.setDiffuse(loadMaterialTexture(_scene, n, _style));
         } else {
-            material.setDiffuse(parseMaterialVec(n));
+            _material.setDiffuse(parseMaterialVec(n));
         }
     }
-    if (const Node& n = matNode["ambient"]) {
+    if (const Node& n = _matNode["ambient"]) {
         if (n.IsMap()) {
-            material.setAmbient(loadMaterialTexture(n, scene, style));
+            _material.setAmbient(loadMaterialTexture(_scene, n, _style));
         } else {
-            material.setAmbient(parseMaterialVec(n));
-        }
-    }
-
-    if (const Node& n = matNode["specular"]) {
-        if (n.IsMap()) {
-            material.setSpecular(loadMaterialTexture(n, scene, style));
-        } else {
-            material.setSpecular(parseMaterialVec(n));
+            _material.setAmbient(parseMaterialVec(n));
         }
     }
 
-    if (const Node& shininess = matNode["shininess"]) {
+    if (const Node& n = _matNode["specular"]) {
+        if (n.IsMap()) {
+            _material.setSpecular(loadMaterialTexture(_scene, n, _style));
+        } else {
+            _material.setSpecular(parseMaterialVec(n));
+        }
+    }
+
+    if (const Node& shininess = _matNode["shininess"]) {
         double value;
         if (YamlUtil::getDouble(shininess, value, false)) {
-            material.setShininess(value);
+            _material.setShininess(value);
         }
     }
-    material.setNormal(loadMaterialTexture(matNode["normal"], scene, style));
+    _material.setNormal(loadMaterialTexture(_scene, _matNode["normal"], _style));
 }
 
-MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode,
-                                                 Scene& scene, Style& style) {
+MaterialTexture SceneLoader::loadMaterialTexture(Scene& _scene, const Node& _matCompNode, Style& _style) {
 
-    if (!matCompNode) { return MaterialTexture{}; }
+    if (!_matCompNode) { return MaterialTexture{}; }
 
-    Node textureNode = matCompNode["texture"];
+    Node textureNode = _matCompNode["texture"];
     if (!textureNode) {
-        LOGNode("Expected a 'texture' parameter", matCompNode);
+        LOGNode("Expected a 'texture' parameter", _matCompNode);
 
         return MaterialTexture{};
     }
@@ -1497,22 +1494,22 @@ MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode,
     const std::string& name = textureNode.Scalar();
 
     MaterialTexture matTex;
-    matTex.tex = scene.loadTexture(name);
+    matTex.tex = _scene.loadTexture(name);
 
-    if (const Node& mappingNode = matCompNode["mapping"]) {
+    if (const Node& mappingNode = _matCompNode["mapping"]) {
         const std::string& mapping = mappingNode.Scalar();
         if (mapping == "uv") {
             matTex.mapping = MappingType::uv;
 
             // Mark the style to generate texture coordinates
-            if (!style.genTexCoords()) {
+            if (!_style.genTexCoords()) {
                 LOGW("Style %s has option `texcoords: false` but material %s has uv mapping",
-                    style.getName().c_str(), name.c_str());
+                    _style.getName().c_str(), name.c_str());
                 LOGW("Defaulting uvs generation to true for style %s",
-                    style.getName().c_str());
+                    _style.getName().c_str());
             }
 
-            style.setTexCoordsGeneration(true);
+            _style.setTexCoordsGeneration(true);
         } else if (mapping == "spheremap") {
             matTex.mapping = MappingType::spheremap;
         } else if (mapping == "planar") {
@@ -1524,7 +1521,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode,
         }
     }
 
-    if (const Node& scaleNode = matCompNode["scale"]) {
+    if (const Node& scaleNode = _matCompNode["scale"]) {
         if (scaleNode.IsSequence() && scaleNode.size() == 2) {
             matTex.scale.x = YamlUtil::getFloatOrDefault(scaleNode[0], matTex.scale.x);
             matTex.scale.y = YamlUtil::getFloatOrDefault(scaleNode[1], matTex.scale.y);
@@ -1535,7 +1532,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode,
         }
     }
 
-    if (const Node& amountNode = matCompNode["amount"]) {
+    if (const Node& amountNode = _matCompNode["amount"]) {
         if (amountNode.IsScalar()) {
             matTex.amount = glm::vec3(YamlUtil::getFloatOrDefault(amountNode, 1.f));
         } else if (!YamlUtil::parseVec(amountNode, matTex.amount)) {
@@ -1550,7 +1547,7 @@ void SceneLoader::applyLayers(Scene& _scene) {
 
     if (const Node& layers = config["layers"]) {
         for (const auto& layer : layers) {
-            try { loadLayer(layer, _scene); }
+            try { loadLayer(_scene, layer); }
             catch (const YAML::RepresentationException& e) {
                 LOGNode("Parsing layer: '%s'", layer, e.what());
             }
@@ -1558,12 +1555,12 @@ void SceneLoader::applyLayers(Scene& _scene) {
     }
 }
 
-void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
-    const std::string& name = layer.first.Scalar();
+void SceneLoader::loadLayer(Scene& _scene, const std::pair<Node, Node>& _layer) {
+    const std::string& name = _layer.first.Scalar();
     std::string source;
     std::vector<std::string> collections;
 
-    if (const Node& data = layer.second["data"]) {
+    if (const Node& data = _layer.second["data"]) {
 
         if (const Node& data_source = data["source"]) {
             if (data_source.IsScalar()) {
@@ -1588,17 +1585,17 @@ void SceneLoader::loadLayer(const std::pair<Node, Node>& layer, Scene& scene) {
     if (collections.empty()) {
         collections.push_back(name);
     }
-    auto sublayer = loadSublayer(layer.second, name, scene);
-    scene.layers().push_back({ std::move(sublayer), source, collections });
+    auto sublayer = loadSublayer(_scene, _layer.second, name);
+    _scene.layers().push_back({ std::move(sublayer), source, collections });
 }
 
-SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layerName, Scene& scene) {
+SceneLayer SceneLoader::loadSublayer(Scene& _scene, const Node& _layer, const std::string& _layerName) {
     std::vector<SceneLayer> sublayers;
     std::vector<DrawRuleData> rules;
     Filter filter;
     bool enabled = true;
 
-    for (const auto& member : layer) {
+    for (const auto& member : _layer) {
 
         const std::string& key = member.first.Scalar();
 
@@ -1609,31 +1606,31 @@ SceneLayer SceneLoader::loadSublayer(const Node& layer, const std::string& layer
             for (auto& ruleNode : member.second) {
 
                 std::vector<StyleParam> params;
-                parseStyleParams(ruleNode.second, scene, "", params);
+                parseStyleParams(_scene, ruleNode.second, "", params);
 
                 const std::string& ruleName = ruleNode.first.Scalar();
-                int ruleId = scene.addIdForName(ruleName);
+                int ruleId = _scene.addIdForName(ruleName);
 
                 rules.push_back({ ruleName, ruleId, std::move(params) });
             }
         } else if (key == "filter") {
-            filter = generateFilter(member.second, scene);
+            filter = generateFilter(_scene, member.second);
             if (!filter.isValid()) {
-                LOGNode("Invalid 'filter' in layer '%s'", member.second, layerName.c_str());
-                return { layerName, {}, {}, {}, false };
+                LOGNode("Invalid 'filter' in layer '%s'", member.second, _layerName.c_str());
+                return { _layerName, {}, {}, {}, false };
             }
         } else if (key == "visible") {
-            if (!layer["enabled"].IsDefined()) {
+            if (!_layer["enabled"].IsDefined()) {
                 YAML::convert<bool>::decode(member.second, enabled);
             }
         } else if (key == "enabled") {
             YAML::convert<bool>::decode(member.second, enabled);
         } else {
             // Member is a sublayer
-            sublayers.push_back(loadSublayer(member.second, (layerName + DELIMITER + key), scene));
+            sublayers.push_back(loadSublayer(_scene, member.second, (_layerName + DELIMITER + key)));
         }
     }
-    return { layerName, std::move(filter), rules, std::move(sublayers), enabled };
+    return { _layerName, std::move(filter), rules, std::move(sublayers), enabled };
 }
 
 void printFilters(const SceneLayer& layer, int indent){
@@ -1645,18 +1642,18 @@ void printFilters(const SceneLayer& layer, int indent){
     }
 };
 
-Filter SceneLoader::generateFilter(const Node& _filter, Scene& scene) {
+Filter SceneLoader::generateFilter(Scene& _scene, const Node& _filter) {
     switch (_filter.Type()) {
     case NodeType::Scalar: {
 
         const std::string& val = _filter.Scalar();
         if (val.compare(0, 8, "function") == 0) {
-            return Filter::MatchFunction(scene.addJsFunction(val));
+            return Filter::MatchFunction(_scene.addJsFunction(val));
         }
         return Filter();
     }
     case NodeType::Sequence: {
-        return generateAnyFilter(_filter, scene);
+        return generateAnyFilter(_scene, _filter);
     }
     case NodeType::Map: {
         std::vector<Filter> filters;
@@ -1665,13 +1662,13 @@ Filter SceneLoader::generateFilter(const Node& _filter, Scene& scene) {
             const Node& node = _filter[key];
             Filter f;
             if (key == "none") {
-                f = generateNoneFilter(node, scene);
+                f = generateNoneFilter(_scene, node);
             } else if (key == "not") {
-                f = generateNoneFilter(node, scene);
+                f = generateNoneFilter(_scene, node);
             } else if (key == "any") {
-                f = generateAnyFilter(node, scene);
+                f = generateAnyFilter(_scene, node);
             } else if (key == "all") {
-                f = generateAllFilter(node, scene);
+                f = generateAllFilter(_scene, node);
             } else {
                 f = generatePredicate(node, key);
             }
@@ -1691,12 +1688,12 @@ Filter SceneLoader::generateFilter(const Node& _filter, Scene& scene) {
     }
 }
 
-Filter SceneLoader::generateAnyFilter(const Node& _filter, Scene& scene) {
+Filter SceneLoader::generateAnyFilter(Scene& _scene, const Node& _filter) {
     if (_filter.IsSequence()) {
         std::vector<Filter> filters;
 
         for (const auto& filt : _filter) {
-            if (Filter f = generateFilter(filt, scene)) {
+            if (Filter f = generateFilter(_scene, filt)) {
                 filters.push_back(std::move(f));
             } else { return Filter(); }
         }
@@ -1705,12 +1702,12 @@ Filter SceneLoader::generateAnyFilter(const Node& _filter, Scene& scene) {
     return Filter();
 }
 
-Filter SceneLoader::generateAllFilter(const Node& _filter, Scene& scene) {
+Filter SceneLoader::generateAllFilter(Scene& _scene, const Node& _filter) {
     if (_filter.IsSequence()) {
         std::vector<Filter> filters;
 
         for (const auto& filt : _filter) {
-            if (Filter f = generateFilter(filt, scene)) {
+            if (Filter f = generateFilter(_scene, filt)) {
                 filters.push_back(std::move(f));
             } else { return Filter(); }
         }
@@ -1719,12 +1716,12 @@ Filter SceneLoader::generateAllFilter(const Node& _filter, Scene& scene) {
     return Filter();
 }
 
-Filter SceneLoader::generateNoneFilter(const Node& _filter, Scene& scene) {
+Filter SceneLoader::generateNoneFilter(Scene& _scene, const Node& _filter) {
     if (_filter.IsSequence()) {
         std::vector<Filter> filters;
 
         for (const auto& filt : _filter) {
-            if (Filter f = generateFilter(filt, scene)) {
+            if (Filter f = generateFilter(_scene, filt)) {
                 filters.push_back(std::move(f));
             } else { return Filter(); }
         }
@@ -1732,7 +1729,7 @@ Filter SceneLoader::generateNoneFilter(const Node& _filter, Scene& scene) {
 
     } else if (_filter.IsMap() || _filter.IsScalar()) {
         // 'not' case
-        if (Filter f = generateFilter(_filter, scene)) {
+        if (Filter f = generateFilter(_scene, _filter)) {
             return Filter::MatchNone({std::move(f)});
         }
     }
@@ -1802,14 +1799,14 @@ Filter SceneLoader::generatePredicate(const Node& _node, std::string _key) {
     }
 }
 
-bool SceneLoader::getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea) {
-    if (!YamlUtil::getDouble(node, val, false)) {
-        auto strVal = node.Scalar();
+bool SceneLoader::getFilterRangeValue(const Node& _node, double& _val, bool& _hasPixelArea) {
+    if (!YamlUtil::getDouble(_node, _val, false)) {
+        auto strVal = _node.Scalar();
         auto n = strVal.find("px2");
         if (n == std::string::npos) { return false; }
         try {
-            val = ff::stof(std::string(strVal, 0, n));
-            hasPixelArea = true;
+            _val = ff::stof(std::string(strVal, 0, n));
+            _hasPixelArea = true;
         } catch (std::invalid_argument) { return false; }
     }
     return true;

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -62,9 +62,6 @@ std::chrono::time_point<std::chrono::system_clock> t_start, t_last;
 
 namespace Tangram {
 
-// TODO: make this configurable: 16MB default in-memory DataSource cache:
-constexpr size_t CACHE_SIZE = 16 * (1024 * 1024);
-
 static const std::string GLOBAL_PREFIX = "global.";
 
 bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
@@ -831,17 +828,27 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
         YamlUtil::getBool(tmsNode, isTms);
     }
 
-    auto rawSources = std::make_unique<MemoryCacheDataSource>();
-    rawSources->setCacheSize(CACHE_SIZE);
+    std::unique_ptr<TileSource::DataSource> rawSources;
 
     if (isMBTilesFile) {
         // If we have MBTiles, we know the source is tiled.
         tiled = true;
         // Create an MBTiles data source from the file at the url and add it to the source chain.
-        rawSources->setNext(std::make_unique<MBTilesDataSource>(_scene.platform(), name, url, ""));
+        rawSources = std::make_unique<MBTilesDataSource>(_scene.platform(), name, url, "");
     } else if (tiled) {
-        rawSources->setNext(std::make_unique<NetworkDataSource>(_scene.platform(), url,
-                                                                std::move(subdomains), isTms));
+        auto cacheSize = _scene.options().memoryTileCacheSize;
+        if (cacheSize > 0) {
+            auto cache = std::make_unique<MemoryCacheDataSource>();
+            cache->setCacheSize(cacheSize);
+            rawSources = std::move(cache);
+        }
+
+        auto s = std::make_unique<NetworkDataSource>(_scene.platform(), url, std::move(subdomains), isTms);
+        if (rawSources) {
+            rawSources->next = std::move(s);
+        } else {
+            rawSources = std::move(s);
+        }
     }
 
     std::shared_ptr<TileSource> sourcePtr;
@@ -852,8 +859,8 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
         if (auto genLabelCentroidsNode = source["generate_label_centroids"]) {
             generateCentroids = true;
         }
-        sourcePtr = std::make_shared<ClientGeoJsonSource>(_scene.platform(), name, url, generateCentroids,
-                                                          zoomOptions);
+        sourcePtr = std::make_shared<ClientGeoJsonSource>(_scene.platform(), name, url,
+                                                          generateCentroids, zoomOptions);
     } else if (type == "Raster") {
         TextureOptions options;
         if (const Node& filtering = source["filtering"]) {
@@ -861,7 +868,6 @@ void SceneLoader::loadSource(const std::string& name, const Node& source, Scene&
                 LOGW("Invalid texture filtering: %s", Dump(filtering).c_str());
             }
         }
-
         sourcePtr = std::make_shared<RasterSource>(name, std::move(rawSources), options, zoomOptions);
     } else {
         sourcePtr = std::make_shared<TileSource>(name, std::move(rawSources), zoomOptions);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -100,16 +100,16 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
     _scene->initTileManager();
     LOGTime("loadTiles");
 
-    applyTextures(_scene);
+    applyTextures(*_scene);
     LOGTime("textures");
 
     _scene->fontContext()->loadFonts();
     LOGTime("initFonts");
 
-    applyFonts(_scene);
+    applyFonts(*_scene);
     LOGTime("applyFonts");
 
-    applyStyles(_scene);
+    applyStyles(*_scene);
     LOGTime("applyStyles");
 
     applyLayers(*_scene);
@@ -313,8 +313,8 @@ void SceneLoader::applyCameras(Scene& _scene) {
     view->update();
 }
 
-void SceneLoader::applyTextures(std::shared_ptr<Scene>& _scene) {
-    const Node& config = _scene->config();
+void SceneLoader::applyTextures(Scene& _scene) {
+    const Node& config = _scene.config();
 
     if (const Node& textures = config["textures"]) {
         for (const auto& texture : textures) {
@@ -326,35 +326,20 @@ void SceneLoader::applyTextures(std::shared_ptr<Scene>& _scene) {
     }
 }
 
-void SceneLoader::applyFonts(std::shared_ptr<Scene>& _scene) {
-    const Node& config = _scene->config();
-
-    if (const Node& fonts = config["fonts"]) {
-        if (fonts.IsMap()) {
-            for (const auto& font : fonts) {
-                try { loadFont(font, _scene); }
-                catch (const YAML::RepresentationException& e) {
-                    LOGNode("Parsing font: '%s'", font, e.what());
-                }
-            }
-        }
-    }
-}
-
-void SceneLoader::applyStyles(std::shared_ptr<Scene>& _scene) {
+void SceneLoader::applyStyles(Scene& _scene) {
 
     // Instantiate built-in styles
-    _scene->styles().emplace_back(new PolygonStyle("polygons"));
-    _scene->styles().emplace_back(new PolylineStyle("lines"));
-    _scene->styles().emplace_back(new TextStyle("text", _scene->fontContext(), true));
-    _scene->styles().emplace_back(new PointStyle("points", _scene->fontContext()));
-    _scene->styles().emplace_back(new RasterStyle("raster"));
-    if (_scene->options().debugStyles) {
-        _scene->styles().emplace_back(new DebugTextStyle("debugtext", _scene->fontContext(), true));
-        _scene->styles().emplace_back(new DebugStyle("debug"));
+    _scene.styles().emplace_back(new PolygonStyle("polygons"));
+    _scene.styles().emplace_back(new PolylineStyle("lines"));
+    _scene.styles().emplace_back(new TextStyle("text", _scene.fontContext(), true));
+    _scene.styles().emplace_back(new PointStyle("points", _scene.fontContext()));
+    _scene.styles().emplace_back(new RasterStyle("raster"));
+    if (_scene.options().debugStyles) {
+        _scene.styles().emplace_back(new DebugTextStyle("debugtext", _scene.fontContext(), true));
+        _scene.styles().emplace_back(new DebugStyle("debug"));
     }
 
-    const Node& config = _scene->config();
+    const Node& config = _scene.config();
     if (const Node& styles = config["styles"]) {
         StyleMixer mixer;
         try {
@@ -375,17 +360,17 @@ void SceneLoader::applyStyles(std::shared_ptr<Scene>& _scene) {
 
     // Styles that are opaque must be ordered first in the scene so that
     // they are rendered 'under' styles that require blending
-    std::sort(_scene->styles().begin(), _scene->styles().end(), Style::compare);
+    std::sort(_scene.styles().begin(), _scene.styles().end(), Style::compare);
 
     // Post style sorting set their respective IDs=>vector indices
     // These indices are used for style geometry lookup in tiles
-    auto& styles = _scene->styles();
+    auto& styles = _scene.styles();
     for(uint32_t i = 0; i < styles.size(); i++) {
         styles[i]->setID(i);
-        styles[i]->setPixelScale(_scene->pixelScale());
+        styles[i]->setPixelScale(_scene.pixelScale());
 
         if (auto pointStyle = dynamic_cast<PointStyle*>(styles[i].get())) {
-            pointStyle->setTextures(_scene->textures());
+            pointStyle->setTextures(_scene.textures());
         }
     }
 }
@@ -436,8 +421,7 @@ void SceneLoader::applyScene(Scene& _scene) {
     }
 }
 
-void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, std::shared_ptr<Scene>& scene) {
-
+void SceneLoader::loadShaderConfig(const Node& shaders, Style& style, Scene& scene) {
     if (!shaders) { return; }
 
     auto& shader = style.getShaderSource();
@@ -550,7 +534,7 @@ glm::vec4 parseMaterialVec(const Node& prop) {
 }
 
 void SceneLoader::loadMaterial(const Node& matNode, Material& material,
-                               std::shared_ptr<Scene>& scene, Style& style) {
+                               Scene& scene, Style& style) {
 
     if (!matNode.IsMap()) { return; }
 
@@ -594,7 +578,8 @@ void SceneLoader::loadMaterial(const Node& matNode, Material& material,
     material.setNormal(loadMaterialTexture(matNode["normal"], scene, style));
 }
 
-MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode, std::shared_ptr<Scene>& scene, Style& style) {
+MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode,
+                                                 Scene& scene, Style& style) {
 
     if (!matCompNode) { return MaterialTexture{}; }
 
@@ -608,7 +593,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode, std::s
     const std::string& name = textureNode.Scalar();
 
     MaterialTexture matTex;
-    matTex.tex = scene->loadTexture(name);
+    matTex.tex = scene.loadTexture(name);
 
     if (const Node& mappingNode = matCompNode["mapping"]) {
         const std::string& mapping = mappingNode.Scalar();
@@ -678,9 +663,7 @@ bool SceneLoader::parseTexFiltering(const Node& filteringNode, TextureOptions& o
     return false;
 }
 
-
-
-void SceneLoader::loadTexture( const std::pair<Node, Node>& node, std::shared_ptr<Scene>& scene) {
+void SceneLoader::loadTexture(const std::pair<Node, Node>& node, Scene& scene) {
 
     const std::string& name = node.first.Scalar();
     const Node& textureConfig = node.second;
@@ -732,11 +715,39 @@ void SceneLoader::loadTexture( const std::pair<Node, Node>& node, std::shared_pt
             }
         }
     }
-    auto texture = scene->fetchTexture(name, Url(url), options, std::move(atlas));
+    scene.fetchTexture(name, Url(url), options, std::move(atlas));
 }
 
-void SceneLoader::loadFontDescription(const Node& node, const std::string& family,
-                                      std::shared_ptr<Scene>& scene) {
+
+void SceneLoader::applyFonts(Scene& _scene) {
+    const Node& config = _scene.config();
+    const Node& fonts = config["fonts"];
+    if (!fonts) { return; }
+    if (!fonts.IsMap()) {
+        // LOG
+        return;
+    }
+    for (const auto& font : fonts) {
+        try {
+            const std::string& family = font.first.Scalar();
+
+            if (font.second.IsMap()) {
+                loadFontDescription(font.second, family, _scene);
+            } else if (font.second.IsSequence()) {
+                for (const auto& node : font.second) {
+                    loadFontDescription(node, family, _scene);
+                }
+            } else {
+                // LOG
+            }
+        }
+        catch (const YAML::RepresentationException& e) {
+            LOGNode("Parsing font: '%s'", font, e.what());
+        }
+    }
+}
+
+void SceneLoader::loadFontDescription(const Node& node, const std::string& family, Scene& scene) {
     if (!node.IsMap()) {
         LOGW("");
         return;
@@ -761,23 +772,10 @@ void SceneLoader::loadFontDescription(const Node& node, const std::string& famil
         return;
     }
 
-    scene->loadFont(uri, family, style, weight);
+    scene.loadFont(uri, family, style, weight);
 }
 
-void SceneLoader::loadFont(const std::pair<Node, Node>& font, std::shared_ptr<Scene>& scene) {
-    const std::string& family = font.first.Scalar();
-
-    if (font.second.IsMap()) {
-        loadFontDescription(font.second, family, scene);
-    } else if (font.second.IsSequence()) {
-        for (const auto& node : font.second) {
-            loadFontDescription(node, family, scene);
-        }
-    }
-}
-
-void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, std::shared_ptr<Scene>& scene) {
-
+void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, Scene& scene) {
     if (!styleNode) {
         LOGW("Can not parse style parameters, bad style YAML Node");
         return;
@@ -860,7 +858,7 @@ void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, std::share
     if (const Node& textureNode = styleNode["texture"]) {
         if (auto pointStyle = dynamic_cast<PointStyle*>(&style)) {
             const std::string& textureName = textureNode.Scalar();
-            auto styleTexture = scene->getTexture(textureName);
+            auto styleTexture = scene.getTexture(textureName);
             if (styleTexture) {
                 pointStyle->setDefaultTexture(styleTexture);
             } else {
@@ -868,7 +866,7 @@ void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, std::share
             }
         } else if (auto polylineStyle = dynamic_cast<PolylineStyle*>(&style)) {
             const std::string& textureName = textureNode.Scalar();
-            auto texture = scene->getTexture(textureName);
+            auto texture = scene.getTexture(textureName);
             if (texture) {
                 polylineStyle->setTexture(texture);
                 polylineStyle->setTexCoordsGeneration(true);
@@ -882,8 +880,8 @@ void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, std::share
 
     if (const Node& drawNode = styleNode["draw"]) {
         std::vector<StyleParam> params;
-        int ruleID = scene->addIdForName(style.getName());
-        parseStyleParams(drawNode, *scene, "", params);
+        int ruleID = scene.addIdForName(style.getName());
+        parseStyleParams(drawNode, scene, "", params);
         /*Note:  ruleID and name is immaterial here, as these are only used for rule merging, but
          * style's default styling rules are applied post rule merging for any style parameter which
          * was not assigned during merging step.
@@ -893,7 +891,7 @@ void SceneLoader::loadStyleProps(Style& style, const Node& styleNode, std::share
     }
 }
 
-bool SceneLoader::loadStyle(const std::string& name, const Node& config, std::shared_ptr<Scene>& scene) {
+bool SceneLoader::loadStyle(const std::string& name, const Node& config, Scene& scene) {
 
     const auto& builtIn = Style::builtInStyleNames();
 
@@ -916,9 +914,9 @@ bool SceneLoader::loadStyle(const std::string& name, const Node& config, std::sh
     } else if (baseStyle == "lines") {
         style = std::make_unique<PolylineStyle>(name);
     } else if (baseStyle == "text") {
-        style = std::make_unique<TextStyle>(name, scene->fontContext(), true);
+        style = std::make_unique<TextStyle>(name, scene.fontContext(), true);
     } else if (baseStyle == "points") {
-        style = std::make_unique<PointStyle>(name, scene->fontContext());
+        style = std::make_unique<PointStyle>(name, scene.fontContext());
     } else if (baseStyle == "raster") {
         style = std::make_unique<RasterStyle>(name);
     } else {
@@ -939,7 +937,7 @@ bool SceneLoader::loadStyle(const std::string& name, const Node& config, std::sh
 
     loadStyleProps(*style.get(), config, scene);
 
-    scene->styles().push_back(std::move(style));
+    scene.styles().push_back(std::move(style));
 
     return true;
 }
@@ -1099,12 +1097,12 @@ void SceneLoader::loadSource(const std::string& name, const Node& source,
     _scene.tileSources().push_back(sourcePtr);
 
     if (auto rasters = source["rasters"]) {
-        loadSourceRasters(sourcePtr, source["rasters"], sources, _scene);
+        loadSourceRasters(*sourcePtr, source["rasters"], sources, _scene);
     }
 
 }
 
-void SceneLoader::loadSourceRasters(std::shared_ptr<TileSource> &source, const Node& rasterNode,
+void SceneLoader::loadSourceRasters(TileSource& source, const Node& rasterNode,
                                     const Node& sources, Scene& scene) {
     if (rasterNode.IsSequence()) {
         for (const auto& raster : rasterNode) {
@@ -1115,7 +1113,7 @@ void SceneLoader::loadSourceRasters(std::shared_ptr<TileSource> &source, const N
                 LOGNode("Parsing sources: '%s'", sources[srcName], e.what());
                 return;
             }
-            source->addRasterSource(scene.getTileSource(srcName));
+            source.addRasterSource(scene.getTileSource(srcName));
         }
     }
 }
@@ -1618,7 +1616,7 @@ void SceneLoader::parseStyleParams(const Node& params, Scene& scene, const std::
     }
 }
 
-bool SceneLoader::parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& scene,
+bool SceneLoader::parseStyleUniforms(const Node& value, Scene& scene,
                                      StyleUniform& styleUniform) {
     if (value.IsScalar()) { // float, bool or string (texture)
         double fValue;
@@ -1635,7 +1633,7 @@ bool SceneLoader::parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& 
             styleUniform.type = "sampler2D";
             styleUniform.value = strVal;
 
-            scene->loadTexture(strVal);
+            scene.loadTexture(strVal);
         }
     } else if (value.IsSequence()) {
         size_t size = value.size();
@@ -1695,7 +1693,7 @@ bool SceneLoader::parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& 
                 const std::string& textureName = strVal.Scalar();
                 textureArrayUniform.names.push_back(textureName);
 
-                scene->loadTexture(textureName);
+                scene.loadTexture(textureName);
             }
 
             styleUniform.value = std::move(textureArrayUniform);
@@ -1708,12 +1706,14 @@ bool SceneLoader::parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& 
     return true;
 }
 
-void SceneLoader::parseTransition(const Node& params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out) {
+void SceneLoader::parseTransition(const Node& params, Scene& scene, std::string _prefix,
+                                  std::vector<StyleParam>& out) {
 
     // First iterate over the mapping of 'events', we currently recognize 'hide', 'selected', and 'show'.
     for (const auto& event : params) {
         if (!event.first.IsScalar() || !event.second.IsMap()) {
-            LOGW("Can't parse 'transitions' entry, expected a mapping of strings to mappings at: %s", _prefix.c_str());
+            LOGW("Can't parse 'transitions' entry, expected a mapping of strings to mappings at: %s",
+                 _prefix.c_str());
             continue;
         }
 
@@ -1723,7 +1723,8 @@ void SceneLoader::parseTransition(const Node& params, Scene& scene, std::string 
         // Iterate over the parameters in the 'event', we currently only recognize 'time'.
         for (const auto& param : event.second) {
             if (!param.first.IsScalar() || !param.second.IsScalar()) {
-                LOGW("Expected a mapping of strings to strings or numbers in: %s", transitionEvent.c_str());
+                LOGW("Expected a mapping of strings to strings or numbers in: %s",
+                     transitionEvent.c_str());
                 continue;
             }
             // Add the parameter to our key, so it's now 'transition:event:param'.

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -28,7 +28,6 @@
 #include "scene/stops.h"
 #include "scene/styleMixer.h"
 #include "scene/styleParam.h"
-#include "util/base64.h"
 #include "util/floatFormatter.h"
 #include "util/yamlPath.h"
 #include "util/yamlUtil.h"
@@ -99,7 +98,6 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
     LOGTime("applyCameras");
 
     _scene->initTileManager();
-    _scene->tileManager()->updateTileSets(*_scene->view());
     LOGTime("loadTiles");
 
     applyTextures(_scene);
@@ -127,10 +125,11 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
         style->build(*_scene);
     }
 
-    _scene->startTileWorker();
-
-
     LOGTime("built styles");
+
+    // Now only waiting for pending fonts and textures:
+    // Let the TileWorker initialize its TileBuilders
+    _scene->initTileWorker();
 
     return true;
 }
@@ -609,7 +608,7 @@ MaterialTexture SceneLoader::loadMaterialTexture(const Node& matCompNode, std::s
     const std::string& name = textureNode.Scalar();
 
     MaterialTexture matTex;
-    matTex.tex = getOrLoadTexture(name, scene);
+    matTex.tex = scene->loadTexture(name);
 
     if (const Node& mappingNode = matCompNode["mapping"]) {
         const std::string& mapping = mappingNode.Scalar();
@@ -680,81 +679,6 @@ bool SceneLoader::parseTexFiltering(const Node& filteringNode, TextureOptions& o
 }
 
 
-std::shared_ptr<Texture> SceneLoader::fetchTexture(const std::string& name, const std::string& urlString,
-                                                   const TextureOptions& options, std::shared_ptr<Scene>& scene,
-                                                   std::unique_ptr<SpriteAtlas> _atlas) {
-    std::shared_ptr<Texture> texture;
-
-    Url url(urlString);
-
-    if (url.hasBase64Data() && url.mediaType() == "image/png") {
-        auto data = url.data();
-
-        std::vector<unsigned char> blob;
-
-        try {
-            blob = Base64::decode(data);
-        } catch(std::runtime_error e) {
-            LOGE("Can't decode Base64 texture '%s'", e.what());
-        }
-
-        if (blob.empty()) {
-            LOGE("Can't decode Base64 texture");
-            return nullptr;
-        }
-        texture = std::make_shared<Texture>(options);
-
-        if (!texture->loadImageFromMemory(blob.data(), blob.size())) {
-            LOGE("Invalid Base64 texture");
-        }
-    } else {
-        texture = std::make_shared<Texture>(options);
-        texture->setSpriteAtlas(std::move(_atlas));
-
-        scene->pendingTextures++;
-        LOGTime("Fetch texture");
-        scene->startUrlRequest(url, [&, url, scene, texture](UrlResponse&& response) {
-                LOGTime("Got texture data");
-                if (response.error) {
-                    LOGE("Error retrieving URL '%s': %s", url.string().c_str(), response.error);
-                } else {
-                    if (texture) {
-                        auto data = reinterpret_cast<const uint8_t*>(response.content.data());
-                        auto length = response.content.size();
-                        if (!texture->loadImageFromMemory(data, length)) {
-                            LOGE("Invalid texture data from URL '%s'", url.string().c_str());
-                        }
-                        if (texture->getSpriteAtlas()) {
-                            texture->getSpriteAtlas()->updateSpriteNodes({texture->getWidth(), texture->getHeight()});
-                        }
-                    }
-                }
-                scene->pendingTextures--;
-                LOGTime("Got texture ready");
-                if (scene->pendingTextures == 0) {
-                    scene->platform().requestRender();
-                }
-            });
-    }
-
-    return texture;
-}
-
-std::shared_ptr<Texture> SceneLoader::getOrLoadTexture(const std::string& name, std::shared_ptr<Scene>& scene) {
-
-    auto entry = scene->textures().find(name);
-    if (entry != scene->textures().end()) {
-        return entry->second;
-    }
-
-    // If texture could not be found by name then interpret name as URL
-    TextureOptions options;
-    auto texture = fetchTexture(name, name, options, scene);
-
-    scene->textures().emplace(name, texture);
-
-    return texture;
-}
 
 void SceneLoader::loadTexture( const std::pair<Node, Node>& node, std::shared_ptr<Scene>& scene) {
 
@@ -808,9 +732,7 @@ void SceneLoader::loadTexture( const std::pair<Node, Node>& node, std::shared_pt
             }
         }
     }
-    auto texture = fetchTexture(name, url, options, scene, std::move(atlas));
-
-    scene->textures().emplace(name, texture);
+    auto texture = scene->fetchTexture(name, Url(url), options, std::move(atlas));
 }
 
 void SceneLoader::loadFontDescription(const Node& node, const std::string& family,
@@ -839,28 +761,7 @@ void SceneLoader::loadFontDescription(const Node& node, const std::string& famil
         return;
     }
 
-    std::string familyNormalized, styleNormalized;
-
-    familyNormalized.resize(family.size());
-    styleNormalized.resize(style.size());
-
-    std::transform(family.begin(), family.end(), familyNormalized.begin(), ::tolower);
-    std::transform(style.begin(), style.end(), styleNormalized.begin(), ::tolower);
-
-    FontDescription _ft(familyNormalized, styleNormalized, weight, uri);
-
-    Url url(uri);
-
-    // Load font file.
-    scene->pendingFonts++;
-    scene->startUrlRequest(url, [_ft, scene](UrlResponse&& response) {
-        if (response.error) {
-            LOGE("Error retrieving font '%s' at %s: ", _ft.alias.c_str(), _ft.uri.c_str(), response.error);
-        } else {
-            scene->fontContext()->addFont(_ft, alfons::InputSource(std::move(response.content)));
-        }
-        scene->pendingFonts--;
-    });
+    scene->loadFont(uri, family, style, weight);
 }
 
 void SceneLoader::loadFont(const std::pair<Node, Node>& font, std::shared_ptr<Scene>& scene) {
@@ -1734,7 +1635,7 @@ bool SceneLoader::parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& 
             styleUniform.type = "sampler2D";
             styleUniform.value = strVal;
 
-            getOrLoadTexture(strVal, scene);
+            scene->loadTexture(strVal);
         }
     } else if (value.IsSequence()) {
         size_t size = value.size();
@@ -1794,7 +1695,7 @@ bool SceneLoader::parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& 
                 const std::string& textureName = strVal.Scalar();
                 textureArrayUniform.names.push_back(textureName);
 
-                getOrLoadTexture(textureName, scene);
+                scene->loadTexture(textureName);
             }
 
             styleUniform.value = std::move(textureArrayUniform);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -82,10 +82,11 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
         return false;
     }
 
-    if (!applyUpdates(*_scene)) {
+    if (!applyUpdates(*_scene, _scene->options().updates)) {
         LOGW("Scene updates failed when loading scene");
         return false;
     }
+
     LOGTime("applyUpdates");
 
     applyGlobals(*_scene);
@@ -128,10 +129,10 @@ bool SceneLoader::loadScene(std::shared_ptr<Scene> _scene) {
     return true;
 }
 
-bool SceneLoader::applyUpdates(Scene& scene) {
+bool SceneLoader::applyUpdates(Scene& scene, const std::vector<SceneUpdate>& updates) {
     auto& root = scene.config();
 
-    for (const auto& update : scene.options().updates) {
+    for (const auto& update : updates) {
         Node value;
 
         try {

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -33,53 +33,53 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static bool loadScene(std::shared_ptr<Scene> _scene);
+    static bool loadScene(std::shared_ptr<Scene> scene);
 
     static bool applyUpdates(Scene& scene, const std::vector<SceneUpdate>& updates);
     static void applyGlobals(Scene& scene);
 
     static void applyScene(Scene& scene);
-    static void loadBackground(const Node& background, Scene& scene);
+    static void loadBackground(Scene& scene, const Node& background);
 
     static void applyCameras(Scene& scene);
-    static void loadCameras(const Node& cameras, Scene& scene);
-    static void loadCamera(const Node& camera, Scene& scene);
+    static void loadCameras(Scene& scene, const Node& cameras);
+    static void loadCamera(Scene& scene, const Node& camera);
 
     static void applyLights(Scene& scene);
-    static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
+    static void loadLight(Scene& scene, const std::pair<Node, Node>& light);
     static void parseLightPosition(const Node& positionNode, PointLight& light);
 
     static void applyTextures(Scene& scene);
-    static void loadTexture(const std::pair<Node, Node>& texture, Scene& scene);
+    static void loadTexture(Scene& scene, const std::pair<Node, Node>& texture);
     static bool parseTexFiltering(const Node& filteringNode, TextureOptions& options);
 
     static void applyFonts(Scene& scene);
-    static void loadFontDescription(const Node& node, const std::string& family, Scene& scene);
+    static void loadFontDescription(Scene& scene, const Node& node, const std::string& family);
 
     static void applySources(Scene& scene);
-    static void loadSource(const std::string& name, const Node& source, Scene& scene);
-    static void loadSourceRasters(TileSource& source, const Node& rasterNode, Scene& scene);
+    static void loadSource(Scene& scene, const std::string& name, const Node& source);
+    static void loadSourceRasters(Scene& scene, TileSource& source, const Node& rasterNode);
 
     static void applyStyles(Scene& scene);
-    static bool loadStyle(const std::string& styleName, const Node& config, Scene& scene);
-    static void loadStyleProps(Style& style, const Node& styleNode, Scene& scene);
-    static void parseStyleParams(const Node& params, Scene& scene, const std::string& propPrefix,
+    static bool loadStyle(Scene& scene, const std::string& styleName, const Node& config);
+    static void loadStyleProps(Scene& scene, Style& style, const Node& styleNode);
+    static void parseStyleParams(Scene& scene, const Node& params, const std::string& propPrefix,
                                  std::vector<StyleParam>& out);
-    static void parseTransition(const Node& params, Scene& scene, std::string _prefix,
+    static void parseTransition(Scene& scene, const Node& params, std::string prefix,
                                 std::vector<StyleParam>& out);
-    static void loadShaderConfig(const Node& shaders, Style& style, Scene& scene);
-    static bool parseStyleUniforms(const Node& value, Scene& scene, StyleUniform& styleUniform);
-    static void loadMaterial(const Node& matNode, Material& material, Scene& scene, Style& style);
-    static MaterialTexture loadMaterialTexture(const Node& matCompNode, Scene& scene, Style& style);
+    static void loadShaderConfig(Scene& scene, const Node& shaders, Style& style);
+    static bool parseStyleUniforms(Scene& scene, const Node& value, StyleUniform& styleUniform);
+    static void loadMaterial(Scene& scene, const Node& matNode, Material& material, Style& style);
+    static MaterialTexture loadMaterialTexture(Scene& scene, const Node& matCompNode, Style& style);
 
     static void applyLayers(Scene& scene);
-    static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
-    static SceneLayer loadSublayer(const Node& layer, const std::string& name, Scene& scene);
-    static Filter generateFilter(const Node& filter, Scene& scene);
-    static Filter generateAnyFilter(const Node& filter, Scene& scene);
-    static Filter generateAllFilter(const Node& filter, Scene& scene);
-    static Filter generateNoneFilter(const Node& filter, Scene& scene);
-    static Filter generatePredicate(const Node& filter, std::string _key);
+    static void loadLayer(Scene& scene, const std::pair<Node, Node>& layer);
+    static SceneLayer loadSublayer(Scene& scene, const Node& layer, const std::string& name);
+    static Filter generateFilter(Scene& scene, const Node& filter);
+    static Filter generateAnyFilter(Scene& scene, const Node& filter);
+    static Filter generateAllFilter(Scene& scene, const Node& filter);
+    static Filter generateNoneFilter(Scene& scene, const Node& filter);
+    static Filter generatePredicate(const Node& filter, std::string key);
     static bool getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea);
 
     SceneLoader() = delete;

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -39,59 +39,53 @@ struct SceneLoader {
 
     static bool loadScene(std::shared_ptr<Scene> _scene);
 
-    static void applyConfig(std::shared_ptr<Scene>& scene);
-    static void applyTextures(std::shared_ptr<Scene>& scene);
-    static void applyFonts(std::shared_ptr<Scene>& scene);
-    static void applyStyles(std::shared_ptr<Scene>& scene);
     static bool applyUpdates(Scene& scene, const std::vector<SceneUpdate>& updates);
     static void applyGlobals(Scene& scene);
-    static void applyCameras(Scene& scene);
-    static void applyLayers(Scene& scene);
-    static void applySources(Scene& scene);
-    static void applyLights(Scene& scene);
+
     static void applyScene(Scene& scene);
-
-    /*** all public for testing ***/
-
     static void loadBackground(const Node& background, Scene& scene);
-    static void loadSource(const std::string& name, const Node& source, const Node& sources, Scene& scene);
-    static void loadSourceRasters(std::shared_ptr<TileSource>& source, const Node& rasterNode, const Node& sources, Scene& scene);
-    static void loadTexture(const std::pair<Node, Node>& texture, std::shared_ptr<Scene>& scene);
-    static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
-    static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
+
+    static void applyCameras(Scene& scene);
     static void loadCameras(const Node& cameras, Scene& scene);
     static void loadCamera(const Node& camera, Scene& scene);
+
+    static void applyLights(Scene& scene);
+    static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
+    static void parseLightPosition(const Node& positionNode, PointLight& light);
+
+    static void applySources(Scene& scene);
+    static void loadSource(const std::string& name, const Node& source, const Node& sources, Scene& scene);
+    static void loadSourceRasters(std::shared_ptr<TileSource>& source, const Node& rasterNode, const Node& sources, Scene& scene);
+
+    static void applyStyles(std::shared_ptr<Scene>& scene);
+    static bool loadStyle(const std::string& styleName, const Node& config, std::shared_ptr<Scene>& scene);
     static void loadStyleProps(Style& style, const Node& styleNode, std::shared_ptr<Scene>& scene);
+    static void parseStyleParams(const Node& params, Scene& scene, const std::string& propPrefix, std::vector<StyleParam>& out);
+    static void parseTransition(const Node& params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out);
     static void loadMaterial(const Node& matNode, Material& material, std::shared_ptr<Scene>& scene, Style& style);
     static void loadShaderConfig(const Node& shaders, Style& style, std::shared_ptr<Scene>& scene);
+    static bool parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
+    static MaterialTexture loadMaterialTexture(const Node& matCompNode, std::shared_ptr<Scene>& scene, Style& style);
+
+    static void applyTextures(std::shared_ptr<Scene>& scene);
+    static void loadTexture(const std::pair<Node, Node>& texture, std::shared_ptr<Scene>& scene);
+
+    static void applyFonts(std::shared_ptr<Scene>& scene);
     static void loadFont(const std::pair<Node, Node>& font, std::shared_ptr<Scene>& scene);
     static void loadFontDescription(const Node& node, const std::string& family, std::shared_ptr<Scene>& scene);
+
+    static void applyLayers(Scene& scene);
+    static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static SceneLayer loadSublayer(const Node& layer, const std::string& name, Scene& scene);
+
     static Filter generateFilter(const Node& filter, Scene& scene);
     static Filter generateAnyFilter(const Node& filter, Scene& scene);
     static Filter generateAllFilter(const Node& filter, Scene& scene);
     static Filter generateNoneFilter(const Node& filter, Scene& scene);
     static Filter generatePredicate(const Node& filter, std::string _key);
     static bool getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea);
-    /* loads a texture with default texture properties */
-    static std::shared_ptr<Texture> getOrLoadTexture(const std::string& url, std::shared_ptr<Scene>& scene);
-    static std::shared_ptr<Texture> fetchTexture(const std::string& name, const std::string& url,
-                                                 const TextureOptions& options, std::shared_ptr<Scene>& scene,
-                                                 std::unique_ptr<SpriteAtlas> _atlas = nullptr);
 
     static bool parseTexFiltering(const Node& filteringNode, TextureOptions& options);
-
-    static MaterialTexture loadMaterialTexture(const Node& matCompNode, std::shared_ptr<Scene>& scene, Style& style);
-
-    static void parseStyleParams(const Node& params, Scene& scene, const std::string& propPrefix, std::vector<StyleParam>& out);
-    static void parseTransition(const Node& params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out);
-
-    static bool parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
-
-    static void parseLightPosition(const Node& positionNode, PointLight& light);
-
-    static bool loadStyle(const std::string& styleName, const Node& config, std::shared_ptr<Scene>& scene);
-
 
     SceneLoader() = delete;
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -16,13 +16,9 @@ namespace Tangram {
 class Material;
 class PointLight;
 class SceneLayer;
-class ShaderProgram;
-class SpriteAtlas;
 class Style;
 class Texture;
-class TileManager;
 class TileSource;
-class View;
 struct Filter;
 struct MaterialTexture;
 struct StyleParam;
@@ -53,9 +49,16 @@ struct SceneLoader {
     static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
     static void parseLightPosition(const Node& positionNode, PointLight& light);
 
+    static void applyTextures(Scene& scene);
+    static void loadTexture(const std::pair<Node, Node>& texture, Scene& scene);
+    static bool parseTexFiltering(const Node& filteringNode, TextureOptions& options);
+
+    static void applyFonts(Scene& scene);
+    static void loadFontDescription(const Node& node, const std::string& family, Scene& scene);
+
     static void applySources(Scene& scene);
-    static void loadSource(const std::string& name, const Node& source, const Node& sources, Scene& scene);
-    static void loadSourceRasters(TileSource& source, const Node& rasterNode, const Node& sources, Scene& scene);
+    static void loadSource(const std::string& name, const Node& source, Scene& scene);
+    static void loadSourceRasters(TileSource& source, const Node& rasterNode, Scene& scene);
 
     static void applyStyles(Scene& scene);
     static bool loadStyle(const std::string& styleName, const Node& config, Scene& scene);
@@ -69,24 +72,15 @@ struct SceneLoader {
     static void loadMaterial(const Node& matNode, Material& material, Scene& scene, Style& style);
     static MaterialTexture loadMaterialTexture(const Node& matCompNode, Scene& scene, Style& style);
 
-    static void applyTextures(Scene& scene);
-    static void loadTexture(const std::pair<Node, Node>& texture, Scene& scene);
-
-    static void applyFonts(Scene& scene);
-    static void loadFontDescription(const Node& node, const std::string& family, Scene& scene);
-
     static void applyLayers(Scene& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static SceneLayer loadSublayer(const Node& layer, const std::string& name, Scene& scene);
-
     static Filter generateFilter(const Node& filter, Scene& scene);
     static Filter generateAnyFilter(const Node& filter, Scene& scene);
     static Filter generateAllFilter(const Node& filter, Scene& scene);
     static Filter generateNoneFilter(const Node& filter, Scene& scene);
     static Filter generatePredicate(const Node& filter, std::string _key);
     static bool getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea);
-
-    static bool parseTexFiltering(const Node& filteringNode, TextureOptions& options);
 
     SceneLoader() = delete;
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -48,6 +48,8 @@ struct SceneLoader {
     static void applyCameras(Scene& scene);
     static void applyLayers(Scene& scene);
     static void applySources(Scene& scene);
+    static void applyLights(Scene& scene);
+    static void applyScene(Scene& scene);
 
     /*** all public for testing ***/
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -51,25 +51,25 @@ struct SceneLoader {
 
     /*** all public for testing ***/
 
-    static void loadBackground(Node background, Scene& scene);
+    static void loadBackground(const Node& background, Scene& scene);
     static void loadSource(const std::string& name, const Node& source, const Node& sources, Scene& scene);
-    static void loadSourceRasters(std::shared_ptr<TileSource>& source, Node rasterNode, const Node& sources, Scene& scene);
+    static void loadSourceRasters(std::shared_ptr<TileSource>& source, const Node& rasterNode, const Node& sources, Scene& scene);
     static void loadTexture(const std::pair<Node, Node>& texture, std::shared_ptr<Scene>& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
     static void loadCameras(const Node& cameras, Scene& scene);
     static void loadCamera(const Node& camera, Scene& scene);
-    static void loadStyleProps(Style& style, Node styleNode, std::shared_ptr<Scene>& scene);
-    static void loadMaterial(Node matNode, Material& material, std::shared_ptr<Scene>& scene, Style& style);
-    static void loadShaderConfig(Node shaders, Style& style, std::shared_ptr<Scene>& scene);
+    static void loadStyleProps(Style& style, const Node& styleNode, std::shared_ptr<Scene>& scene);
+    static void loadMaterial(const Node& matNode, Material& material, std::shared_ptr<Scene>& scene, Style& style);
+    static void loadShaderConfig(const Node& shaders, Style& style, std::shared_ptr<Scene>& scene);
     static void loadFont(const std::pair<Node, Node>& font, std::shared_ptr<Scene>& scene);
     static void loadFontDescription(const Node& node, const std::string& family, std::shared_ptr<Scene>& scene);
     static SceneLayer loadSublayer(const Node& layer, const std::string& name, Scene& scene);
-    static Filter generateFilter(Node filter, Scene& scene);
-    static Filter generateAnyFilter(Node filter, Scene& scene);
-    static Filter generateAllFilter(Node filter, Scene& scene);
-    static Filter generateNoneFilter(Node filter, Scene& scene);
-    static Filter generatePredicate(Node filter, std::string _key);
+    static Filter generateFilter(const Node& filter, Scene& scene);
+    static Filter generateAnyFilter(const Node& filter, Scene& scene);
+    static Filter generateAllFilter(const Node& filter, Scene& scene);
+    static Filter generateNoneFilter(const Node& filter, Scene& scene);
+    static Filter generatePredicate(const Node& filter, std::string _key);
     static bool getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea);
     /* loads a texture with default texture properties */
     static std::shared_ptr<Texture> getOrLoadTexture(const std::string& url, std::shared_ptr<Scene>& scene);
@@ -77,18 +77,18 @@ struct SceneLoader {
                                                  const TextureOptions& options, std::shared_ptr<Scene>& scene,
                                                  std::unique_ptr<SpriteAtlas> _atlas = nullptr);
 
-    static bool parseTexFiltering(Node& filteringNode, TextureOptions& options);
+    static bool parseTexFiltering(const Node& filteringNode, TextureOptions& options);
 
-    static MaterialTexture loadMaterialTexture(Node matCompNode, std::shared_ptr<Scene>& scene, Style& style);
+    static MaterialTexture loadMaterialTexture(const Node& matCompNode, std::shared_ptr<Scene>& scene, Style& style);
 
-    static void parseStyleParams(Node params, Scene& scene, const std::string& propPrefix, std::vector<StyleParam>& out);
-    static void parseTransition(Node params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out);
+    static void parseStyleParams(const Node& params, Scene& scene, const std::string& propPrefix, std::vector<StyleParam>& out);
+    static void parseTransition(const Node& params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out);
 
     static bool parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
 
-    static void parseLightPosition(Node positionNode, PointLight& light);
+    static void parseLightPosition(const Node& positionNode, PointLight& light);
 
-    static bool loadStyle(const std::string& styleName, Node config, std::shared_ptr<Scene>& scene);
+    static bool loadStyle(const std::string& styleName, const Node& config, std::shared_ptr<Scene>& scene);
 
 
     SceneLoader() = delete;

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -55,24 +55,25 @@ struct SceneLoader {
 
     static void applySources(Scene& scene);
     static void loadSource(const std::string& name, const Node& source, const Node& sources, Scene& scene);
-    static void loadSourceRasters(std::shared_ptr<TileSource>& source, const Node& rasterNode, const Node& sources, Scene& scene);
+    static void loadSourceRasters(TileSource& source, const Node& rasterNode, const Node& sources, Scene& scene);
 
-    static void applyStyles(std::shared_ptr<Scene>& scene);
-    static bool loadStyle(const std::string& styleName, const Node& config, std::shared_ptr<Scene>& scene);
-    static void loadStyleProps(Style& style, const Node& styleNode, std::shared_ptr<Scene>& scene);
-    static void parseStyleParams(const Node& params, Scene& scene, const std::string& propPrefix, std::vector<StyleParam>& out);
-    static void parseTransition(const Node& params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out);
-    static void loadMaterial(const Node& matNode, Material& material, std::shared_ptr<Scene>& scene, Style& style);
-    static void loadShaderConfig(const Node& shaders, Style& style, std::shared_ptr<Scene>& scene);
-    static bool parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
-    static MaterialTexture loadMaterialTexture(const Node& matCompNode, std::shared_ptr<Scene>& scene, Style& style);
+    static void applyStyles(Scene& scene);
+    static bool loadStyle(const std::string& styleName, const Node& config, Scene& scene);
+    static void loadStyleProps(Style& style, const Node& styleNode, Scene& scene);
+    static void parseStyleParams(const Node& params, Scene& scene, const std::string& propPrefix,
+                                 std::vector<StyleParam>& out);
+    static void parseTransition(const Node& params, Scene& scene, std::string _prefix,
+                                std::vector<StyleParam>& out);
+    static void loadShaderConfig(const Node& shaders, Style& style, Scene& scene);
+    static bool parseStyleUniforms(const Node& value, Scene& scene, StyleUniform& styleUniform);
+    static void loadMaterial(const Node& matNode, Material& material, Scene& scene, Style& style);
+    static MaterialTexture loadMaterialTexture(const Node& matCompNode, Scene& scene, Style& style);
 
-    static void applyTextures(std::shared_ptr<Scene>& scene);
-    static void loadTexture(const std::pair<Node, Node>& texture, std::shared_ptr<Scene>& scene);
+    static void applyTextures(Scene& scene);
+    static void loadTexture(const std::pair<Node, Node>& texture, Scene& scene);
 
-    static void applyFonts(std::shared_ptr<Scene>& scene);
-    static void loadFont(const std::pair<Node, Node>& font, std::shared_ptr<Scene>& scene);
-    static void loadFontDescription(const Node& node, const std::string& family, std::shared_ptr<Scene>& scene);
+    static void applyFonts(Scene& scene);
+    static void loadFontDescription(const Node& node, const std::string& family, Scene& scene);
 
     static void applyLayers(Scene& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -49,14 +49,14 @@ struct SceneLoader {
 
     /*** all public for testing ***/
 
-    static void loadBackground(Node background, const std::shared_ptr<Scene>& scene);
+    static void loadBackground(Node background, Scene& scene);
     static void loadSource(const std::shared_ptr<Platform>& platform, const std::string& name,
                            const Node& source, const Node& sources, Scene& scene);
     static void loadSourceRasters(const std::shared_ptr<Platform>& platform, std::shared_ptr<TileSource>& source, Node rasterNode,
                                   const Node& sources, Scene& scene);
     static void loadTexture(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& texture, const std::shared_ptr<Scene>& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
-    static void loadLight(const std::pair<Node, Node>& light, const std::shared_ptr<Scene>& scene);
+    static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
     static void loadCameras(const Node& cameras, Scene& scene);
     static void loadCamera(const Node& camera, Scene& scene);
     static void loadStyleProps(const std::shared_ptr<Platform>& platform, Style& style, Node styleNode, const std::shared_ptr<Scene>& scene);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -40,10 +40,11 @@ struct SceneLoader {
     static bool loadScene(const std::shared_ptr<Platform>& _platform, std::shared_ptr<Scene> _scene,
                           const std::vector<SceneUpdate>& updates = {});
 
-    static bool applyConfig(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
+    static void applyConfig(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
     static bool applyUpdates(const std::shared_ptr<Platform>& platform, Scene& scene,
                              const std::vector<SceneUpdate>& updates);
     static void applyGlobals(Scene& scene);
+    static void applyCameras(Scene& scene);
     static void applySources(const std::shared_ptr<Platform>& _platform, Scene& scene);
 
     /*** all public for testing ***/
@@ -56,8 +57,8 @@ struct SceneLoader {
     static void loadTexture(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& texture, const std::shared_ptr<Scene>& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static void loadLight(const std::pair<Node, Node>& light, const std::shared_ptr<Scene>& scene);
-    static void loadCameras(Node cameras, const std::shared_ptr<Scene>& scene);
-    static void loadCamera(const Node& camera, const std::shared_ptr<Scene>& scene);
+    static void loadCameras(const Node& cameras, Scene& scene);
+    static void loadCamera(const Node& camera, Scene& scene);
     static void loadStyleProps(const std::shared_ptr<Platform>& platform, Style& style, Node styleNode, const std::shared_ptr<Scene>& scene);
     static void loadMaterial(const std::shared_ptr<Platform>& platform, Node matNode, Material& material, const std::shared_ptr<Scene>& scene, Style& style);
     static void loadShaderConfig(const std::shared_ptr<Platform>& platform, Node shaders, Style& style, const std::shared_ptr<Scene>& scene);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -37,35 +37,33 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static bool loadScene(Platform& _platform, std::shared_ptr<Scene> _scene,
-                          const std::vector<SceneUpdate>& updates = {});
+    static bool loadScene(std::shared_ptr<Scene> _scene);
 
-    static void applyConfig(Platform& platform, const std::shared_ptr<Scene>& scene);
-    static void applyTextures(Platform& platform, const std::shared_ptr<Scene>& scene);
-    static void applyFonts(Platform& platform, const std::shared_ptr<Scene>& scene);
-    static void applyStyles(Platform& platform, const std::shared_ptr<Scene>& scene);
-    static bool applyUpdates(Platform& platform, Scene& scene, const std::vector<SceneUpdate>& updates);
+    static void applyConfig(std::shared_ptr<Scene>& scene);
+    static void applyTextures(std::shared_ptr<Scene>& scene);
+    static void applyFonts(std::shared_ptr<Scene>& scene);
+    static void applyStyles(std::shared_ptr<Scene>& scene);
+    static bool applyUpdates(Scene& scene);
     static void applyGlobals(Scene& scene);
     static void applyCameras(Scene& scene);
     static void applyLayers(Scene& scene);
-    static void applySources(Platform& _platform, Scene& scene);
+    static void applySources(Scene& scene);
 
     /*** all public for testing ***/
 
     static void loadBackground(Node background, Scene& scene);
-    static void loadSource(Platform& platform, const std::string& name,
-                           const Node& source, const Node& sources, Scene& scene);
-    static void loadSourceRasters(Platform& platform, std::shared_ptr<TileSource>& source, Node rasterNode,
-                                  const Node& sources, Scene& scene);
-    static void loadTexture(Platform& platform, const std::pair<Node, Node>& texture, const std::shared_ptr<Scene>& scene);
+    static void loadSource(const std::string& name, const Node& source, const Node& sources, Scene& scene);
+    static void loadSourceRasters(std::shared_ptr<TileSource>& source, Node rasterNode, const Node& sources, Scene& scene);
+    static void loadTexture(const std::pair<Node, Node>& texture, std::shared_ptr<Scene>& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
     static void loadCameras(const Node& cameras, Scene& scene);
     static void loadCamera(const Node& camera, Scene& scene);
-    static void loadStyleProps(Platform& platform, Style& style, Node styleNode, const std::shared_ptr<Scene>& scene);
-    static void loadMaterial(Platform& platform, Node matNode, Material& material, const std::shared_ptr<Scene>& scene, Style& style);
-    static void loadShaderConfig(Platform& platform, Node shaders, Style& style, const std::shared_ptr<Scene>& scene);
-    static void loadFont(Platform& platform, const std::pair<Node, Node>& font, const std::shared_ptr<Scene>& scene);
+    static void loadStyleProps(Style& style, Node styleNode, std::shared_ptr<Scene>& scene);
+    static void loadMaterial(Node matNode, Material& material, std::shared_ptr<Scene>& scene, Style& style);
+    static void loadShaderConfig(Node shaders, Style& style, std::shared_ptr<Scene>& scene);
+    static void loadFont(const std::pair<Node, Node>& font, std::shared_ptr<Scene>& scene);
+    static void loadFontDescription(const Node& node, const std::string& family, std::shared_ptr<Scene>& scene);
     static SceneLayer loadSublayer(const Node& layer, const std::string& name, Scene& scene);
     static Filter generateFilter(Node filter, Scene& scene);
     static Filter generateAnyFilter(Node filter, Scene& scene);
@@ -74,26 +72,24 @@ struct SceneLoader {
     static Filter generatePredicate(Node filter, std::string _key);
     static bool getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea);
     /* loads a texture with default texture properties */
-    static std::shared_ptr<Texture> getOrLoadTexture(Platform& platform, const std::string& url, const std::shared_ptr<Scene>& scene);
-    static std::shared_ptr<Texture> fetchTexture(Platform& platform, const std::string& name, const std::string& url,
-                                                 const TextureOptions& options, const std::shared_ptr<Scene>& scene,
+    static std::shared_ptr<Texture> getOrLoadTexture(const std::string& url, std::shared_ptr<Scene>& scene);
+    static std::shared_ptr<Texture> fetchTexture(const std::string& name, const std::string& url,
+                                                 const TextureOptions& options, std::shared_ptr<Scene>& scene,
                                                  std::unique_ptr<SpriteAtlas> _atlas = nullptr);
 
     static bool parseTexFiltering(Node& filteringNode, TextureOptions& options);
 
-    static MaterialTexture loadMaterialTexture(Platform& platform, Node matCompNode,
-                                               const std::shared_ptr<Scene>& scene, Style& style);
+    static MaterialTexture loadMaterialTexture(Node matCompNode, std::shared_ptr<Scene>& scene, Style& style);
 
     static void parseStyleParams(Node params, Scene& scene, const std::string& propPrefix, std::vector<StyleParam>& out);
     static void parseTransition(Node params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out);
 
-    static bool parseStyleUniforms(Platform& platform, const Node& value,
-                                   const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
+    static bool parseStyleUniforms(const Node& value, std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
 
     static void parseLightPosition(Node positionNode, PointLight& light);
 
-    static bool loadStyle(Platform& platform, const std::string& styleName,
-                          Node config, const std::shared_ptr<Scene>& scene);
+    static bool loadStyle(const std::string& styleName, Node config, std::shared_ptr<Scene>& scene);
+
 
     SceneLoader() = delete;
 

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -54,7 +54,7 @@ struct SceneLoader {
     static void loadSourceRasters(const std::shared_ptr<Platform>& platform, std::shared_ptr<TileSource>& source, Node rasterNode,
                                   const Node& sources, Scene& scene);
     static void loadTexture(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& texture, const std::shared_ptr<Scene>& scene);
-    static void loadLayer(const std::pair<Node, Node>& layer, const std::shared_ptr<Scene>& scene);
+    static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static void loadLight(const std::pair<Node, Node>& light, const std::shared_ptr<Scene>& scene);
     static void loadCameras(Node cameras, const std::shared_ptr<Scene>& scene);
     static void loadCamera(const Node& camera, const std::shared_ptr<Scene>& scene);
@@ -62,7 +62,7 @@ struct SceneLoader {
     static void loadMaterial(const std::shared_ptr<Platform>& platform, Node matNode, Material& material, const std::shared_ptr<Scene>& scene, Style& style);
     static void loadShaderConfig(const std::shared_ptr<Platform>& platform, Node shaders, Style& style, const std::shared_ptr<Scene>& scene);
     static void loadFont(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& font, const std::shared_ptr<Scene>& scene);
-    static SceneLayer loadSublayer(const Node& layer, const std::string& name, const std::shared_ptr<Scene>& scene);
+    static SceneLayer loadSublayer(const Node& layer, const std::string& name, Scene& scene);
     static Filter generateFilter(Node filter, Scene& scene);
     static Filter generateAnyFilter(Node filter, Scene& scene);
     static Filter generateAllFilter(Node filter, Scene& scene);
@@ -80,9 +80,8 @@ struct SceneLoader {
     static MaterialTexture loadMaterialTexture(const std::shared_ptr<Platform>& platform, Node matCompNode,
                                                const std::shared_ptr<Scene>& scene, Style& style);
 
-    static void parseStyleParams(Node params, const std::shared_ptr<Scene>& scene, const std::string& propPrefix,
-                                 std::vector<StyleParam>& out);
-    static void parseTransition(Node params, const std::shared_ptr<Scene>& scene, std::string _prefix, std::vector<StyleParam>& out);
+    static void parseStyleParams(Node params, Scene& scene, const std::string& propPrefix, std::vector<StyleParam>& out);
+    static void parseTransition(Node params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out);
 
     static bool parseStyleUniforms(const std::shared_ptr<Platform>& platform, const Node& value,
                                    const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -43,15 +43,16 @@ struct SceneLoader {
     static bool applyConfig(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
     static bool applyUpdates(const std::shared_ptr<Platform>& platform, Scene& scene,
                              const std::vector<SceneUpdate>& updates);
-    static void applyGlobals(Node root, Scene& scene);
+    static void applyGlobals(Scene& scene);
+    static void applySources(const std::shared_ptr<Platform>& _platform, Scene& scene);
 
     /*** all public for testing ***/
 
     static void loadBackground(Node background, const std::shared_ptr<Scene>& scene);
     static void loadSource(const std::shared_ptr<Platform>& platform, const std::string& name,
-                           const Node& source, const Node& sources, const std::shared_ptr<Scene>& scene);
+                           const Node& source, const Node& sources, Scene& scene);
     static void loadSourceRasters(const std::shared_ptr<Platform>& platform, std::shared_ptr<TileSource>& source, Node rasterNode,
-                                  const Node& sources, const std::shared_ptr<Scene>& scene);
+                                  const Node& sources, Scene& scene);
     static void loadTexture(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& texture, const std::shared_ptr<Scene>& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, const std::shared_ptr<Scene>& scene);
     static void loadLight(const std::pair<Node, Node>& light, const std::shared_ptr<Scene>& scene);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -43,7 +43,7 @@ struct SceneLoader {
     static void applyTextures(std::shared_ptr<Scene>& scene);
     static void applyFonts(std::shared_ptr<Scene>& scene);
     static void applyStyles(std::shared_ptr<Scene>& scene);
-    static bool applyUpdates(Scene& scene);
+    static bool applyUpdates(Scene& scene, const std::vector<SceneUpdate>& updates);
     static void applyGlobals(Scene& scene);
     static void applyCameras(Scene& scene);
     static void applyLayers(Scene& scene);

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -37,36 +37,35 @@ struct StyleUniform {
 struct SceneLoader {
     using Node = YAML::Node;
 
-    static bool loadScene(const std::shared_ptr<Platform>& _platform, std::shared_ptr<Scene> _scene,
+    static bool loadScene(Platform& _platform, std::shared_ptr<Scene> _scene,
                           const std::vector<SceneUpdate>& updates = {});
 
-    static void applyConfig(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
-    static void applyTextures(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
-    static void applyFonts(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
-    static void applyStyles(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
-    static bool applyUpdates(const std::shared_ptr<Platform>& platform, Scene& scene,
-                             const std::vector<SceneUpdate>& updates);
+    static void applyConfig(Platform& platform, const std::shared_ptr<Scene>& scene);
+    static void applyTextures(Platform& platform, const std::shared_ptr<Scene>& scene);
+    static void applyFonts(Platform& platform, const std::shared_ptr<Scene>& scene);
+    static void applyStyles(Platform& platform, const std::shared_ptr<Scene>& scene);
+    static bool applyUpdates(Platform& platform, Scene& scene, const std::vector<SceneUpdate>& updates);
     static void applyGlobals(Scene& scene);
     static void applyCameras(Scene& scene);
     static void applyLayers(Scene& scene);
-    static void applySources(const std::shared_ptr<Platform>& _platform, Scene& scene);
+    static void applySources(Platform& _platform, Scene& scene);
 
     /*** all public for testing ***/
 
     static void loadBackground(Node background, Scene& scene);
-    static void loadSource(const std::shared_ptr<Platform>& platform, const std::string& name,
+    static void loadSource(Platform& platform, const std::string& name,
                            const Node& source, const Node& sources, Scene& scene);
-    static void loadSourceRasters(const std::shared_ptr<Platform>& platform, std::shared_ptr<TileSource>& source, Node rasterNode,
+    static void loadSourceRasters(Platform& platform, std::shared_ptr<TileSource>& source, Node rasterNode,
                                   const Node& sources, Scene& scene);
-    static void loadTexture(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& texture, const std::shared_ptr<Scene>& scene);
+    static void loadTexture(Platform& platform, const std::pair<Node, Node>& texture, const std::shared_ptr<Scene>& scene);
     static void loadLayer(const std::pair<Node, Node>& layer, Scene& scene);
     static void loadLight(const std::pair<Node, Node>& light, Scene& scene);
     static void loadCameras(const Node& cameras, Scene& scene);
     static void loadCamera(const Node& camera, Scene& scene);
-    static void loadStyleProps(const std::shared_ptr<Platform>& platform, Style& style, Node styleNode, const std::shared_ptr<Scene>& scene);
-    static void loadMaterial(const std::shared_ptr<Platform>& platform, Node matNode, Material& material, const std::shared_ptr<Scene>& scene, Style& style);
-    static void loadShaderConfig(const std::shared_ptr<Platform>& platform, Node shaders, Style& style, const std::shared_ptr<Scene>& scene);
-    static void loadFont(const std::shared_ptr<Platform>& platform, const std::pair<Node, Node>& font, const std::shared_ptr<Scene>& scene);
+    static void loadStyleProps(Platform& platform, Style& style, Node styleNode, const std::shared_ptr<Scene>& scene);
+    static void loadMaterial(Platform& platform, Node matNode, Material& material, const std::shared_ptr<Scene>& scene, Style& style);
+    static void loadShaderConfig(Platform& platform, Node shaders, Style& style, const std::shared_ptr<Scene>& scene);
+    static void loadFont(Platform& platform, const std::pair<Node, Node>& font, const std::shared_ptr<Scene>& scene);
     static SceneLayer loadSublayer(const Node& layer, const std::string& name, Scene& scene);
     static Filter generateFilter(Node filter, Scene& scene);
     static Filter generateAnyFilter(Node filter, Scene& scene);
@@ -75,25 +74,25 @@ struct SceneLoader {
     static Filter generatePredicate(Node filter, std::string _key);
     static bool getFilterRangeValue(const Node& node, double& val, bool& hasPixelArea);
     /* loads a texture with default texture properties */
-    static std::shared_ptr<Texture> getOrLoadTexture(const std::shared_ptr<Platform>& platform, const std::string& url, const std::shared_ptr<Scene>& scene);
-    static std::shared_ptr<Texture> fetchTexture(const std::shared_ptr<Platform>& platform, const std::string& name, const std::string& url,
+    static std::shared_ptr<Texture> getOrLoadTexture(Platform& platform, const std::string& url, const std::shared_ptr<Scene>& scene);
+    static std::shared_ptr<Texture> fetchTexture(Platform& platform, const std::string& name, const std::string& url,
                                                  const TextureOptions& options, const std::shared_ptr<Scene>& scene,
                                                  std::unique_ptr<SpriteAtlas> _atlas = nullptr);
 
     static bool parseTexFiltering(Node& filteringNode, TextureOptions& options);
 
-    static MaterialTexture loadMaterialTexture(const std::shared_ptr<Platform>& platform, Node matCompNode,
+    static MaterialTexture loadMaterialTexture(Platform& platform, Node matCompNode,
                                                const std::shared_ptr<Scene>& scene, Style& style);
 
     static void parseStyleParams(Node params, Scene& scene, const std::string& propPrefix, std::vector<StyleParam>& out);
     static void parseTransition(Node params, Scene& scene, std::string _prefix, std::vector<StyleParam>& out);
 
-    static bool parseStyleUniforms(const std::shared_ptr<Platform>& platform, const Node& value,
+    static bool parseStyleUniforms(Platform& platform, const Node& value,
                                    const std::shared_ptr<Scene>& scene, StyleUniform& styleUniform);
 
     static void parseLightPosition(Node positionNode, PointLight& light);
 
-    static bool loadStyle(const std::shared_ptr<Platform>& platform, const std::string& styleName,
+    static bool loadStyle(Platform& platform, const std::string& styleName,
                           Node config, const std::shared_ptr<Scene>& scene);
 
     SceneLoader() = delete;

--- a/core/src/scene/sceneLoader.h
+++ b/core/src/scene/sceneLoader.h
@@ -41,10 +41,14 @@ struct SceneLoader {
                           const std::vector<SceneUpdate>& updates = {});
 
     static void applyConfig(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
+    static void applyTextures(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
+    static void applyFonts(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
+    static void applyStyles(const std::shared_ptr<Platform>& platform, const std::shared_ptr<Scene>& scene);
     static bool applyUpdates(const std::shared_ptr<Platform>& platform, Scene& scene,
                              const std::vector<SceneUpdate>& updates);
     static void applyGlobals(Scene& scene);
     static void applyCameras(Scene& scene);
+    static void applyLayers(Scene& scene);
     static void applySources(const std::shared_ptr<Platform>& _platform, Scene& scene);
 
     /*** all public for testing ***/

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -284,7 +284,25 @@ StyleParam::Value StyleParam::parseNode(StyleParamKey key, const YAML::Node& nod
         LOGW("text:order parameter is ignored.");
         break;
     case StyleParamKey::order:
-    case StyleParamKey::outline_order:
+    case StyleParamKey::outline_order: {
+        int result = -1;
+        if (YamlUtil::getInt(node, result)) {
+            if (result >= 0) {
+                return static_cast<uint32_t>(result);
+            }
+        } else if (node.IsSequence()) {
+            LOGW("NumberProperty '%s' value '%s'", keyName(key).c_str(), Dump(node).c_str());
+            if (node.size() == 1 && node[0].IsScalar()) {
+                return NumberProperty{node[0].Scalar(),0};
+            }
+            if (node.size() == 2 && node[0].IsScalar() &&
+                YamlUtil::getInt(node[1], result)) {
+                return NumberProperty{node[0].Scalar(), result};
+            }
+        }
+        LOGW("Invalid '%s' value '%s'", keyName(key).c_str(), Dump(node).c_str());
+        break;
+    }
     case StyleParamKey::priority:
     case StyleParamKey::text_max_lines:
     case StyleParamKey::text_priority: {

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -189,6 +189,21 @@ struct StyleParam {
         }
     };
 
+    struct NumberProperty {
+        std::string key;
+        int offset;
+        bool operator==(const NumberProperty& _other) const {
+            return key == _other.key && offset == _other.offset;
+        }
+    };
+
+    struct StringProperty {
+        std::string key;
+        bool operator==(const StringProperty& _other) const {
+            return key == _other.key;
+        }
+    };
+
     struct SizeValue {
         ValueUnitPair x = { NAN, Unit::pixel };
         ValueUnitPair y = { NAN, Unit::pixel };
@@ -227,8 +242,10 @@ struct StyleParam {
         }
     };
 
-    using Value = variant<none_type, Undefined, bool, float, uint32_t, std::string, glm::vec2, SizeValue, Width,
-                          LabelProperty::Placement, LabelProperty::Anchors, TextSource>;
+    using Value = variant<none_type, Undefined, bool, float, uint32_t,
+                          std::string, glm::vec2, SizeValue, Width,
+                          LabelProperty::Placement, LabelProperty::Anchors,
+                          TextSource, NumberProperty, StringProperty>;
 
     StyleParam() :
         key(StyleParamKey::none),

--- a/core/src/selection/selectionQuery.cpp
+++ b/core/src/selection/selectionQuery.cpp
@@ -2,7 +2,7 @@
 
 #include "gl/framebuffer.h"
 #include "labels/label.h"
-#include "labels/labels.h"
+#include "labels/labelManager.h"
 #include "marker/marker.h"
 #include "marker/markerManager.h"
 #include "tile/tileManager.h"
@@ -21,7 +21,7 @@ QueryType SelectionQuery::type() const {
 }
 
 void SelectionQuery::process(const View& _view, const FrameBuffer& _framebuffer, const MarkerManager& _markerManager,
-                             const TileManager& _tileManager, const Labels& _labels, std::vector<SelectionColorRead>& _colorCache) const {
+                             const TileManager& _tileManager, const LabelManager& _labels, std::vector<SelectionColorRead>& _colorCache) const {
 
     float radius = m_radius * _view.pixelScale();
     glm::vec2 windowCoordinates = _view.normalizedWindowCoordinates(m_position.x - radius, m_position.y + radius);

--- a/core/src/selection/selectionQuery.h
+++ b/core/src/selection/selectionQuery.h
@@ -9,7 +9,7 @@ namespace Tangram {
 class MarkerManager;
 class FrameBuffer;
 class TileManager;
-class Labels;
+class LabelManager;
 class View;
 
 enum class QueryType {
@@ -32,7 +32,8 @@ public:
     SelectionQuery(glm::vec2 _position, float _radius, QueryCallback _queryCallback);
 
     void process(const View& _view, const FrameBuffer& _framebuffer, const MarkerManager& _markerManager,
-                 const TileManager& _tileManager, const Labels& _labels, std::vector<SelectionColorRead>& _cache) const;
+                 const TileManager& _tileManager, const LabelManager& _labelManager,
+                 std::vector<SelectionColorRead>& _cache) const;
 
     QueryType type() const;
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -152,7 +152,19 @@ auto PolygonStyleBuilder<V>::parseRule(const DrawRule& _rule, const Properties& 
     Parameters p;
     _rule.get(StyleParamKey::color, p.color);
     _rule.get(StyleParamKey::extrude, p.extrude);
-    _rule.get(StyleParamKey::order, p.order);
+
+    //_rule.get(StyleParamKey::order, p.order);
+    auto& order = _rule.findParameter(StyleParamKey::order);
+    if (order.value.is<uint32_t>()) {
+        p.order = order.value.get<uint32_t>();
+    } else if (order.value.is<StyleParam::NumberProperty>()) {
+        double v;
+        auto& np = order.value.get<StyleParam::NumberProperty>();
+        if (_props.getNumber(np.key, v)) {
+            p.order = int(v) + np.offset;
+        }
+    }
+
     _rule.get(StyleParamKey::tile_edges, p.keepTileEdges);
 
     if (Tangram::getDebugFlag(Tangram::DebugFlags::proxy_colors)) {

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -556,16 +556,15 @@ void Style::applyDefaultDrawRules(DrawRule& _rule) const {
 
 bool StyleBuilder::checkRule(const DrawRule& _rule) const {
 
-    uint32_t checkColor;
-    uint32_t checkOrder;
-
-    if (!_rule.get(StyleParamKey::color, checkColor)) {
-        if (!style().hasColorShaderBlock()) {
-            return false;
-        }
+    auto& color = _rule.findParameter(StyleParamKey::color);
+    if (!color.value.is<uint32_t>() &&
+        !style().hasColorShaderBlock()) {
+        return false;
     }
 
-    if (!_rule.get(StyleParamKey::order, checkOrder)) {
+    auto& order = _rule.findParameter(StyleParamKey::order);
+    if (!order.value.is<uint32_t>() &&
+        !order.value.is<StyleParam::NumberProperty>()) {
         return false;
     }
 

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -17,7 +17,7 @@ namespace Tangram {
 
 const std::vector<float> FontContext::s_fontRasterSizes = { 16, 28, 40 };
 
-FontContext::FontContext(std::shared_ptr<const Platform> _platform) :
+FontContext::FontContext(std::shared_ptr<Platform> _platform) :
     m_sdfRadius(SDF_WIDTH),
     m_atlas(*this, GlyphTexture::size, m_sdfRadius),
     m_batch(m_atlas, m_scratch),

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -17,7 +17,7 @@ namespace Tangram {
 
 const std::vector<float> FontContext::s_fontRasterSizes = { 16, 28, 40 };
 
-FontContext::FontContext(std::shared_ptr<Platform> _platform) :
+FontContext::FontContext(Platform& _platform) :
     m_sdfRadius(SDF_WIDTH),
     m_atlas(*this, GlyphTexture::size, m_sdfRadius),
     m_batch(m_atlas, m_scratch),
@@ -28,7 +28,7 @@ void FontContext::setPixelScale(float _scale) {
 }
 
 void FontContext::loadFonts() {
-    auto fallbacks = m_platform->systemFontFallbacksHandle();
+    auto fallbacks = m_platform.systemFontFallbacksHandle();
 
     for (size_t i = 0; i < s_fontRasterSizes.size(); i++) {
         m_font[i] = m_alfons.addFont("default", s_fontRasterSizes[i]);
@@ -344,7 +344,7 @@ std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, c
 
     bool useFallbackFont = false;
 
-    auto systemFontHandle = m_platform->systemFont(_family, _weight, _style);
+    auto systemFontHandle = m_platform.systemFont(_family, _weight, _style);
 
     alfons::InputSource source;
 

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -70,7 +70,7 @@ public:
 
     static constexpr int max_textures = 64;
 
-    FontContext(std::shared_ptr<Platform> _platform);
+    FontContext(Platform& _platform);
     virtual ~FontContext() {}
 
     void loadFonts();
@@ -149,7 +149,7 @@ private:
     alfons::TextBatch m_batch;
     TextWrapper m_textWrapper;
 
-    std::shared_ptr<const Platform> m_platform;
+    Platform& m_platform;
 
 };
 

--- a/core/src/text/fontContext.h
+++ b/core/src/text/fontContext.h
@@ -70,7 +70,7 @@ public:
 
     static constexpr int max_textures = 64;
 
-    FontContext(std::shared_ptr<const Platform> _platform);
+    FontContext(std::shared_ptr<Platform> _platform);
     virtual ~FontContext() {}
 
     void loadFonts();

--- a/core/src/tile/tile.cpp
+++ b/core/src/tile/tile.cpp
@@ -1,6 +1,5 @@
 #include "tile/tile.h"
 
-#include "data/tileSource.h"
 #include "labels/labelSet.h"
 #include "style/style.h"
 #include "tile/tileID.h"
@@ -11,10 +10,10 @@
 
 namespace Tangram {
 
-Tile::Tile(TileID _id, const TileSource* _source) :
+Tile::Tile(TileID _id, const int32_t& _sourceId, const int32_t& _sourceGeneration) :
     m_id(_id),
-    m_sourceId(_source ? _source->id() : 0),
-    m_sourceGeneration(_source ? _source->generation() : 0) {
+    m_sourceId(_sourceId),
+    m_sourceGeneration(_sourceGeneration) {
 
     m_scale = MapProjection::metersPerTileAtZoom(_id.z);
     m_tileOrigin = MapProjection::tileSouthWestCorner(_id);

--- a/core/src/tile/tile.h
+++ b/core/src/tile/tile.h
@@ -14,7 +14,6 @@
 
 namespace Tangram {
 
-class TileSource;
 class MapProjection;
 struct Properties;
 class Style;
@@ -41,7 +40,7 @@ class Tile {
 
 public:
 
-    Tile(TileID _id, const TileSource* _source = nullptr);
+    Tile(TileID _id, const int32_t& _sourceId = 0, const int32_t& _sourceGeneration = 0);
 
     virtual ~Tile();
 

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -99,7 +99,7 @@ std::unique_ptr<Tile> TileBuilder::build(TileID _tileID, const TileData& _tileDa
 
     m_selectionFeatures.clear();
 
-    auto tile = std::make_unique<Tile>(_tileID, &_source);
+    auto tile = std::make_unique<Tile>(_tileID, _source.id(), _source.generation());
 
     tile->initGeometry(m_scene->styles().size());
 

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -15,13 +15,13 @@
 
 namespace Tangram {
 
-TileBuilder::TileBuilder(std::shared_ptr<Scene> _scene)
+TileBuilder::TileBuilder(Scene& _scene)
     : m_scene(_scene) {
 
-    m_styleContext.initFunctions(*_scene);
+    m_styleContext.initFunctions(_scene);
 
     // Initialize StyleBuilders
-    for (auto& style : _scene->styles()) {
+    for (auto& style : _scene.styles()) {
         m_styleBuilder[style->getName()] = style->createBuilder();
     }
 }
@@ -64,10 +64,10 @@ void TileBuilder::applyStyling(const Feature& _feature, const SceneLayer& _layer
         bool interactive = false;
         if (rule.get(StyleParamKey::interactive, interactive) && interactive) {
             if (selectionColor == 0) {
-                selectionColor = m_scene->featureSelection()->nextColorIdentifier();
+                selectionColor = m_scene.featureSelection()->nextColorIdentifier();
             }
             rule.selectionColor = selectionColor;
-            rule.featureSelection = m_scene->featureSelection().get();
+            rule.featureSelection = m_scene.featureSelection().get();
         } else {
             rule.selectionColor = 0;
         }
@@ -101,7 +101,7 @@ std::unique_ptr<Tile> TileBuilder::build(TileID _tileID, const TileData& _tileDa
 
     auto tile = std::make_unique<Tile>(_tileID, _source.id(), _source.generation());
 
-    tile->initGeometry(m_scene->styles().size());
+    tile->initGeometry(m_scene.styles().size());
 
     m_styleContext.setKeywordZoom(_tileID.s);
 
@@ -110,7 +110,7 @@ std::unique_ptr<Tile> TileBuilder::build(TileID _tileID, const TileData& _tileDa
             builder.second->setup(*tile);
     }
 
-    for (const auto& datalayer : m_scene->layers()) {
+    for (const auto& datalayer : m_scene.layers()) {
 
         if (datalayer.source() != _source.name()) { continue; }
 
@@ -135,7 +135,7 @@ std::unique_ptr<Tile> TileBuilder::build(TileID _tileID, const TileData& _tileDa
         builder.second->addLayoutItems(m_labelLayout);
     }
 
-    float tileSize = MapProjection::tileSize() * m_scene->pixelScale();
+    float tileSize = MapProjection::tileSize() * m_scene.pixelScale();
 
     m_labelLayout.process(_tileID, tile->getInverseScale(), tileSize);
 

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -8,25 +8,22 @@
 #include "scene/dataLayer.h"
 #include "scene/scene.h"
 #include "selection/featureSelection.h"
-#include "style/style.h"
 #include "tile/tile.h"
 #include "util/mapProjection.h"
 #include "view/view.h"
 
 namespace Tangram {
 
-TileBuilder::TileBuilder(Scene& _scene)
-    : m_scene(_scene) {
-
-    m_styleContext.initFunctions(_scene);
+void TileBuilder::init() {
+    m_styleContext.initFunctions(m_scene);
 
     // Initialize StyleBuilders
-    for (auto& style : _scene.styles()) {
-        m_styleBuilder[style->getName()] = style->createBuilder();
+    for (auto& style : m_scene.styles()) {
+        if (auto builder = style->createBuilder()) {
+            m_styleBuilder[style->getName()] = std::move(builder);
+        }
     }
 }
-
-TileBuilder::~TileBuilder() {}
 
 StyleBuilder* TileBuilder::getStyleBuilder(const std::string& _name) {
     auto it = m_styleBuilder.find(_name);
@@ -106,8 +103,7 @@ std::unique_ptr<Tile> TileBuilder::build(TileID _tileID, const TileData& _tileDa
     m_styleContext.setKeywordZoom(_tileID.s);
 
     for (auto& builder : m_styleBuilder) {
-        if (builder.second)
-            builder.second->setup(*tile);
+        if (builder.second) { builder.second->setup(*tile); }
     }
 
     for (const auto& datalayer : m_scene.layers()) {

--- a/core/src/tile/tileBuilder.h
+++ b/core/src/tile/tileBuilder.h
@@ -4,11 +4,11 @@
 #include "labels/labelCollider.h"
 #include "scene/styleContext.h"
 #include "scene/drawRule.h"
+#include "style/style.h"
 
 namespace Tangram {
 
 class DataLayer;
-class StyleBuilder;
 class Tile;
 class TileSource;
 struct Feature;
@@ -19,15 +19,15 @@ class TileBuilder {
 
 public:
 
-    explicit TileBuilder(Scene& _scene);
-
-    ~TileBuilder();
+    explicit TileBuilder(Scene& _scene) : m_scene(_scene) {}
 
     StyleBuilder* getStyleBuilder(const std::string& _name);
 
     std::unique_ptr<Tile> build(TileID _tileID, const TileData& _data, const TileSource& _source);
 
     const Scene& scene() const { return m_scene; }
+
+    void init();
 
 private:
 

--- a/core/src/tile/tileBuilder.h
+++ b/core/src/tile/tileBuilder.h
@@ -19,7 +19,7 @@ class TileBuilder {
 
 public:
 
-    TileBuilder(std::shared_ptr<Scene> _scene);
+    explicit TileBuilder(Scene& _scene);
 
     ~TileBuilder();
 
@@ -27,14 +27,14 @@ public:
 
     std::unique_ptr<Tile> build(TileID _tileID, const TileData& _data, const TileSource& _source);
 
-    const Scene& scene() const { return *m_scene; }
+    const Scene& scene() const { return m_scene; }
 
 private:
 
     // Determine and apply DrawRules for a @_feature
     void applyStyling(const Feature& _feature, const SceneLayer& _layer);
 
-    std::shared_ptr<Scene> m_scene;
+    Scene& m_scene;
 
     StyleContext m_styleContext;
     DrawRuleMergeSet m_ruleSet;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -134,16 +134,16 @@ TileManager::TileSet::TileSet(std::shared_ptr<TileSource> _source, bool _clientS
     source(_source), clientTileSource(_clientSource) {}
 
 
-TileManager::TileManager(std::shared_ptr<Platform> platform, TileTaskQueue& _tileWorker) :
+TileManager::TileManager(Platform& platform, TileTaskQueue& _tileWorker) :
     m_workers(_tileWorker) {
 
     m_tileCache = std::unique_ptr<TileCache>(new TileCache(DEFAULT_CACHE_SIZE));
 
     // Callback to pass task from Download-Thread to Worker-Queue
-    m_dataCallback = TileTaskCb{[this, platform](std::shared_ptr<TileTask> task) {
+    m_dataCallback = TileTaskCb{[&](std::shared_ptr<TileTask> task) {
 
         if (task->isReady()) {
-             platform->requestRender();
+             platform.requestRender();
 
         } else if (task->hasData()) {
             m_workers.enqueue(task);

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -12,7 +12,7 @@
 
 #include <algorithm>
 
-#define DBG(...) LOGD(__VA_ARGS__)
+#define DBG(...) LOG(__VA_ARGS__)
 
 namespace Tangram {
 
@@ -506,6 +506,9 @@ void TileManager::loadTiles() {
         auto& entry = tileIt->second;
 
         tileSet.source->loadTileData(entry.task, m_dataCallback);
+
+        DBG("> load %s", tileId.toString().c_str());
+
     }
 
     DBG("loading:%d cache: %fMB",

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -12,7 +12,7 @@
 
 #include <algorithm>
 
-#define DBG(...) // LOGD(__VA_ARGS__)
+#define DBG(...) LOGD(__VA_ARGS__)
 
 namespace Tangram {
 
@@ -133,7 +133,6 @@ struct TileManager::TileEntry {
 TileManager::TileSet::TileSet(std::shared_ptr<TileSource> _source, bool _clientSource) :
     source(_source), clientTileSource(_clientSource) {}
 
-TileManager::TileSet::~TileSet() {}
 
 TileManager::TileManager(std::shared_ptr<Platform> platform, TileTaskQueue& _tileWorker) :
     m_workers(_tileWorker) {
@@ -160,6 +159,8 @@ TileManager::~TileManager() {
 }
 
 void TileManager::setTileSources(const std::vector<std::shared_ptr<TileSource>>& _sources) {
+
+    LOG("setTileSources %d", _sources.size());
 
     m_tileCache->clear();
 
@@ -188,7 +189,7 @@ void TileManager::setTileSources(const std::vector<std::shared_ptr<TileSource>>&
                          [&](const TileSet& a) {
                              return a.source->name() == source->name();
                          }) == m_tileSets.end()) {
-            LOGN("add source %s", source->name().c_str());
+            LOGW("add source %s", source->name().c_str());
             m_tileSets.push_back({ source, false });
         } else {
             LOGW("Duplicate named datasource (not added): %s", source->name().c_str());
@@ -448,7 +449,7 @@ void TileManager::updateTileSet(TileSet& _tileSet, const ViewState& _view) {
                 else { rasterLoading++; }
             }
         }
-        DBG("> %s - ready:%d proxy:%d/%d loading:%d rDone:%d rLoading:%d rPending:%d canceled:%d",
+        DBG("> %s - ready:%d proxy:%d/%d loading:%d rDone:%d rLoading:%d canceled:%d",
              it.first.toString().c_str(),
              bool(entry.tile),
              entry.getProxyCounter(),
@@ -456,7 +457,6 @@ void TileManager::updateTileSet(TileSet& _tileSet, const ViewState& _view) {
              entry.task && !entry.task->isReady(),
              rasterDone,
              rasterLoading,
-             entry.rastersPending(),
              entry.task && entry.task->isCanceled());
 #endif
 
@@ -508,8 +508,8 @@ void TileManager::loadTiles() {
         tileSet.source->loadTileData(entry.task, m_dataCallback);
     }
 
-    DBG("loading:%d pending:%d cache: %fMB",
-        m_loadTasks.size(), m_loadPending,
+    DBG("loading:%d cache: %fMB",
+        m_loadTasks.size(),
         (double(m_tileCache->getMemoryUsage()) / (1024 * 1024)));
 
     m_loadTasks.clear();

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -34,7 +34,7 @@ class TileManager {
 
 public:
 
-    TileManager(std::shared_ptr<Platform> platform, TileTaskQueue& _tileWorker);
+    TileManager(Platform& platform, TileTaskQueue& _tileWorker);
 
     virtual ~TileManager();
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -130,11 +130,6 @@ protected:
 
     bool m_tileSetChanged = false;
 
-    /* Callback for TileSource:
-     * Passes TileTask back with data for further processing by <TileWorker>s
-     */
-    TileTaskCb m_dataCallback;
-
     /* Temporary list of tiles that need to be loaded */
     std::vector<std::tuple<double, TileSet*, TileID>> m_loadTasks;
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -77,7 +77,6 @@ protected:
 
     struct TileSet {
         TileSet(std::shared_ptr<TileSource> _source, bool _clientSource);
-        ~TileSet();
 
         std::shared_ptr<TileSource> source;
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -14,10 +14,9 @@
 #include <set>
 #include <vector>
 
-class Platform;
-
 namespace Tangram {
 
+class Scene;
 class TileSource;
 class TileCache;
 class View;
@@ -34,7 +33,7 @@ class TileManager {
 
 public:
 
-    TileManager(Platform& platform, TileTaskQueue& _tileWorker);
+    explicit TileManager(Scene& _scene);
 
     virtual ~TileManager();
 
@@ -57,7 +56,7 @@ public:
         return m_tilesInProgress > 0;
     }
 
-    std::shared_ptr<TileSource> getClientTileSource(int32_t sourceID);
+    TileSource* getClientTileSource(int32_t sourceID);
 
     void addClientTileSource(std::shared_ptr<TileSource> _source);
 
@@ -118,6 +117,8 @@ protected:
      */
     void clearProxyTiles(TileSet& _tileSet, const TileID& _tileID, TileEntry& _tile, std::vector<TileID>& _removes);
 
+    Scene& m_scene;
+
     int32_t m_tilesInProgress = 0;
 
     std::vector<TileSet> m_tileSets;
@@ -126,8 +127,6 @@ protected:
     std::vector<std::shared_ptr<Tile>> m_tiles;
 
     std::unique_ptr<TileCache> m_tileCache;
-
-    TileTaskQueue& m_workers;
 
     bool m_tileSetChanged = false;
 

--- a/core/src/tile/tileTask.cpp
+++ b/core/src/tile/tileTask.cpp
@@ -25,7 +25,7 @@ TileTask::~TileTask() {}
 TileSource& TileTask::source() {
     auto scene = m_scene.lock();
     assert(scene);
-    return  *scene->getTileSource(m_sourceId);
+    return *scene->getTileSource(m_sourceId);
 }
 
 std::unique_ptr<Tile> TileTask::getTile() {

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -14,7 +14,7 @@
 
 namespace Tangram {
 
-TileWorker::TileWorker(std::shared_ptr<Platform> _platform, int _numWorker) : m_platform(_platform) {
+TileWorker::TileWorker(Platform& _platform, int _numWorker) : m_platform(_platform) {
     m_running = true;
 
     for (int i = 0; i < _numWorker; i++) {
@@ -95,7 +95,7 @@ void TileWorker::run(Worker* instance) {
         LOG("process %s", task->tileId().toString().c_str());
         task->process(*builder);
 
-        m_platform->requestRender();
+        m_platform.requestRender();
     }
 }
 

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -92,6 +92,7 @@ void TileWorker::run(Worker* instance) {
             continue;
         }
 
+        LOG("process %s", task->tileId().toString().c_str());
         task->process(*builder);
 
         m_platform->requestRender();
@@ -110,6 +111,7 @@ void TileWorker::enqueue(std::shared_ptr<TileTask> task) {
         if (!m_running) {
             return;
         }
+        LOG("enqueue %s", task->tileId().toString().c_str());
         m_queue.push_back(std::move(task));
     }
     m_condition.notify_one();

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -43,11 +43,12 @@ void TileWorker::run(Worker* instance) {
             std::unique_lock<std::mutex> lock(m_mutex);
 
             m_condition.wait(lock, [&, this]{
-                    return !m_running || !m_queue.empty();
+                    return !m_running || !m_queue.empty() || !instance->tileBuilder;
                 });
 
             if (instance->tileBuilder) {
                 builder = std::move(instance->tileBuilder);
+                builder->init();
                 LOG("Passed new TileBuilder to TileWorker");
             }
 

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -97,7 +97,7 @@ void TileWorker::run(Worker* instance) {
     }
 }
 
-void TileWorker::setScene(std::shared_ptr<Scene>& _scene) {
+void TileWorker::setScene(Scene& _scene) {
     for (auto& worker : m_workers) {
         worker->tileBuilder = std::make_unique<TileBuilder>(_scene);
     }

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -4,6 +4,7 @@
 #include "log.h"
 #include "map.h"
 #include "platform.h"
+#include "scene/scene.h"
 #include "tile/tileBuilder.h"
 #include "tile/tileID.h"
 #include "tile/tileTask.h"
@@ -42,8 +43,10 @@ void TileWorker::run(Worker* instance) {
         {
             std::unique_lock<std::mutex> lock(m_mutex);
 
-            m_condition.wait(lock, [&, this]{
-                    return !m_running || !m_queue.empty() || !instance->tileBuilder;
+            m_condition.wait(lock, [&, this] {
+                return (!m_queue.empty() && builder && builder->scene().isReady()) ||
+                     !m_running ||
+                     instance->tileBuilder;
                 });
 
             if (instance->tileBuilder) {
@@ -51,13 +54,13 @@ void TileWorker::run(Worker* instance) {
                 builder->init();
                 LOG("Passed new TileBuilder to TileWorker");
             }
-
             // Check if thread should stop
             if (!m_running) {
                 break;
             }
 
-            if (!builder) {
+            if (!builder || !builder->scene().isReady()) {
+                if (builder) LOG("Waiting for Scene to become ready");
                 continue;
             }
 
@@ -100,21 +103,32 @@ void TileWorker::run(Worker* instance) {
 }
 
 void TileWorker::setScene(Scene& _scene) {
+    LOG("Set Scene on TileWorker");
+
     for (auto& worker : m_workers) {
         worker->tileBuilder = std::make_unique<TileBuilder>(_scene);
     }
+    m_condition.notify_all();
 }
 
 void TileWorker::enqueue(std::shared_ptr<TileTask> task) {
-    LOG("%d enqueue %s", m_running, task->tileId().toString().c_str());
     {
         std::unique_lock<std::mutex> lock(m_mutex);
-        if (!m_running) {
-            return;
-        }
+        if (!m_running) { return; }
+        LOG("%d enqueue %s", m_queue.size()+1, task->tileId().toString().c_str());
         m_queue.push_back(std::move(task));
     }
     m_condition.notify_one();
+}
+
+void TileWorker::poke() {
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        LOG("Poking TileWorker - enqueued %d", m_queue.size());
+
+        if (!m_running || m_queue.empty()) { return; }
+    }
+    m_condition.notify_all();
 }
 
 void TileWorker::stop() {

--- a/core/src/tile/tileWorker.cpp
+++ b/core/src/tile/tileWorker.cpp
@@ -106,12 +106,12 @@ void TileWorker::setScene(Scene& _scene) {
 }
 
 void TileWorker::enqueue(std::shared_ptr<TileTask> task) {
+    LOG("%d enqueue %s", m_running, task->tileId().toString().c_str());
     {
         std::unique_lock<std::mutex> lock(m_mutex);
         if (!m_running) {
             return;
         }
-        LOG("enqueue %s", task->tileId().toString().c_str());
         m_queue.push_back(std::move(task));
     }
     m_condition.notify_one();

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -21,7 +21,7 @@ class TileWorker : public TileTaskQueue {
 
 public:
 
-    TileWorker(std::shared_ptr<Platform> _platform, int _numWorker);
+    TileWorker(Platform& _platform, int _numWorker);
 
     ~TileWorker();
 
@@ -51,7 +51,7 @@ private:
     std::mutex m_mutex;
     std::vector<std::shared_ptr<TileTask>> m_queue;
 
-    std::shared_ptr<Platform> m_platform;
+    Platform& m_platform;
 };
 
 }

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -31,7 +31,7 @@ public:
 
     bool isRunning() const { return m_running; }
 
-    void setScene(std::shared_ptr<Scene>& _scene);
+    void setScene(Scene& _scene);
 
 private:
 

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -27,6 +27,9 @@ public:
 
     virtual void enqueue(std::shared_ptr<TileTask> task) override;
 
+    // Trigger when scene is completed and TileBuilder can do its job.
+    void poke();
+
     void stop();
 
     bool isRunning() const { return m_running; }

--- a/core/src/tile/tileWorker.h
+++ b/core/src/tile/tileWorker.h
@@ -21,7 +21,7 @@ class TileWorker : public TileTaskQueue {
 
 public:
 
-    TileWorker(Platform& _platform, int _numWorker);
+    explicit TileWorker(int _numWorker);
 
     ~TileWorker();
 
@@ -53,8 +53,6 @@ private:
 
     std::mutex m_mutex;
     std::vector<std::shared_ptr<TileTask>> m_queue;
-
-    Platform& m_platform;
 };
 
 }

--- a/core/src/util/inputHandler.cpp
+++ b/core/src/util/inputHandler.cpp
@@ -1,7 +1,5 @@
 #include "util/inputHandler.h"
 
-#include "platform.h"
-
 #include "glm/gtx/rotate_vector.hpp"
 #include "glm/vec2.hpp"
 #include <cmath>
@@ -26,7 +24,7 @@
 
 namespace Tangram {
 
-InputHandler::InputHandler(std::shared_ptr<Platform> _platform, View& _view) : m_platform(_platform), m_view(_view) {}
+InputHandler::InputHandler(View& _view) : m_view(_view) {}
 
 bool InputHandler::update(float _dt) {
 
@@ -42,16 +40,13 @@ bool InputHandler::update(float _dt) {
 
         m_velocityZoom -= _dt * DAMPING_ZOOM * m_velocityZoom;
         m_view.zoom(m_velocityZoom * _dt);
-
-        m_platform->requestRender();
     }
 
     return isFlinging;
 }
 
 void InputHandler::handleTapGesture(float _posX, float _posY) {
-
-    onGesture();
+    cancelFling();
 
     float viewCenterX = 0.5f * m_view.getWidth();
     float viewCenterY = 0.5f * m_view.getHeight();
@@ -60,18 +55,14 @@ void InputHandler::handleTapGesture(float _posX, float _posY) {
     m_view.screenToGroundPlane(_posX, _posY);
 
     m_view.translate((_posX - viewCenterX), (_posY - viewCenterY));
-
 }
 
 void InputHandler::handleDoubleTapGesture(float _posX, float _posY) {
-
     handlePinchGesture(_posX, _posY, 2.f, 0.f);
-
 }
 
 void InputHandler::handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
-
-    onGesture();
+    cancelFling();
 
     m_view.screenToGroundPlane(_startX, _startY);
     m_view.screenToGroundPlane(_endX, _endY);
@@ -80,7 +71,6 @@ void InputHandler::handlePanGesture(float _startX, float _startY, float _endX, f
     float dy = _startY - _endY;
 
     m_view.translate(dx, dy);
-
 }
 
 void InputHandler::handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY) {
@@ -91,7 +81,7 @@ void InputHandler::handleFlingGesture(float _posX, float _posY, float _velocityX
 
     const static float epsilon = 0.0167f;
 
-    onGesture();
+    cancelFling();
 
     float startX = _posX;
     float startY = _posY;
@@ -105,12 +95,10 @@ void InputHandler::handleFlingGesture(float _posX, float _posY, float _velocityX
     float dy = (startY - endY) / epsilon;
 
     setVelocity(0.f, glm::vec2(dx, dy));
-
 }
 
 void InputHandler::handlePinchGesture(float _posX, float _posY, float _scale, float _velocity) {
-
-    onGesture();
+    cancelFling();
 
     float z = m_view.getZoom();
     static float invLog2 = 1 / log(2);
@@ -127,12 +115,10 @@ void InputHandler::handlePinchGesture(float _posX, float _posY, float _scale, fl
     if (std::abs(vz) >= THRESHOLD_START_ZOOM) {
         setVelocity(vz, glm::vec2(0.f));
     }
-
 }
 
 void InputHandler::handleRotateGesture(float _posX, float _posY, float _radians) {
-
-    onGesture();
+    cancelFling();
 
     // Get vector from center of rotation to view center
     m_view.screenToGroundPlane(_posX, _posY);
@@ -143,12 +129,10 @@ void InputHandler::handleRotateGesture(float _posX, float _posY, float _radians)
     m_view.translate(translation.x, translation.y);
 
     m_view.roll(_radians);
-
 }
 
 void InputHandler::handleShoveGesture(float _distance) {
-
-    onGesture();
+    cancelFling();
 
     float angle = -M_PI * _distance / m_view.getHeight();
     m_view.pitch(angle);
@@ -156,20 +140,10 @@ void InputHandler::handleShoveGesture(float _distance) {
 }
 
 void InputHandler::cancelFling() {
-
     setVelocity(0.f, { 0.f, 0.f});
-
-}
-
-void InputHandler::onGesture() {
-
-    setVelocity(0.f, { 0.f, 0.f });
-    m_platform->requestRender();
-
 }
 
 void InputHandler::setVelocity(float _zoom, glm::vec2 _translate) {
-
     // setup deltas for momentum on gesture
     m_velocityPan = _translate;
     m_velocityZoom = _zoom;

--- a/core/src/util/inputHandler.h
+++ b/core/src/util/inputHandler.h
@@ -7,12 +7,10 @@
 
 namespace Tangram {
 
-class Platform;
-
 class InputHandler {
 
 public:
-    InputHandler(std::shared_ptr<Platform> _platform, View& _view);
+    explicit InputHandler(View& _view);
 
     void handleTapGesture(float _posX, float _posY);
     void handleDoubleTapGesture(float _posX, float _posY);
@@ -34,10 +32,6 @@ public:
 private:
 
     void setVelocity(float _zoom, glm::vec2 _pan);
-
-    void onGesture();
-
-    std::shared_ptr<Platform> m_platform;
 
     View& m_view;
 

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -53,7 +53,7 @@ ViewState View::state() const {
 
     return {
         m_changed,
-        glm::dvec2(m_pos.x, -m_pos.y),
+        glm::dvec2(m_pos.x, m_pos.y),
         m_zoom,
         powf(2.f, m_zoom),
         m_zoom - std::floor(m_zoom),

--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 
+apply from: 'profiling.gradle'
+
 android {
   compileSdkVersion 27
 
@@ -26,7 +28,6 @@ android {
       minifyEnabled true
     }
   }
-
 }
 
 dependencies {

--- a/platforms/android/demo/profiling.gradle
+++ b/platforms/android/demo/profiling.gradle
@@ -1,0 +1,57 @@
+
+// Set when building only part of the abis in the apk.
+def abiFiltersForWrapScript = []
+
+android {
+    buildTypes {
+        profiling {
+            initWith debug
+            externalNativeBuild {
+                cmake {
+                    // cmake Debug build type uses -O0, which makes the code slow.
+                    arguments "-DCMAKE_BUILD_TYPE=Release"
+                }
+            }
+            packagingOptions {
+                // Exclude wrap.sh for architectures not built.
+                if (abiFiltersForWrapScript) {
+                    def exclude_abis = ["armeabi", "armeabi-v7a", "arm64-v8a",
+                                        "x86", "x86_64", "mips", "mips64"]
+                            .findAll{ !(it in abiFiltersForWrapScript) }
+                            .collect{ "**/" + it + "/wrap.sh" }
+                    excludes += exclude_abis
+                }
+            }
+
+            // Add lib/xxx/wrap.sh in the apk. This is to enable java profiling on Android O
+            // devices.
+            sourceSets {
+                profiling {
+                    resources {
+                        srcDir {
+                            "profiling_apk_add_dir"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def writeWrapScriptToFullyCompileJavaApp(wrapFile) {
+    wrapFile.withWriter { writer ->
+        writer.write('#!/system/bin/sh\n')
+        writer.write('\$@\n')
+    }
+}
+
+task createProfilingApkAddDir {
+    for (String abi : ["armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64", "mips", "mips64"]) {
+        def dir = new File("app/profiling_apk_add_dir/lib/" + abi)
+        dir.mkdirs()
+        def wrapFile = new File(dir, "wrap.sh")
+        writeWrapScriptToFullyCompileJavaApp(wrapFile)
+        println "write file " + wrapFile.path
+    }
+}
+

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -53,7 +53,9 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
     private static final String TAG = "TangramDemo";
 
     private static final String[] SCENE_PRESETS = {
+            "asset:///snap.yaml",
             "asset:///scene.yaml",
+            "asset:///snapzen/scene.yaml",
             "https://www.nextzen.org/carto/bubble-wrap-style/9/bubble-wrap-style.zip",
             "https://www.nextzen.org/carto/refill-style/11/refill-style.zip",
             "https://www.nextzen.org/carto/walkabout-style/7/walkabout-style.zip",

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -102,7 +102,7 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
         sceneSelector.setOnSelectionListener(new PresetSelectionTextView.OnSelectionListener() {
             @Override
             public void onSelection(String selection) {
-                map.loadSceneFile(selection, sceneUpdates);
+                map.loadSceneFileAsync(selection, sceneUpdates);
             }
         });
 
@@ -119,7 +119,10 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
         map = mapController;
         String sceneUrl = sceneSelector.getCurrentString();
         map.setSceneLoadListener(this);
-        map.loadSceneFile(sceneUrl, sceneUpdates);
+
+        map.updateCameraPosition(CameraUpdateFactory.newLngLatZoom(new LngLat(-74.00976419448854, 40.70532700869127), 16));
+        Log.d("Tangram", "START SCENE LOAD");
+        map.loadSceneFileAsync(sceneUrl, sceneUpdates);
 
         TouchInput touchInput = map.getTouchInput();
         touchInput.setTapResponder(this);
@@ -152,7 +155,7 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
             }
         });
 
-        map.updateCameraPosition(CameraUpdateFactory.newLngLatZoom(new LngLat(-74.00976419448854, 40.70532700869127), 16));
+
 
         markers = map.addDataLayer("touch");
     }

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -133,30 +133,6 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
         map.setLabelPickListener(this);
         map.setMarkerPickListener(this);
 
-        map.setMapChangeListener(new MapChangeListener() {
-            @Override
-            public void onViewComplete() {
-                Log.d(TAG, "View complete");
-            }
-
-            @Override
-            public void onRegionWillChange(boolean animated) {
-                Log.d(TAG, "On Region Will Change Animated: " + animated);
-            }
-
-            @Override
-            public void onRegionIsChanging() {
-                Log.d(TAG, "On Region Is Changing");
-            }
-
-            @Override
-            public void onRegionDidChange(boolean animated) {
-                Log.d(TAG, "On Region Did Change Animated: " + animated);
-            }
-        });
-
-
-
         markers = map.addDataLayer("touch");
     }
 

--- a/platforms/android/profiling.md
+++ b/platforms/android/profiling.md
@@ -1,0 +1,12 @@
+# Android
+
+- https://android.googlesource.com/platform/system/extras/+/master/simpleperf/doc/
+- https://android.googlesource.com/platform/system/extras/+/master/simpleperf/demo/README.md#profiling-javac-application
+
+## Studio
+
+- Run 'Profile selected configuration'
+- Click CPU row
+- Select 'Sampled (Native)'
+- Click 'Record a method trace', right next to it
+- Select thread of interest to show Call-/Flame-chart

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -5,6 +5,7 @@ group = GROUP
 version = VERSION_NAME
 
 apply from: 'versioning.gradle'
+apply from: 'profiling.gradle'
 
 android {
   compileSdkVersion 27
@@ -28,7 +29,8 @@ android {
         targets 'tangram'
         arguments '-DTANGRAM_PLATFORM=android',
                   '-DANDROID_TOOLCHAIN=clang',
-                  '-DANDROID_STL=c++_shared'
+                  '-DANDROID_STL=c++_shared',
+                '-DCMAKE_BUILD_TYPE=Release'
         cppFlags '-std=c++14',
                  '-pedantic',
                  '-fPIC',

--- a/platforms/android/tangram/profiling.gradle
+++ b/platforms/android/tangram/profiling.gradle
@@ -1,0 +1,58 @@
+
+// Set when building only part of the abis in the apk.
+def abiFiltersForWrapScript = []
+
+android {
+    buildTypes {
+        profiling {
+            initWith debug
+            externalNativeBuild {
+                cmake {
+                    // cmake Debug build type uses -O0, which makes the code slow.
+                    arguments "-DCMAKE_BUILD_TYPE=Release"
+                    cppFlags '-fno-omit-frame-pointer'
+                }
+            }
+            packagingOptions {
+                // Exclude wrap.sh for architectures not built.
+                if (abiFiltersForWrapScript) {
+                    def exclude_abis = ["armeabi", "armeabi-v7a", "arm64-v8a",
+                                        "x86", "x86_64", "mips", "mips64"]
+                            .findAll{ !(it in abiFiltersForWrapScript) }
+                            .collect{ "**/" + it + "/wrap.sh" }
+                    excludes += exclude_abis
+                }
+            }
+
+            // Add lib/xxx/wrap.sh in the apk. This is to enable java profiling on Android O
+            // devices.
+            sourceSets {
+                profiling {
+                    resources {
+                        srcDir {
+                            "profiling_apk_add_dir"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def writeWrapScriptToFullyCompileJavaApp(wrapFile) {
+    wrapFile.withWriter { writer ->
+        writer.write('#!/system/bin/sh\n')
+        writer.write('\$@\n')
+    }
+}
+
+task createProfilingApkAddDir {
+    for (String abi : ["armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64", "mips", "mips64"]) {
+        def dir = new File("app/profiling_apk_add_dir/lib/" + abi)
+        dir.mkdirs()
+        def wrapFile = new File(dir, "wrap.sh")
+        writeWrapScriptToFullyCompileJavaApp(wrapFile)
+        println "write file " + wrapFile.path
+    }
+}
+

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -292,14 +292,15 @@ UrlRequestHandle AndroidPlatform::startUrlRequest(Url _url, UrlCallback _callbac
 
     // Get the current value of the request counter and add one, atomically.
     UrlRequestHandle requestHandle = m_urlRequestCount++;
+    if (!_callback) { return requestHandle; }
 
     // If the requested URL does not use HTTP or HTTPS, retrieve it synchronously.
     if (!_url.hasHttpScheme()) {
-        UrlResponse response;
-        response.content = bytesFromFile(_url);
-        if (_callback) {
-            _callback(std::move(response));
-        }
+        m_fileWorker.enqueue([=](){
+             UrlResponse response;
+             response.content = bytesFromFile(_url);
+             _callback(std::move(response));
+        });
         return requestHandle;
     }
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -60,9 +60,9 @@ static jmethodID hashmapInitMID = 0;
 static jmethodID hashmapPutMID = 0;
 
 static bool glExtensionsLoaded = false;
-
+// FIXME WHAT THIS FOR?
 void AndroidPlatform::bindJniEnvToThread(JNIEnv* jniEnv) {
-    jniEnv->GetJavaVM(&jvm);
+   jniEnv->GetJavaVM(&jvm);
 }
 
 jint AndroidPlatform::jniOnLoad(JavaVM* javaVM) {
@@ -132,10 +132,16 @@ private:
 public:
     JniThreadBinding(JavaVM* _jvm) : jvm(_jvm) {
         status = jvm->GetEnv((void**)&jniEnv, TANGRAM_JNI_VERSION);
-        if (status == JNI_EDETACHED) { jvm->AttachCurrentThread(&jniEnv, NULL);}
+        if (status == JNI_EDETACHED) {
+            LOG("---------------->>> ATTACH");
+            jvm->AttachCurrentThread(&jniEnv, NULL);
+        }
     }
     ~JniThreadBinding() {
-        if (status == JNI_EDETACHED) { jvm->DetachCurrentThread(); }
+        if (status == JNI_EDETACHED) {
+            LOG("---------------->>> DETACH");
+            jvm->DetachCurrentThread();
+        }
     }
 
     JNIEnv* operator->() const {
@@ -172,7 +178,9 @@ std::string AndroidPlatform::fontPath(const std::string& _family, const std::str
     return resultStr;
 }
 
-AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance) {
+AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance)
+    : m_jniWorker(jvm) {
+
     m_tangramInstance = _jniEnv->NewGlobalRef(_tangramInstance);
 
     m_assetManager = AAssetManager_fromJava(_jniEnv, _assetManager);
@@ -190,29 +198,30 @@ void AndroidPlatform::dispose(JNIEnv* _jniEnv) {
 }
 
 void AndroidPlatform::requestRender() const {
-
-    JniThreadBinding jniEnv(jvm);
-
-    jniEnv->CallVoidMethod(m_tangramInstance, requestRenderMethodID);
-}
-
-std::string AndroidPlatform::fontFallbackPath(int _importance, int _weightHint) const {
-
-    JniThreadBinding jniEnv(jvm);
-
-    jstring returnStr = (jstring) jniEnv->CallObjectMethod(m_tangramInstance, getFontFallbackFilePath, _importance, _weightHint);
-
-    auto resultStr = stringFromJString(jniEnv, returnStr);
-    jniEnv->DeleteLocalRef(returnStr);
-
-    return resultStr;
+    m_jniWorker.enqueue([&](JNIEnv *jniEnv) {
+        jniEnv->CallVoidMethod(m_tangramInstance, requestRenderMethodID);
+    });
 }
 
 std::vector<FontSourceHandle> AndroidPlatform::systemFontFallbacksHandle() const {
+    JniThreadBinding jniEnv(jvm);
+
     std::vector<FontSourceHandle> handles;
 
     int importance = 0;
     int weightHint = 400;
+
+    auto fontFallbackPath = [&](int _importance, int _weightHint) {
+
+        jstring returnStr = (jstring) jniEnv->CallObjectMethod(m_tangramInstance,
+                                                               getFontFallbackFilePath, _importance,
+                                                               _weightHint);
+
+        auto resultStr = stringFromJString(jniEnv, returnStr);
+        jniEnv->DeleteLocalRef(returnStr);
+
+        return resultStr;
+    };
 
     std::string fallbackPath = fontFallbackPath(importance, weightHint);
 
@@ -288,8 +297,6 @@ std::vector<char> AndroidPlatform::bytesFromFile(const Url& url) const {
 
 UrlRequestHandle AndroidPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
 
-    JniThreadBinding jniEnv(jvm);
-
     // Get the current value of the request counter and add one, atomically.
     UrlRequestHandle requestHandle = m_urlRequestCount++;
     if (!_callback) { return requestHandle; }
@@ -310,33 +317,36 @@ UrlRequestHandle AndroidPlatform::startUrlRequest(Url _url, UrlCallback _callbac
         m_callbacks[requestHandle] = _callback;
     }
 
-    jlong jRequestHandle = static_cast<jlong>(requestHandle);
+    m_jniWorker.enqueue([=](JNIEnv *jniEnv) {
+        jlong jRequestHandle = static_cast<jlong>(requestHandle);
 
-    // Check that it's safe to convert the UrlRequestHandle to a jlong and back.
-    assert(requestHandle == static_cast<UrlRequestHandle>(jRequestHandle));
+        // Check that it's safe to convert the UrlRequestHandle to a jlong and back... cmon :P
+        assert(requestHandle == static_cast<UrlRequestHandle>(jRequestHandle));
 
-    jstring jUrl = jstringFromString(jniEnv, _url.string());
+        jstring jUrl = jstringFromString(jniEnv, _url.string());
 
-    // Call the MapController method to start the URL request.
-    jniEnv->CallVoidMethod(m_tangramInstance, startUrlRequestMID, jUrl, jRequestHandle);
-
+        // Call the MapController method to start the URL request.
+        jniEnv->CallVoidMethod(m_tangramInstance, startUrlRequestMID, jUrl, jRequestHandle);
+    });
     return requestHandle;
 }
 
 void AndroidPlatform::cancelUrlRequest(UrlRequestHandle request) {
 
-    JniThreadBinding jniEnv(jvm);
+    m_jniWorker.enqueue([=](JNIEnv *jniEnv) {
 
-    jlong jRequestHandle = static_cast<jlong>(request);
+        jlong jRequestHandle = static_cast<jlong>(request);
 
-    jniEnv->CallVoidMethod(m_tangramInstance, cancelUrlRequestMID, jRequestHandle);
+        jniEnv->CallVoidMethod(m_tangramInstance, cancelUrlRequestMID, jRequestHandle);
+    });
 
     // We currently don't try to cancel requests for local files.
 }
 
 void AndroidPlatform::onUrlComplete(JNIEnv* _jniEnv, jlong _jRequestHandle, jbyteArray _jBytes, jstring _jError) {
     // Start building a response object.
-    UrlResponse response;
+    //auto response = std::make_unique<UrlResponse>();
+   UrlResponse response;
 
     // If the request was successful, we will receive a non-null byte array.
     if (_jBytes != nullptr) {
@@ -353,20 +363,21 @@ void AndroidPlatform::onUrlComplete(JNIEnv* _jniEnv, jlong _jRequestHandle, jbyt
         response.error = error.c_str();
     }
 
-    // Find the callback associated with the request.
-    UrlCallback callback;
-    {
-        std::lock_guard<std::mutex> lock(m_callbackMutex);
-        UrlRequestHandle requestHandle = static_cast<UrlRequestHandle>(_jRequestHandle);
-        auto it = m_callbacks.find(requestHandle);
-        if (it != m_callbacks.end()) {
-            callback = std::move(it->second);
-            m_callbacks.erase(it);
+
+    m_fileWorker.enqueue([this, _jRequestHandle, r = std::move(response)]() mutable {
+        // Find the callback associated with the request.
+        UrlCallback callback;
+        {
+            std::lock_guard<std::mutex> lock(m_callbackMutex);
+            UrlRequestHandle requestHandle = static_cast<UrlRequestHandle>(_jRequestHandle);
+            auto it = m_callbacks.find(requestHandle);
+            if (it != m_callbacks.end()) {
+                callback = std::move(it->second);
+                m_callbacks.erase(it);
+            }
         }
-    }
-    if (callback) {
-        callback(std::move(response));
-    }
+        if (callback) { callback(std::move(r)); }
+    });
 }
 
 void setCurrentThreadPriority(int priority) {

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -181,7 +181,7 @@ std::string AndroidPlatform::fontPath(const std::string& _family, const std::str
 AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance)
     : m_jniWorker(jvm) {
 
-    m_tangramInstance = _jniEnv->NewGlobalRef(_tangramInstance);
+    m_tangramInstance = _jniEnv->NewWeakGlobalRef(_tangramInstance);
 
     m_assetManager = AAssetManager_fromJava(_jniEnv, _assetManager);
 
@@ -191,10 +191,6 @@ AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject
     }
 
     sqlite3_ndk_init(m_assetManager);
-}
-
-void AndroidPlatform::dispose(JNIEnv* _jniEnv) {
-    _jniEnv->DeleteGlobalRef(m_tangramInstance);
 }
 
 void AndroidPlatform::requestRender() const {

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -299,9 +299,14 @@ UrlRequestHandle AndroidPlatform::startUrlRequest(Url _url, UrlCallback _callbac
 
     // If the requested URL does not use HTTP or HTTPS, retrieve it synchronously.
     if (!_url.hasHttpScheme()) {
+        LOGE("Enqueue file task");
+
         m_fileWorker.enqueue([=](){
+
              UrlResponse response;
              response.content = bytesFromFile(_url);
+             LOGE("Ready file task");
+
              _callback(std::move(response));
         });
         return requestHandle;

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "platform.h"
+#include "jniWorker.h"
 #include "util/asyncWorker.h"
 
 
@@ -31,6 +32,7 @@ public:
 
     AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance);
     void dispose(JNIEnv* _jniEnv);
+    void shutdown() override {}
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
@@ -65,6 +67,7 @@ private:
     std::mutex m_callbackMutex;
     std::unordered_map<UrlRequestHandle, UrlCallback> m_callbacks;
 
+    mutable JniWorker m_jniWorker;  // FIX requestRender const.. Lets use Rust if we want this for real
     AsyncWorker m_fileWorker;
 
 };

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -31,7 +31,6 @@ class AndroidPlatform : public Platform {
 public:
 
     AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance);
-    void dispose(JNIEnv* _jniEnv);
     void shutdown() override {}
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "platform.h"
+#include "util/asyncWorker.h"
+
 
 #include <jni.h>
 #include <android/asset_manager.h>
-
 #include <atomic>
 #include <mutex>
 #include <string>
@@ -63,6 +64,8 @@ private:
     // m_callbackMutex should be locked any time m_callbacks is accessed.
     std::mutex m_callbackMutex;
     std::unordered_map<UrlRequestHandle, UrlCallback> m_callbacks;
+
+    AsyncWorker m_fileWorker;
 
 };
 

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -144,16 +144,9 @@ extern "C" {
         return reinterpret_cast<jlong>(map);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeDispose(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeDispose(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
         assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        // Don't dispose MapController ref before map is teared down,
-        // delete map or worker threads might call back to it (e.g. requestRender)
-        auto platform = map->getPlatform();
-
-        delete map;
-
-        static_cast<Tangram::AndroidPlatform&>(*platform).dispose(jniEnv);
+        delete reinterpret_cast<Tangram::Map*>(mapPtr);
     }
 
     JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path, jobjectArray updateStrings) {

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -530,8 +530,7 @@ extern "C" {
 
         assert(mapPtr > 0);
         assert(sourcePtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(map->getPlatform(), sourcePtr);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
 
         size_t n_points = jniEnv->GetArrayLength(jcoordinates) / 2;
         size_t n_rings = (jrings == NULL) ? 0 : jniEnv->GetArrayLength(jrings);
@@ -586,8 +585,7 @@ extern "C" {
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddGeoJson(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr, jstring geojson) {
         assert(mapPtr > 0);
         assert(sourcePtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(map->getPlatform(), sourcePtr);
+        auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
         auto data = stringFromJString(jniEnv, geojson);
         source->addData(data);
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -185,7 +185,7 @@ public class MapController implements Renderer {
         fontFileParser = new FontFileParser();
         fontFileParser.parse();
 
-        mapPointer = nativeInit(this, assetManager);
+        mapPointer = nativeInit(assetManager);
         if (mapPointer <= 0) {
             throw new RuntimeException("Unable to create a native Map object! There may be insufficient memory available.");
         }
@@ -1257,7 +1257,7 @@ public class MapController implements Renderer {
     // ==============
 
     private synchronized native void nativeOnLowMemory(long mapPtr);
-    private synchronized native long nativeInit(MapController instance, AssetManager assetManager);
+    private synchronized native long nativeInit(AssetManager assetManager);
     private synchronized native void nativeDispose(long mapPtr);
     private synchronized native int nativeLoadScene(long mapPtr, String path, String[] updateStrings);
     private synchronized native int nativeLoadSceneAsync(long mapPtr, String path, String[] updateStrings);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -42,6 +42,12 @@ public class MapController implements Renderer {
         return touchInput.onTouch(mapView, ev);
     }
 
+    public void resize(int width, int height) {
+        if (mapPointer > 0) {
+            nativeResize(mapPointer, width, height);
+        }
+    }
+
     /**
      * Options for interpolating map parameters
      */
@@ -227,6 +233,8 @@ public class MapController implements Renderer {
         touchInput.setSimultaneousDetectionDisabled(Gestures.SCALE, Gestures.LONG_PRESS);
 
         uiThreadHandler = new Handler(context.getMainLooper());
+
+        nativeSetPixelScale(mapPointer, displayMetrics.density);
     }
 
     /**
@@ -1416,7 +1424,6 @@ public class MapController implements Renderer {
             return;
         }
 
-        nativeSetPixelScale(mapPointer, displayMetrics.density);
         nativeResize(mapPointer, width, height);
     }
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.widget.FrameLayout;
 
@@ -125,6 +126,8 @@ public class MapView extends FrameLayout {
                 mapController = controller;
                 mapController.UIThreadInit(viewHolder, handler);
                 addView(viewHolder.getView());
+                Log.d("Tangram", "UIThreadInit " + getWidth() + " / "+ getHeight());
+                mapController.resize( getWidth(), getHeight());
             }
         }
         callback.onMapReady(mapController);
@@ -285,6 +288,15 @@ public class MapView extends FrameLayout {
      */
     public void onLowMemory() {
         mapController.onLowMemory();
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        super.onLayout(changed, l, t, r, b);
+        Log.d("Tangram", "WINDOW LAYOUT " + getWidth() + " / "+ getHeight());
+        if (mapController != null) {
+            mapController.resize( getWidth(), getHeight());
+        }
     }
 
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
@@ -117,8 +117,14 @@ public class DefaultHttpHandler implements HttpHandler {
     @Override
     public void cancelRequest(final Object request) {
         if (request instanceof Call) {
+
             Call call = (Call)request;
-            call.cancel();
+            if (okClient.dispatcher().runningCalls().indexOf(call) < 0) {
+                call.cancel();
+                Log.d("Tangram", "Cancel request" + call.toString());
+            } else {
+                Log.d("Tangram", "Skip Cancel" + call.toString());
+            }
         }
     }
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
@@ -90,7 +90,9 @@ public class DefaultHttpHandler implements HttpHandler {
             public void onResponse(final Call call, final Response response) {
                 byte[] data = null;
                 final ResponseBody body = response.body();
+
                 if (body != null) {
+                    Log.e("Tangram", "body size:" + body.contentLength());
                     try {
                         data = body.bytes();
                         cb.onResponse(response.code(), data);
@@ -105,6 +107,7 @@ public class DefaultHttpHandler implements HttpHandler {
         };
         final Request.Builder builder = new Request.Builder().url(httpUrl);
         configureRequest(httpUrl, builder);
+        //builder.addHeader("Accept-Encoding", "gzip");
         final Request request = builder.build();
         Call call = okClient.newCall(request);
         call.enqueue(callback);

--- a/platforms/common/glfwApp.cpp
+++ b/platforms/common/glfwApp.cpp
@@ -34,8 +34,6 @@ constexpr double scroll_span_multiplier = 0.05; // scaling for zoom and rotation
 constexpr double scroll_distance_multiplier = 5.0; // scaling for shove
 constexpr double single_tap_time = 0.25; //seconds (to avoid a long press being considered as a tap)
 
-std::shared_ptr<Platform> platform;
-
 std::string sceneFile = "scene.yaml";
 std::string sceneYaml;
 std::string apiKey;
@@ -112,9 +110,8 @@ void setScene(const std::string& _path, const std::string& _yaml) {
     sceneYaml = _yaml;
 }
 
-void create(std::shared_ptr<Platform> p, int w, int h) {
+void create(std::unique_ptr<Platform> p, int w, int h) {
 
-    platform = p;
     width = w;
     height = h;
 
@@ -136,7 +133,7 @@ void create(std::shared_ptr<Platform> p, int w, int h) {
 
     // Setup tangram
     if (!map) {
-        map = new Tangram::Map(platform);
+        map = new Tangram::Map(std::move(p));
     }
 
     // Build a version string for the window title.
@@ -237,7 +234,7 @@ void run() {
         glfwSwapBuffers(main_window);
 
         // Poll for and process events
-        if (platform->isContinuousRendering()) {
+        if (map->getPlatform().isContinuousRendering()) {
             glfwPollEvents();
         } else {
             glfwWaitEvents();
@@ -332,7 +329,7 @@ void mouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
         logMsg("Clicked:  %f, %f\n", x, y);
         logMsg("Remapped: %f, %f\n", xx, yy);
 
-        platform->requestRender();
+        map->getPlatform().requestRender();
     }
 
     last_time_released = time;

--- a/platforms/common/glfwApp.h
+++ b/platforms/common/glfwApp.h
@@ -7,7 +7,7 @@ namespace Tangram {
 
 namespace GlfwApp {
 
-void create(std::shared_ptr<Platform> platform, int width, int height);
+void create(std::unique_ptr<Platform> platform, int width, int height);
 void setScene(const std::string& _path, const std::string& _yaml);
 void loadSceneFile(bool setPosition = false);
 void parseArgs(int argc, char* argv[]);

--- a/platforms/common/linuxSystemFontHelper.cpp
+++ b/platforms/common/linuxSystemFontHelper.cpp
@@ -57,13 +57,14 @@ std::vector<std::string> systemFallbackFonts(FcConfig* fcConfig) {
             }
 
             FcLangSet *r = FcLangSetSubtract(ls, fls);
-            if (FcLangSetEqual(r, empty)) { continue; }
+            if (!FcLangSetEqual(r, empty)) {
+                FcLangSet *u = FcLangSetUnion(r, fls);
+                FcLangSetDestroy(fls);
+                fls = u;
 
-            FcLangSet *u = FcLangSetUnion(ls, fls);
-            FcLangSetDestroy(fls);
-            fls = u;
-
-            fallbackFonts.emplace_back(reinterpret_cast<char*>(file));
+                fallbackFonts.emplace_back(reinterpret_cast<char*>(file));
+            }
+            FcLangSetDestroy(r);
         }
     }
 

--- a/platforms/common/urlClient.h
+++ b/platforms/common/urlClient.h
@@ -15,7 +15,7 @@ class UrlClient {
 public:
 
     struct Options {
-        uint32_t numberOfThreads = 4;
+        uint32_t numberOfThreads = 6;
         uint32_t connectionTimeoutMs = 3000;
         uint32_t requestTimeoutMs = 30000;
     };

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -120,8 +120,7 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeState) {
 - (void)setup
 {
     __weak TGMapView* weakSelf = self;
-    std::shared_ptr<Tangram::Platform> platform(new Tangram::iOSPlatform(weakSelf));
-    _map = new Tangram::Map(platform);
+    _map = new Tangram::Map(std::make_unique<Tangram::iOSPlatform>(weakSelf));
 
     NSNotificationCenter* notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter addObserver:self

--- a/platforms/linux/config.cmake
+++ b/platforms/linux/config.cmake
@@ -21,6 +21,10 @@ if (CMAKE_COMPILER_IS_GNUCC)
   endif()
 endif()
 
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
+
 check_unsupported_compiler_version()
 
 add_definitions(-DTANGRAM_LINUX)

--- a/platforms/linux/src/linuxPlatform.cpp
+++ b/platforms/linux/src/linuxPlatform.cpp
@@ -26,12 +26,23 @@ void logMsg(const char* fmt, ...) {
 }
 
 LinuxPlatform::LinuxPlatform() :
-    m_urlClient(UrlClient::Options{}) {
+    m_urlClient(std::make_unique<UrlClient>(UrlClient::Options{})) {
     m_fcConfig = FcInitLoadConfigAndFonts();
 }
 
 LinuxPlatform::LinuxPlatform(UrlClient::Options urlClientOptions) :
-    m_urlClient(urlClientOptions) {}
+    m_urlClient(std::make_unique<UrlClient>(urlClientOptions)) {
+    m_fcConfig = FcInitLoadConfigAndFonts();
+}
+
+LinuxPlatform::~LinuxPlatform() {
+    FcConfigDestroy(m_fcConfig);
+}
+
+void LinuxPlatform::shutdown() {
+    // Stop all UrlWorker threads
+    m_urlClient.reset();
+}
 
 void LinuxPlatform::requestRender() const {
     glfwPostEmptyEvent();
@@ -39,28 +50,26 @@ void LinuxPlatform::requestRender() const {
 
 std::vector<FontSourceHandle> LinuxPlatform::systemFontFallbacksHandle() const {
 
-    /*
-     * Read system fontconfig to get list of fallback font for each supported language
-     */
+    // Read system fontconfig to get list of fallback font for each
+    // supported language
     auto fallbackFonts = systemFallbackFonts(m_fcConfig);
 
-    /*
-     * create FontSourceHandle from the found list of fallback fonts
-     */
+    // Create FontSourceHandle from the found list of fallback fonts
     std::vector<FontSourceHandle> handles;
     handles.reserve(fallbackFonts.size());
 
-    for (auto& path : fallbackFonts) {
-        handles.emplace_back(Url(path));
-    }
+    std::transform(std::begin(fallbackFonts), std::end(fallbackFonts),
+                   std::back_inserter(handles),
+                   [](auto& path) { return FontSourceHandle(Url(path)); });
 
     return handles;
 }
 
-FontSourceHandle LinuxPlatform::systemFont(const std::string& _name, const std::string& _weight,
+FontSourceHandle LinuxPlatform::systemFont(const std::string& _name,
+                                           const std::string& _weight,
                                            const std::string& _face) const {
 
-    std::string fontFile = systemFontPath(m_fcConfig, _name, _weight, _face);
+    auto fontFile = systemFontPath(m_fcConfig, _name, _weight, _face);
 
     if (fontFile.empty()) { return {}; }
 
@@ -68,14 +77,14 @@ FontSourceHandle LinuxPlatform::systemFont(const std::string& _name, const std::
 }
 
 UrlRequestHandle LinuxPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
-    return m_urlClient.addRequest(_url.string(), _callback);
+    if (!m_urlClient) { return 0; }
+    return m_urlClient->addRequest(_url.string(), _callback);
 }
 
 void LinuxPlatform::cancelUrlRequest(UrlRequestHandle _request) {
-    m_urlClient.cancelRequest(_request);
+    if (!m_urlClient) { return; }
+    m_urlClient->cancelRequest(_request);
 }
-
-LinuxPlatform::~LinuxPlatform() {}
 
 void setCurrentThreadPriority(int priority) {
     setpriority(PRIO_PROCESS, 0, priority);

--- a/platforms/linux/src/linuxPlatform.cpp
+++ b/platforms/linux/src/linuxPlatform.cpp
@@ -25,8 +25,8 @@ void logMsg(const char* fmt, ...) {
     va_end(args);
 }
 
-LinuxPlatform::LinuxPlatform() :
-    m_urlClient(std::make_unique<UrlClient>(UrlClient::Options{})) {
+LinuxPlatform::LinuxPlatform() {
+    m_urlClient = std::make_unique<UrlClient>(UrlClient::Options{});
     m_fcConfig = FcInitLoadConfigAndFonts();
 }
 
@@ -80,17 +80,35 @@ FontSourceHandle LinuxPlatform::systemFont(const std::string& _name,
 
 UrlRequestHandle LinuxPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
     if (m_shutdown) { return 0; }
-    return m_urlClient->addRequest(_url.string(),
-                                   [this, cb = _callback](UrlResponse&& r) {
-                                       LOG(">>-------------->>");
-                                       cb(std::move(r));
-                                       LOG("<<--------------<<");
-                                       requestRender();
-                                   });
+    if (_url.hasHttpScheme()) {
+        return m_urlClient->addRequest(_url.string(),
+                                       [this, cb = _callback](UrlResponse&& r) {
+                                           LOG(">>-------------->>");
+                                           cb(std::move(r));
+                                           LOG("<<--------------<<");
+                                           requestRender();
+                                       });
+    } else {
+        m_fileWorker.enqueue([path = _url.path(), _callback](){
+             UrlResponse response;
+             auto allocator = [&](size_t size) {
+                 response.content.resize(size);
+                 return response.content.data();
+             };
+
+             Platform::bytesFromFileSystem(path.c_str(), allocator);
+             //LOGE("Ready file task: %s", path.c_str());
+
+             _callback(std::move(response));
+        });
+        return std::numeric_limits<uint64_t>::max();
+    }
 }
 
 void LinuxPlatform::cancelUrlRequest(UrlRequestHandle _request) {
     if (m_shutdown) { return; }
+    if (_request == std::numeric_limits<uint64_t>::max()) { return; }
+
     m_urlClient->cancelRequest(_request);
 }
 

--- a/platforms/linux/src/linuxPlatform.h
+++ b/platforms/linux/src/linuxPlatform.h
@@ -8,12 +8,11 @@
 namespace Tangram {
 
 class LinuxPlatform : public Platform {
-
 public:
-
     LinuxPlatform();
-    LinuxPlatform(UrlClient::Options urlClientOptions);
+    explicit LinuxPlatform(UrlClient::Options urlClientOptions);
     ~LinuxPlatform() override;
+
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight,
@@ -23,11 +22,9 @@ public:
     void shutdown() override;
 
 protected:
-
-
     FcConfig* m_fcConfig = nullptr;
     std::unique_ptr<UrlClient> m_urlClient;
-
+    bool m_shutdown = false;
 };
 
 } // namespace Tangram

--- a/platforms/linux/src/linuxPlatform.h
+++ b/platforms/linux/src/linuxPlatform.h
@@ -17,15 +17,16 @@ public:
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight,
-            const std::string& _face) const override;
+                                const std::string& _face) const override;
     UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;
     void cancelUrlRequest(UrlRequestHandle _request) override;
+    void shutdown() override;
 
 protected:
 
 
     FcConfig* m_fcConfig = nullptr;
-    UrlClient m_urlClient;
+    std::unique_ptr<UrlClient> m_urlClient;
 
 };
 

--- a/platforms/linux/src/linuxPlatform.h
+++ b/platforms/linux/src/linuxPlatform.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <fontconfig/fontconfig.h>
+#include <atomic>
 
 #include "platform.h"
 #include "urlClient.h"
+#include "util/asyncWorker.h"
 
 namespace Tangram {
 
@@ -24,7 +26,8 @@ public:
 protected:
     FcConfig* m_fcConfig = nullptr;
     std::unique_ptr<UrlClient> m_urlClient;
-    bool m_shutdown = false;
+    AsyncWorker m_fileWorker;
+    std::atomic<bool> m_shutdown{false};
 };
 
 } // namespace Tangram

--- a/platforms/linux/src/main.cpp
+++ b/platforms/linux/src/main.cpp
@@ -12,10 +12,8 @@ using namespace Tangram;
 
 int main(int argc, char* argv[]) {
 
-    auto platform = std::make_shared<LinuxPlatform>();
-
     // Create the windowed app.
-    GlfwApp::create(platform, 1024, 768);
+    GlfwApp::create(std::make_unique<LinuxPlatform>(), 1024, 768);
 
     GlfwApp::parseArgs(argc, argv);
 

--- a/platforms/linux/src/main.cpp
+++ b/platforms/linux/src/main.cpp
@@ -13,7 +13,7 @@ using namespace Tangram;
 int main(int argc, char* argv[]) {
 
     // Create the windowed app.
-    GlfwApp::create(std::make_unique<LinuxPlatform>(), 1024, 768);
+    GlfwApp::create(std::make_unique<LinuxPlatform>(), 1280, 1024);
 
     GlfwApp::parseArgs(argc, argv);
 

--- a/platforms/osx/src/main.mm
+++ b/platforms/osx/src/main.mm
@@ -93,10 +93,8 @@ using namespace Tangram;
 
 int main(int argc, char* argv[]) {
 
-    auto platform = std::make_shared<OSXPlatform>();
-
     // Create the windowed app.
-    GlfwApp::create(platform, 1024, 768);
+    GlfwApp::create(std::make_unique<OSXPlatform>(), 1024, 768);
 
     // Menu and window changes must come after window is created.
     [TGPreferences setup];

--- a/scenes/scene.yaml
+++ b/scenes/scene.yaml
@@ -2,15 +2,15 @@ global:
     feature_order: function () { return feature.sort_rank; }
     sdk_api_key: ''
 
-fonts:
-    Montserrat:
-        url: https://fonts.gstatic.com/s/montserrat/v7/zhcz-_WihjSQC0oHJ9TCYL3hpw3pgy2gAi-Ip7WPMi0.woff
-    Open Sans:
-        - weight: 400
-          url: https://fonts.gstatic.com/s/opensans/v13/wMws1cEtxWZc6AZZIpiqWALUuEpTyoUstqEm5AMlJo4.woff
-        - weight: 400
-          style: italic
-          url: https://fonts.gstatic.com/s/opensans/v13/O4NhV7_qs9r9seTo7fnsVLO3LdcAZYWl9Si6vvxL-qU.woff
+# fonts:
+#     Montserrat:
+#         url: https://fonts.gstatic.com/s/montserrat/v7/zhcz-_WihjSQC0oHJ9TCYL3hpw3pgy2gAi-Ip7WPMi0.woff
+#     Open Sans:
+#         - weight: 400
+#           url: https://fonts.gstatic.com/s/opensans/v13/wMws1cEtxWZc6AZZIpiqWALUuEpTyoUstqEm5AMlJo4.woff
+#         - weight: 400
+#           style: italic
+#           url: https://fonts.gstatic.com/s/opensans/v13/O4NhV7_qs9r9seTo7fnsVLO3LdcAZYWl9Si6vvxL-qU.woff
 
 scene:
     background:

--- a/tests/src/mockPlatform.h
+++ b/tests/src/mockPlatform.h
@@ -10,6 +10,7 @@ class MockPlatform : public Platform {
 
 public:
 
+    void shutdown() override {}
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -245,8 +245,8 @@ TEST_CASE( "Test evalFilter - Init filter function from yaml", "[Duktape][evalFi
     YAML::Node n0 = YAML::Load(R"(filter: function() { return feature.sort_key === 2; })");
     YAML::Node n1 = YAML::Load(R"(filter: function() { return feature.name === 'test'; })");
 
-    Filter filter0 = SceneLoader::generateFilter(n0["filter"], scene);
-    Filter filter1 = SceneLoader::generateFilter(n1["filter"], scene);
+    Filter filter0 = SceneLoader::generateFilter(scene, n0["filter"]);
+    Filter filter1 = SceneLoader::generateFilter(scene, n1["filter"]);
 
     REQUIRE(scene.functions().size() == 2);
 
@@ -295,7 +295,7 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
 
     std::vector<StyleParam> styles;
 
-    SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
+    SceneLoader::parseStyleParams(scene, n0["draw"], "", styles);
 
     REQUIRE(scene.functions().size() == 3);
 
@@ -354,7 +354,7 @@ TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
 
     scene.config() = n0;
 
-    SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
+    SceneLoader::parseStyleParams(scene, n0["draw"], "", styles);
 
     REQUIRE(scene.functions().size() == 4);
 

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -292,7 +292,7 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
 
     std::vector<StyleParam> styles;
 
-    SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
+    SceneLoader::parseStyleParams(n0["draw"], *scene, "", styles);
 
     REQUIRE(scene->functions().size() == 3);
 
@@ -350,7 +350,7 @@ TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
 
     scene->config() = n0;
 
-    SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
+    SceneLoader::parseStyleParams(n0["draw"], *scene, "", styles);
 
     REQUIRE(scene->functions().size() == 4);
 

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -240,7 +240,8 @@ TEST_CASE( "Test evalStyleFn - StyleParamKey::text_source", "[Duktape][evalStyle
 }
 
 TEST_CASE( "Test evalFilter - Init filter function from yaml", "[Duktape][evalFilter]") {
-    Scene scene(std::make_shared<MockPlatform>(), Url());
+    MockPlatform platform;
+    Scene scene(platform);
     YAML::Node n0 = YAML::Load(R"(filter: function() { return feature.sort_key === 2; })");
     YAML::Node n1 = YAML::Load(R"(filter: function() { return feature.name === 'test'; })");
 
@@ -282,7 +283,9 @@ TEST_CASE( "Test evalFilter - Init filter function from yaml", "[Duktape][evalFi
 }
 
 TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][evalStyle]") {
-    std::shared_ptr<Scene> scene = std::make_shared<Scene>(std::make_shared<MockPlatform>(), Url());
+    MockPlatform platform;
+    Scene scene(platform);
+
     YAML::Node n0 = YAML::Load(R"(
             draw:
                 color: function() { return '#ffff00ff'; }
@@ -292,16 +295,16 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
 
     std::vector<StyleParam> styles;
 
-    SceneLoader::parseStyleParams(n0["draw"], *scene, "", styles);
+    SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
 
-    REQUIRE(scene->functions().size() == 3);
+    REQUIRE(scene.functions().size() == 3);
 
     // for (auto& str : scene.functions()) {
     //     logMsg("F: '%s'\n", str.c_str());
     // }
 
     StyleContext ctx;
-    ctx.initFunctions(*scene);
+    ctx.initFunctions(scene);
 
     for (auto& style : styles) {
         //logMsg("S: %d - '%s' %d\n", style.key, style.toString().c_str(), style.function);
@@ -330,7 +333,8 @@ TEST_CASE("Test evalStyle - Init StyleParam function from yaml", "[Duktape][eval
 }
 
 TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
-    std::shared_ptr<Scene> scene = std::make_shared<Scene>(std::make_shared<MockPlatform>(), Url());
+    MockPlatform platform;
+    Scene scene(platform);
     YAML::Node n0 = YAML::Load(R"(
             global:
                 width: 2
@@ -348,14 +352,14 @@ TEST_CASE( "Test evalFunction explicit", "[Duktape][evalFunction]") {
 
     std::vector<StyleParam> styles;
 
-    scene->config() = n0;
+    scene.config() = n0;
 
-    SceneLoader::parseStyleParams(n0["draw"], *scene, "", styles);
+    SceneLoader::parseStyleParams(n0["draw"], scene, "", styles);
 
-    REQUIRE(scene->functions().size() == 4);
+    REQUIRE(scene.functions().size() == 4);
 
     StyleContext ctx;
-    ctx.initFunctions(*scene);
+    ctx.initFunctions(scene);
 
     for (auto& style : styles) {
         if (style.key == StyleParamKey::color) {

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -1,6 +1,6 @@
 #include "catch.hpp"
 #include "gl/dynamicQuadMesh.h"
-#include "labels/labels.h"
+#include "labels/labelManager.h"
 #include "labels/textLabel.h"
 #include "labels/textLabels.h"
 #include "map.h"
@@ -116,7 +116,7 @@ TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
         TestTransform(ScreenTransform::Buffer& _buffer, Range& _range) : transform(_buffer, _range) {}
     };
 
-    class TestLabels : public Labels {
+    class TestLabels : public LabelManager {
     public:
         TestLabels(View& _v) {
             m_isect2d.resize({1, 1}, {_v.getWidth(), _v.getHeight()});

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -11,43 +11,43 @@
 using namespace Tangram;
 using namespace YAML;
 
-std::shared_ptr<MockPlatform> getPlatformWithImportFiles() {
+MockPlatform getPlatformWithImportFiles() {
 
-    auto platform = std::make_shared<MockPlatform>();
+    MockPlatform platform;
 
-    platform->putMockUrlContents("/root/a.yaml", R"END(
+    platform.putMockUrlContents("/root/a.yaml", R"END(
         import: b.yaml
         value: a
         has_a: true
     )END");
 
-    platform->putMockUrlContents("/root/b.yaml", R"END(
+    platform.putMockUrlContents("/root/b.yaml", R"END(
         value: b
         has_b: true
     )END");
 
-    platform->putMockUrlContents("/root/c.yaml", R"END(
+    platform.putMockUrlContents("/root/c.yaml", R"END(
         import: [a.yaml, b.yaml]
         value: c
         has_c: true
     )END");
 
-    platform->putMockUrlContents("/root/cycle_simple.yaml", R"END(
+    platform.putMockUrlContents("/root/cycle_simple.yaml", R"END(
         import: cycle_simple.yaml
         value: cyclic
     )END");
 
-    platform->putMockUrlContents("/root/cycle_tricky.yaml", R"END(
+    platform.putMockUrlContents("/root/cycle_tricky.yaml", R"END(
         import: imports/cycle_tricky.yaml
         has_cycle_tricky: true
     )END");
 
-    platform->putMockUrlContents("/root/imports/cycle_tricky.yaml", R"END(
+    platform.putMockUrlContents("/root/imports/cycle_tricky.yaml", R"END(
         import: ../cycle_tricky.yaml
         has_imports_cycle_tricky: true
     )END");
 
-    platform->putMockUrlContents("/root/urls.yaml", R"END(
+    platform.putMockUrlContents("/root/urls.yaml", R"END(
         import: imports/urls.yaml
         fonts: { fontA: { url: https://host/font.woff } }
         sources: { sourceA: { url: 'https://host/tiles/{z}/{y}/{x}.mvt' } }
@@ -66,7 +66,7 @@ std::shared_ptr<MockPlatform> getPlatformWithImportFiles() {
                         u_float: 0.25
     )END");
 
-    platform->putMockUrlContents("/root/imports/urls.yaml", R"END(
+    platform.putMockUrlContents("/root/imports/urls.yaml", R"END(
         fonts: { fontB: [ { url: fonts/0.ttf }, { url: fonts/1.ttf } ] }
         sources: { sourceB: { url: "tiles/{z}/{y}/{x}.mvt" } }
         textures:
@@ -82,7 +82,7 @@ std::shared_ptr<MockPlatform> getPlatformWithImportFiles() {
                         u_tex2: tex2
     )END");
 
-    platform->putMockUrlContents("/root/globals.yaml", R"END(
+    platform.putMockUrlContents("/root/globals.yaml", R"END(
         fonts: { aFont: { url: global.fontUrl } }
         sources: { aSource: { url: global.sourceUrl } }
         textures: { aTexture: { url: global.textureUrl } }
@@ -92,9 +92,13 @@ std::shared_ptr<MockPlatform> getPlatformWithImportFiles() {
     return platform;
 }
 
+std::shared_ptr<Scene> getScene(MockPlatform& platform, const Url& url) {
+    return std::make_shared<Scene>(platform, std::make_unique<SceneOptions>(url));
+}
+
 TEST_CASE("Imported scenes are merged with the parent scene", "[import][core]") {
-    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
-    Importer importer(std::make_shared<Scene>(platform, Url("/root/a.yaml")));
+    auto platform = getPlatformWithImportFiles();
+    Importer importer(getScene(platform, Url("/root/a.yaml")));
     auto root = importer.applySceneImports(platform);
 
     CHECK(root["value"].Scalar() == "a");
@@ -103,8 +107,8 @@ TEST_CASE("Imported scenes are merged with the parent scene", "[import][core]") 
 }
 
 TEST_CASE("Nested imports are merged recursively", "[import][core]") {
-    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
-    Importer importer(std::make_shared<Scene>(platform, Url("/root/c.yaml")));
+    auto platform = getPlatformWithImportFiles();
+    Importer importer(getScene(platform, Url("/root/c.yaml")));
     auto root = importer.applySceneImports(platform);
 
     CHECK(root["value"].Scalar() == "c");
@@ -114,8 +118,8 @@ TEST_CASE("Nested imports are merged recursively", "[import][core]") {
 }
 
 TEST_CASE("Imports that would start a cycle are ignored", "[import][core]") {
-    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
-    Importer importer(std::make_shared<Scene>(platform, Url("/root/cycle_simple.yaml")));
+    auto platform = getPlatformWithImportFiles();
+    Importer importer(getScene(platform, Url("/root/cycle_simple.yaml")));
 
     // If import cycles aren't checked for and stopped, this call won't return.
     auto root = importer.applySceneImports(platform);
@@ -125,8 +129,8 @@ TEST_CASE("Imports that would start a cycle are ignored", "[import][core]") {
 }
 
 TEST_CASE("Tricky import cycles are ignored", "[import][core]") {
-    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
-    Importer importer(std::make_shared<Scene>(platform, Url("/root/cycle_tricky.yaml")));
+    auto platform = getPlatformWithImportFiles();
+    Importer importer(getScene(platform, Url("/root/cycle_tricky.yaml")));
 
     // The nested import should resolve to the same path as the original file,
     // and so the importer should break the cycle.
@@ -138,8 +142,8 @@ TEST_CASE("Tricky import cycles are ignored", "[import][core]") {
 }
 
 TEST_CASE("Scene URLs are resolved against their parent during import", "[import][core]") {
-    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
-    Importer importer(std::make_shared<Scene>(platform, Url("/root/urls.yaml")));
+    auto platform = getPlatformWithImportFiles();
+    Importer importer(getScene(platform, Url("/root/urls.yaml")));
     auto root = importer.applySceneImports(platform);
 
     // Check that global texture URLs are resolved correctly.
@@ -193,8 +197,8 @@ TEST_CASE("Scene URLs are resolved against their parent during import", "[import
 }
 
 TEST_CASE("References to globals are not treated like URLs during importing", "[import][core]") {
-    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
-    Importer importer(std::make_shared<Scene>(platform, Url("/root/globals.yaml")));
+    auto platform = getPlatformWithImportFiles();
+    Importer importer(getScene(platform, Url("/root/globals.yaml")));
     auto root = importer.applySceneImports(platform);
 
     // Check that font global references are preserved.
@@ -210,22 +214,22 @@ TEST_CASE("References to globals are not treated like URLs during importing", "[
 }
 
 TEST_CASE("Map overwrites sequence", "[import][core]") {
-    std::shared_ptr<MockPlatform> platform = getPlatformWithImportFiles();
-    platform->putMockUrlContents("/base.yaml", R"END(
+    auto platform = getPlatformWithImportFiles();
+    platform.putMockUrlContents("/base.yaml", R"END(
         import: [roads.yaml, roads-labels.yaml]
     )END");
 
-    platform->putMockUrlContents("/roads.yaml", R"END(
+    platform.putMockUrlContents("/roads.yaml", R"END(
             filter:
                 - kind: highway
                 - $zoom: { min: 8 }
     )END");
 
-    platform->putMockUrlContents("/roads-labels.yaml", R"END(
+    platform.putMockUrlContents("/roads-labels.yaml", R"END(
                 filter: { kind: highway }
     )END");
 
-    Importer importer(std::make_shared<Scene>(platform, Url("/base.yaml")));
+    Importer importer(getScene(platform, Url("/base.yaml")));
     auto root = importer.applySceneImports(platform);
 
     CHECK(root["filter"].IsMap());
@@ -234,19 +238,19 @@ TEST_CASE("Map overwrites sequence", "[import][core]") {
 }
 
 TEST_CASE("Sequence overwrites map", "[import][core]") {
-    std::shared_ptr<MockPlatform> platform = std::make_shared<MockPlatform>();
-    platform->putMockUrlContents("/base.yaml", R"END(
+    MockPlatform platform;
+    platform.putMockUrlContents("/base.yaml", R"END(
         import: [map.yaml, sequence.yaml]
     )END");
-    platform->putMockUrlContents("/map.yaml", R"END(
+    platform.putMockUrlContents("/map.yaml", R"END(
             a: { b: c }
     )END");
 
-    platform->putMockUrlContents("/sequence.yaml", R"END(
+    platform.putMockUrlContents("/sequence.yaml", R"END(
             a: [ b, c]
     )END");
 
-    Importer importer(std::make_shared<Scene>(platform, Url("/base.yaml")));
+    Importer importer(getScene(platform, Url("/base.yaml")));
     auto root = importer.applySceneImports(platform);
 
     CHECK(root["a"].IsSequence());
@@ -254,21 +258,21 @@ TEST_CASE("Sequence overwrites map", "[import][core]") {
 }
 
 TEST_CASE("Scalar and null overwrite correctly", "[import][core]") {
-    std::shared_ptr<MockPlatform> platform = std::make_shared<MockPlatform>();
-    platform->putMockUrlContents("/base.yaml", R"END(
+    MockPlatform platform;
+    platform.putMockUrlContents("/base.yaml", R"END(
         import: [scalar.yaml, null.yaml]
         scalar_at_end: scalar
         null_at_end: null
     )END");
-    platform->putMockUrlContents("/scalar.yaml", R"END(
+    platform.putMockUrlContents("/scalar.yaml", R"END(
             null_at_end: scalar
     )END");
 
-    platform->putMockUrlContents("/null.yaml", R"END(
+    platform.putMockUrlContents("/null.yaml", R"END(
             scalar_at_end: null
     )END");
 
-    Importer importer(std::make_shared<Scene>(platform, Url("/base.yaml")));
+    Importer importer(getScene(platform, Url("/base.yaml")));
     auto root = importer.applySceneImports(platform);
 
     CHECK(root["scalar_at_end"].Scalar() == "scalar");
@@ -276,12 +280,12 @@ TEST_CASE("Scalar and null overwrite correctly", "[import][core]") {
 }
 
 TEST_CASE("Scene load from source string", "[import][core]") {
-    std::shared_ptr<MockPlatform> platform = std::make_shared<MockPlatform>();
+    MockPlatform platform;
     std::unordered_map<Url, std::string> testScenes;
-    platform->putMockUrlContents("/resource_root/scalar.yaml", R"END(
+    platform.putMockUrlContents("/resource_root/scalar.yaml", R"END(
             null_at_end: scalar
     )END");
-    platform->putMockUrlContents("/resource_root/null.yaml", R"END(
+    platform.putMockUrlContents("/resource_root/null.yaml", R"END(
             scalar_at_end: null
     )END");
 
@@ -291,7 +295,8 @@ TEST_CASE("Scene load from source string", "[import][core]") {
         null_at_end: null
     )END";
 
-    auto scene = std::make_shared<Scene>(platform, base_yaml, "/resource_root/");
+    auto scene = std::make_shared<Scene>(platform,
+                                         std::make_unique<SceneOptions>(base_yaml, Url("/resource_root/")));
 
     Importer importer(scene);
     

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -93,7 +93,7 @@ std::shared_ptr<MockPlatform> getPlatformWithImportFiles() {
 }
 
 TEST_CASE("Imported scenes are merged with the parent scene", "[import][core]") {
-    std::shared_ptr<Platform> platform = getPlatformWithImportFiles();
+    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
     Importer importer(std::make_shared<Scene>(platform, Url("/root/a.yaml")));
     auto root = importer.applySceneImports(platform);
 
@@ -103,7 +103,7 @@ TEST_CASE("Imported scenes are merged with the parent scene", "[import][core]") 
 }
 
 TEST_CASE("Nested imports are merged recursively", "[import][core]") {
-    std::shared_ptr<Platform> platform = getPlatformWithImportFiles();
+    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
     Importer importer(std::make_shared<Scene>(platform, Url("/root/c.yaml")));
     auto root = importer.applySceneImports(platform);
 
@@ -114,7 +114,7 @@ TEST_CASE("Nested imports are merged recursively", "[import][core]") {
 }
 
 TEST_CASE("Imports that would start a cycle are ignored", "[import][core]") {
-    std::shared_ptr<Platform> platform = getPlatformWithImportFiles();
+    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
     Importer importer(std::make_shared<Scene>(platform, Url("/root/cycle_simple.yaml")));
 
     // If import cycles aren't checked for and stopped, this call won't return.
@@ -125,7 +125,7 @@ TEST_CASE("Imports that would start a cycle are ignored", "[import][core]") {
 }
 
 TEST_CASE("Tricky import cycles are ignored", "[import][core]") {
-    std::shared_ptr<Platform> platform = getPlatformWithImportFiles();
+    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
     Importer importer(std::make_shared<Scene>(platform, Url("/root/cycle_tricky.yaml")));
 
     // The nested import should resolve to the same path as the original file,
@@ -138,7 +138,7 @@ TEST_CASE("Tricky import cycles are ignored", "[import][core]") {
 }
 
 TEST_CASE("Scene URLs are resolved against their parent during import", "[import][core]") {
-    std::shared_ptr<Platform> platform = getPlatformWithImportFiles();
+    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
     Importer importer(std::make_shared<Scene>(platform, Url("/root/urls.yaml")));
     auto root = importer.applySceneImports(platform);
 
@@ -193,7 +193,7 @@ TEST_CASE("Scene URLs are resolved against their parent during import", "[import
 }
 
 TEST_CASE("References to globals are not treated like URLs during importing", "[import][core]") {
-    std::shared_ptr<Platform> platform = getPlatformWithImportFiles();
+    std::shared_ptr<Tangram::Platform> platform = getPlatformWithImportFiles();
     Importer importer(std::make_shared<Scene>(platform, Url("/root/globals.yaml")));
     auto root = importer.applySceneImports(platform);
 

--- a/tests/unit/sceneLoaderTests.cpp
+++ b/tests/unit/sceneLoaderTests.cpp
@@ -17,7 +17,7 @@ using YAML::Node;
 TEST_CASE("Style with the same name as a built-in style are ignored") {
     MockPlatform platform;
     Scene scene{platform, std::make_unique<SceneOptions>(Url())};
-    SceneLoader::loadStyle("polygons", Node(), scene);
+    SceneLoader::loadStyle(scene, "polygons", Node());
     REQUIRE(scene.styles().size() == 0);
 
 }
@@ -39,7 +39,7 @@ TEST_CASE("Correctly instantiate a style from a YAML configuration") {
             emission: 0.0
         )END");
 
-    SceneLoader::loadStyle("roads", node, scene);
+    SceneLoader::loadStyle(scene, "roads", node);
 
     auto& styles = scene.styles();
 

--- a/tests/unit/sceneLoaderTests.cpp
+++ b/tests/unit/sceneLoaderTests.cpp
@@ -16,18 +16,18 @@ using YAML::Node;
 
 TEST_CASE("Style with the same name as a built-in style are ignored") {
     MockPlatform platform;
-    auto scene = std::make_shared<Scene>(platform, std::make_unique<SceneOptions>(Url()));
+    Scene scene{platform, std::make_unique<SceneOptions>(Url())};
     SceneLoader::loadStyle("polygons", Node(), scene);
-    REQUIRE(scene->styles().size() == 0);
+    REQUIRE(scene.styles().size() == 0);
 
 }
 
 TEST_CASE("Correctly instantiate a style from a YAML configuration") {
     MockPlatform platform;
-    auto scene = std::make_shared<Scene>(platform, std::make_unique<SceneOptions>(Url()));
+    Scene scene{platform, std::make_unique<SceneOptions>(Url())};
 
-    scene->styles().emplace_back(new PolygonStyle("polygons"));
-    scene->styles().emplace_back(new PolylineStyle("lines"));
+    scene.styles().emplace_back(new PolygonStyle("polygons"));
+    scene.styles().emplace_back(new PolylineStyle("lines"));
 
     YAML::Node node = YAML::Load(R"END(
         animated: true
@@ -41,7 +41,7 @@ TEST_CASE("Correctly instantiate a style from a YAML configuration") {
 
     SceneLoader::loadStyle("roads", node, scene);
 
-    auto& styles = scene->styles();
+    auto& styles = scene.styles();
 
     REQUIRE(styles.size() == 3);
     REQUIRE(styles[0]->getName() == "polygons");

--- a/tests/unit/sceneLoaderTests.cpp
+++ b/tests/unit/sceneLoaderTests.cpp
@@ -15,16 +15,16 @@ using namespace Tangram;
 using YAML::Node;
 
 TEST_CASE("Style with the same name as a built-in style are ignored") {
-    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
-    std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
-    SceneLoader::loadStyle(platform, "polygons", Node(), scene);
+    MockPlatform platform;
+    auto scene = std::make_shared<Scene>(platform, std::make_unique<SceneOptions>(Url()));
+    SceneLoader::loadStyle("polygons", Node(), scene);
     REQUIRE(scene->styles().size() == 0);
 
 }
 
 TEST_CASE("Correctly instantiate a style from a YAML configuration") {
-    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
-    std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
+    MockPlatform platform;
+    auto scene = std::make_shared<Scene>(platform, std::make_unique<SceneOptions>(Url()));
 
     scene->styles().emplace_back(new PolygonStyle("polygons"));
     scene->styles().emplace_back(new PolylineStyle("lines"));
@@ -39,7 +39,7 @@ TEST_CASE("Correctly instantiate a style from a YAML configuration") {
             emission: 0.0
         )END");
 
-    SceneLoader::loadStyle(platform, "roads", node, scene);
+    SceneLoader::loadStyle("roads", node, scene);
 
     auto& styles = scene->styles();
 

--- a/tests/unit/sceneLoaderTests.cpp
+++ b/tests/unit/sceneLoaderTests.cpp
@@ -15,7 +15,7 @@ using namespace Tangram;
 using YAML::Node;
 
 TEST_CASE("Style with the same name as a built-in style are ignored") {
-    std::shared_ptr<Platform> platform = std::make_shared<MockPlatform>();
+    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
     std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
     SceneLoader::loadStyle(platform, "polygons", Node(), scene);
     REQUIRE(scene->styles().size() == 0);
@@ -23,7 +23,7 @@ TEST_CASE("Style with the same name as a built-in style are ignored") {
 }
 
 TEST_CASE("Correctly instantiate a style from a YAML configuration") {
-    std::shared_ptr<Platform> platform = std::make_shared<MockPlatform>();
+    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
     std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
 
     scene->styles().emplace_back(new PolygonStyle("polygons"));

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -43,26 +43,26 @@ bool loadConfig(const std::string& _sceneString, Node& root) {
 
 TEST_CASE("Apply scene update to a top-level node") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"map", "new_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     CHECK(root["map"].Scalar() == "new_value");
 }
 
 TEST_CASE("Apply scene update to a map entry") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"map.a", "new_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     CHECK(root["map"]["a"].Scalar() == "new_value");
     // Check that nearby values are unchanged.
@@ -71,13 +71,13 @@ TEST_CASE("Apply scene update to a map entry") {
 
 TEST_CASE("Apply scene update to a nested map entry") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"nest.map.a", "new_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     CHECK(root["nest"]["map"]["a"].Scalar() == "new_value");
     // Check that nearby values are unchanged.
@@ -86,26 +86,26 @@ TEST_CASE("Apply scene update to a nested map entry") {
 
 TEST_CASE("Apply scene update to a sequence node") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"seq", "new_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     CHECK(root["seq"].Scalar() == "new_value");
 }
 
 TEST_CASE("Apply scene update to a nested sequence node") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"nest.seq", "new_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     CHECK(root["nest"]["seq"].Scalar() == "new_value");
     // Check that nearby values are unchanged.
@@ -114,13 +114,13 @@ TEST_CASE("Apply scene update to a nested sequence node") {
 
 TEST_CASE("Apply scene update to a new map entry") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"map.c", "new_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     CHECK(root["map"]["c"].Scalar() == "new_value");
     // Check that nearby values are unchanged.
@@ -129,26 +129,26 @@ TEST_CASE("Apply scene update to a new map entry") {
 
 TEST_CASE("Do not apply scene update to a non-existent node") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"none.a", "new_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     REQUIRE(!root["none"]);
 }
 
 TEST_CASE("Apply scene update that removes a node") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"nest.map", "null"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     CHECK(!root["nest"]["map"]["a"]);
     CHECK(root["nest"]["map"].IsNull());
@@ -157,13 +157,13 @@ TEST_CASE("Apply scene update that removes a node") {
 
 TEST_CASE("Apply multiple scene updates in order of request") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"map.a", "first_value"}, {"map.a", "second_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
     CHECK(root["map"]["a"].Scalar() == "second_value");
     // Check that nearby values are unchanged.
@@ -172,8 +172,8 @@ TEST_CASE("Apply multiple scene updates in order of request") {
 
 TEST_CASE("Apply and propogate repeated global value updates") {
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     Node& root = scene.config();
     // Apply initial globals.
@@ -183,7 +183,7 @@ TEST_CASE("Apply and propogate repeated global value updates") {
     // Add an update.
     std::vector<SceneUpdate> updates = {{"global.b", "new_global_b_value"}};
     // Apply the update.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     CHECK(root["global"]["b"].Scalar() == "new_global_b_value");
     // Apply updated globals.
     SceneLoader::applyGlobals(scene);
@@ -192,7 +192,7 @@ TEST_CASE("Apply and propogate repeated global value updates") {
     // Add an update.
     updates = {{"global.b", "newer_global_b_value"}};
     // Apply the update.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     CHECK(root["global"]["b"].Scalar() == "newer_global_b_value");
     // Apply updated globals.
     SceneLoader::applyGlobals(scene);
@@ -203,49 +203,49 @@ TEST_CASE("Apply and propogate repeated global value updates") {
 TEST_CASE("Regression: scene update requesting a sequence from a scalar") {
 
     // Setup.
-    auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     // Add an update.
     std::vector<SceneUpdate> updates = {{"map.a#0", "new_value"}};
     // Apply scene updates, reload scene.
-    SceneLoader::applyUpdates(platform_mock, scene, updates);
+    SceneLoader::applyUpdates(scene, updates);
     const Node& root = scene.config();
 
     // causes yaml exception 'operator[] call on a scalar'
 }
 
 TEST_CASE("Scene update statuses") {
- auto platform_mock = std::make_shared<MockPlatform>();
-    Scene scene(platform_mock, Url());
+    MockPlatform platform;
+    Scene scene(platform, std::make_unique<SceneOptions>(Url()));
     REQUIRE(loadConfig(sceneString, scene.config()));
     Node& root = scene.config();
 
     std::vector<SceneUpdate> updates = {{"map.a", "{ first_value"}};
-    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(SceneLoader::applyUpdates(scene, updates) == false);
     CHECK(scene.errors.front().error == Error::scene_update_value_yaml_syntax_error);
     scene.errors.clear();
 
     updates = {{"someKey.somePath", "someValue"}};
-    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(SceneLoader::applyUpdates(scene, updates) == false);
     CHECK(scene.errors.front().error == Error::scene_update_path_not_found);
     scene.errors.clear();
 
     updates = {{"map.a.map_a_value", "someValue"}};
-    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(SceneLoader::applyUpdates(scene, updates) == false);
     CHECK(scene.errors.front().error == Error::scene_update_path_not_found);
     scene.errors.clear();
 
     updates = {{"!map#0", "first_value"}};
-    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(SceneLoader::applyUpdates(scene, updates) == false);
     CHECK(scene.errors.front().error == Error::scene_update_path_not_found);
     scene.errors.clear();
 
     updates = {{"key_not_existing", "first_value"}};
-    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == true);
+    CHECK(SceneLoader::applyUpdates(scene, updates) == true);
 
     updates = {{"!map#0", "{ first_value"}};
-    CHECK(SceneLoader::applyUpdates(platform_mock, scene, updates) == false);
+    CHECK(SceneLoader::applyUpdates(scene, updates) == false);
     CHECK(scene.errors.front().error == Error::scene_update_value_yaml_syntax_error);
     scene.errors.clear();
 }

--- a/tests/unit/sceneUpdateTests.cpp
+++ b/tests/unit/sceneUpdateTests.cpp
@@ -177,7 +177,7 @@ TEST_CASE("Apply and propogate repeated global value updates") {
     REQUIRE(loadConfig(sceneString, scene.config()));
     Node& root = scene.config();
     // Apply initial globals.
-    SceneLoader::applyGlobals(root, scene);
+    SceneLoader::applyGlobals(scene);
     CHECK(root["seq"][1].Scalar() == "global_a_value");
     CHECK(root["map"]["b"].Scalar() == "global_b_value");
     // Add an update.
@@ -186,7 +186,7 @@ TEST_CASE("Apply and propogate repeated global value updates") {
     SceneLoader::applyUpdates(platform_mock, scene, updates);
     CHECK(root["global"]["b"].Scalar() == "new_global_b_value");
     // Apply updated globals.
-    SceneLoader::applyGlobals(root, scene);
+    SceneLoader::applyGlobals(scene);
     CHECK(root["seq"][1].Scalar() == "global_a_value");
     CHECK(root["map"]["b"].Scalar() == "new_global_b_value");
     // Add an update.
@@ -195,7 +195,7 @@ TEST_CASE("Apply and propogate repeated global value updates") {
     SceneLoader::applyUpdates(platform_mock, scene, updates);
     CHECK(root["global"]["b"].Scalar() == "newer_global_b_value");
     // Apply updated globals.
-    SceneLoader::applyGlobals(root, scene);
+    SceneLoader::applyGlobals(scene);
     CHECK(root["seq"][1].Scalar() == "global_a_value");
     CHECK(root["map"]["b"].Scalar() == "newer_global_b_value");
 }

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -28,7 +28,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_float"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_float"], uniformValues));
     REQUIRE(uniformValues.value.is<float>());
     REQUIRE(uniformValues.value.get<float>() == 0.5);
     REQUIRE(uniformValues.type == "float");
@@ -45,12 +45,12 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_true"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_true"], uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 1);
     REQUIRE(uniformValues.type == "bool");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_false"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_false"], uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 0);
     REQUIRE(uniformValues.type == "bool");
@@ -69,20 +69,20 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec2"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_vec2"], uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec2>());
     REQUIRE(uniformValues.value.get<glm::vec2>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec2>().y == 0.2f);
     REQUIRE(uniformValues.type == "vec2");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec3"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_vec3"], uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec3>());
     REQUIRE(uniformValues.value.get<glm::vec3>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec3>().y == 0.2f);
     REQUIRE(uniformValues.value.get<glm::vec3>().z == 0.3f);
     REQUIRE(uniformValues.type == "vec3");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec4"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_vec4"], uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec4>());
     REQUIRE(uniformValues.value.get<glm::vec4>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec4>().y == 0.2f);
@@ -90,7 +90,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
     REQUIRE(uniformValues.value.get<glm::vec4>().w == 0.4f);
     REQUIRE(uniformValues.type == "vec4");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_array"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_array"], uniformValues));
     REQUIRE(uniformValues.value.is<UniformArray1f>());
     REQUIRE(uniformValues.value.get<UniformArray1f>()[0] == 0.1f);
     REQUIRE(uniformValues.value.get<UniformArray1f>()[1] == 0.2f);
@@ -111,12 +111,12 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_tex"], uniformValues));
     REQUIRE(uniformValues.value.is<std::string>());
     REQUIRE(uniformValues.value.get<std::string>() == "img/cross.png");
     REQUIRE(uniformValues.type == "sampler2D");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex2"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(scene, node["u_tex2"], uniformValues));
     REQUIRE(uniformValues.value.is<UniformTextureArray>());
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names.size() == 3);
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names[0] == "img/cross.png");

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -20,7 +20,7 @@ using YAML::Node;
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[StyleUniforms][core][yaml]") {
     MockPlatform platform;
-    auto scene = std::make_shared<Scene>(platform);
+    Scene scene{platform};
 
     Node node = YAML::Load(R"END(
         u_float: 0.5
@@ -36,7 +36,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "[StyleUniforms][core][yaml]") {
     MockPlatform platform;
-    auto scene = std::make_shared<Scene>(platform);
+    Scene scene{platform};
 
     Node node = YAML::Load(R"END(
         u_true: true
@@ -58,7 +58,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform value", "[StyleUniforms][core][yaml]") {
     MockPlatform platform;
-    auto scene = std::make_shared<Scene>(platform);
+    Scene scene{platform};
 
     Node node = YAML::Load(R"END(
         u_vec2: [0.1, 0.2]
@@ -102,7 +102,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", "[StyleUniforms][core][yaml]") {
     std::unordered_map<Url, std::string> testScenes;
     MockPlatform platform;
-    auto scene = std::make_shared<Scene>(platform);
+    Scene scene{platform};
 
     Node node = YAML::Load(R"END(
         u_tex: img/cross.png

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -19,7 +19,7 @@ using namespace Tangram;
 using YAML::Node;
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[StyleUniforms][core][yaml]") {
-    std::shared_ptr<Platform> platform = std::make_shared<MockPlatform>();
+    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
     std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
 
     Node node = YAML::Load(R"END(
@@ -35,7 +35,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "[StyleUniforms][core][yaml]") {
-    std::shared_ptr<Platform> platform = std::make_shared<MockPlatform>();
+    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
     std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
 
     Node node = YAML::Load(R"END(
@@ -57,7 +57,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform value", "[StyleUniforms][core][yaml]") {
-    std::shared_ptr<Platform> platform = std::make_shared<MockPlatform>();
+    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
     std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
 
     Node node = YAML::Load(R"END(
@@ -101,7 +101,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", "[StyleUniforms][core][yaml]") {
     std::unordered_map<Url, std::string> testScenes;
-    std::shared_ptr<Platform> platform = std::make_shared<MockPlatform>();
+    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
     std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
 
     Node node = YAML::Load(R"END(

--- a/tests/unit/styleUniformsTests.cpp
+++ b/tests/unit/styleUniformsTests.cpp
@@ -19,8 +19,8 @@ using namespace Tangram;
 using YAML::Node;
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[StyleUniforms][core][yaml]") {
-    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
-    std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
+    MockPlatform platform;
+    auto scene = std::make_shared<Scene>(platform);
 
     Node node = YAML::Load(R"END(
         u_float: 0.5
@@ -28,15 +28,15 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Float uniform value", "[S
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_float"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_float"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<float>());
     REQUIRE(uniformValues.value.get<float>() == 0.5);
     REQUIRE(uniformValues.type == "float");
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "[StyleUniforms][core][yaml]") {
-    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
-    std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
+    MockPlatform platform;
+    auto scene = std::make_shared<Scene>(platform);
 
     Node node = YAML::Load(R"END(
         u_true: true
@@ -45,20 +45,20 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: Boolean uniform value", "
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_true"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_true"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 1);
     REQUIRE(uniformValues.type == "bool");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_false"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_false"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<bool>());
     REQUIRE(uniformValues.value.get<bool>() == 0);
     REQUIRE(uniformValues.type == "bool");
 }
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform value", "[StyleUniforms][core][yaml]") {
-    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
-    std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
+    MockPlatform platform;
+    auto scene = std::make_shared<Scene>(platform);
 
     Node node = YAML::Load(R"END(
         u_vec2: [0.1, 0.2]
@@ -69,20 +69,20 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_vec2"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec2"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec2>());
     REQUIRE(uniformValues.value.get<glm::vec2>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec2>().y == 0.2f);
     REQUIRE(uniformValues.type == "vec2");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_vec3"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec3"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec3>());
     REQUIRE(uniformValues.value.get<glm::vec3>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec3>().y == 0.2f);
     REQUIRE(uniformValues.value.get<glm::vec3>().z == 0.3f);
     REQUIRE(uniformValues.type == "vec3");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_vec4"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_vec4"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<glm::vec4>());
     REQUIRE(uniformValues.value.get<glm::vec4>().x == 0.1f);
     REQUIRE(uniformValues.value.get<glm::vec4>().y == 0.2f);
@@ -90,7 +90,7 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
     REQUIRE(uniformValues.value.get<glm::vec4>().w == 0.4f);
     REQUIRE(uniformValues.type == "vec4");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_array"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_array"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<UniformArray1f>());
     REQUIRE(uniformValues.value.get<UniformArray1f>()[0] == 0.1f);
     REQUIRE(uniformValues.value.get<UniformArray1f>()[1] == 0.2f);
@@ -101,8 +101,8 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: vec2, vec3, vec4 uniform 
 
 TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", "[StyleUniforms][core][yaml]") {
     std::unordered_map<Url, std::string> testScenes;
-    std::shared_ptr<Tangram::Platform> platform = std::make_shared<MockPlatform>();
-    std::shared_ptr<Scene> scene = std::make_shared<Scene>(platform, Url());
+    MockPlatform platform;
+    auto scene = std::make_shared<Scene>(platform);
 
     Node node = YAML::Load(R"END(
         u_tex: img/cross.png
@@ -111,12 +111,12 @@ TEST_CASE( "Style Uniforms Parsing and Injection Test: textures uniform value", 
 
     StyleUniform uniformValues;
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_tex"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<std::string>());
     REQUIRE(uniformValues.value.get<std::string>() == "img/cross.png");
     REQUIRE(uniformValues.type == "sampler2D");
 
-    REQUIRE(SceneLoader::parseStyleUniforms(platform, node["u_tex2"], scene, uniformValues));
+    REQUIRE(SceneLoader::parseStyleUniforms(node["u_tex2"], scene, uniformValues));
     REQUIRE(uniformValues.value.is<UniformTextureArray>());
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names.size() == 3);
     REQUIRE(uniformValues.value.get<UniformTextureArray>().names[0] == "img/cross.png");

--- a/tests/unit/tileManagerTests.cpp
+++ b/tests/unit/tileManagerTests.cpp
@@ -140,7 +140,8 @@ public:
 
 TEST_CASE( "Use proxy Tile - Dont remove proxy if it is now visible", "[TileManager][updateTileSets]" ) {
     TestTileWorker worker;
-    TestTileManager tileManager(std::make_shared<MockPlatform>(), worker);
+    MockPlatform platform;
+    TestTileManager tileManager(platform, worker);
 
     auto source = std::make_shared<TestTileSource>();
     std::vector<std::shared_ptr<TileSource>> sources = { source };
@@ -186,18 +187,20 @@ TEST_CASE( "Use proxy Tile - Dont remove proxy if it is now visible", "[TileMana
 TEST_CASE( "Mock TileWorker Initialization", "[TileManager][Constructor]" ) {
 
     TestTileWorker worker;
-    TileManager tileManager(std::shared_ptr<MockPlatform>(), worker);
+    MockPlatform platform;
+    TileManager tileManager(platform, worker);
 }
 
 TEST_CASE( "Real TileWorker Initialization", "[TileManager][Constructor]" ) {
-    auto platform = std::make_shared<MockPlatform>();
+    MockPlatform platform;
     TileWorker worker(platform, 1);
     TileManager tileManager(platform, worker);
 }
 
 TEST_CASE( "Load visible Tile", "[TileManager][updateTileSets]" ) {
     TestTileWorker worker;
-    TestTileManager tileManager(std::make_shared<MockPlatform>(), worker);
+    MockPlatform platform;
+    TestTileManager tileManager(platform, worker);
 
     auto source = std::make_shared<TestTileSource>();
     std::vector<std::shared_ptr<TileSource>> sources = { source };
@@ -222,7 +225,8 @@ TEST_CASE( "Load visible Tile", "[TileManager][updateTileSets]" ) {
 
 TEST_CASE( "Use proxy Tile", "[TileManager][updateTileSets]" ) {
     TestTileWorker worker;
-    TestTileManager tileManager(std::make_shared<MockPlatform>(), worker);
+    MockPlatform platform;
+    TestTileManager tileManager(platform, worker);
 
     auto source = std::make_shared<TestTileSource>();
     std::vector<std::shared_ptr<TileSource>> sources = { source };
@@ -260,7 +264,8 @@ TEST_CASE( "Use proxy Tile", "[TileManager][updateTileSets]" ) {
 
 TEST_CASE( "Use proxy Tile - circular proxies", "[TileManager][updateTileSets]" ) {
     TestTileWorker worker;
-    TestTileManager tileManager(std::make_shared<MockPlatform>(), worker);
+    MockPlatform platform;
+    TestTileManager tileManager(platform, worker);
 
     auto source = std::make_shared<TestTileSource>();
     std::vector<std::shared_ptr<TileSource>> sources = { source };

--- a/tests/unit/tileManagerTests.cpp
+++ b/tests/unit/tileManagerTests.cpp
@@ -89,14 +89,15 @@ struct TestTileSource : TileSource {
         m_generateGeometry = true;
     }
 
-    void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override {
+    void loadTileTask(std::shared_ptr<TileTask> _task) override {
         tileTaskCount++;
         static_cast<Task*>(_task.get())->gotData = true;
         _task->startedLoading();
-        _cb.func(std::move(_task));
+        //FIXME
+        //_cb.func(std::move(_task));
     }
 
-    void cancelLoadingTile(TileTask& _tile) override {}
+    void cancelTileTask(TileTask& _tile) override {}
 
     std::shared_ptr<TileData> parse(const TileTask& _task) const override {
         return nullptr;

--- a/tests/unit/tileManagerTests.cpp
+++ b/tests/unit/tileManagerTests.cpp
@@ -40,7 +40,9 @@ struct TestTileWorker : TileTaskQueue {
                 continue;
             }
 
-            task->setTile(std::make_unique<Tile>(task->tileId(), task->source().get()));
+            task->setTile(std::make_unique<Tile>(task->tileId(),
+                                                 task->source()->id(),
+                                                 task->source()->generation()));
 
             pendingTiles = true;
             processedCount++;
@@ -52,7 +54,9 @@ struct TestTileWorker : TileTaskQueue {
         auto task = tasks[position];
         tasks.erase(tasks.begin() + position);
 
-        task->setTile(std::make_unique<Tile>(task->tileId(), task->source().get()));
+        task->setTile(std::make_unique<Tile>(task->tileId(),
+                                             task->source()->id(),
+                                             task->source()->generation()));
 
         pendingTiles = true;
         processedCount++;

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -25,7 +25,7 @@ Filter load(const std::string& filterYaml) {
     MockPlatform platform;
     Scene scene(platform);
     YAML::Node node = YAML::Load(filterYaml);
-    auto filter = SceneLoader::generateFilter(node["filter"], scene);
+    auto filter = SceneLoader::generateFilter(scene, node["filter"]);
     ctx.initFunctions(scene);
     return filter;
 }

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -22,7 +22,8 @@ Context ctx;
 Feature civic, bmw1, bike;
 
 Filter load(const std::string& filterYaml) {
-    Scene scene(std::make_shared<MockPlatform>(), Url());
+    MockPlatform platform;
+    Scene scene(platform);
     YAML::Node node = YAML::Load(filterYaml);
     auto filter = SceneLoader::generateFilter(node["filter"], scene);
     ctx.initFunctions(scene);


### PR DESCRIPTION
Goals
- Enable tile fetching as soon as possible, not waiting for the Scene to be completely loaded
- In general these changes should improve parallelization of sceneloading
- Move all things that hold data referencing Scene into Scene so that it's simple to free all data of an old Scene - not having multiple instances (TileWorker, TileBuilder, MarkerManager, ..) still holding references to it.

This adds lots of timing logs - We should test it on some more devices and different scenes to see where is more room for improvement.

