### PR TITLE
Platform work

### DIFF
--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -97,16 +97,13 @@ protected:
     // It's purpose is to be able to cancel UrlRequests
     using UrlRequestId = uint64_t;
 
-    // TODO is this safe on ios/osx that task identifier are never 0?
-    // Wouldn't hur too much if we don't cancel one request though
-    static constexpr UrlRequestId UrlRequestNotCancelable = 0;
-
     // To be called by implementations to pass UrlResponse
-    void onUrlResponse(UrlRequestHandle _request, UrlResponse&& _response);
+    void onUrlResponse(const UrlRequestHandle _request, UrlResponse&& _response);
 
-    virtual void urlRequestCanceled(UrlRequestId _id) = 0;
+    virtual void cancelUrlRequestImpl(const UrlRequestId _id) = 0;
 
-    virtual UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) = 0;
+    // Return true when UrlRequestId has been set (i.e. when request is async and can be canceled)
+    virtual bool startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) = 0;
 
     static bool bytesFromFileSystem(const char* _path, std::function<char*(size_t)> _allocator);
 
@@ -118,6 +115,7 @@ protected:
     struct UrlRequestEntry {
         UrlCallback callback;
         UrlRequestId id;
+        bool cancelable;
     };
     std::unordered_map<UrlRequestHandle, UrlRequestEntry> m_urlCallbacks;
     std::atomic_uint_fast64_t m_urlRequestCount = {0};

--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -98,12 +98,12 @@ protected:
     using UrlRequestId = uint64_t;
 
     // To be called by implementations to pass UrlResponse
-    void onUrlResponse(const UrlRequestHandle _request, UrlResponse&& _response);
+    void onUrlResponse(UrlRequestHandle _request, UrlResponse&& _response);
 
-    virtual void cancelUrlRequestImpl(const UrlRequestId _id) = 0;
+    virtual void cancelUrlRequestImpl(UrlRequestId _id) = 0;
 
     // Return true when UrlRequestId has been set (i.e. when request is async and can be canceled)
-    virtual bool startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) = 0;
+    virtual bool startUrlRequestImpl(const Url& _url, UrlRequestHandle _request, UrlRequestId& _id) = 0;
 
     static bool bytesFromFileSystem(const char* _path, std::function<char*(size_t)> _allocator);
 

--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -2,16 +2,26 @@
 
 #include "util/url.h"
 
+#include <atomic>
 #include <functional>
+#include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace Tangram {
 
-
-// Identifier type for URL requests. This handle is interpreted differently for
-// each platform type, so do not perform any application logic with its value.
+// Handle for URL requests.
+// This is the handle which Platform uses to identify an UrlRequest.
 using UrlRequestHandle = uint64_t;
+
+// Platform specific id for URL requests. This id is interpreted differently for
+// each platform type, so do not perform any application logic with its value.
+//
+// It's purpose is to be able to cancel UrlRequests
+using UrlRequestId = uint64_t;
+
+constexpr UrlRequestId UrlRequestNotCancelable = 0;
 
 // Result of a URL request. If the request could not be completed or if the
 // host returned an HTTP status code >= 400, a non-null error string will be
@@ -61,7 +71,9 @@ public:
     Platform();
     virtual ~Platform();
 
-    virtual void shutdown() = 0;
+    // Subclasses must call Platform::shutdown() when overriding shutdown
+    virtual void shutdown();
+
     // Request that a new frame be rendered by the windowing system
     virtual void requestRender() const = 0;
 
@@ -75,12 +87,12 @@ public:
     // finished, the callback _callback will be run with the data or error that
     // was retrieved from the URL _url. The callback may run on a different
     // thread than the original call to startUrlRequest.
-    virtual UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) = 0;
+    UrlRequestHandle startUrlRequest(Url _url, UrlCallback&& _callback);
 
     // Stop retrieving data from a URL that was previously requested. When a
     // request is canceled its callback will still be run, but the response
     // will have an error string and the data may not be complete.
-    virtual void cancelUrlRequest(UrlRequestHandle _request) = 0;
+    void cancelUrlRequest(UrlRequestHandle _request);
 
     virtual FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const;
 
@@ -88,12 +100,26 @@ public:
 
 protected:
 
+    // To be called by implementations to pass UrlResponse
+    void onUrlResponse(UrlRequestHandle _request, UrlResponse&& _response);
+
+    virtual void urlRequestCanceled(UrlRequestId _id) = 0;
+
+    virtual UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) = 0;
+
     static bool bytesFromFileSystem(const char* _path, std::function<char*(size_t)> _allocator);
 
-private:
+    std::atomic<bool> m_shutdown{false};
 
     bool m_continuousRendering;
 
+    std::mutex m_callbackMutex;
+    struct UrlRequestEntry {
+        UrlCallback callback;
+        UrlRequestId id;
+    };
+    std::unordered_map<UrlRequestHandle, UrlRequestEntry> m_urlCallbacks;
+    std::atomic_uint_fast64_t m_urlRequestCount = {0};
 };
 
 } // namespace Tangram

--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -61,6 +61,7 @@ public:
     Platform();
     virtual ~Platform();
 
+    virtual void shutdown() = 0;
     // Request that a new frame be rendered by the windowing system
     virtual void requestRender() const = 0;
 

--- a/core/include/tangram/platform.h
+++ b/core/include/tangram/platform.h
@@ -15,14 +15,6 @@ namespace Tangram {
 // This is the handle which Platform uses to identify an UrlRequest.
 using UrlRequestHandle = uint64_t;
 
-// Platform specific id for URL requests. This id is interpreted differently for
-// each platform type, so do not perform any application logic with its value.
-//
-// It's purpose is to be able to cancel UrlRequests
-using UrlRequestId = uint64_t;
-
-constexpr UrlRequestId UrlRequestNotCancelable = 0;
-
 // Result of a URL request. If the request could not be completed or if the
 // host returned an HTTP status code >= 400, a non-null error string will be
 // present. This error string is only valid in the scope of the UrlCallback
@@ -99,6 +91,15 @@ public:
     virtual std::vector<FontSourceHandle> systemFontFallbacksHandle() const;
 
 protected:
+    // Platform implementation specific id for URL requests. This id is
+    // interpreted differently for each platform type, so do not perform any
+    // application logic with its value.
+    // It's purpose is to be able to cancel UrlRequests
+    using UrlRequestId = uint64_t;
+
+    // TODO is this safe on ios/osx that task identifier are never 0?
+    // Wouldn't hur too much if we don't cancel one request though
+    static constexpr UrlRequestId UrlRequestNotCancelable = 0;
 
     // To be called by implementations to pass UrlResponse
     void onUrlResponse(UrlRequestHandle _request, UrlResponse&& _response);

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -67,7 +67,7 @@ ClientGeoJsonSource::ClientGeoJsonSource(std::shared_ptr<Platform> _platform,
             }
             m_hasPendingData = false;
         };
-        m_platform->startUrlRequest(_url, onUrlFinished);
+        m_platform->startUrlRequest(_url, std::move(onUrlFinished));
         m_hasPendingData = true;
     }
 

--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -76,7 +76,7 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
             auto& dlTask = static_cast<BinaryTileTask&>(*task);
             dlTask.rawTileData = std::make_shared<std::vector<char>>(std::move(response.content));
         }
-        callback.func(task);
+        callback.func(std::move(task));
     };
 
     auto& dlTask = static_cast<BinaryTileTask&>(*task);

--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -80,7 +80,7 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
     };
 
     auto& dlTask = static_cast<BinaryTileTask&>(*task);
-    dlTask.urlRequestHandle = m_platform->startUrlRequest(url, onRequestFinish);
+    dlTask.urlRequestHandle = m_platform->startUrlRequest(url, std::move(onRequestFinish));
     dlTask.urlRequestStarted = true;
 
     return true;

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -125,6 +125,8 @@ Map::~Map() {
     // In any case after shutdown Platform may not call back into Map!
     platform->shutdown();
 
+    impl->tileManager.clearTileSets();
+
     // The unique_ptr to Impl will be automatically destroyed when Map is destroyed.
     impl->tileWorker.stop();
     impl->asyncWorker.reset();

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -118,6 +118,13 @@ Map::Map(std::shared_ptr<Platform> _platform) : platform(_platform) {
 }
 
 Map::~Map() {
+    // Let the platform stop all outstanding tasks:
+    // Send cancel to UrlRequests so any thread blocking on a response can join,
+    // and discard incoming UrlRequest directly.
+    //
+    // In any case after shutdown Platform may not call back into Map!
+    platform->shutdown();
+
     // The unique_ptr to Impl will be automatically destroyed when Map is destroyed.
     impl->tileWorker.stop();
     impl->asyncWorker.reset();

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -54,7 +54,7 @@ class Map::Impl {
 public:
     Impl(std::shared_ptr<Platform> _platform) :
         platform(_platform),
-        inputHandler(_platform, view),
+        inputHandler(view),
         scene(std::make_shared<Scene>(_platform, Url())),
         tileWorker(_platform, MAX_WORKERS),
         tileManager(_platform, tileWorker) {}
@@ -470,7 +470,7 @@ bool Map::update(float _dt) {
     }
 
     // Request render if labels are in fading states or markers are easing.
-    if (impl->isCameraEasing || labelsNeedUpdate || markersNeedUpdate) {
+    if (isFlinging || impl->isCameraEasing || labelsNeedUpdate || markersNeedUpdate) {
         platform->requestRender();
     }
 
@@ -1038,36 +1038,43 @@ void Map::markerRemoveAll() {
 void Map::handleTapGesture(float _posX, float _posY) {
     cancelCameraAnimation();
     impl->inputHandler.handleTapGesture(_posX, _posY);
+    impl->platform->requestRender();
 }
 
 void Map::handleDoubleTapGesture(float _posX, float _posY) {
     cancelCameraAnimation();
     impl->inputHandler.handleDoubleTapGesture(_posX, _posY);
+    impl->platform->requestRender();
 }
 
 void Map::handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
     cancelCameraAnimation();
     impl->inputHandler.handlePanGesture(_startX, _startY, _endX, _endY);
+    impl->platform->requestRender();
 }
 
 void Map::handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY) {
     cancelCameraAnimation();
     impl->inputHandler.handleFlingGesture(_posX, _posY, _velocityX, _velocityY);
+    impl->platform->requestRender();
 }
 
 void Map::handlePinchGesture(float _posX, float _posY, float _scale, float _velocity) {
     cancelCameraAnimation();
     impl->inputHandler.handlePinchGesture(_posX, _posY, _scale, _velocity);
+    impl->platform->requestRender();
 }
 
 void Map::handleRotateGesture(float _posX, float _posY, float _radians) {
     cancelCameraAnimation();
     impl->inputHandler.handleRotateGesture(_posX, _posY, _radians);
+    impl->platform->requestRender();
 }
 
 void Map::handleShoveGesture(float _distance) {
     cancelCameraAnimation();
     impl->inputHandler.handleShoveGesture(_distance);
+    impl->platform->requestRender();
 }
 
 void Map::setupGL() {

--- a/core/src/platform.cpp
+++ b/core/src/platform.cpp
@@ -95,7 +95,7 @@ UrlRequestHandle Platform::startUrlRequest(Url _url, UrlCallback&& _callback) {
     entry->id = startUrlRequest(_url, handle);
 
     if (entry->id == UrlRequestNotCancelable) {
-        LOGW("Cannot cancel request for handle %d! %s", handle, _url.path().c_str());
+        LOGW("Cannot cancel request for handle %llu! %s", handle, _url.path().c_str());
     }
 
     return handle;

--- a/core/src/platform.cpp
+++ b/core/src/platform.cpp
@@ -94,10 +94,6 @@ UrlRequestHandle Platform::startUrlRequest(Url _url, UrlCallback&& _callback) {
     // Start Platform specific url request
     entry->id = startUrlRequest(_url, handle);
 
-    if (entry->id == UrlRequestNotCancelable) {
-        LOGW("Cannot cancel request for handle %llu! %s", handle, _url.path().c_str());
-    }
-
     return handle;
 }
 

--- a/core/src/platform.cpp
+++ b/core/src/platform.cpp
@@ -3,6 +3,7 @@
 
 #include <fstream>
 #include <string>
+#include <cassert>
 
 namespace Tangram {
 
@@ -44,6 +45,94 @@ FontSourceHandle Platform::systemFont(const std::string& _name, const std::strin
 std::vector<FontSourceHandle> Platform::systemFontFallbacksHandle() const {
     // No-op by default
     return {};
+}
+
+void Platform::shutdown() {
+    if (m_shutdown.exchange(true)) { return; }
+
+    {
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+
+        UrlResponse response;
+        response.error = "Shutting down";
+
+        for (auto& entry : m_urlCallbacks) {
+            auto& request = entry.second;
+            if (request.callback) {
+                request.callback(std::move(response));
+            }
+            if (request.id) {
+                urlRequestCanceled(request.id);
+            }
+        }
+        m_urlCallbacks.clear();
+    }
+}
+
+UrlRequestHandle Platform::startUrlRequest(Url _url, UrlCallback&& _callback) {
+    assert(_callback);
+
+    if (m_shutdown) {
+        UrlResponse response;
+        response.error = "Shutting down";
+        if (_callback) {
+            _callback(std::move(response));
+        }
+        return 0;
+    }
+
+    UrlRequestHandle handle= ++m_urlRequestCount;
+
+    // Need to do this in advance in case startUrlRequest calls back synchronously..
+    UrlRequestEntry* entry = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+        auto it = m_urlCallbacks.emplace(handle, UrlRequestEntry{std::move(_callback), 0});
+        entry = &it.first->second;
+    }
+
+    // Start Platform specific url request
+    entry->id = startUrlRequest(_url, handle);
+
+    if (entry->id == UrlRequestNotCancelable) {
+        LOGW("Cannot cancel request for handle %d! %s", handle, _url.path().c_str());
+    }
+
+    return handle;
+}
+
+void Platform::cancelUrlRequest(UrlRequestHandle _request) {
+    UrlRequestId id = 0;
+
+    {
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+        auto it = m_urlCallbacks.find(_request);
+        if (it != m_urlCallbacks.end()) {
+            id = it->second.id;
+        }
+    }
+
+    if (id != UrlRequestNotCancelable) {
+         urlRequestCanceled(id);
+    }
+}
+
+void Platform::onUrlResponse(UrlRequestHandle _request, UrlResponse&& _response) {
+    if (m_shutdown) {
+        LOGW("onUrlResponse after shutdown");
+        return;
+    }
+    // Find the callback associated with the request.
+    UrlCallback callback;
+    {
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+        auto it = m_urlCallbacks.find(_request);
+        if (it != m_urlCallbacks.end()) {
+            callback = std::move(it->second.callback);
+            m_urlCallbacks.erase(it);
+        }
+    }
+    if (callback) { callback(std::move(_response)); }
 }
 
 } // namespace Tangram

--- a/core/src/scene/scene.cpp
+++ b/core/src/scene/scene.cpp
@@ -102,7 +102,7 @@ UrlRequestHandle Scene::startUrlRequest(std::shared_ptr<Platform> platform, Url 
     }
 
     // For non-zip URLs, send it to the platform.
-    return platform->startUrlRequest(url, callback);
+    return platform->startUrlRequest(url, std::move(callback));
 }
 
 void Scene::addZipArchive(Url url, std::shared_ptr<ZipArchive> zipArchive) {

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -296,20 +296,6 @@ void FontContext::releaseFonts() {
     std::lock_guard<std::mutex> lock(m_fontMutex);
     // Unload Freetype and Harfbuzz resources for all font faces
     m_alfons.unload();
-
-    // Release system font fallbacks input source data from default fonts, since
-    // those are 'weak' resources (would be automatically reloaded by alfons from
-    // its URI or source callback.
-    for (auto& font : m_font) {
-        if (!font) { continue; }
-        for (auto& face : font->faces()) {
-            alfons::InputSource& fontSource = face->descriptor().source;
-
-            if (fontSource.isUri() || fontSource.hasSourceCallback()) {
-                fontSource.clearData();
-            }
-        }
-    }
 }
 
 void FontContext::ScratchBuffer::drawGlyph(const alfons::Rect& q, const alfons::AtlasGlyph& atlasGlyph) {

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -133,7 +133,19 @@ struct TileManager::TileEntry {
 TileManager::TileSet::TileSet(std::shared_ptr<TileSource> _source, bool _clientSource) :
     source(_source), clientTileSource(_clientSource) {}
 
-TileManager::TileSet::~TileSet() {}
+TileManager::TileSet::~TileSet() {
+    cancelTasks();
+}
+
+void TileManager::TileSet::cancelTasks() {
+    for (auto& tile : tiles) {
+        auto& entry = tile.second;
+        if (entry.isInProgress()) {
+            source->cancelLoadingTile(*entry.task);
+        }
+        entry.clearTask();
+    }
+}
 
 TileManager::TileManager(std::shared_ptr<Platform> platform, TileTaskQueue& _tileWorker) :
     m_workers(_tileWorker) {
@@ -225,7 +237,10 @@ bool TileManager::removeClientTileSource(TileSource& _tileSource) {
 }
 
 void TileManager::clearTileSets(bool clearSourceCaches) {
+
     for (auto& tileSet : m_tileSets) {
+        tileSet.cancelTasks();
+
         tileSet.tiles.clear();
 
         if (clearSourceCaches) {
@@ -239,6 +254,8 @@ void TileManager::clearTileSets(bool clearSourceCaches) {
 void TileManager::clearTileSet(int32_t _sourceId) {
     for (auto& tileSet : m_tileSets) {
         if (tileSet.source->id() != _sourceId) { continue; }
+
+        tileSet.cancelTasks();
         tileSet.tiles.clear();
     }
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -78,6 +78,7 @@ protected:
     struct TileSet {
         TileSet(std::shared_ptr<TileSource> _source, bool _clientSource);
         ~TileSet();
+        void cancelTasks();
 
         std::shared_ptr<TileSource> source;
 

--- a/core/src/util/asyncWorker.h
+++ b/core/src/util/asyncWorker.h
@@ -31,6 +31,9 @@ public:
         m_condition.notify_one();
     }
 
+    void waitForCompletion() {
+        m_waitForCompletion = true;
+    }
 private:
 
     void run() {
@@ -39,7 +42,14 @@ private:
             {
                 std::unique_lock<std::mutex> lock(m_mutex);
                 m_condition.wait(lock, [&]{ return !m_running || !m_queue.empty(); });
-                if (!m_running) { break; }
+
+                if (!m_running) {
+                    if (!m_waitForCompletion) {
+                        break;
+                    } else if (m_queue.empty()) {
+                        break;
+                    }
+                }
 
                 task = std::move(m_queue.front());
                 m_queue.pop_front();
@@ -49,7 +59,8 @@ private:
     }
 
     std::thread thread;
-    bool m_running = true;
+    std::atomic<bool> m_running {true};
+    std::atomic<bool> m_waitForCompletion {false};
     std::condition_variable m_condition;
     std::mutex m_mutex;
     std::deque<std::function<void()>> m_queue;

--- a/core/src/util/asyncWorker.h
+++ b/core/src/util/asyncWorker.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <condition_variable>
 #include <deque>
 #include <mutex>

--- a/core/src/util/inputHandler.cpp
+++ b/core/src/util/inputHandler.cpp
@@ -1,7 +1,5 @@
 #include "util/inputHandler.h"
 
-#include "platform.h"
-
 #include "glm/gtx/rotate_vector.hpp"
 #include "glm/vec2.hpp"
 #include <cmath>
@@ -26,7 +24,7 @@
 
 namespace Tangram {
 
-InputHandler::InputHandler(std::shared_ptr<Platform> _platform, View& _view) : m_platform(_platform), m_view(_view) {}
+InputHandler::InputHandler(View& _view) : m_view(_view) {}
 
 bool InputHandler::update(float _dt) {
 
@@ -42,16 +40,13 @@ bool InputHandler::update(float _dt) {
 
         m_velocityZoom -= _dt * DAMPING_ZOOM * m_velocityZoom;
         m_view.zoom(m_velocityZoom * _dt);
-
-        m_platform->requestRender();
     }
 
     return isFlinging;
 }
 
 void InputHandler::handleTapGesture(float _posX, float _posY) {
-
-    onGesture();
+    cancelFling();
 
     float viewCenterX = 0.5f * m_view.getWidth();
     float viewCenterY = 0.5f * m_view.getHeight();
@@ -60,18 +55,14 @@ void InputHandler::handleTapGesture(float _posX, float _posY) {
     m_view.screenToGroundPlane(_posX, _posY);
 
     m_view.translate((_posX - viewCenterX), (_posY - viewCenterY));
-
 }
 
 void InputHandler::handleDoubleTapGesture(float _posX, float _posY) {
-
     handlePinchGesture(_posX, _posY, 2.f, 0.f);
-
 }
 
 void InputHandler::handlePanGesture(float _startX, float _startY, float _endX, float _endY) {
-
-    onGesture();
+    cancelFling();
 
     m_view.screenToGroundPlane(_startX, _startY);
     m_view.screenToGroundPlane(_endX, _endY);
@@ -80,7 +71,6 @@ void InputHandler::handlePanGesture(float _startX, float _startY, float _endX, f
     float dy = _startY - _endY;
 
     m_view.translate(dx, dy);
-
 }
 
 void InputHandler::handleFlingGesture(float _posX, float _posY, float _velocityX, float _velocityY) {
@@ -91,7 +81,7 @@ void InputHandler::handleFlingGesture(float _posX, float _posY, float _velocityX
 
     const static float epsilon = 0.0167f;
 
-    onGesture();
+    cancelFling();
 
     float startX = _posX;
     float startY = _posY;
@@ -105,12 +95,10 @@ void InputHandler::handleFlingGesture(float _posX, float _posY, float _velocityX
     float dy = (startY - endY) / epsilon;
 
     setVelocity(0.f, glm::vec2(dx, dy));
-
 }
 
 void InputHandler::handlePinchGesture(float _posX, float _posY, float _scale, float _velocity) {
-
-    onGesture();
+    cancelFling();
 
     float z = m_view.getZoom();
     static float invLog2 = 1 / log(2);
@@ -127,12 +115,10 @@ void InputHandler::handlePinchGesture(float _posX, float _posY, float _scale, fl
     if (std::abs(vz) >= THRESHOLD_START_ZOOM) {
         setVelocity(vz, glm::vec2(0.f));
     }
-
 }
 
 void InputHandler::handleRotateGesture(float _posX, float _posY, float _radians) {
-
-    onGesture();
+    cancelFling();
 
     // Get vector from center of rotation to view center
     m_view.screenToGroundPlane(_posX, _posY);
@@ -143,12 +129,10 @@ void InputHandler::handleRotateGesture(float _posX, float _posY, float _radians)
     m_view.translate(translation.x, translation.y);
 
     m_view.roll(_radians);
-
 }
 
 void InputHandler::handleShoveGesture(float _distance) {
-
-    onGesture();
+    cancelFling();
 
     float angle = -M_PI * _distance / m_view.getHeight();
     m_view.pitch(angle);
@@ -156,20 +140,10 @@ void InputHandler::handleShoveGesture(float _distance) {
 }
 
 void InputHandler::cancelFling() {
-
     setVelocity(0.f, { 0.f, 0.f});
-
-}
-
-void InputHandler::onGesture() {
-
-    setVelocity(0.f, { 0.f, 0.f });
-    m_platform->requestRender();
-
 }
 
 void InputHandler::setVelocity(float _zoom, glm::vec2 _translate) {
-
     // setup deltas for momentum on gesture
     m_velocityPan = _translate;
     m_velocityZoom = _zoom;

--- a/core/src/util/inputHandler.h
+++ b/core/src/util/inputHandler.h
@@ -7,12 +7,10 @@
 
 namespace Tangram {
 
-class Platform;
-
 class InputHandler {
 
 public:
-    InputHandler(std::shared_ptr<Platform> _platform, View& _view);
+    explicit InputHandler(View& _view);
 
     void handleTapGesture(float _posX, float _posY);
     void handleDoubleTapGesture(float _posX, float _posY);
@@ -34,10 +32,6 @@ public:
 private:
 
     void setVelocity(float _zoom, glm::vec2 _pan);
-
-    void onGesture();
-
-    std::shared_ptr<Platform> m_platform;
 
     View& m_view;
 

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -29,19 +29,24 @@ android {
         arguments '-DTANGRAM_PLATFORM=android',
                   '-DANDROID_STL=c++_shared'
         cppFlags '-std=c++14',
+                 '-fvisibility=hidden', // export only JNIEXPORT
                  '-pedantic',
                  '-fPIC',
                  '-fexceptions',
                  '-frtti',
+                 // linker
+                 '-Wl,--exclude-libs,ALL', // dont export static lib symbols
                  //warnings
                  '-Wall',
                  '-Wignored-qualifiers',
                  '-Wtype-limits',
-                 '-Wmissing-field-initializers',
+                 '-Wno-missing-field-initializers',
                  '-Wno-format-pedantic',
                  '-Wno-gnu-statement-expression',
-                 '-Wgnu-anonymous-struct',
-                 '-Wno-nested-anon-types'
+                 '-Wno-gnu-anonymous-struct',
+                 '-Wno-nested-anon-types',
+                 '-Wno-unused-command-line-argument', // for -Wl linker flags..
+                 '-Wno-unknown-warning-option'
 
         if (abi == 'all') {
           abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -65,7 +65,6 @@ static jmethodID hashmapPutMID = 0;
 static bool glExtensionsLoaded = false;
 
 
-
 void AndroidPlatform::bindJniEnvToThread(JNIEnv* jniEnv) {
     jniEnv->GetJavaVM(&jvm);
 }

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -295,14 +295,15 @@ UrlRequestHandle AndroidPlatform::startUrlRequest(Url _url, UrlCallback _callbac
 
     // Get the current value of the request counter and add one, atomically.
     UrlRequestHandle requestHandle = m_urlRequestCount++;
+    if (!_callback) { return requestHandle; }
 
     // If the requested URL does not use HTTP or HTTPS, retrieve it synchronously.
     if (!_url.hasHttpScheme()) {
-        UrlResponse response;
-        response.content = bytesFromFile(_url);
-        if (_callback) {
-            _callback(std::move(response));
-        }
+        m_fileWorker.enqueue([=](){
+             UrlResponse response;
+             response.content = bytesFromFile(_url);
+             _callback(std::move(response));
+        });
         return requestHandle;
     }
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -1,5 +1,7 @@
 #include "androidPlatform.h"
 
+#include "jniThreadBinding.h"
+
 #include "data/properties.h"
 #include "data/propertyItem.h"
 #include "log.h"
@@ -127,35 +129,6 @@ jstring jstringFromString(JNIEnv* jniEnv, const std::string& string) {
     return jniEnv->NewString(s, chars.length());
 }
 
-class JniThreadBinding {
-private:
-    JavaVM* jvm;
-    JNIEnv *jniEnv;
-    int status;
-public:
-    JniThreadBinding(JavaVM* _jvm) : jvm(_jvm) {
-        status = jvm->GetEnv((void**)&jniEnv, TANGRAM_JNI_VERSION);
-        if (status == JNI_EDETACHED) {
-            LOG("---------------->>> ATTACH");
-            jvm->AttachCurrentThread(&jniEnv, NULL);
-        }
-    }
-    ~JniThreadBinding() {
-        if (status == JNI_EDETACHED) {
-            LOG("---------------->>> DETACH");
-            jvm->DetachCurrentThread();
-        }
-    }
-
-    JNIEnv* operator->() const {
-        return jniEnv;
-    }
-
-    operator JNIEnv*() const {
-        return jniEnv;
-    }
-};
-
 void logMsg(const char* fmt, ...) {
 
     va_list args;
@@ -164,7 +137,6 @@ void logMsg(const char* fmt, ...) {
     va_end(args);
 
 }
-
 
 
 AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance)

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -182,7 +182,7 @@ std::string AndroidPlatform::fontPath(const std::string& _family, const std::str
 AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance)
     : m_jniWorker(jvm) {
 
-    m_tangramInstance = _jniEnv->NewGlobalRef(_tangramInstance);
+    m_tangramInstance = _jniEnv->NewWeakGlobalRef(_tangramInstance);
 
     m_assetManager = AAssetManager_fromJava(_jniEnv, _assetManager);
 
@@ -194,10 +194,6 @@ AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject
 #ifdef TANGRAM_MBTILES_DATASOURCE
     sqlite3_ndk_init(m_assetManager);
 #endif
-}
-
-void AndroidPlatform::dispose(JNIEnv* _jniEnv) {
-    _jniEnv->DeleteGlobalRef(m_tangramInstance);
 }
 
 void AndroidPlatform::requestRender() const {

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -133,10 +133,14 @@ private:
 public:
     JniThreadBinding(JavaVM* _jvm) : jvm(_jvm) {
         status = jvm->GetEnv((void**)&jniEnv, TANGRAM_JNI_VERSION);
-        if (status == JNI_EDETACHED) { jvm->AttachCurrentThread(&jniEnv, NULL);}
+        if (status == JNI_EDETACHED) {
+            jvm->AttachCurrentThread(&jniEnv, NULL);
+        }
     }
     ~JniThreadBinding() {
-        if (status == JNI_EDETACHED) { jvm->DetachCurrentThread(); }
+        if (status == JNI_EDETACHED) {
+            jvm->DetachCurrentThread();
+        }
     }
 
     JNIEnv* operator->() const {
@@ -173,7 +177,9 @@ std::string AndroidPlatform::fontPath(const std::string& _family, const std::str
     return resultStr;
 }
 
-AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance) {
+AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance)
+    : m_jniWorker(jvm) {
+
     m_tangramInstance = _jniEnv->NewGlobalRef(_tangramInstance);
 
     m_assetManager = AAssetManager_fromJava(_jniEnv, _assetManager);
@@ -193,29 +199,30 @@ void AndroidPlatform::dispose(JNIEnv* _jniEnv) {
 }
 
 void AndroidPlatform::requestRender() const {
-
-    JniThreadBinding jniEnv(jvm);
-
-    jniEnv->CallVoidMethod(m_tangramInstance, requestRenderMethodID);
-}
-
-std::string AndroidPlatform::fontFallbackPath(int _importance, int _weightHint) const {
-
-    JniThreadBinding jniEnv(jvm);
-
-    jstring returnStr = (jstring) jniEnv->CallObjectMethod(m_tangramInstance, getFontFallbackFilePath, _importance, _weightHint);
-
-    auto resultStr = stringFromJString(jniEnv, returnStr);
-    jniEnv->DeleteLocalRef(returnStr);
-
-    return resultStr;
+    m_jniWorker.enqueue([&](JNIEnv *jniEnv) {
+        jniEnv->CallVoidMethod(m_tangramInstance, requestRenderMethodID);
+    });
 }
 
 std::vector<FontSourceHandle> AndroidPlatform::systemFontFallbacksHandle() const {
+    JniThreadBinding jniEnv(jvm);
+
     std::vector<FontSourceHandle> handles;
 
     int importance = 0;
     int weightHint = 400;
+
+    auto fontFallbackPath = [&](int _importance, int _weightHint) {
+
+        jstring returnStr = (jstring) jniEnv->CallObjectMethod(m_tangramInstance,
+                                                               getFontFallbackFilePath, _importance,
+                                                               _weightHint);
+
+        auto resultStr = stringFromJString(jniEnv, returnStr);
+        jniEnv->DeleteLocalRef(returnStr);
+
+        return resultStr;
+    };
 
     std::string fallbackPath = fontFallbackPath(importance, weightHint);
 
@@ -291,8 +298,6 @@ std::vector<char> AndroidPlatform::bytesFromFile(const Url& url) const {
 
 UrlRequestHandle AndroidPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
 
-    JniThreadBinding jniEnv(jvm);
-
     // Get the current value of the request counter and add one, atomically.
     UrlRequestHandle requestHandle = m_urlRequestCount++;
     if (!_callback) { return requestHandle; }
@@ -313,26 +318,28 @@ UrlRequestHandle AndroidPlatform::startUrlRequest(Url _url, UrlCallback _callbac
         m_callbacks[requestHandle] = _callback;
     }
 
-    jlong jRequestHandle = static_cast<jlong>(requestHandle);
+    m_jniWorker.enqueue([=](JNIEnv *jniEnv) {
+        jlong jRequestHandle = static_cast<jlong>(requestHandle);
 
-    // Check that it's safe to convert the UrlRequestHandle to a jlong and back.
-    assert(requestHandle == static_cast<UrlRequestHandle>(jRequestHandle));
+        // Check that it's safe to convert the UrlRequestHandle to a jlong and back... cmon :P
+        assert(requestHandle == static_cast<UrlRequestHandle>(jRequestHandle));
 
-    jstring jUrl = jstringFromString(jniEnv, _url.string());
+        jstring jUrl = jstringFromString(jniEnv, _url.string());
 
-    // Call the MapController method to start the URL request.
-    jniEnv->CallVoidMethod(m_tangramInstance, startUrlRequestMID, jUrl, jRequestHandle);
-
+        // Call the MapController method to start the URL request.
+        jniEnv->CallVoidMethod(m_tangramInstance, startUrlRequestMID, jUrl, jRequestHandle);
+    });
     return requestHandle;
 }
 
 void AndroidPlatform::cancelUrlRequest(UrlRequestHandle request) {
 
-    JniThreadBinding jniEnv(jvm);
+    m_jniWorker.enqueue([=](JNIEnv *jniEnv) {
 
-    jlong jRequestHandle = static_cast<jlong>(request);
+        jlong jRequestHandle = static_cast<jlong>(request);
 
-    jniEnv->CallVoidMethod(m_tangramInstance, cancelUrlRequestMID, jRequestHandle);
+        jniEnv->CallVoidMethod(m_tangramInstance, cancelUrlRequestMID, jRequestHandle);
+    });
 
     // We currently don't try to cancel requests for local files.
 }
@@ -356,20 +363,21 @@ void AndroidPlatform::onUrlComplete(JNIEnv* _jniEnv, jlong _jRequestHandle, jbyt
         response.error = error.c_str();
     }
 
-    // Find the callback associated with the request.
-    UrlCallback callback;
-    {
-        std::lock_guard<std::mutex> lock(m_callbackMutex);
-        UrlRequestHandle requestHandle = static_cast<UrlRequestHandle>(_jRequestHandle);
-        auto it = m_callbacks.find(requestHandle);
-        if (it != m_callbacks.end()) {
-            callback = std::move(it->second);
-            m_callbacks.erase(it);
+
+    m_fileWorker.enqueue([this, _jRequestHandle, r = std::move(response)]() mutable {
+        // Find the callback associated with the request.
+        UrlCallback callback;
+        {
+            std::lock_guard<std::mutex> lock(m_callbackMutex);
+            UrlRequestHandle requestHandle = static_cast<UrlRequestHandle>(_jRequestHandle);
+            auto it = m_callbacks.find(requestHandle);
+            if (it != m_callbacks.end()) {
+                callback = std::move(it->second);
+                m_callbacks.erase(it);
+            }
         }
-    }
-    if (callback) {
-        callback(std::move(response));
-    }
+        if (callback) { callback(std::move(r)); }
+    });
 }
 
 void setCurrentThreadPriority(int priority) {

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -134,11 +134,13 @@ public:
     JniThreadBinding(JavaVM* _jvm) : jvm(_jvm) {
         status = jvm->GetEnv((void**)&jniEnv, TANGRAM_JNI_VERSION);
         if (status == JNI_EDETACHED) {
+            LOG("---------------->>> ATTACH");
             jvm->AttachCurrentThread(&jniEnv, NULL);
         }
     }
     ~JniThreadBinding() {
         if (status == JNI_EDETACHED) {
+            LOG("---------------->>> DETACH");
             jvm->DetachCurrentThread();
         }
     }

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -294,7 +294,7 @@ std::vector<char> AndroidPlatform::bytesFromFile(const Url& url) const {
     return data;
 }
 
-UrlRequestId AndroidPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
+Platform::UrlRequestId AndroidPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
 
     // If the requested URL does not use HTTP or HTTPS, retrieve it asynchronously.
     if (!_url.hasHttpScheme()) {
@@ -324,7 +324,7 @@ UrlRequestId AndroidPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle
     return _handle;
 }
 
-void AndroidPlatform::urlRequestCanceled(UrlRequestId _id) {
+void AndroidPlatform::urlRequestCanceled(Platform::UrlRequestId _id) {
 
     m_jniWorker.enqueue([=](JNIEnv *jniEnv) {
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -196,6 +196,10 @@ AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject
 #endif
 }
 
+void AndroidPlatform::shutdown() {
+    Platform::shutdown();
+    m_jniWorker.stop();
+}
 void AndroidPlatform::requestRender() const {
     m_jniWorker.enqueue([&](JNIEnv *jniEnv) {
         jniEnv->CallVoidMethod(m_tangramInstance, requestRenderMethodID);

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -31,6 +31,7 @@ class AndroidPlatform : public Platform {
 public:
 
     AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance);
+    void shutdown() override;
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "platform.h"
+#include "util/asyncWorker.h"
+
 
 #include <jni.h>
 #include <android/asset_manager.h>
-
 #include <atomic>
 #include <mutex>
 #include <string>
@@ -64,6 +65,8 @@ private:
     // m_callbackMutex should be locked any time m_callbacks is accessed.
     std::mutex m_callbackMutex;
     std::unordered_map<UrlRequestHandle, UrlCallback> m_callbacks;
+
+    AsyncWorker m_fileWorker;
 
 };
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -31,7 +31,7 @@ class AndroidPlatform : public Platform {
 public:
 
     AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance);
-    void shutdown() override {}
+    void shutdown() override;
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
@@ -69,6 +69,7 @@ private:
     mutable JniWorker m_jniWorker;  // FIX requestRender const.. Lets use Rust if we want this for real
     AsyncWorker m_fileWorker;
 
+    bool m_shutdown = false;
 };
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "platform.h"
+#include "jniWorker.h"
 #include "util/asyncWorker.h"
 
 
@@ -66,6 +67,7 @@ private:
     std::mutex m_callbackMutex;
     std::unordered_map<UrlRequestHandle, UrlCallback> m_callbacks;
 
+    mutable JniWorker m_jniWorker;  // FIX requestRender const.. Lets use Rust if we want this for real
     AsyncWorker m_fileWorker;
 
 };

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -31,13 +31,12 @@ class AndroidPlatform : public Platform {
 public:
 
     AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance);
-    void shutdown() override;
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
-    UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;
-    void cancelUrlRequest(UrlRequestHandle _request) override;
+    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
+    void urlRequestCanceled(UrlRequestId _id) override;
     void sceneReadyCallback(SceneID id, const SceneError* error);
     void cameraAnimationCallback(bool finished);
     void featurePickCallback(const FeaturePickResult* featurePickResult);
@@ -60,16 +59,10 @@ private:
     jobject m_tangramInstance;
     AAssetManager* m_assetManager;
 
-    std::atomic_uint_fast64_t m_urlRequestCount;
 
-    // m_callbackMutex should be locked any time m_callbacks is accessed.
-    std::mutex m_callbackMutex;
-    std::unordered_map<UrlRequestHandle, UrlCallback> m_callbacks;
 
     mutable JniWorker m_jniWorker;  // FIX requestRender const.. Lets use Rust if we want this for real
     AsyncWorker m_fileWorker;
-
-    bool m_shutdown = false;
 };
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -38,8 +38,8 @@ public:
     void setContinuousRendering(bool _isContinuous) override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
-    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
-    void urlRequestCanceled(UrlRequestId _id) override;
+    bool startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) override;
+    void cancelUrlRequestImpl(const UrlRequestId _id) override;
 
     void onUrlComplete(JNIEnv* jniEnv, jlong jRequestHandle, jbyteArray jBytes, jstring jError);
 

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "map.h"
 #include "platform.h"
 #include "jniWorker.h"
 #include "util/asyncWorker.h"
@@ -26,6 +27,7 @@ using SceneID = int32_t;
 std::string stringFromJString(JNIEnv* jniEnv, jstring string);
 jstring jstringFromString(JNIEnv* jniEnv, const std::string& string);
 
+
 class AndroidPlatform : public Platform {
 
 public:
@@ -38,11 +40,6 @@ public:
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
     void urlRequestCanceled(UrlRequestId _id) override;
-    void sceneReadyCallback(SceneID id, const SceneError* error);
-    void cameraAnimationCallback(bool finished);
-    void featurePickCallback(const FeaturePickResult* featurePickResult);
-    void labelPickCallback(const LabelPickResult* labelPickResult);
-    void markerPickCallback(const MarkerPickResult* markerPickResult);
 
     void onUrlComplete(JNIEnv* jniEnv, jlong jRequestHandle, jbyteArray jBytes, jstring jError);
 
@@ -60,10 +57,20 @@ private:
     jobject m_tangramInstance;
     AAssetManager* m_assetManager;
 
-
-
-    mutable JniWorker m_jniWorker;  // FIX requestRender const.. Lets use Rust if we want this for real
+    mutable JniWorker m_jniWorker;
     AsyncWorker m_fileWorker;
 };
+
+class AndroidMap : public Map {
+public:
+    AndroidMap(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance);
+    void pickFeature(float posX, float posY);
+    void pickMarker(float posX, float posY);
+    void pickLabel(float posX, float posY);
+
+
+    jobject m_tangramInstance;
+};
+
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -31,7 +31,6 @@ class AndroidPlatform : public Platform {
 public:
 
     AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance);
-    void dispose(JNIEnv* _jniEnv);
     void shutdown() override {}
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.h
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.h
@@ -30,6 +30,7 @@ public:
 
     AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject _tangramInstance);
     void dispose(JNIEnv* _jniEnv);
+    void shutdown() override {}
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -144,16 +144,9 @@ extern "C" {
         return reinterpret_cast<jlong>(map);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeDispose(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeDispose(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
         assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        // Don't dispose MapController ref before map is teared down,
-        // delete map or worker threads might call back to it (e.g. requestRender)
-        auto platform = map->getPlatform();
-
-        delete map;
-
-        static_cast<Tangram::AndroidPlatform&>(*platform).dispose(jniEnv);
+        delete reinterpret_cast<Tangram::Map*>(mapPtr);
     }
 
     JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path, jobjectArray updateStrings) {

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -198,6 +198,12 @@ extern "C" {
         delete reinterpret_cast<Tangram::Map*>(mapPtr);
     }
 
+    JNIEXPORT void MapController(nativeShutdown)(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
+        assert(mapPtr > 0);
+
+        reinterpret_cast<Tangram::Map*>(mapPtr)->getPlatform()->shutdown();
+    }
+
     JNIEXPORT jint MapController(nativeLoadScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
                                                   jobjectArray updateStrings) {
         assert(mapPtr > 0);

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -7,6 +7,10 @@
 
 using namespace Tangram;
 
+#define FUNC(CLASS, NAME) JNICALL Java_com_mapzen_tangram_ ## CLASS ## _ ## NAME
+#define MapController(NAME) FUNC(MapController, NAME)
+#define MapRenderer(NAME) FUNC(MapRenderer, NAME)
+
 std::vector<Tangram::SceneUpdate> unpackSceneUpdates(JNIEnv* jniEnv, jobjectArray updateStrings) {
     size_t nUpdateStrings = (updateStrings == NULL)? 0 : jniEnv->GetArrayLength(updateStrings);
 
@@ -31,7 +35,47 @@ extern "C" {
         AndroidPlatform::jniOnUnload(vm);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeGetCameraPosition(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdoubleArray lonLat, jfloatArray zoomRotationTilt) {
+    ///////////////// MapRenderer ////////////////
+
+    JNIEXPORT jboolean MapRenderer(nativeUpdate)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat dt) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto result = map->update(dt);
+        return static_cast<jboolean>(result);
+    }
+
+    JNIEXPORT jboolean MapRenderer(nativeRender)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        return map->render();
+    }
+
+    JNIEXPORT void MapRenderer(nativeSetupGL)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+        AndroidPlatform::bindJniEnvToThread(jniEnv);
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->setupGL();
+    }
+
+    JNIEXPORT void MapRenderer(nativeResize)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint width, jint height) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        map->resize(width, height);
+    }
+
+    JNIEXPORT void MapRenderer(nativeCaptureSnapshot)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jintArray buffer) {
+        assert(mapPtr > 0);
+        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        jint* ptr = jniEnv->GetIntArrayElements(buffer, NULL);
+        unsigned int* data = reinterpret_cast<unsigned int*>(ptr);
+        map->captureSnapshot(data);
+        jniEnv->ReleaseIntArrayElements(buffer, ptr, JNI_ABORT);
+    }
+
+    ///////////////// MapController ////////////////
+
+    JNIEXPORT void MapController(nativeGetCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                          jdoubleArray lonLat, jfloatArray zoomRotationTilt) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jdouble* pos = jniEnv->GetDoubleArrayElements(lonLat, NULL);
@@ -48,7 +92,7 @@ extern "C" {
         jniEnv->ReleaseFloatArrayElements(zoomRotationTilt, zrt, 0);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeUpdateCameraPosition(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+    JNIEXPORT void MapController(nativeUpdateCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                                                             jint set, jdouble lon, jdouble lat,
                                                                                             jfloat zoom, jfloat zoomBy,
                                                                                             jfloat rotation, jfloat rotateBy,
@@ -79,8 +123,9 @@ extern "C" {
         map->updateCameraPosition(update, duration, static_cast<Tangram::EaseType>(ease));
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeGetEnclosingCameraPosition(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdouble aLng, jdouble aLat, jdouble bLng, jdouble bLat,
-                                                                                                  jintArray jpad, jdoubleArray lngLatZoom) {
+    JNIEXPORT void MapController(nativeGetEnclosingCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                                   jdouble aLng, jdouble aLat, jdouble bLng, jdouble bLat,
+                                                                   jintArray jpad, jdoubleArray lngLatZoom) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         EdgePadding padding;
@@ -97,7 +142,8 @@ extern "C" {
         jniEnv->ReleaseDoubleArrayElements(lngLatZoom, arr, 0);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeFlyTo(JNIEnv* jniEnv, jobject obj,  jlong mapPtr, jdouble lon, jdouble lat, jfloat zoom, jfloat duration, jfloat speed) {
+    JNIEXPORT void MapController(nativeFlyTo)(JNIEnv* jniEnv, jobject obj,  jlong mapPtr, jdouble lon, jdouble lat,
+                                              jfloat zoom, jfloat duration, jfloat speed) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         CameraPosition camera = map->getCameraPosition();
@@ -107,13 +153,14 @@ extern "C" {
         map->flyTo(camera, duration, speed);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeCancelCameraAnimation(JNIEnv* jniEnv, jobject obj,  jlong mapPtr) {
+    JNIEXPORT void MapController(nativeCancelCameraAnimation)(JNIEnv* jniEnv, jobject obj,  jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->cancelCameraAnimation();
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeScreenPositionToLngLat(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdoubleArray coordinates) {
+    JNIEXPORT jboolean MapController(nativeScreenPositionToLngLat)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                                   jdoubleArray coordinates) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
@@ -122,7 +169,8 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeLngLatToScreenPosition(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdoubleArray coordinates) {
+    JNIEXPORT jboolean MapController(nativeLngLatToScreenPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                                   jdoubleArray coordinates) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
@@ -131,7 +179,7 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject tangramInstance, jobject assetManager) {
+    JNIEXPORT jlong MapController(nativeInit)(JNIEnv* jniEnv, jobject tangramInstance, jobject assetManager) {
         auto platform = std::make_shared<Tangram::AndroidPlatform>(jniEnv, assetManager, tangramInstance);
         auto map = new Tangram::Map(platform);
         map->setSceneReadyListener([platform](Tangram::SceneID id, const Tangram::SceneError* error) {
@@ -144,13 +192,14 @@ extern "C" {
         return reinterpret_cast<jlong>(map);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeDispose(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
+    JNIEXPORT void MapController(nativeDispose)(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
         assert(mapPtr > 0);
 
         delete reinterpret_cast<Tangram::Map*>(mapPtr);
     }
 
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeLoadScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path, jobjectArray updateStrings) {
+    JNIEXPORT jint MapController(nativeLoadScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
+                                                  jobjectArray updateStrings) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto cPath = stringFromJString(jniEnv, path);
@@ -162,7 +211,8 @@ extern "C" {
         return sceneId;
     }
 
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeLoadSceneAsync(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path, jobjectArray updateStrings) {
+    JNIEXPORT jint MapController(nativeLoadSceneAsync)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
+                                                       jobjectArray updateStrings) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto cPath = stringFromJString(jniEnv, path);
@@ -176,7 +226,8 @@ extern "C" {
 
     }
 
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeLoadSceneYaml(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml, jstring path, jobjectArray updateStrings) {
+    JNIEXPORT jint MapController(nativeLoadSceneYaml)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml,
+                                                      jstring path, jobjectArray updateStrings) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto cYaml = stringFromJString(jniEnv, yaml);
@@ -189,7 +240,8 @@ extern "C" {
         return sceneId;
     }
 
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeLoadSceneYamlAsync(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml, jstring path, jobjectArray updateStrings) {
+    JNIEXPORT jint MapController(nativeLoadSceneYamlAsync)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml,
+                                                           jstring path, jobjectArray updateStrings) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto cYaml = stringFromJString(jniEnv, yaml);
@@ -202,130 +254,111 @@ extern "C" {
         return sceneId;
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeResize(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint width, jint height) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        map->resize(width, height);
-    }
-
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeUpdate(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat dt) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto result = map->update(dt);
-        return static_cast<jboolean>(result);
-    }
-
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeRender(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        return map->render();
-    }
-
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetupGL(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        AndroidPlatform::bindJniEnvToThread(jniEnv);
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        map->setupGL();
-    }
-
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPixelScale(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat scale) {
+    JNIEXPORT void MapController(nativeSetPixelScale)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat scale) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->setPixelScale(scale);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetCameraType(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint type) {
+    JNIEXPORT void MapController(nativeSetCameraType)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint type) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->setCameraType(type);
     }
 
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeGetCameraType(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    JNIEXPORT jint MapController(nativeGetCameraType)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         return map->getCameraType();
     }
 
-    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetMinZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    JNIEXPORT jfloat MapController(nativeGetMinZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         return map->getMinZoom();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetMinZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat minZoom) {
+    JNIEXPORT void MapController(nativeSetMinZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat minZoom) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->setMinZoom(minZoom);
     }
 
-    JNIEXPORT jfloat JNICALL Java_com_mapzen_tangram_MapController_nativeGetMaxZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    JNIEXPORT jfloat MapController(nativeGetMaxZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         return map->getMaxZoom();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetMaxZoom(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat maxZoom) {
+    JNIEXPORT void MapController(nativeSetMaxZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat maxZoom) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->setMaxZoom(maxZoom);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleTapGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    JNIEXPORT void MapController(nativeHandleTapGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                         jfloat posX, jfloat posY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->handleTapGesture(posX, posY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleDoubleTapGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    JNIEXPORT void MapController(nativeHandleDoubleTapGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                               jfloat posX, jfloat posY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->handleDoubleTapGesture(posX, posY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandlePanGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
+    JNIEXPORT void MapController(nativeHandlePanGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                         jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->handlePanGesture(startX, startY, endX, endY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleFlingGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jfloat velocityX, jfloat velocityY) {
+    JNIEXPORT void MapController(nativeHandleFlingGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                           jfloat posX, jfloat posY, jfloat velocityX, jfloat velocityY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->handleFlingGesture(posX, posY, velocityX, velocityY);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandlePinchGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jfloat scale, jfloat velocity) {
+    JNIEXPORT void MapController(nativeHandlePinchGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                           jfloat posX, jfloat posY, jfloat scale, jfloat velocity) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->handlePinchGesture(posX, posY, scale, velocity);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleRotateGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY, jfloat rotation) {
+    JNIEXPORT void MapController(nativeHandleRotateGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                            jfloat posX, jfloat posY, jfloat rotation) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->handleRotateGesture(posX, posY, rotation);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeHandleShoveGesture(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat distance) {
+    JNIEXPORT void MapController(nativeHandleShoveGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat distance) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->handleShoveGesture(distance);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeOnUrlComplete(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong requestHandle, jbyteArray fetchedBytes, jstring errorString) {
+    JNIEXPORT void MapController(nativeOnUrlComplete)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong requestHandle,
+                                                      jbyteArray fetchedBytes, jstring errorString) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
         platform->onUrlComplete(jniEnv, requestHandle, fetchedBytes, errorString);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetPickRadius(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radius) {
+    JNIEXPORT void MapController(nativeSetPickRadius)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radius) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->setPickRadius(radius);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickFeature(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    JNIEXPORT void MapController(nativePickFeature)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
@@ -334,7 +367,7 @@ extern "C" {
         });
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickMarker(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    JNIEXPORT void MapController(nativePickMarker)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
@@ -343,7 +376,7 @@ extern "C" {
         });
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativePickLabel(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    JNIEXPORT void MapController(nativePickLabel)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
@@ -353,21 +386,22 @@ extern "C" {
     }
 
     // NOTE unsigned int to jlong for precision... else we can do jint return
-    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerAdd(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    JNIEXPORT jlong MapController(nativeMarkerAdd)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto markerID = map->markerAdd();
         return static_cast<jlong>(markerID);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerRemove(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID) {
+    JNIEXPORT jboolean MapController(nativeMarkerRemove)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerRemove(static_cast<unsigned int>(markerID));
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetStylingFromString(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jstring styling) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetStylingFromString)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                                       jlong markerID, jstring styling) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto styleString = stringFromJString(jniEnv, styling);
@@ -375,7 +409,8 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetStylingFromPath(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jstring path) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetStylingFromPath)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                                     jlong markerID, jstring path) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto pathString = stringFromJString(jniEnv, path);
@@ -383,7 +418,8 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetBitmap(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jobject jbitmap, jfloat density) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetBitmap)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                            jlong markerID, jobject jbitmap, jfloat density) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
 
@@ -426,21 +462,25 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPoint(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdouble lng, jdouble lat) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetPoint)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                           jlong markerID, jdouble lng, jdouble lat) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerSetPoint(static_cast<unsigned int>(markerID), Tangram::LngLat(lng, lat));
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPointEased(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdouble lng, jdouble lat, jfloat duration, jint ease) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetPointEased)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                                jlong markerID, jdouble lng, jdouble lat, jfloat duration, jint ease) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto result = map->markerSetPointEased(static_cast<unsigned int>(markerID), Tangram::LngLat(lng, lat), duration, static_cast<Tangram::EaseType>(ease));
+        auto result = map->markerSetPointEased(static_cast<unsigned int>(markerID),
+                Tangram::LngLat(lng, lat), duration, static_cast<Tangram::EaseType>(ease));
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPolyline(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdoubleArray jcoordinates, jint count) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetPolyline)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                              jlong markerID, jdoubleArray jcoordinates, jint count) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         if (!jcoordinates || count == 0) { return false; }
@@ -457,7 +497,9 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetPolygon(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jdoubleArray jcoordinates, jintArray jcounts, jint rings) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetPolygon)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                             jlong markerID, jdoubleArray jcoordinates,
+                                                             jintArray jcounts, jint rings) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         if (!jcoordinates || !jcounts || rings == 0) { return false; }
@@ -481,27 +523,27 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetVisible(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jboolean visible) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetVisible)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jboolean visible) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerSetVisible(static_cast<unsigned int>(markerID), visible);
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetDrawOrder(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jint drawOrder) {
+    JNIEXPORT jboolean MapController(nativeMarkerSetDrawOrder)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jint drawOrder) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto result = map->markerSetDrawOrder(markerID, drawOrder);
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerRemoveAll(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    JNIEXPORT void MapController(nativeMarkerRemoveAll)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->markerRemoveAll();
     }
 
-    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeAddTileSource(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring name, jboolean generateCentroid) {
+    JNIEXPORT jlong MapController(nativeAddTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring name, jboolean generateCentroid) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         auto sourceName = stringFromJString(jniEnv, name);
@@ -510,7 +552,7 @@ extern "C" {
         return reinterpret_cast<jlong>(source.get());
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeRemoveTileSource(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+    JNIEXPORT void MapController(nativeRemoveTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         assert(sourcePtr > 0);
@@ -518,7 +560,7 @@ extern "C" {
         map->removeTileSource(*source);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeClearTileSource(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+    JNIEXPORT void MapController(nativeClearTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         assert(sourcePtr > 0);
@@ -526,7 +568,7 @@ extern "C" {
         map->clearTileSource(*source, true, true);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddFeature(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr,
+    JNIEXPORT void MapController(nativeAddFeature)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr,
         jdoubleArray jcoordinates, jintArray jrings, jobjectArray jproperties) {
 
         assert(mapPtr > 0);
@@ -583,7 +625,7 @@ extern "C" {
 
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeAddGeoJson(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr, jstring geojson) {
+    JNIEXPORT void MapController(nativeAddGeoJson)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr, jstring geojson) {
         assert(mapPtr > 0);
         assert(sourcePtr > 0);
         auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
@@ -591,26 +633,17 @@ extern "C" {
         source->addData(data);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetDebugFlag(JNIEnv* jniEnv, jobject obj, jint flag, jboolean on) {
+    JNIEXPORT void MapController(nativeSetDebugFlag)(JNIEnv* jniEnv, jobject obj, jint flag, jboolean on) {
         Tangram::setDebugFlag(static_cast<Tangram::DebugFlags>(flag), on);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeUseCachedGlState(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jboolean use) {
+    JNIEXPORT void MapController(nativeUseCachedGlState)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jboolean use) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->useCachedGlState(use);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeCaptureSnapshot(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jintArray buffer) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        jint* ptr = jniEnv->GetIntArrayElements(buffer, NULL);
-        unsigned int* data = reinterpret_cast<unsigned int*>(ptr);
-        map->captureSnapshot(data);
-        jniEnv->ReleaseIntArrayElements(buffer, ptr, JNI_ABORT);
-    }
-
-    JNIEXPORT jint JNICALL Java_com_mapzen_tangram_MapController_nativeUpdateScene(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jobjectArray updateStrings) {
+    JNIEXPORT jint MapController(nativeUpdateScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jobjectArray updateStrings) {
         assert(mapPtr > 0);
 
         auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
@@ -619,13 +652,13 @@ extern "C" {
         return map->updateSceneAsync(sceneUpdates);
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeOnLowMemory(JNIEnv* jnienv, jobject obj, jlong mapPtr) {
+    JNIEXPORT void MapController(nativeOnLowMemory)(JNIEnv* jnienv, jobject obj, jlong mapPtr) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->onMemoryWarning();
     }
 
-    JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeSetDefaultBackgroundColor(JNIEnv* jnienv, jobject obj, jlong mapPtr, jfloat r, jfloat g, jfloat b) {
+    JNIEXPORT void MapController(nativeSetDefaultBackgroundColor)(JNIEnv* jnienv, jobject obj, jlong mapPtr, jfloat r, jfloat g, jfloat b) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
         map->setDefaultBackgroundColor(r, g, b);

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -146,6 +146,7 @@ extern "C" {
 
     JNIEXPORT void JNICALL Java_com_mapzen_tangram_MapController_nativeDispose(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
         assert(mapPtr > 0);
+
         delete reinterpret_cast<Tangram::Map*>(mapPtr);
     }
 

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -131,7 +131,7 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject obj, jobject tangramInstance, jobject assetManager) {
+    JNIEXPORT jlong JNICALL Java_com_mapzen_tangram_MapController_nativeInit(JNIEnv* jniEnv, jobject tangramInstance, jobject assetManager) {
         auto platform = std::make_shared<Tangram::AndroidPlatform>(jniEnv, assetManager, tangramInstance);
         auto map = new Tangram::Map(platform);
         map->setSceneReadyListener([platform](Tangram::SceneID id, const Tangram::SceneError* error) {

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -10,6 +10,7 @@ using namespace Tangram;
 #define FUNC(CLASS, NAME) JNICALL Java_com_mapzen_tangram_ ## CLASS ## _ ## NAME
 #define MapController(NAME) FUNC(MapController, NAME)
 #define MapRenderer(NAME) FUNC(MapRenderer, NAME)
+#define auto_map(ptr) assert(ptr); auto map = reinterpret_cast<Tangram::AndroidMap*>(mapPtr)
 
 std::vector<Tangram::SceneUpdate> unpackSceneUpdates(JNIEnv* jniEnv, jobjectArray updateStrings) {
     size_t nUpdateStrings = (updateStrings == NULL)? 0 : jniEnv->GetArrayLength(updateStrings);
@@ -38,34 +39,29 @@ extern "C" {
     ///////////////// MapRenderer ////////////////
 
     JNIEXPORT jboolean MapRenderer(nativeUpdate)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat dt) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         auto result = map->update(dt);
         return static_cast<jboolean>(result);
     }
 
     JNIEXPORT jboolean MapRenderer(nativeRender)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         return map->render();
     }
 
     JNIEXPORT void MapRenderer(nativeSetupGL)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
         AndroidPlatform::bindJniEnvToThread(jniEnv);
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->setupGL();
     }
 
     JNIEXPORT void MapRenderer(nativeResize)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint width, jint height) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->resize(width, height);
     }
 
     JNIEXPORT void MapRenderer(nativeCaptureSnapshot)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jintArray buffer) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         jint* ptr = jniEnv->GetIntArrayElements(buffer, NULL);
         unsigned int* data = reinterpret_cast<unsigned int*>(ptr);
         map->captureSnapshot(data);
@@ -76,8 +72,7 @@ extern "C" {
 
     JNIEXPORT void MapController(nativeGetCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                           jdoubleArray lonLat, jfloatArray zoomRotationTilt) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         jdouble* pos = jniEnv->GetDoubleArrayElements(lonLat, NULL);
         jfloat* zrt = jniEnv->GetFloatArrayElements(zoomRotationTilt, NULL);
 
@@ -93,16 +88,14 @@ extern "C" {
     }
 
     JNIEXPORT void MapController(nativeUpdateCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                                                            jint set, jdouble lon, jdouble lat,
-                                                                                            jfloat zoom, jfloat zoomBy,
-                                                                                            jfloat rotation, jfloat rotateBy,
-                                                                                            jfloat tilt, jfloat tiltBy,
-                                                                                            jdouble b1lon, jdouble b1lat,
-                                                                                            jdouble b2lon, jdouble b2lat,
-                                                                                            jintArray jpad,
-                                                                                            jfloat duration, jint ease) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+                                                             jint set, jdouble lon, jdouble lat,
+                                                             jfloat zoom, jfloat zoomBy,
+                                                             jfloat rotation, jfloat rotateBy,
+                                                             jfloat tilt, jfloat tiltBy,
+                                                             jdouble b1lon, jdouble b1lat,
+                                                             jdouble b2lon, jdouble b2lat,
+                                                             jintArray jpad, jfloat duration, jint ease) {
+        auto_map(mapPtr);
 
         CameraUpdate update;
         update.set = set;
@@ -124,10 +117,11 @@ extern "C" {
     }
 
     JNIEXPORT void MapController(nativeGetEnclosingCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                                   jdouble aLng, jdouble aLat, jdouble bLng, jdouble bLat,
+                                                                   jdouble aLng, jdouble aLat,
+                                                                   jdouble bLng, jdouble bLat,
                                                                    jintArray jpad, jdoubleArray lngLatZoom) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         EdgePadding padding;
         if (jpad != NULL) {
             jint* jpadArray = jniEnv->GetIntArrayElements(jpad, NULL);
@@ -144,8 +138,8 @@ extern "C" {
 
     JNIEXPORT void MapController(nativeFlyTo)(JNIEnv* jniEnv, jobject obj,  jlong mapPtr, jdouble lon, jdouble lat,
                                               jfloat zoom, jfloat duration, jfloat speed) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         CameraPosition camera = map->getCameraPosition();
         camera.longitude = lon;
         camera.latitude = lat;
@@ -154,15 +148,15 @@ extern "C" {
     }
 
     JNIEXPORT void MapController(nativeCancelCameraAnimation)(JNIEnv* jniEnv, jobject obj,  jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         map->cancelCameraAnimation();
     }
 
     JNIEXPORT jboolean MapController(nativeScreenPositionToLngLat)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                                    jdoubleArray coordinates) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
         bool result = map->screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
         jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
@@ -171,8 +165,8 @@ extern "C" {
 
     JNIEXPORT jboolean MapController(nativeLngLatToScreenPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                                    jdoubleArray coordinates) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
         bool result = map->lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
         jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
@@ -180,34 +174,26 @@ extern "C" {
     }
 
     JNIEXPORT jlong MapController(nativeInit)(JNIEnv* jniEnv, jobject tangramInstance, jobject assetManager) {
-        auto platform = std::make_shared<Tangram::AndroidPlatform>(jniEnv, assetManager, tangramInstance);
-        auto map = new Tangram::Map(platform);
-        map->setSceneReadyListener([platform](Tangram::SceneID id, const Tangram::SceneError* error) {
-            platform->sceneReadyCallback(id, error);
-        });
-        map->setCameraAnimationListener([platform](bool success) {
-            platform->cameraAnimationCallback(success);
-        });
-
+        auto map  = new Tangram::AndroidMap(jniEnv, assetManager, tangramInstance);
         return reinterpret_cast<jlong>(map);
     }
 
     JNIEXPORT void MapController(nativeDispose)(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
-        assert(mapPtr > 0);
+        auto_map(mapPtr);
 
-        delete reinterpret_cast<Tangram::Map*>(mapPtr);
+        delete map;
     }
 
     JNIEXPORT void MapController(nativeShutdown)(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
-        assert(mapPtr > 0);
+        auto_map(mapPtr);
 
-        reinterpret_cast<Tangram::Map*>(mapPtr)->getPlatform()->shutdown();
+        map->getPlatform()->shutdown();
     }
 
     JNIEXPORT jint MapController(nativeLoadScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
                                                   jobjectArray updateStrings) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         auto cPath = stringFromJString(jniEnv, path);
 
         auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
@@ -219,8 +205,8 @@ extern "C" {
 
     JNIEXPORT jint MapController(nativeLoadSceneAsync)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
                                                        jobjectArray updateStrings) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         auto cPath = stringFromJString(jniEnv, path);
 
         auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
@@ -234,8 +220,8 @@ extern "C" {
 
     JNIEXPORT jint MapController(nativeLoadSceneYaml)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml,
                                                       jstring path, jobjectArray updateStrings) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         auto cYaml = stringFromJString(jniEnv, yaml);
         auto cPath = stringFromJString(jniEnv, path);
 
@@ -248,8 +234,8 @@ extern "C" {
 
     JNIEXPORT jint MapController(nativeLoadSceneYamlAsync)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml,
                                                            jstring path, jobjectArray updateStrings) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         auto cYaml = stringFromJString(jniEnv, yaml);
         auto cPath = stringFromJString(jniEnv, path);
 
@@ -261,155 +247,128 @@ extern "C" {
     }
 
     JNIEXPORT void MapController(nativeSetPixelScale)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat scale) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->setPixelScale(scale);
     }
 
     JNIEXPORT void MapController(nativeSetCameraType)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint type) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->setCameraType(type);
     }
 
     JNIEXPORT jint MapController(nativeGetCameraType)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         return map->getCameraType();
     }
 
     JNIEXPORT jfloat MapController(nativeGetMinZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         return map->getMinZoom();
     }
 
     JNIEXPORT void MapController(nativeSetMinZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat minZoom) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->setMinZoom(minZoom);
     }
 
     JNIEXPORT jfloat MapController(nativeGetMaxZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         return map->getMaxZoom();
     }
 
     JNIEXPORT void MapController(nativeSetMaxZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat maxZoom) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->setMaxZoom(maxZoom);
     }
 
     JNIEXPORT void MapController(nativeHandleTapGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                          jfloat posX, jfloat posY) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->handleTapGesture(posX, posY);
     }
 
     JNIEXPORT void MapController(nativeHandleDoubleTapGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                                jfloat posX, jfloat posY) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->handleDoubleTapGesture(posX, posY);
     }
 
     JNIEXPORT void MapController(nativeHandlePanGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                          jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->handlePanGesture(startX, startY, endX, endY);
     }
 
     JNIEXPORT void MapController(nativeHandleFlingGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                            jfloat posX, jfloat posY, jfloat velocityX, jfloat velocityY) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->handleFlingGesture(posX, posY, velocityX, velocityY);
     }
 
     JNIEXPORT void MapController(nativeHandlePinchGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                            jfloat posX, jfloat posY, jfloat scale, jfloat velocity) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->handlePinchGesture(posX, posY, scale, velocity);
     }
 
     JNIEXPORT void MapController(nativeHandleRotateGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                             jfloat posX, jfloat posY, jfloat rotation) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->handleRotateGesture(posX, posY, rotation);
     }
 
     JNIEXPORT void MapController(nativeHandleShoveGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat distance) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->handleShoveGesture(distance);
     }
 
     JNIEXPORT void MapController(nativeOnUrlComplete)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong requestHandle,
                                                       jbyteArray fetchedBytes, jstring errorString) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
         platform->onUrlComplete(jniEnv, requestHandle, fetchedBytes, errorString);
     }
 
     JNIEXPORT void MapController(nativeSetPickRadius)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radius) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         map->setPickRadius(radius);
     }
 
     JNIEXPORT void MapController(nativePickFeature)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
-        map->pickFeatureAt(posX, posY, [=](auto pickResult) {
-            platform->featurePickCallback(pickResult);
-        });
+        auto_map(mapPtr);
+        map->pickFeature(posX, posY);
+
     }
 
     JNIEXPORT void MapController(nativePickMarker)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
-        map->pickMarkerAt(posX, posY, [=](auto pickResult) {
-            platform->markerPickCallback(pickResult);
-        });
+        auto_map(mapPtr);
+        map->pickMarker(posX, posY);
     }
 
     JNIEXPORT void MapController(nativePickLabel)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
-        auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
-        map->pickLabelAt(posX, posY, [=](auto pickResult) {
-            platform->labelPickCallback(pickResult);
-        });
+        auto_map(mapPtr);
+        map->pickLabel(posX, posY);
     }
 
     // NOTE unsigned int to jlong for precision... else we can do jint return
     JNIEXPORT jlong MapController(nativeMarkerAdd)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         auto markerID = map->markerAdd();
         return static_cast<jlong>(markerID);
     }
 
     JNIEXPORT jboolean MapController(nativeMarkerRemove)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
         auto result = map->markerRemove(static_cast<unsigned int>(markerID));
         return static_cast<jboolean>(result);
     }
 
     JNIEXPORT jboolean MapController(nativeMarkerSetStylingFromString)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                                        jlong markerID, jstring styling) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         auto styleString = stringFromJString(jniEnv, styling);
         auto result = map->markerSetStylingFromString(static_cast<unsigned int>(markerID), styleString.c_str());
         return static_cast<jboolean>(result);
@@ -417,8 +376,8 @@ extern "C" {
 
     JNIEXPORT jboolean MapController(nativeMarkerSetStylingFromPath)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                                      jlong markerID, jstring path) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         auto pathString = stringFromJString(jniEnv, path);
         auto result = map->markerSetStylingFromPath(static_cast<unsigned int>(markerID), pathString.c_str());
         return static_cast<jboolean>(result);
@@ -426,8 +385,7 @@ extern "C" {
 
     JNIEXPORT jboolean MapController(nativeMarkerSetBitmap)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                             jlong markerID, jobject jbitmap, jfloat density) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
 
         AndroidBitmapInfo bitmapInfo;
         if (AndroidBitmap_getInfo(jniEnv, jbitmap, &bitmapInfo) != ANDROID_BITMAP_RESULT_SUCCESS) {
@@ -470,25 +428,27 @@ extern "C" {
 
     JNIEXPORT jboolean MapController(nativeMarkerSetPoint)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                            jlong markerID, jdouble lng, jdouble lat) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         auto result = map->markerSetPoint(static_cast<unsigned int>(markerID), Tangram::LngLat(lng, lat));
         return static_cast<jboolean>(result);
     }
 
     JNIEXPORT jboolean MapController(nativeMarkerSetPointEased)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                                jlong markerID, jdouble lng, jdouble lat, jfloat duration, jint ease) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+                                                                jlong markerID, jdouble lng, jdouble lat,
+                                                                jfloat duration, jint ease) {
+        auto_map(mapPtr);
+
         auto result = map->markerSetPointEased(static_cast<unsigned int>(markerID),
                 Tangram::LngLat(lng, lat), duration, static_cast<Tangram::EaseType>(ease));
         return static_cast<jboolean>(result);
     }
 
     JNIEXPORT jboolean MapController(nativeMarkerSetPolyline)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                              jlong markerID, jdoubleArray jcoordinates, jint count) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+                                                              jlong markerID, jdoubleArray jcoordinates,
+                                                              jint count) {
+        auto_map(mapPtr);
+
         if (!jcoordinates || count == 0) { return false; }
 
         auto* coordinates = jniEnv->GetDoubleArrayElements(jcoordinates, NULL);
@@ -506,8 +466,8 @@ extern "C" {
     JNIEXPORT jboolean MapController(nativeMarkerSetPolygon)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                                              jlong markerID, jdoubleArray jcoordinates,
                                                              jintArray jcounts, jint rings) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         if (!jcoordinates || !jcounts || rings == 0) { return false; }
 
         auto* coordinates = jniEnv->GetDoubleArrayElements(jcoordinates, NULL);
@@ -529,46 +489,49 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean MapController(nativeMarkerSetVisible)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jboolean visible) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+    JNIEXPORT jboolean MapController(nativeMarkerSetVisible)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                             jlong markerID, jboolean visible) {
+        auto_map(mapPtr);
+
         auto result = map->markerSetVisible(static_cast<unsigned int>(markerID), visible);
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean MapController(nativeMarkerSetDrawOrder)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jint drawOrder) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+    JNIEXPORT jboolean MapController(nativeMarkerSetDrawOrder)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                               jlong markerID, jint drawOrder) {
+        auto_map(mapPtr);
+
         auto result = map->markerSetDrawOrder(markerID, drawOrder);
         return static_cast<jboolean>(result);
     }
 
     JNIEXPORT void MapController(nativeMarkerRemoveAll)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         map->markerRemoveAll();
     }
 
-    JNIEXPORT jlong MapController(nativeAddTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring name, jboolean generateCentroid) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+    JNIEXPORT jlong MapController(nativeAddTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                       jstring name, jboolean generateCentroid) {
+        auto_map(mapPtr);
+
         auto sourceName = stringFromJString(jniEnv, name);
-        auto source = std::shared_ptr<Tangram::TileSource>(new Tangram::ClientGeoJsonSource(map->getPlatform(), sourceName, "", generateCentroid));
+        auto source = std::make_shared<Tangram::ClientGeoJsonSource>(map->getPlatform(), sourceName, "", generateCentroid);
         map->addTileSource(source);
         return reinterpret_cast<jlong>(source.get());
     }
 
     JNIEXPORT void MapController(nativeRemoveTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         assert(sourcePtr > 0);
         auto source = reinterpret_cast<Tangram::TileSource*>(sourcePtr);
         map->removeTileSource(*source);
     }
 
     JNIEXPORT void MapController(nativeClearTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         assert(sourcePtr > 0);
         auto source = reinterpret_cast<Tangram::TileSource*>(sourcePtr);
         map->clearTileSource(*source, true, true);
@@ -631,7 +594,8 @@ extern "C" {
 
     }
 
-    JNIEXPORT void MapController(nativeAddGeoJson)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr, jstring geojson) {
+    JNIEXPORT void MapController(nativeAddGeoJson)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                   jlong sourcePtr, jstring geojson) {
         assert(mapPtr > 0);
         assert(sourcePtr > 0);
         auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(sourcePtr);
@@ -644,29 +608,30 @@ extern "C" {
     }
 
     JNIEXPORT void MapController(nativeUseCachedGlState)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jboolean use) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         map->useCachedGlState(use);
     }
 
-    JNIEXPORT jint MapController(nativeUpdateScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jobjectArray updateStrings) {
-        assert(mapPtr > 0);
+    JNIEXPORT jint MapController(nativeUpdateScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                                    jobjectArray updateStrings) {
+        auto_map(mapPtr);
 
         auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
 
         return map->updateSceneAsync(sceneUpdates);
     }
 
     JNIEXPORT void MapController(nativeOnLowMemory)(JNIEnv* jnienv, jobject obj, jlong mapPtr) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+        auto_map(mapPtr);
+
         map->onMemoryWarning();
     }
 
-    JNIEXPORT void MapController(nativeSetDefaultBackgroundColor)(JNIEnv* jnienv, jobject obj, jlong mapPtr, jfloat r, jfloat g, jfloat b) {
-        assert(mapPtr > 0);
-        auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
+    JNIEXPORT void MapController(nativeSetDefaultBackgroundColor)(JNIEnv* jnienv, jobject obj, jlong mapPtr,
+                                                                  jfloat r, jfloat g, jfloat b) {
+        auto_map(mapPtr);
+
         map->setDefaultBackgroundColor(r, g, b);
     }
 }

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -22,10 +22,7 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(JNIEnv* jniEnv, jobjectArra
     return sceneUpdates;
 }
 
-#define EXTERN_C_BEGIN extern "C" {
-#define EXTERN_C_END }
-
-EXTERN_C_BEGIN
+extern "C" {
 
 JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     return AndroidPlatform::jniOnLoad(vm);
@@ -627,4 +624,4 @@ void MapData(AddGeoJson)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr, jstring g
     source->addData(data);
 }
 
-EXTERN_C_END
+} // extern "C"

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -22,15 +22,18 @@ std::vector<Tangram::SceneUpdate> unpackSceneUpdates(JNIEnv* jniEnv, jobjectArra
     return sceneUpdates;
 }
 
-extern "C" {
+#define EXTERN_C_BEGIN extern "C" {
+#define EXTERN_C_END }
 
-    JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
-        return AndroidPlatform::jniOnLoad(vm);
-    }
+EXTERN_C_BEGIN
 
-    JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
-        AndroidPlatform::jniOnUnload(vm);
-    }
+JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+    return AndroidPlatform::jniOnLoad(vm);
+}
+
+JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
+    AndroidPlatform::jniOnUnload(vm);
+}
 
 
 #define FUNC(CLASS, NAME) JNIEXPORT JNICALL Java_com_mapzen_tangram_ ## CLASS ## _native ## NAME
@@ -38,593 +41,590 @@ extern "C" {
 #define auto_map(ptr) assert(ptr); auto map = reinterpret_cast<Tangram::AndroidMap*>(mapPtr)
 #define auto_source(ptr) assert(ptr); auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(ptr)
 
+
 #define MapRenderer(NAME) FUNC(MapRenderer, NAME)
 
-    jboolean MapRenderer(Update)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat dt) {
-        auto_map(mapPtr);
-        auto result = map->update(dt);
-        return static_cast<jboolean>(result);
-    }
+jboolean MapRenderer(Update)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat dt) {
+    auto_map(mapPtr);
+    auto result = map->update(dt);
+    return static_cast<jboolean>(result);
+}
 
-    jboolean MapRenderer(Render)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        auto_map(mapPtr);
-        return map->render();
-    }
+jboolean MapRenderer(Render)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    auto_map(mapPtr);
+    return map->render();
+}
 
-    void MapRenderer(SetupGL)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        AndroidPlatform::bindJniEnvToThread(jniEnv);
-        auto_map(mapPtr);
-        map->setupGL();
-    }
+void MapRenderer(SetupGL)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    AndroidPlatform::bindJniEnvToThread(jniEnv);
+    auto_map(mapPtr);
+    map->setupGL();
+}
 
-    void MapRenderer(Resize)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint width, jint height) {
-        auto_map(mapPtr);
-        map->resize(width, height);
-    }
+void MapRenderer(Resize)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint width, jint height) {
+    auto_map(mapPtr);
+    map->resize(width, height);
+}
 
-    void MapRenderer(CaptureSnapshot)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jintArray buffer) {
-        auto_map(mapPtr);
-        jint* ptr = jniEnv->GetIntArrayElements(buffer, NULL);
-        unsigned int* data = reinterpret_cast<unsigned int*>(ptr);
-        map->captureSnapshot(data);
-        jniEnv->ReleaseIntArrayElements(buffer, ptr, JNI_ABORT);
-    }
+void MapRenderer(CaptureSnapshot)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jintArray buffer) {
+    auto_map(mapPtr);
+    jint* ptr = jniEnv->GetIntArrayElements(buffer, NULL);
+    unsigned int* data = reinterpret_cast<unsigned int*>(ptr);
+    map->captureSnapshot(data);
+    jniEnv->ReleaseIntArrayElements(buffer, ptr, JNI_ABORT);
+}
 
 
 #define MapController(NAME) FUNC(MapController, NAME)
 
-    void MapController(GetCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                          jdoubleArray lonLat, jfloatArray zoomRotationTilt) {
-        auto_map(mapPtr);
-        jdouble* pos = jniEnv->GetDoubleArrayElements(lonLat, NULL);
-        jfloat* zrt = jniEnv->GetFloatArrayElements(zoomRotationTilt, NULL);
+void MapController(GetCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jdoubleArray lonLat,
+                                      jfloatArray zoomRotationTilt) {
+    auto_map(mapPtr);
+    jdouble* pos = jniEnv->GetDoubleArrayElements(lonLat, NULL);
+    jfloat* zrt = jniEnv->GetFloatArrayElements(zoomRotationTilt, NULL);
 
-        auto camera = map->getCameraPosition();
-        pos[0] = camera.longitude;
-        pos[1] = camera.latitude;
-        zrt[0] = camera.zoom;
-        zrt[1] = camera.rotation;
-        zrt[2] = camera.tilt;
+    auto camera = map->getCameraPosition();
+    pos[0] = camera.longitude;
+    pos[1] = camera.latitude;
+    zrt[0] = camera.zoom;
+    zrt[1] = camera.rotation;
+    zrt[2] = camera.tilt;
 
-        jniEnv->ReleaseDoubleArrayElements(lonLat, pos, 0);
-        jniEnv->ReleaseFloatArrayElements(zoomRotationTilt, zrt, 0);
+    jniEnv->ReleaseDoubleArrayElements(lonLat, pos, 0);
+    jniEnv->ReleaseFloatArrayElements(zoomRotationTilt, zrt, 0);
+}
+
+void MapController(UpdateCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                         jint set, jdouble lon, jdouble lat,
+                                         jfloat zoom, jfloat zoomBy,
+                                         jfloat rotation, jfloat rotateBy,
+                                         jfloat tilt, jfloat tiltBy,
+                                         jdouble b1lon, jdouble b1lat,
+                                         jdouble b2lon, jdouble b2lat,
+                                         jintArray jpad, jfloat duration, jint ease) {
+    auto_map(mapPtr);
+
+    CameraUpdate update;
+    update.set = set;
+
+    update.lngLat = LngLat{lon,lat};
+    update.zoom = zoom;
+    update.zoomBy = zoomBy;
+    update.rotation = rotation;
+    update.rotationBy = rotateBy;
+    update.tilt = tilt;
+    update.tiltBy = tiltBy;
+    update.bounds = std::array<LngLat,2>{{LngLat{b1lon, b1lat}, LngLat{b2lon, b2lat}}};
+    if (jpad != NULL) {
+        jint* jpadArray = jniEnv->GetIntArrayElements(jpad, NULL);
+        update.padding = EdgePadding{jpadArray[0], jpadArray[1], jpadArray[2], jpadArray[3]};
+        jniEnv->ReleaseIntArrayElements(jpad, jpadArray, JNI_ABORT);
     }
+    map->updateCameraPosition(update, duration, static_cast<Tangram::EaseType>(ease));
+}
 
-    void MapController(UpdateCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                             jint set, jdouble lon, jdouble lat,
-                                             jfloat zoom, jfloat zoomBy,
-                                             jfloat rotation, jfloat rotateBy,
-                                             jfloat tilt, jfloat tiltBy,
-                                             jdouble b1lon, jdouble b1lat,
-                                             jdouble b2lon, jdouble b2lat,
-                                             jintArray jpad, jfloat duration, jint ease) {
-        auto_map(mapPtr);
+void MapController(GetEnclosingCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                               jdouble aLng, jdouble aLat,
+                                               jdouble bLng, jdouble bLat,
+                                               jintArray jpad, jdoubleArray lngLatZoom) {
+    auto_map(mapPtr);
 
-        CameraUpdate update;
-        update.set = set;
-
-        update.lngLat = LngLat{lon,lat};
-        update.zoom = zoom;
-        update.zoomBy = zoomBy;
-        update.rotation = rotation;
-        update.rotationBy = rotateBy;
-        update.tilt = tilt;
-        update.tiltBy = tiltBy;
-        update.bounds = std::array<LngLat,2>{{LngLat{b1lon, b1lat}, LngLat{b2lon, b2lat}}};
-        if (jpad != NULL) {
-            jint* jpadArray = jniEnv->GetIntArrayElements(jpad, NULL);
-            update.padding = EdgePadding{jpadArray[0], jpadArray[1], jpadArray[2], jpadArray[3]};
-            jniEnv->ReleaseIntArrayElements(jpad, jpadArray, JNI_ABORT);
-        }
-        map->updateCameraPosition(update, duration, static_cast<Tangram::EaseType>(ease));
+    EdgePadding padding;
+    if (jpad != NULL) {
+        jint* jpadArray = jniEnv->GetIntArrayElements(jpad, NULL);
+        padding = EdgePadding(jpadArray[0], jpadArray[1], jpadArray[2], jpadArray[3]);
+        jniEnv->ReleaseIntArrayElements(jpad, jpadArray, JNI_ABORT);
     }
+    CameraPosition camera = map->getEnclosingCameraPosition(LngLat{aLng,aLat}, LngLat{bLng,bLat}, padding);
+    jdouble* arr = jniEnv->GetDoubleArrayElements(lngLatZoom, NULL);
+    arr[0] = camera.longitude;
+    arr[1] = camera.latitude;
+    arr[2] = camera.zoom;
+    jniEnv->ReleaseDoubleArrayElements(lngLatZoom, arr, 0);
+}
 
-    void MapController(GetEnclosingCameraPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                   jdouble aLng, jdouble aLat,
-                                                   jdouble bLng, jdouble bLat,
-                                                   jintArray jpad, jdoubleArray lngLatZoom) {
-        auto_map(mapPtr);
+void MapController(FlyTo)(JNIEnv* jniEnv, jobject obj,  jlong mapPtr, jdouble lon, jdouble lat,
+                          jfloat zoom, jfloat duration, jfloat speed) {
+    auto_map(mapPtr);
 
-        EdgePadding padding;
-        if (jpad != NULL) {
-            jint* jpadArray = jniEnv->GetIntArrayElements(jpad, NULL);
-            padding = EdgePadding(jpadArray[0], jpadArray[1], jpadArray[2], jpadArray[3]);
-            jniEnv->ReleaseIntArrayElements(jpad, jpadArray, JNI_ABORT);
-        }
-        CameraPosition camera = map->getEnclosingCameraPosition(LngLat{aLng,aLat}, LngLat{bLng,bLat}, padding);
-        jdouble* arr = jniEnv->GetDoubleArrayElements(lngLatZoom, NULL);
-        arr[0] = camera.longitude;
-        arr[1] = camera.latitude;
-        arr[2] = camera.zoom;
-        jniEnv->ReleaseDoubleArrayElements(lngLatZoom, arr, 0);
-    }
+    CameraPosition camera = map->getCameraPosition();
+    camera.longitude = lon;
+    camera.latitude = lat;
+    camera.zoom = zoom;
+    map->flyTo(camera, duration, speed);
+}
 
-    void MapController(FlyTo)(JNIEnv* jniEnv, jobject obj,  jlong mapPtr, jdouble lon, jdouble lat,
-                              jfloat zoom, jfloat duration, jfloat speed) {
-        auto_map(mapPtr);
+void MapController(CancelCameraAnimation)(JNIEnv* jniEnv, jobject obj,  jlong mapPtr) {
+    auto_map(mapPtr);
+    map->cancelCameraAnimation();
+}
 
-        CameraPosition camera = map->getCameraPosition();
-        camera.longitude = lon;
-        camera.latitude = lat;
-        camera.zoom = zoom;
-        map->flyTo(camera, duration, speed);
-    }
+jboolean MapController(ScreenPositionToLngLat)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                               jdoubleArray coordinates) {
+    auto_map(mapPtr);
 
-    void MapController(CancelCameraAnimation)(JNIEnv* jniEnv, jobject obj,  jlong mapPtr) {
-        auto_map(mapPtr);
-        map->cancelCameraAnimation();
-    }
+    jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
+    bool result = map->screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
+    jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
+    return static_cast<jboolean>(result);
+}
 
-    jboolean MapController(ScreenPositionToLngLat)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                   jdoubleArray coordinates) {
-        auto_map(mapPtr);
+jboolean MapController(LngLatToScreenPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                               jdoubleArray coordinates) {
+    auto_map(mapPtr);
 
-        jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
-        bool result = map->screenPositionToLngLat(arr[0], arr[1], &arr[0], &arr[1]);
-        jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
-        return static_cast<jboolean>(result);
-    }
+    jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
+    bool result = map->lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
+    jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
+    return static_cast<jboolean>(result);
+}
 
-    jboolean MapController(LngLatToScreenPosition)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                   jdoubleArray coordinates) {
-        auto_map(mapPtr);
+jlong MapController(Init)(JNIEnv* jniEnv, jobject tangramInstance, jobject assetManager) {
+    auto map  = new Tangram::AndroidMap(jniEnv, assetManager, tangramInstance);
+    return reinterpret_cast<jlong>(map);
+}
 
-        jdouble* arr = jniEnv->GetDoubleArrayElements(coordinates, NULL);
-        bool result = map->lngLatToScreenPosition(arr[0], arr[1], &arr[0], &arr[1]);
-        jniEnv->ReleaseDoubleArrayElements(coordinates, arr, 0);
-        return static_cast<jboolean>(result);
-    }
+void MapController(Dispose)(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
+    auto_map(mapPtr);
+    delete map;
+}
 
-    jlong MapController(Init)(JNIEnv* jniEnv, jobject tangramInstance, jobject assetManager) {
-        auto map  = new Tangram::AndroidMap(jniEnv, assetManager, tangramInstance);
-        return reinterpret_cast<jlong>(map);
-    }
+void MapController(Shutdown)(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
+    auto_map(mapPtr);
+    map->getPlatform()->shutdown();
+}
 
-    void MapController(Dispose)(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
-        auto_map(mapPtr);
-        delete map;
-    }
+jint MapController(LoadScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
+                              jobjectArray updateStrings) {
+    auto_map(mapPtr);
 
-    void MapController(Shutdown)(JNIEnv* jniEnv, jobject tangramInstance, jlong mapPtr) {
-        auto_map(mapPtr);
-        map->getPlatform()->shutdown();
-    }
+    auto cPath = stringFromJString(jniEnv, path);
 
-    jint MapController(LoadScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
+    auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
+    Url sceneUrl = Url(cPath).resolved("asset:///");
+    jint sceneId = map->loadScene(sceneUrl.string(), false, sceneUpdates);
+
+    return sceneId;
+}
+
+jint MapController(LoadSceneAsync)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
+                                   jobjectArray updateStrings) {
+    auto_map(mapPtr);
+
+    auto cPath = stringFromJString(jniEnv, path);
+
+    auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
+    Url sceneUrl = Url(cPath).resolved("asset:///");
+    jint sceneId = map->loadSceneAsync(sceneUrl.string(), false, sceneUpdates);
+
+    return sceneId;
+
+
+}
+
+jint MapController(LoadSceneYaml)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml, jstring path,
                                   jobjectArray updateStrings) {
-        auto_map(mapPtr);
+    auto_map(mapPtr);
 
-        auto cPath = stringFromJString(jniEnv, path);
+    auto cYaml = stringFromJString(jniEnv, yaml);
+    auto cPath = stringFromJString(jniEnv, path);
 
-        auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
-        Url sceneUrl = Url(cPath).resolved("asset:///");
-        jint sceneId = map->loadScene(sceneUrl.string(), false, sceneUpdates);
+    auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
+    Url sceneUrl = Url(cPath).resolved("asset:///");
+    jint sceneId = map->loadSceneYaml(cYaml, sceneUrl.string(), false, sceneUpdates);
 
-        return sceneId;
-    }
+    return sceneId;
+}
 
-    jint MapController(LoadSceneAsync)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring path,
+jint MapController(LoadSceneYamlAsync)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml, jstring path,
                                        jobjectArray updateStrings) {
-        auto_map(mapPtr);
+    auto_map(mapPtr);
 
-        auto cPath = stringFromJString(jniEnv, path);
+    auto cYaml = stringFromJString(jniEnv, yaml);
+    auto cPath = stringFromJString(jniEnv, path);
 
-        auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
-        Url sceneUrl = Url(cPath).resolved("asset:///");
-        jint sceneId = map->loadSceneAsync(sceneUrl.string(), false, sceneUpdates);
+    auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
+    Url sceneUrl = Url(cPath).resolved("asset:///");
+    jint sceneId = map->loadSceneYamlAsync(cYaml, sceneUrl.string(), false, sceneUpdates);
 
-        return sceneId;
+    return sceneId;
+}
 
+void MapController(SetPixelScale)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat scale) {
+    auto_map(mapPtr);
+    map->setPixelScale(scale);
+}
 
+void MapController(SetCameraType)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint type) {
+    auto_map(mapPtr);
+    map->setCameraType(type);
+}
+
+jint MapController(GetCameraType)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    auto_map(mapPtr);
+    return map->getCameraType();
+}
+
+jfloat MapController(GetMinZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    auto_map(mapPtr);
+    return map->getMinZoom();
+}
+
+void MapController(SetMinZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat minZoom) {
+    auto_map(mapPtr);
+    map->setMinZoom(minZoom);
+}
+
+jfloat MapController(GetMaxZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    auto_map(mapPtr);
+    return map->getMaxZoom();
+}
+
+void MapController(SetMaxZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat maxZoom) {
+    auto_map(mapPtr);
+    map->setMaxZoom(maxZoom);
+}
+
+void MapController(HandleTapGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    auto_map(mapPtr);
+    map->handleTapGesture(posX, posY);
+}
+
+void MapController(HandleDoubleTapGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    auto_map(mapPtr);
+    map->handleDoubleTapGesture(posX, posY);
+}
+
+void MapController(HandlePanGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat startX, jfloat startY,
+                                     jfloat endX, jfloat endY) {
+    auto_map(mapPtr);
+    map->handlePanGesture(startX, startY, endX, endY);
+}
+
+void MapController(HandleFlingGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY,
+                                       jfloat velocityX, jfloat velocityY) {
+    auto_map(mapPtr);
+    map->handleFlingGesture(posX, posY, velocityX, velocityY);
+}
+
+void MapController(HandlePinchGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY,
+                                       jfloat scale, jfloat velocity) {
+    auto_map(mapPtr);
+    map->handlePinchGesture(posX, posY, scale, velocity);
+}
+
+void MapController(HandleRotateGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY,
+                                        jfloat rotation) {
+    auto_map(mapPtr);
+    map->handleRotateGesture(posX, posY, rotation);
+}
+
+void MapController(HandleShoveGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat distance) {
+    auto_map(mapPtr);
+    map->handleShoveGesture(distance);
+}
+
+void MapController(OnUrlComplete)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong requestHandle,
+                                  jbyteArray fetchedBytes, jstring errorString) {
+    auto_map(mapPtr);
+
+    auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
+    platform->onUrlComplete(jniEnv, requestHandle, fetchedBytes, errorString);
+}
+
+void MapController(SetPickRadius)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radius) {
+    auto_map(mapPtr);
+    map->setPickRadius(radius);
+}
+
+void MapController(PickFeature)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    auto_map(mapPtr);
+    map->pickFeature(posX, posY);
+
+}
+
+void MapController(PickMarker)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    auto_map(mapPtr);
+    map->pickMarker(posX, posY);
+}
+
+void MapController(PickLabel)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
+    auto_map(mapPtr);
+    map->pickLabel(posX, posY);
+}
+
+// NOTE unsigned int to jlong for precision... else we can do jint return
+jlong MapController(MarkerAdd)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    auto_map(mapPtr);
+    auto markerID = map->markerAdd();
+    return static_cast<jlong>(markerID);
+}
+
+jboolean MapController(MarkerRemove)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID) {
+    auto_map(mapPtr);
+    auto result = map->markerRemove(static_cast<unsigned int>(markerID));
+    return static_cast<jboolean>(result);
+}
+
+jboolean MapController(MarkerSetStylingFromString)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                                   jstring styling) {
+    auto_map(mapPtr);
+
+    auto styleString = stringFromJString(jniEnv, styling);
+    auto result = map->markerSetStylingFromString(static_cast<unsigned int>(markerID), styleString.c_str());
+    return static_cast<jboolean>(result);
+}
+
+jboolean MapController(MarkerSetStylingFromPath)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                                 jstring path) {
+    auto_map(mapPtr);
+
+    auto pathString = stringFromJString(jniEnv, path);
+    auto result = map->markerSetStylingFromPath(static_cast<unsigned int>(markerID), pathString.c_str());
+    return static_cast<jboolean>(result);
+}
+
+jboolean MapController(MarkerSetBitmap)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                        jobject jbitmap, jfloat density) {
+    auto_map(mapPtr);
+
+    AndroidBitmapInfo bitmapInfo;
+    if (AndroidBitmap_getInfo(jniEnv, jbitmap, &bitmapInfo) != ANDROID_BITMAP_RESULT_SUCCESS) {
+        return static_cast<jboolean>(false);
     }
-
-    jint MapController(LoadSceneYaml)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml,
-                                      jstring path, jobjectArray updateStrings) {
-        auto_map(mapPtr);
-
-        auto cYaml = stringFromJString(jniEnv, yaml);
-        auto cPath = stringFromJString(jniEnv, path);
-
-        auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
-        Url sceneUrl = Url(cPath).resolved("asset:///");
-        jint sceneId = map->loadSceneYaml(cYaml, sceneUrl.string(), false, sceneUpdates);
-
-        return sceneId;
+    if (bitmapInfo.format != ANDROID_BITMAP_FORMAT_RGBA_8888) {
+        // TODO: Add different conversion functions for other formats.
+        return static_cast<jboolean>(false);
     }
-
-    jint MapController(LoadSceneYamlAsync)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jstring yaml,
-                                           jstring path, jobjectArray updateStrings) {
-        auto_map(mapPtr);
-
-        auto cYaml = stringFromJString(jniEnv, yaml);
-        auto cPath = stringFromJString(jniEnv, path);
-
-        auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
-        Url sceneUrl = Url(cPath).resolved("asset:///");
-        jint sceneId = map->loadSceneYamlAsync(cYaml, sceneUrl.string(), false, sceneUpdates);
-
-        return sceneId;
+    uint32_t* pixelInput;
+    if (AndroidBitmap_lockPixels(jniEnv, jbitmap, (void**)&pixelInput) != ANDROID_BITMAP_RESULT_SUCCESS) {
+        return static_cast<jboolean>(false);
     }
-
-    void MapController(SetPixelScale)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat scale) {
-        auto_map(mapPtr);
-        map->setPixelScale(scale);
-    }
-
-    void MapController(SetCameraType)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jint type) {
-        auto_map(mapPtr);
-        map->setCameraType(type);
-    }
-
-    jint MapController(GetCameraType)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        auto_map(mapPtr);
-        return map->getCameraType();
-    }
-
-    jfloat MapController(GetMinZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        auto_map(mapPtr);
-        return map->getMinZoom();
-    }
-
-    void MapController(SetMinZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat minZoom) {
-        auto_map(mapPtr);
-        map->setMinZoom(minZoom);
-    }
-
-    jfloat MapController(GetMaxZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        auto_map(mapPtr);
-        return map->getMaxZoom();
-    }
-
-    void MapController(SetMaxZoom)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat maxZoom) {
-        auto_map(mapPtr);
-        map->setMaxZoom(maxZoom);
-    }
-
-    void MapController(HandleTapGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                         jfloat posX, jfloat posY) {
-        auto_map(mapPtr);
-        map->handleTapGesture(posX, posY);
-    }
-
-    void MapController(HandleDoubleTapGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                               jfloat posX, jfloat posY) {
-        auto_map(mapPtr);
-        map->handleDoubleTapGesture(posX, posY);
-    }
-
-    void MapController(HandlePanGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                         jfloat startX, jfloat startY, jfloat endX, jfloat endY) {
-        auto_map(mapPtr);
-        map->handlePanGesture(startX, startY, endX, endY);
-    }
-
-    void MapController(HandleFlingGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                           jfloat posX, jfloat posY, jfloat velocityX, jfloat velocityY) {
-        auto_map(mapPtr);
-        map->handleFlingGesture(posX, posY, velocityX, velocityY);
-    }
-
-    void MapController(HandlePinchGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                           jfloat posX, jfloat posY, jfloat scale, jfloat velocity) {
-        auto_map(mapPtr);
-        map->handlePinchGesture(posX, posY, scale, velocity);
-    }
-
-    void MapController(HandleRotateGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                            jfloat posX, jfloat posY, jfloat rotation) {
-        auto_map(mapPtr);
-        map->handleRotateGesture(posX, posY, rotation);
-    }
-
-    void MapController(HandleShoveGesture)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat distance) {
-        auto_map(mapPtr);
-        map->handleShoveGesture(distance);
-    }
-
-    void MapController(OnUrlComplete)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong requestHandle,
-                                      jbyteArray fetchedBytes, jstring errorString) {
-        auto_map(mapPtr);
-
-        auto platform = static_cast<AndroidPlatform*>(map->getPlatform().get());
-        platform->onUrlComplete(jniEnv, requestHandle, fetchedBytes, errorString);
-    }
-
-    void MapController(SetPickRadius)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat radius) {
-        auto_map(mapPtr);
-        map->setPickRadius(radius);
-    }
-
-    void MapController(PickFeature)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
-        auto_map(mapPtr);
-        map->pickFeature(posX, posY);
-
-    }
-
-    void MapController(PickMarker)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
-        auto_map(mapPtr);
-        map->pickMarker(posX, posY);
-    }
-
-    void MapController(PickLabel)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jfloat posX, jfloat posY) {
-        auto_map(mapPtr);
-        map->pickLabel(posX, posY);
-    }
-
-    // NOTE unsigned int to jlong for precision... else we can do jint return
-    jlong MapController(MarkerAdd)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        auto_map(mapPtr);
-        auto markerID = map->markerAdd();
-        return static_cast<jlong>(markerID);
-    }
-
-    jboolean MapController(MarkerRemove)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID) {
-        auto_map(mapPtr);
-        auto result = map->markerRemove(static_cast<unsigned int>(markerID));
-        return static_cast<jboolean>(result);
-    }
-
-    jboolean MapController(MarkerSetStylingFromString)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                       jlong markerID, jstring styling) {
-        auto_map(mapPtr);
-
-        auto styleString = stringFromJString(jniEnv, styling);
-        auto result = map->markerSetStylingFromString(static_cast<unsigned int>(markerID), styleString.c_str());
-        return static_cast<jboolean>(result);
-    }
-
-    jboolean MapController(MarkerSetStylingFromPath)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                     jlong markerID, jstring path) {
-        auto_map(mapPtr);
-
-        auto pathString = stringFromJString(jniEnv, path);
-        auto result = map->markerSetStylingFromPath(static_cast<unsigned int>(markerID), pathString.c_str());
-        return static_cast<jboolean>(result);
-    }
-
-    jboolean MapController(MarkerSetBitmap)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                            jlong markerID, jobject jbitmap, jfloat density) {
-        auto_map(mapPtr);
-
-        AndroidBitmapInfo bitmapInfo;
-        if (AndroidBitmap_getInfo(jniEnv, jbitmap, &bitmapInfo) != ANDROID_BITMAP_RESULT_SUCCESS) {
-            return static_cast<jboolean>(false);
-        }
-        if (bitmapInfo.format != ANDROID_BITMAP_FORMAT_RGBA_8888) {
-            // TODO: Add different conversion functions for other formats.
-            return static_cast<jboolean>(false);
-        }
-        uint32_t* pixelInput;
-        if (AndroidBitmap_lockPixels(jniEnv, jbitmap, (void**)&pixelInput) != ANDROID_BITMAP_RESULT_SUCCESS) {
-            return static_cast<jboolean>(false);
-        }
-        int width = bitmapInfo.width;
-        int height = bitmapInfo.height;
-        uint32_t* pixelOutput = new uint32_t[height * width];
-        int i = 0;
-        for (int row = 0; row < height; row++) {
-            // Flips image upside-down
-            int flippedRow = (height - 1 - row) * width;
-            for (int col = 0; col < width; col++) {
-                uint32_t pixel = pixelInput[i++];
-                // Undo alpha pre-multiplication.
-                auto rgba = reinterpret_cast<uint8_t*>(&pixel);
-                int a = rgba[3];
-                if (a != 0) {
-                    auto alphaInv = 255.f/a;
-                    rgba[0] = static_cast<uint8_t>(rgba[0] * alphaInv);
-                    rgba[1] = static_cast<uint8_t>(rgba[1] * alphaInv);
-                    rgba[2] = static_cast<uint8_t>(rgba[2] * alphaInv);
-                }
-                pixelOutput[flippedRow + col] = pixel;
+    int width = bitmapInfo.width;
+    int height = bitmapInfo.height;
+    uint32_t* pixelOutput = new uint32_t[height * width];
+    int i = 0;
+    for (int row = 0; row < height; row++) {
+        // Flips image upside-down
+        int flippedRow = (height - 1 - row) * width;
+        for (int col = 0; col < width; col++) {
+            uint32_t pixel = pixelInput[i++];
+            // Undo alpha pre-multiplication.
+            auto rgba = reinterpret_cast<uint8_t*>(&pixel);
+            int a = rgba[3];
+            if (a != 0) {
+                auto alphaInv = 255.f/a;
+                rgba[0] = static_cast<uint8_t>(rgba[0] * alphaInv);
+                rgba[1] = static_cast<uint8_t>(rgba[1] * alphaInv);
+                rgba[2] = static_cast<uint8_t>(rgba[2] * alphaInv);
             }
+            pixelOutput[flippedRow + col] = pixel;
         }
-        AndroidBitmap_unlockPixels(jniEnv, jbitmap);
-        auto result = map->markerSetBitmap(static_cast<unsigned int>(markerID), width, height, pixelOutput, density);
-        delete[] pixelOutput;
-        return static_cast<jboolean>(result);
+    }
+    AndroidBitmap_unlockPixels(jniEnv, jbitmap);
+    auto result = map->markerSetBitmap(static_cast<unsigned int>(markerID), width, height, pixelOutput, density);
+    delete[] pixelOutput;
+    return static_cast<jboolean>(result);
+}
+
+jboolean MapController(MarkerSetPoint)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                       jdouble lng, jdouble lat) {
+    auto_map(mapPtr);
+
+    auto result = map->markerSetPoint(static_cast<unsigned int>(markerID), Tangram::LngLat(lng, lat));
+    return static_cast<jboolean>(result);
+}
+
+jboolean MapController(MarkerSetPointEased)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                            jdouble lng, jdouble lat, jfloat duration, jint ease) {
+    auto_map(mapPtr);
+
+    auto result = map->markerSetPointEased(static_cast<unsigned int>(markerID),
+                                           Tangram::LngLat(lng, lat), duration,
+                                           static_cast<Tangram::EaseType>(ease));
+    return static_cast<jboolean>(result);
+}
+
+jboolean MapController(MarkerSetPolyline)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                          jdoubleArray jcoordinates, jint count) {
+    auto_map(mapPtr);
+
+    if (!jcoordinates || count == 0) { return false; }
+
+    auto* coordinates = jniEnv->GetDoubleArrayElements(jcoordinates, NULL);
+    std::vector<Tangram::LngLat> polyline;
+    polyline.reserve(count);
+
+    for (size_t i = 0; i < count; ++i) {
+        polyline.emplace_back(coordinates[2 * i], coordinates[2 * i + 1]);
     }
 
-    jboolean MapController(MarkerSetPoint)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                           jlong markerID, jdouble lng, jdouble lat) {
-        auto_map(mapPtr);
+    auto result = map->markerSetPolyline(static_cast<unsigned int>(markerID), polyline.data(), count);
+    return static_cast<jboolean>(result);
+}
 
-        auto result = map->markerSetPoint(static_cast<unsigned int>(markerID), Tangram::LngLat(lng, lat));
-        return static_cast<jboolean>(result);
-    }
+jboolean MapController(MarkerSetPolygon)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                         jdoubleArray jcoordinates, jintArray jcounts, jint rings) {
+    auto_map(mapPtr);
 
-    jboolean MapController(MarkerSetPointEased)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                                jlong markerID, jdouble lng, jdouble lat,
-                                                jfloat duration, jint ease) {
-        auto_map(mapPtr);
+    if (!jcoordinates || !jcounts || rings == 0) { return false; }
 
-        auto result = map->markerSetPointEased(static_cast<unsigned int>(markerID),
-                Tangram::LngLat(lng, lat), duration, static_cast<Tangram::EaseType>(ease));
-        return static_cast<jboolean>(result);
-    }
+    auto* coordinates = jniEnv->GetDoubleArrayElements(jcoordinates, NULL);
+    auto* counts = jniEnv->GetIntArrayElements(jcounts, NULL);
 
-    jboolean MapController(MarkerSetPolyline)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                              jlong markerID, jdoubleArray jcoordinates,
-                                              jint count) {
-        auto_map(mapPtr);
+    std::vector<Tangram::LngLat> polygonCoords;
 
-        if (!jcoordinates || count == 0) { return false; }
-
-        auto* coordinates = jniEnv->GetDoubleArrayElements(jcoordinates, NULL);
-        std::vector<Tangram::LngLat> polyline;
-        polyline.reserve(count);
-
-        for (size_t i = 0; i < count; ++i) {
-            polyline.emplace_back(coordinates[2 * i], coordinates[2 * i + 1]);
+    size_t coordsCount = 0;
+    for (size_t i = 0; i < rings; i++) {
+        size_t ringCount = *(counts+i);
+        for (size_t j = 0; j < ringCount; j++) {
+            polygonCoords.emplace_back(coordinates[coordsCount + 2 * j],
+                                       coordinates[coordsCount + 2 * j + 1]);
         }
-
-        auto result = map->markerSetPolyline(static_cast<unsigned int>(markerID), polyline.data(), count);
-        return static_cast<jboolean>(result);
+        coordsCount += ringCount;
     }
 
-    jboolean MapController(MarkerSetPolygon)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                             jlong markerID, jdoubleArray jcoordinates,
-                                             jintArray jcounts, jint rings) {
-        auto_map(mapPtr);
+    auto result = map->markerSetPolygon(static_cast<unsigned int>(markerID),
+                                        polygonCoords.data(), counts, rings);
 
-        if (!jcoordinates || !jcounts || rings == 0) { return false; }
+    return static_cast<jboolean>(result);
+}
 
-        auto* coordinates = jniEnv->GetDoubleArrayElements(jcoordinates, NULL);
-        auto* counts = jniEnv->GetIntArrayElements(jcounts, NULL);
+jboolean MapController(MarkerSetVisible)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                         jboolean visible) {
+    auto_map(mapPtr);
 
-        std::vector<Tangram::LngLat> polygonCoords;
+    auto result = map->markerSetVisible(static_cast<unsigned int>(markerID), visible);
+    return static_cast<jboolean>(result);
+}
 
-        size_t coordsCount = 0;
-        for (size_t i = 0; i < rings; i++) {
-            size_t ringCount = *(counts+i);
-            for (size_t j = 0; j < ringCount; j++) {
-                polygonCoords.emplace_back(coordinates[coordsCount + 2 * j],
-                                           coordinates[coordsCount + 2 * j + 1]);
-            }
-            coordsCount += ringCount;
-        }
+jboolean MapController(MarkerSetDrawOrder)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID,
+                                           jint drawOrder) {
+    auto_map(mapPtr);
 
-        auto result = map->markerSetPolygon(static_cast<unsigned int>(markerID),
-                                            polygonCoords.data(), counts, rings);
+    auto result = map->markerSetDrawOrder(markerID, drawOrder);
+    return static_cast<jboolean>(result);
+}
 
-        return static_cast<jboolean>(result);
-    }
-
-    jboolean MapController(MarkerSetVisible)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                             jlong markerID, jboolean visible) {
-        auto_map(mapPtr);
-
-        auto result = map->markerSetVisible(static_cast<unsigned int>(markerID), visible);
-        return static_cast<jboolean>(result);
-    }
-
-    jboolean MapController(MarkerSetDrawOrder)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                               jlong markerID, jint drawOrder) {
-        auto_map(mapPtr);
-
-        auto result = map->markerSetDrawOrder(markerID, drawOrder);
-        return static_cast<jboolean>(result);
-    }
-
-    void MapController(MarkerRemoveAll)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
-        auto_map(mapPtr);
-        map->markerRemoveAll();
-    }
+void MapController(MarkerRemoveAll)(JNIEnv* jniEnv, jobject obj, jlong mapPtr) {
+    auto_map(mapPtr);
+    map->markerRemoveAll();
+}
 
 
-    void MapController(SetDebugFlag)(JNIEnv* jniEnv, jobject obj, jint flag, jboolean on) {
-        Tangram::setDebugFlag(static_cast<Tangram::DebugFlags>(flag), on);
-    }
+void MapController(SetDebugFlag)(JNIEnv* jniEnv, jobject obj, jint flag, jboolean on) {
+    Tangram::setDebugFlag(static_cast<Tangram::DebugFlags>(flag), on);
+}
 
-    void MapController(UseCachedGlState)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jboolean use) {
-        auto_map(mapPtr);
-        map->useCachedGlState(use);
-    }
+void MapController(UseCachedGlState)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jboolean use) {
+    auto_map(mapPtr);
+    map->useCachedGlState(use);
+}
 
-    jint MapController(UpdateScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                    jobjectArray updateStrings) {
-        auto_map(mapPtr);
+jint MapController(UpdateScene)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jobjectArray updateStrings) {
+    auto_map(mapPtr);
 
-        auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
-        return map->updateSceneAsync(sceneUpdates);
-    }
+    auto sceneUpdates = unpackSceneUpdates(jniEnv, updateStrings);
+    return map->updateSceneAsync(sceneUpdates);
+}
 
-    void MapController(OnLowMemory)(JNIEnv* jnienv, jobject obj, jlong mapPtr) {
-        auto_map(mapPtr);
-        map->onMemoryWarning();
-    }
+void MapController(OnLowMemory)(JNIEnv* jnienv, jobject obj, jlong mapPtr) {
+    auto_map(mapPtr);
+    map->onMemoryWarning();
+}
 
-    void MapController(SetDefaultBackgroundColor)(JNIEnv* jnienv, jobject obj, jlong mapPtr,
-                                                  jfloat r, jfloat g, jfloat b) {
-        auto_map(mapPtr);
-        map->setDefaultBackgroundColor(r, g, b);
-    }
+void MapController(SetDefaultBackgroundColor)(JNIEnv* jnienv, jobject obj, jlong mapPtr,
+                                              jfloat r, jfloat g, jfloat b) {
+    auto_map(mapPtr);
+    map->setDefaultBackgroundColor(r, g, b);
+}
 
-    jlong MapController(AddTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
-                                       jstring name, jboolean generateCentroid) {
-        auto_map(mapPtr);
+jlong MapController(AddTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+                                   jstring name, jboolean generateCentroid) {
+    auto_map(mapPtr);
 
-        auto sourceName = stringFromJString(jniEnv, name);
-        auto source = std::make_shared<Tangram::ClientGeoJsonSource>(map->getPlatform(),
-                                                                     sourceName, "",
-                                                                     generateCentroid);
-        map->addTileSource(source);
-        return reinterpret_cast<jlong>(source.get());
-    }
+    auto sourceName = stringFromJString(jniEnv, name);
+    auto source = std::make_shared<Tangram::ClientGeoJsonSource>(map->getPlatform(),
+                                                                 sourceName, "",
+                                                                 generateCentroid);
+    map->addTileSource(source);
+    return reinterpret_cast<jlong>(source.get());
+}
 
-    void MapController(RemoveTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
-        auto_map(mapPtr);
-        auto_source(sourcePtr);
-        map->removeTileSource(*source);
-    }
+void MapController(RemoveTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+    auto_map(mapPtr);
+    auto_source(sourcePtr);
+    map->removeTileSource(*source);
+}
 
-    void MapController(ClearTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
-        auto_map(mapPtr);
-        auto_source(sourcePtr);
-        map->clearTileSource(*source, true, true);
-    }
+void MapController(ClearTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+    auto_map(mapPtr);
+    auto_source(sourcePtr);
+    map->clearTileSource(*source, true, true);
+}
 
 
 #define MapData(NAME) FUNC(MapData, NAME)
 
-    void MapData(AddFeature)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr, jdoubleArray jcoordinates,
-                             jintArray jrings, jobjectArray jproperties) {
+void MapData(AddFeature)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr, jdoubleArray jcoordinates,
+                         jintArray jrings, jobjectArray jproperties) {
 
-        auto_source(sourcePtr);
+    auto_source(sourcePtr);
 
-        size_t n_points = jniEnv->GetArrayLength(jcoordinates) / 2;
-        size_t n_rings = (jrings == NULL) ? 0 : jniEnv->GetArrayLength(jrings);
-        size_t n_properties = (jproperties == NULL) ? 0 : jniEnv->GetArrayLength(jproperties) / 2;
+    size_t n_points = jniEnv->GetArrayLength(jcoordinates) / 2;
+    size_t n_rings = (jrings == NULL) ? 0 : jniEnv->GetArrayLength(jrings);
+    size_t n_properties = (jproperties == NULL) ? 0 : jniEnv->GetArrayLength(jproperties) / 2;
 
-        Tangram::Properties properties;
+    Tangram::Properties properties;
 
-        for (size_t i = 0; i < n_properties; ++i) {
-            jstring jkey = (jstring) (jniEnv->GetObjectArrayElement(jproperties, 2 * i));
-            jstring jvalue = (jstring) (jniEnv->GetObjectArrayElement(jproperties, 2 * i + 1));
-            auto key = stringFromJString(jniEnv, jkey);
-            auto value = stringFromJString(jniEnv, jvalue);
-            properties.set(key, value);
-            jniEnv->DeleteLocalRef(jkey);
-            jniEnv->DeleteLocalRef(jvalue);
-        }
-
-        auto* coordinates = jniEnv->GetDoubleArrayElements(jcoordinates, NULL);
-
-        if (n_rings > 0) {
-            // If rings are defined, this is a polygon feature.
-            auto* rings = jniEnv->GetIntArrayElements(jrings, NULL);
-            std::vector<std::vector<Tangram::LngLat>> polygon;
-            size_t ring_start = 0, ring_end = 0;
-            for (size_t i = 0; i < n_rings; ++i) {
-                ring_end += rings[i];
-                std::vector<Tangram::LngLat> ring;
-                for (; ring_start < ring_end; ++ring_start) {
-                    ring.push_back({coordinates[2 * ring_start], coordinates[2 * ring_start + 1]});
-                }
-                polygon.push_back(std::move(ring));
-            }
-            source->addPoly(properties, polygon);
-            jniEnv->ReleaseIntArrayElements(jrings, rings, JNI_ABORT);
-        } else if (n_points > 1) {
-            // If no rings defined but multiple points, this is a polyline feature.
-            std::vector<Tangram::LngLat> polyline;
-            for (size_t i = 0; i < n_points; ++i) {
-                polyline.push_back({coordinates[2 * i], coordinates[2 * i + 1]});
-            }
-            source->addLine(properties, polyline);
-        } else {
-            // This is a point feature.
-            auto point = Tangram::LngLat(coordinates[0], coordinates[1]);
-            source->addPoint(properties, point);
-        }
-
-        jniEnv->ReleaseDoubleArrayElements(jcoordinates, coordinates, JNI_ABORT);
+    for (size_t i = 0; i < n_properties; ++i) {
+        jstring jkey = (jstring) (jniEnv->GetObjectArrayElement(jproperties, 2 * i));
+        jstring jvalue = (jstring) (jniEnv->GetObjectArrayElement(jproperties, 2 * i + 1));
+        auto key = stringFromJString(jniEnv, jkey);
+        auto value = stringFromJString(jniEnv, jvalue);
+        properties.set(key, value);
+        jniEnv->DeleteLocalRef(jkey);
+        jniEnv->DeleteLocalRef(jvalue);
     }
 
-    void MapData(AddGeoJson)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr, jstring geojson) {
-        auto_source(sourcePtr);
+    auto* coordinates = jniEnv->GetDoubleArrayElements(jcoordinates, NULL);
 
-        auto data = stringFromJString(jniEnv, geojson);
-        source->addData(data);
+    if (n_rings > 0) {
+        // If rings are defined, this is a polygon feature.
+        auto* rings = jniEnv->GetIntArrayElements(jrings, NULL);
+        std::vector<std::vector<Tangram::LngLat>> polygon;
+        size_t ring_start = 0, ring_end = 0;
+        for (size_t i = 0; i < n_rings; ++i) {
+            ring_end += rings[i];
+            std::vector<Tangram::LngLat> ring;
+            for (; ring_start < ring_end; ++ring_start) {
+                ring.push_back({coordinates[2 * ring_start], coordinates[2 * ring_start + 1]});
+            }
+            polygon.push_back(std::move(ring));
+        }
+        source->addPoly(properties, polygon);
+        jniEnv->ReleaseIntArrayElements(jrings, rings, JNI_ABORT);
+    } else if (n_points > 1) {
+        // If no rings defined but multiple points, this is a polyline feature.
+        std::vector<Tangram::LngLat> polyline;
+        for (size_t i = 0; i < n_points; ++i) {
+            polyline.push_back({coordinates[2 * i], coordinates[2 * i + 1]});
+        }
+        source->addLine(properties, polyline);
+    } else {
+        // This is a point feature.
+        auto point = Tangram::LngLat(coordinates[0], coordinates[1]);
+        source->addPoint(properties, point);
     }
+
+    jniEnv->ReleaseDoubleArrayElements(jcoordinates, coordinates, JNI_ABORT);
 }
+
+void MapData(AddGeoJson)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr, jstring geojson) {
+    auto_source(sourcePtr);
+
+    auto data = stringFromJString(jniEnv, geojson);
+    source->addData(data);
+}
+
+EXTERN_C_END

--- a/platforms/android/tangram/src/main/cpp/jniThreadBinding.h
+++ b/platforms/android/tangram/src/main/cpp/jniThreadBinding.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <jni.h>
+
+class JniThreadBinding {
+private:
+    JavaVM* jvm;
+    JNIEnv *jniEnv;
+    int status;
+public:
+    JniThreadBinding(JavaVM* _jvm) : jvm(_jvm) {
+        status = jvm->GetEnv((void**)&jniEnv, JNI_VERSION_1_6);
+        if (status == JNI_EDETACHED) { jvm->AttachCurrentThread(&jniEnv, NULL);}
+    }
+    ~JniThreadBinding() {
+        if (status == JNI_EDETACHED) { jvm->DetachCurrentThread(); }
+    }
+
+    JNIEnv* operator->() const {
+        return jniEnv;
+    }
+
+    operator JNIEnv*() const {
+        return jniEnv;
+    }
+};

--- a/platforms/android/tangram/src/main/cpp/jniWorker.h
+++ b/platforms/android/tangram/src/main/cpp/jniWorker.h
@@ -1,0 +1,69 @@
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <jni.h>
+
+namespace Tangram {
+
+class JniWorker {
+public:
+
+    explicit JniWorker(JavaVM* _jvm) : jvm(_jvm){
+
+        thread = std::thread(&JniWorker::run, this);
+
+        pthread_setname_np(thread.native_handle(), "TangramJNI Worker");
+    }
+
+    ~JniWorker() {
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            m_running = false;
+        }
+        m_condition.notify_all();
+        thread.join();
+    }
+
+    void enqueue(std::function<void(JNIEnv *jniEnv)> _task) {
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            if (!m_running) { return; }
+
+            m_queue.push_back(std::move(_task));
+        }
+        m_condition.notify_one();
+    }
+
+private:
+
+    void run() {
+        jvm->AttachCurrentThread(&jniEnv, NULL);
+
+        while (true) {
+            std::function<void(JNIEnv *jniEnv)> task;
+            {
+                std::unique_lock<std::mutex> lock(m_mutex);
+                m_condition.wait(lock, [&]{ return !m_running || !m_queue.empty(); });
+                if (!m_running) { break; }
+
+                task = std::move(m_queue.front());
+                m_queue.pop_front();
+            }
+            task(jniEnv);
+        }
+        jvm->DetachCurrentThread();
+    }
+
+    std::thread thread;
+    bool m_running = true;
+    std::condition_variable m_condition;
+    std::mutex m_mutex;
+    std::deque<std::function<void(JNIEnv *)>> m_queue;
+
+    JavaVM* jvm;
+    JNIEnv *jniEnv;
+
+};
+
+}

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/FontConfig.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/FontConfig.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class FontFileParser {
+class FontConfig {
 
     private static boolean initialized = false;
     private static Map<String, String> fontDict;
@@ -35,7 +35,7 @@ class FontFileParser {
     private static final String oldFontXMLPath = "/system/etc/system_fonts.xml";
     private static final String oldFontXMLFallbackPath = "/system/etc/fallback_fonts.xml";
 
-    private FontFileParser() {}
+    private FontConfig() {}
 
     public static synchronized void init() {
         if (initialized) { return; }
@@ -54,7 +54,7 @@ class FontFileParser {
         parse();
 
         time = System.currentTimeMillis() - time;
-        Log.d("Tangram", "FontFileParser init took " + time + "ms");
+        Log.d("Tangram", "FontConfig init took " + time + "ms");
     }
 
     private static void addFallback(final Integer weight, final String filename) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/FontFileParser.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/FontFileParser.java
@@ -23,8 +23,9 @@ import java.util.Map;
 
 class FontFileParser {
 
-    private Map<String, String> fontDict;
-    private SparseArray<List<String>> fallbackFontDict;
+    private static boolean initialized = false;
+    private static Map<String, String> fontDict;
+    private static SparseArray<List<String>> fallbackFontDict;
 
     private static final String systemFontPath = "/system/fonts/";
     // Android version >= 5.0
@@ -34,7 +35,14 @@ class FontFileParser {
     private static final String oldFontXMLPath = "/system/etc/system_fonts.xml";
     private static final String oldFontXMLFallbackPath = "/system/etc/fallback_fonts.xml";
 
-    public FontFileParser() {
+    private FontFileParser() {}
+
+    public static synchronized void init() {
+        if (initialized) { return; }
+        initialized = true;
+
+        long time = System.currentTimeMillis();
+
         if (Build.VERSION.SDK_INT > 18) {
             fontDict = new ArrayMap<>();
         }
@@ -42,9 +50,14 @@ class FontFileParser {
             fontDict = new HashMap<>();
         }
         fallbackFontDict = new SparseArray<>();
+
+        parse();
+
+        time = System.currentTimeMillis() - time;
+        Log.d("Tangram", "FontFileParser init took " + time + "ms");
     }
 
-    private void addFallback(final Integer weight, final String filename) {
+    private static void addFallback(final Integer weight, final String filename) {
         final String fullFileName = systemFontPath + filename;
         if (!new File(fullFileName).exists()) {
             return;
@@ -58,7 +71,7 @@ class FontFileParser {
     }
 
 
-    private void processDocumentPreLollipop(@NonNull final XmlPullParser parser) throws XmlPullParserException, IOException {
+    private static void processDocumentPreLollipop(@NonNull final XmlPullParser parser) throws XmlPullParserException, IOException {
         parser.nextTag();
         parser.require(XmlPullParser.START_TAG, null, "familyset");
 
@@ -150,7 +163,7 @@ class FontFileParser {
         }
     }
 
-    private void processDocument(@NonNull final XmlPullParser parser) throws XmlPullParserException, IOException {
+    private static void processDocument(@NonNull final XmlPullParser parser) throws XmlPullParserException, IOException {
         final List<String> familyWeights = new ArrayList<>();
 
         parser.nextTag();
@@ -263,7 +276,7 @@ class FontFileParser {
         }
     }
 
-    private void skip(@NonNull final XmlPullParser parser) throws XmlPullParserException, IOException {
+    private static void skip(@NonNull final XmlPullParser parser) throws XmlPullParserException, IOException {
         int depth = 1;
         while (depth > 0) {
             switch (parser.next()) {
@@ -277,7 +290,7 @@ class FontFileParser {
         }
     }
 
-    public void parse() {
+    public static void parse() {
 
         File fontFile = new File(fontXMLPath);
         if (fontFile.exists()) {
@@ -296,7 +309,7 @@ class FontFileParser {
         }
     }
 
-    private void parse(final File fileXml, final boolean oldXML) {
+    private static void parse(final File fileXml, final boolean oldXML) {
         InputStream in;
 
         try {
@@ -332,7 +345,9 @@ class FontFileParser {
         }
     }
 
-    public String getFontFile(final String _key) {
+    public static synchronized String getFontFile(final String _key) {
+        if (!initialized) { init(); }
+
         return fontDict.containsKey(_key) ? fontDict.get(_key) : "";
     }
 
@@ -342,7 +357,9 @@ class FontFileParser {
      * The weightHint value determines the closest fallback hint for boldness
      * See /etc/fonts/font_fallback for documentation
      */
-    public String getFontFallback(final int importance, final int weightHint) {
+    public static synchronized String getFontFallback(final int importance, final int weightHint) {
+        if (!initialized) { init(); }
+
         int diffWeight = Integer.MAX_VALUE;
         String fallback = "";
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1242,104 +1242,6 @@ public class MapController {
         return nativeMarkerSetDrawOrder(mapPointer, markerId, drawOrder);
     }
 
-    // Native methods
-    // ==============
-
-    private synchronized native void nativeOnLowMemory(long mapPtr);
-    private synchronized native long nativeInit(AssetManager assetManager);
-    private synchronized native void nativeDispose(long mapPtr);
-    private synchronized native void nativeShutdown(long mapPtr);
-    private synchronized native int nativeLoadScene(long mapPtr, String path, String[] updateStrings);
-    private synchronized native int nativeLoadSceneAsync(long mapPtr, String path, String[] updateStrings);
-    private synchronized native int nativeLoadSceneYaml(long mapPtr, String yaml, String resourceRoot, String[] updateStrings);
-    private synchronized native int nativeLoadSceneYamlAsync(long mapPtr, String yaml, String resourceRoot, String[] updateStrings);
-
-    private synchronized native void nativeGetCameraPosition(long mapPtr, double[] lonLatOut, float[] zoomRotationTiltOut);
-    private synchronized native void nativeUpdateCameraPosition(long mapPtr, int set, double lon, double lat, float zoom, float zoomBy,
-                                                                float rotation, float rotateBy, float tilt, float tiltBy,
-                                                                double b1lon, double b1lat, double b2lon, double b2lat, int[] padding,
-                                                                float duration, int ease);
-    private synchronized native void nativeFlyTo(long mapPtr, double lon, double lat, float zoom, float duration, float speed);
-    private synchronized native void nativeGetEnclosingCameraPosition(long mapPtr, double aLng, double aLat, double bLng, double bLat, int[] buffer, double[] lngLatZoom);
-    private synchronized native void nativeCancelCameraAnimation(long mapPtr);
-    private synchronized native boolean nativeScreenPositionToLngLat(long mapPtr, double[] coordinates);
-    private synchronized native boolean nativeLngLatToScreenPosition(long mapPtr, double[] coordinates);
-    private synchronized native void nativeSetPixelScale(long mapPtr, float scale);
-    private synchronized native void nativeSetCameraType(long mapPtr, int type);
-    private synchronized native int nativeGetCameraType(long mapPtr);
-    private synchronized native float nativeGetMinZoom(long mapPtr);
-    private synchronized native void nativeSetMinZoom(long mapPtr, float minZoom);
-    private synchronized native float nativeGetMaxZoom(long mapPtr);
-    private synchronized native void nativeSetMaxZoom(long mapPtr, float maxZoom);
-    private synchronized native void nativeHandleTapGesture(long mapPtr, float posX, float posY);
-    private synchronized native void nativeHandleDoubleTapGesture(long mapPtr, float posX, float posY);
-    private synchronized native void nativeHandlePanGesture(long mapPtr, float startX, float startY, float endX, float endY);
-    private synchronized native void nativeHandleFlingGesture(long mapPtr, float posX, float posY, float velocityX, float velocityY);
-    private synchronized native void nativeHandlePinchGesture(long mapPtr, float posX, float posY, float scale, float velocity);
-    private synchronized native void nativeHandleRotateGesture(long mapPtr, float posX, float posY, float rotation);
-    private synchronized native void nativeHandleShoveGesture(long mapPtr, float distance);
-    private synchronized native int nativeUpdateScene(long mapPtr, String[] updateStrings);
-    private synchronized native void nativeSetPickRadius(long mapPtr, float radius);
-    private synchronized native void nativePickFeature(long mapPtr, float posX, float posY);
-    private synchronized native void nativePickLabel(long mapPtr, float posX, float posY);
-    private synchronized native void nativePickMarker(long mapPtr, float posX, float posY);
-    private synchronized native long nativeMarkerAdd(long mapPtr);
-    private synchronized native boolean nativeMarkerRemove(long mapPtr, long markerID);
-    private synchronized native boolean nativeMarkerSetStylingFromString(long mapPtr, long markerID, String styling);
-    private synchronized native boolean nativeMarkerSetStylingFromPath(long mapPtr, long markerID, String path);
-    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, Bitmap bitmap, float density);
-    private synchronized native boolean nativeMarkerSetPoint(long mapPtr, long markerID, double lng, double lat);
-    private synchronized native boolean nativeMarkerSetPointEased(long mapPtr, long markerID, double lng, double lat, float duration, int ease);
-    private synchronized native boolean nativeMarkerSetPolyline(long mapPtr, long markerID, double[] coordinates, int count);
-    private synchronized native boolean nativeMarkerSetPolygon(long mapPtr, long markerID, double[] coordinates, int[] rings, int count);
-    private synchronized native boolean nativeMarkerSetVisible(long mapPtr, long markerID, boolean visible);
-    private synchronized native boolean nativeMarkerSetDrawOrder(long mapPtr, long markerID, int drawOrder);
-    private synchronized native void nativeMarkerRemoveAll(long mapPtr);
-
-    private synchronized native void nativeUseCachedGlState(long mapPtr, boolean use);
-
-
-    private synchronized native void nativeSetDefaultBackgroundColor(long mapPtr, float r, float g, float b);
-
-    private native void nativeOnUrlComplete(long mapPtr, long requestHandle, byte[] rawDataBytes, String errorMessage);
-
-    synchronized native long nativeAddTileSource(long mapPtr, String name, boolean generateCentroid);
-    synchronized native void nativeRemoveTileSource(long mapPtr, long sourcePtr);
-    synchronized native void nativeClearTileSource(long mapPtr, long sourcePtr);
-    synchronized native void nativeAddFeature(long mapPtr, long sourcePtr, double[] coordinates, int[] rings, String[] properties);
-    synchronized native void nativeAddGeoJson(long mapPtr, long sourcePtr, String geoJson);
-
-    native void nativeSetDebugFlag(int flag, boolean on);
-
-    // Private members
-    // ===============
-
-    long mapPointer;
-    private MapRenderer mapRenderer;
-
-    private GLViewHolder viewHolder;
-    private MapRegionChangeState currentState = MapRegionChangeState.IDLE;
-    private AssetManager assetManager;
-    private TouchInput touchInput;
-    private FontFileParser fontFileParser;
-    private DisplayMetrics displayMetrics = new DisplayMetrics();
-    private HttpHandler httpHandler;
-    private final Map<Long, Object> httpRequestHandles = Collections.synchronizedMap(new HashMap());
-    MapChangeListener mapChangeListener;
-    private FeaturePickListener featurePickListener;
-    private SceneLoadListener sceneLoadListener;
-    private LabelPickListener labelPickListener;
-    private MarkerPickListener markerPickListener;
-    private FrameCaptureCallback frameCaptureCallback;
-    private boolean frameCaptureAwaitCompleteView;
-    private Map<String, MapData> clientTileSources;
-    private LongSparseArray<Marker> markers;
-    private Handler uiThreadHandler;
-    private CameraAnimationCallback cameraAnimationCallback;
-    private CameraAnimationCallback pendingCameraAnimationCallback;
-    private final Object cameraAnimationCallbackLock = new Object();
-    private boolean isGLRendererSet = false;
-
 
     // Networking methods
     // ==================
@@ -1496,4 +1398,97 @@ public class MapController {
         return fontFileParser.getFontFallback(importance, weightHint);
     }
 
+    // Private members
+    // ===============
+
+    long mapPointer;
+    private MapRenderer mapRenderer;
+    private GLViewHolder viewHolder;
+    private MapRegionChangeState currentState = MapRegionChangeState.IDLE;
+    private AssetManager assetManager;
+    private TouchInput touchInput;
+    private FontFileParser fontFileParser;
+    private DisplayMetrics displayMetrics = new DisplayMetrics();
+    private HttpHandler httpHandler;
+    private final Map<Long, Object> httpRequestHandles = Collections.synchronizedMap(new HashMap());
+    MapChangeListener mapChangeListener;
+    private FeaturePickListener featurePickListener;
+    private SceneLoadListener sceneLoadListener;
+    private LabelPickListener labelPickListener;
+    private MarkerPickListener markerPickListener;
+    private FrameCaptureCallback frameCaptureCallback;
+    private boolean frameCaptureAwaitCompleteView;
+    private Map<String, MapData> clientTileSources;
+    private LongSparseArray<Marker> markers;
+    private Handler uiThreadHandler;
+    private CameraAnimationCallback cameraAnimationCallback;
+    private CameraAnimationCallback pendingCameraAnimationCallback;
+    private final Object cameraAnimationCallbackLock = new Object();
+    private boolean isGLRendererSet = false;
+
+    // Native methods
+    // ==============
+
+    private synchronized native void nativeOnLowMemory(long mapPtr);
+    private synchronized native long nativeInit(AssetManager assetManager);
+    private synchronized native void nativeDispose(long mapPtr);
+    private synchronized native void nativeShutdown(long mapPtr);
+    private synchronized native int nativeLoadScene(long mapPtr, String path, String[] updateStrings);
+    private synchronized native int nativeLoadSceneAsync(long mapPtr, String path, String[] updateStrings);
+    private synchronized native int nativeLoadSceneYaml(long mapPtr, String yaml, String resourceRoot, String[] updateStrings);
+    private synchronized native int nativeLoadSceneYamlAsync(long mapPtr, String yaml, String resourceRoot, String[] updateStrings);
+
+    private synchronized native void nativeGetCameraPosition(long mapPtr, double[] lonLatOut, float[] zoomRotationTiltOut);
+    private synchronized native void nativeUpdateCameraPosition(long mapPtr, int set, double lon, double lat, float zoom, float zoomBy,
+                                                                float rotation, float rotateBy, float tilt, float tiltBy,
+                                                                double b1lon, double b1lat, double b2lon, double b2lat, int[] padding,
+                                                                float duration, int ease);
+    private synchronized native void nativeFlyTo(long mapPtr, double lon, double lat, float zoom, float duration, float speed);
+    private synchronized native void nativeGetEnclosingCameraPosition(long mapPtr, double aLng, double aLat, double bLng, double bLat, int[] buffer, double[] lngLatZoom);
+    private synchronized native void nativeCancelCameraAnimation(long mapPtr);
+    private synchronized native boolean nativeScreenPositionToLngLat(long mapPtr, double[] coordinates);
+    private synchronized native boolean nativeLngLatToScreenPosition(long mapPtr, double[] coordinates);
+    private synchronized native void nativeSetPixelScale(long mapPtr, float scale);
+    private synchronized native void nativeSetCameraType(long mapPtr, int type);
+    private synchronized native int nativeGetCameraType(long mapPtr);
+    private synchronized native float nativeGetMinZoom(long mapPtr);
+    private synchronized native void nativeSetMinZoom(long mapPtr, float minZoom);
+    private synchronized native float nativeGetMaxZoom(long mapPtr);
+    private synchronized native void nativeSetMaxZoom(long mapPtr, float maxZoom);
+    private synchronized native void nativeHandleTapGesture(long mapPtr, float posX, float posY);
+    private synchronized native void nativeHandleDoubleTapGesture(long mapPtr, float posX, float posY);
+    private synchronized native void nativeHandlePanGesture(long mapPtr, float startX, float startY, float endX, float endY);
+    private synchronized native void nativeHandleFlingGesture(long mapPtr, float posX, float posY, float velocityX, float velocityY);
+    private synchronized native void nativeHandlePinchGesture(long mapPtr, float posX, float posY, float scale, float velocity);
+    private synchronized native void nativeHandleRotateGesture(long mapPtr, float posX, float posY, float rotation);
+    private synchronized native void nativeHandleShoveGesture(long mapPtr, float distance);
+    private synchronized native int nativeUpdateScene(long mapPtr, String[] updateStrings);
+    private synchronized native void nativeSetPickRadius(long mapPtr, float radius);
+    private synchronized native void nativePickFeature(long mapPtr, float posX, float posY);
+    private synchronized native void nativePickLabel(long mapPtr, float posX, float posY);
+    private synchronized native void nativePickMarker(long mapPtr, float posX, float posY);
+    private synchronized native long nativeMarkerAdd(long mapPtr);
+    private synchronized native boolean nativeMarkerRemove(long mapPtr, long markerID);
+    private synchronized native boolean nativeMarkerSetStylingFromString(long mapPtr, long markerID, String styling);
+    private synchronized native boolean nativeMarkerSetStylingFromPath(long mapPtr, long markerID, String path);
+    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, Bitmap bitmap, float density);
+    private synchronized native boolean nativeMarkerSetPoint(long mapPtr, long markerID, double lng, double lat);
+    private synchronized native boolean nativeMarkerSetPointEased(long mapPtr, long markerID, double lng, double lat, float duration, int ease);
+    private synchronized native boolean nativeMarkerSetPolyline(long mapPtr, long markerID, double[] coordinates, int count);
+    private synchronized native boolean nativeMarkerSetPolygon(long mapPtr, long markerID, double[] coordinates, int[] rings, int count);
+    private synchronized native boolean nativeMarkerSetVisible(long mapPtr, long markerID, boolean visible);
+    private synchronized native boolean nativeMarkerSetDrawOrder(long mapPtr, long markerID, int drawOrder);
+    private synchronized native void nativeMarkerRemoveAll(long mapPtr);
+    private synchronized native void nativeUseCachedGlState(long mapPtr, boolean use);
+    private synchronized native void nativeSetDefaultBackgroundColor(long mapPtr, float r, float g, float b);
+
+    private native void nativeOnUrlComplete(long mapPtr, long requestHandle, byte[] rawDataBytes, String errorMessage);
+
+    synchronized native long nativeAddTileSource(long mapPtr, String name, boolean generateCentroid);
+    synchronized native void nativeRemoveTileSource(long mapPtr, long sourcePtr);
+    synchronized native void nativeClearTileSource(long mapPtr, long sourcePtr);
+    synchronized native void nativeAddFeature(long mapPtr, long sourcePtr, double[] coordinates, int[] rings, String[] properties);
+    synchronized native void nativeAddGeoJson(long mapPtr, long sourcePtr, String geoJson);
+
+    native void nativeSetDebugFlag(int flag, boolean on);
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -127,7 +127,7 @@ public class MapController {
      */
     public interface FrameCaptureCallback {
         /**
-         * Called on the render-thread when a frame was captured.
+         * Called on the ui-thread when a frame was captured.
          */
         void onCaptured(@NonNull final Bitmap bitmap);
     }
@@ -1048,7 +1048,8 @@ public class MapController {
 
     /**
      * Set a listener for map change events
-     * @param listener The {@link MapChangeListener} to call when the map change events occur due to camera updates or user interaction
+     * @param listener The {@link MapChangeListener} to call when the map change events occur
+     *                due to camera updates or user interaction
      */
     public void setMapChangeListener(@Nullable final MapChangeListener listener) {
         mapChangeListener = listener;

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -155,7 +155,7 @@ public class MapController {
         assetManager = context.getAssets();
 
         // Parse font file description
-        //FontFileParser.init();
+        //FontConfig.init();
 
         mapPointer = nativeInit(assetManager);
         if (mapPointer <= 0) {
@@ -1364,12 +1364,12 @@ public class MapController {
     // =============
     @Keep
     String getFontFilePath(final String key) {
-        return FontFileParser.getFontFile(key);
+        return FontConfig.getFontFile(key);
     }
 
     @Keep
     String getFontFallbackFilePath(final int importance, final int weightHint) {
-        return FontFileParser.getFontFallback(importance, weightHint);
+        return FontConfig.getFontFallback(importance, weightHint);
     }
 
     // Private members

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -5,7 +5,6 @@ import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.graphics.Rect;
-import android.opengl.GLSurfaceView.Renderer;
 import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.IntRange;
@@ -25,15 +24,10 @@ import com.mapzen.tangram.networking.DefaultHttpHandler;
 import com.mapzen.tangram.networking.HttpHandler;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import javax.microedition.khronos.egl.EGLConfig;
-import javax.microedition.khronos.opengles.GL10;
 
 /**
  * {@code MapController} is the main class for interacting with a Tangram map.

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -161,8 +161,7 @@ public class MapController {
         assetManager = context.getAssets();
 
         // Parse font file description
-        fontFileParser = new FontFileParser();
-        fontFileParser.parse();
+        //FontFileParser.init();
 
         mapPointer = nativeInit(assetManager);
         if (mapPointer <= 0) {
@@ -1371,12 +1370,12 @@ public class MapController {
     // =============
     @Keep
     String getFontFilePath(final String key) {
-        return fontFileParser.getFontFile(key);
+        return FontFileParser.getFontFile(key);
     }
 
     @Keep
     String getFontFallbackFilePath(final int importance, final int weightHint) {
-        return fontFileParser.getFontFallback(importance, weightHint);
+        return FontFileParser.getFontFallback(importance, weightHint);
     }
 
     // Private members
@@ -1388,7 +1387,6 @@ public class MapController {
     private MapRegionChangeState currentState = MapRegionChangeState.IDLE;
     private AssetManager assetManager;
     private TouchInput touchInput;
-    private FontFileParser fontFileParser;
     private DisplayMetrics displayMetrics = new DisplayMetrics();
     private HttpHandler httpHandler;
     private final Map<Long, Object> httpRequestHandles = Collections.synchronizedMap(new HashMap());

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -17,6 +17,7 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.LongSparseArray;
 import android.view.MotionEvent;
+import android.view.View;
 
 import com.mapzen.tangram.TouchInput.Gestures;
 import com.mapzen.tangram.viewholder.GLViewHolder;
@@ -38,7 +39,7 @@ import javax.microedition.khronos.opengles.GL10;
 public class MapController implements Renderer {
 
 
-    public boolean handleGesture(MapView mapView, MotionEvent ev) {
+    public boolean handleGesture(View mapView, MotionEvent ev) {
         return touchInput.onTouch(mapView, ev);
     }
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -185,7 +185,7 @@ public class MapController implements Renderer {
         fontFileParser = new FontFileParser();
         fontFileParser.parse();
 
-        mapPointer = nativeInit(this, assetManager);
+        mapPointer = nativeInit(assetManager);
         if (mapPointer <= 0) {
             throw new RuntimeException("Unable to create a native Map object! There may be insufficient memory available.");
         }
@@ -1257,7 +1257,7 @@ public class MapController implements Renderer {
     // ==============
 
     private synchronized native void nativeOnLowMemory(long mapPtr);
-    private synchronized native long nativeInit(MapController instance, AssetManager assetManager);
+    private synchronized native long nativeInit(AssetManager assetManager);
     private synchronized native void nativeDispose(long mapPtr);
     private synchronized native int nativeLoadScene(long mapPtr, String path, String[] updateStrings);
     private synchronized native int nativeLoadSceneAsync(long mapPtr, String path, String[] updateStrings);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1144,17 +1144,6 @@ public class MapController {
         nativeClearTileSource(mapPointer, sourcePtr);
     }
 
-    void addFeature(final long sourcePtr, final double[] coordinates, final int[] rings, final String[] properties) {
-        checkPointer(mapPointer);
-        checkPointer(sourcePtr);
-        nativeAddFeature(mapPointer, sourcePtr, coordinates, rings, properties);
-    }
-
-    void addGeoJson(final long sourcePtr, final String geoJson) {
-        checkPointer(mapPointer);
-        checkPointer(sourcePtr);
-        nativeAddGeoJson(mapPointer, sourcePtr, geoJson);
-    }
 
     void checkPointer(final long ptr) {
         if (ptr <= 0) {
@@ -1474,13 +1463,12 @@ public class MapController {
     private synchronized native void nativeUseCachedGlState(long mapPtr, boolean use);
     private synchronized native void nativeSetDefaultBackgroundColor(long mapPtr, float r, float g, float b);
 
+    private synchronized native long nativeAddTileSource(long mapPtr, String name, boolean generateCentroid);
+    private synchronized native void nativeRemoveTileSource(long mapPtr, long sourcePtr);
+    private synchronized native void nativeClearTileSource(long mapPtr, long sourcePtr);
+
+    private synchronized native void nativeSetDebugFlag(int flag, boolean on);
+
     private native void nativeOnUrlComplete(long mapPtr, long requestHandle, byte[] rawDataBytes, String errorMessage);
 
-    synchronized native long nativeAddTileSource(long mapPtr, String name, boolean generateCentroid);
-    synchronized native void nativeRemoveTileSource(long mapPtr, long sourcePtr);
-    synchronized native void nativeClearTileSource(long mapPtr, long sourcePtr);
-    synchronized native void nativeAddFeature(long mapPtr, long sourcePtr, double[] coordinates, int[] rings, String[] properties);
-    synchronized native void nativeAddGeoJson(long mapPtr, long sourcePtr, String geoJson);
-
-    native void nativeSetDebugFlag(int flag, boolean on);
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1247,15 +1247,6 @@ public class MapController {
     // Networking methods
     // ==================
 
-    void cancelAllNetworkRequests() {
-        synchronized (httpRequestHandles) {
-            for (Object handle : httpRequestHandles.values()) {
-                httpHandler.cancelRequest(handle);
-            }
-            httpRequestHandles.clear();
-        }
-    }
-
     @Keep
     void cancelUrlRequest(final long requestHandle) {
         Object request = httpRequestHandles.remove(requestHandle);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -37,6 +37,8 @@ public class MapData {
      * @param geometry The feature to add
      */
     protected void addFeature(@NonNull final Geometry geometry) {
+        if (map == null) { return; }
+
         map.addFeature(pointer,
                 geometry.getCoordinateArray(),
                 geometry.getRingArray(),
@@ -111,6 +113,8 @@ public class MapData {
      */
     @NonNull
     public MapData addGeoJson(final String data) {
+        if (map == null) { return this; }
+
         map.addGeoJson(pointer, data);
         return this;
     }
@@ -121,6 +125,8 @@ public class MapData {
      */
     @NonNull
     public MapData clear() {
+        if (map == null) { return this; }
+
         map.clearTileSource(pointer);
         return this;
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapRenderer.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapRenderer.java
@@ -9,14 +9,14 @@ import android.view.View;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
-public class MapRenderer  implements GLSurfaceView.Renderer {
+class MapRenderer implements GLSurfaceView.Renderer {
 
-    public MapRenderer(MapController mapController, Handler uiThreadHandler) {
+    MapRenderer(MapController mapController, Handler uiThreadHandler) {
         this.uiThreadHandler = uiThreadHandler;
-
         this.map = mapController;
         this.mapPointer = mapController.mapPointer;
     }
+
     // GLSurfaceView.Renderer methods
     // ==============================
 
@@ -97,7 +97,7 @@ public class MapRenderer  implements GLSurfaceView.Renderer {
         }
     }
 
-    public void captureFrame(MapController.FrameCaptureCallback callback, boolean waitForCompleteView) {
+    void captureFrame(MapController.FrameCaptureCallback callback, boolean waitForCompleteView) {
         frameCaptureCallback = callback;
         frameCaptureAwaitCompleteView = waitForCompleteView;
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapRenderer.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapRenderer.java
@@ -1,0 +1,154 @@
+package com.mapzen.tangram;
+
+import android.graphics.Bitmap;
+import android.opengl.GLSurfaceView;
+import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.view.View;
+
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
+
+public class MapRenderer  implements GLSurfaceView.Renderer {
+
+    public MapRenderer(MapController mapController, Handler uiThreadHandler) {
+        this.uiThreadHandler = uiThreadHandler;
+
+        this.map = mapController;
+        this.mapPointer = mapController.mapPointer;
+    }
+    // GLSurfaceView.Renderer methods
+    // ==============================
+
+    @Override
+    public void onDrawFrame(final GL10 gl) {
+        final long newTime = System.nanoTime();
+        final float delta = (newTime - time) / 1000000000.0f;
+        time = newTime;
+
+        if (mapPointer <= 0) {
+            // No native instance is initialized, so stop here. This can happen during Activity
+            // shutdown when the map has been disposed but the View hasn't been destroyed yet.
+            return;
+        }
+
+        boolean mapViewComplete;
+        boolean isCameraEasing;
+
+        synchronized(map) {
+            mapViewComplete = nativeUpdate(mapPointer, delta);
+            isCameraEasing = nativeRender(mapPointer);
+        }
+
+        if (isCameraEasing) {
+            uiThreadHandler.post(setMapRegionAnimatingRunnable);
+        } else if (isPrevCameraEasing) {
+            uiThreadHandler.post(setMapRegionIdleRunnable);
+        }
+
+        boolean viewComplete = mapViewComplete && !isPrevMapViewComplete;
+
+        if (viewComplete) {
+            if (map.mapChangeListener != null) {
+                map.mapChangeListener.onViewComplete();
+            }
+        }
+        if (frameCaptureCallback != null) {
+            if (!frameCaptureAwaitCompleteView || viewComplete) {
+                frameCaptureCallback.onCaptured(capture());
+                frameCaptureCallback = null;
+            }
+        }
+
+        isPrevCameraEasing = isCameraEasing;
+        isPrevMapViewComplete = mapViewComplete;
+    }
+
+    @Override
+    public void onSurfaceChanged(final GL10 gl, final int width, final int height) {
+        if (mapPointer <= 0) {
+            // No native instance is initialized, so stop here. This can happen during Activity
+            // shutdown when the map has been disposed but the View hasn't been destroyed yet.
+            return;
+        }
+
+        synchronized (map) {
+            nativeResize(mapPointer, width, height);
+        }
+    }
+
+    @Override
+    public void onSurfaceCreated(final GL10 gl, final EGLConfig config) {
+        if (mapPointer <= 0) {
+            // No native instance is initialized, so stop here. This can happen during Activity
+            // shutdown when the map has been disposed but the View hasn't been destroyed yet.
+            return;
+        }
+
+        synchronized (map) {
+            nativeSetupGL(mapPointer);
+        }
+    }
+
+    public void captureFrame(MapController.FrameCaptureCallback callback, boolean waitForCompleteView) {
+        frameCaptureCallback = callback;
+        frameCaptureAwaitCompleteView = waitForCompleteView;
+
+    }
+
+    @NonNull
+    private Bitmap capture() {
+        View view = map.getGLViewHolder().getView();
+
+        final int w = view.getWidth();
+        final int h = view.getHeight();
+
+        final int b[] = new int[w * h];
+        final int bt[] = new int[w * h];
+
+        synchronized (map) {
+            nativeCaptureSnapshot(mapPointer, b);
+        }
+        for (int i = 0; i < h; i++) {
+            for (int j = 0; j < w; j++) {
+                final int pix = b[i * w + j];
+                final int pb = (pix >> 16) & 0xff;
+                final int pr = (pix << 16) & 0x00ff0000;
+                final int pix1 = (pix & 0xff00ff00) | pr | pb;
+                bt[(h - i - 1) * w + j] = pix1;
+            }
+        }
+
+        return Bitmap.createBitmap(bt, w, h, Bitmap.Config.ARGB_8888);
+    }
+
+    private final Handler uiThreadHandler;
+    private final MapController map;
+    private final long mapPointer;
+    private long time = System.nanoTime();
+    private boolean isPrevCameraEasing = false;
+    private boolean isPrevMapViewComplete = false;
+
+
+    private native void nativeSetupGL(long mapPtr);
+    private native void nativeResize(long mapPtr, int width, int height);
+    private native boolean nativeUpdate(long mapPtr, float dt);
+    private native boolean nativeRender(long mapPtr);
+    private native void nativeCaptureSnapshot(long mapPtr, int[] buffer);
+
+    private MapController.FrameCaptureCallback frameCaptureCallback;
+    private boolean frameCaptureAwaitCompleteView;
+
+    private Runnable setMapRegionAnimatingRunnable = new Runnable() {
+        @Override
+        public void run() {
+            map.setMapRegionState(MapController.MapRegionChangeState.ANIMATING);
+        }
+    };
+    private Runnable setMapRegionIdleRunnable = new Runnable() {
+        @Override
+        public void run() {
+            map.setMapRegionState(MapController.MapRegionChangeState.IDLE);
+        }
+    };
+}

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -108,7 +108,9 @@ public class MapView extends FrameLayout {
 
         loadLibraryTask = loadNativeLibraryAsync(new NativeLibraryLoadCb() {
             @Override
-            public void onLibraryReadyAsync(Boolean ok) {}
+            public void onLibraryReadyAsync(Boolean ok) {
+                //FontFileParser.init();
+            }
 
             @Override
             public void onLibraryReady(Boolean ok) {
@@ -165,9 +167,20 @@ public class MapView extends FrameLayout {
             return null;
         }
 
+        long time = System.currentTimeMillis();
+
         mapController = getMapInstance(getContext());
+
+        long now = System.currentTimeMillis();
+        Log.d("Tangram", "MapController creation took " + (now - time)+ "ms");
+        time = now;
+
         if (mapController != null) {
             mapController.UIThreadInit(viewHolder, handler);
+
+            now = System.currentTimeMillis();
+            Log.d("Tangram", "MapController init took " + (now - time) + "ms");
+
             addView(viewHolder.getView());
         }
         return mapController;
@@ -186,11 +199,14 @@ public class MapView extends FrameLayout {
      * @return true when everything went as expected
      */
     public static boolean loadNativeLibrary() {
+        long time = System.currentTimeMillis();
         if (NativeLibraryLoader.sNativeLibraryLoaded) {
             libraryLoaded = true;
+            time = System.currentTimeMillis() - time;
+            Log.d("Tangram", "Loading native library took " + time + "ms");
             return true;
         }
-        android.util.Log.e("Tangram", "Unable to initialize MapController: Failed to initialize native libraries");
+        Log.e("Tangram", "Unable to initialize MapController: Failed to load native library");
         return false;
     }
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -109,7 +109,7 @@ public class MapView extends FrameLayout {
         loadLibraryTask = loadNativeLibraryAsync(new NativeLibraryLoadCb() {
             @Override
             public void onLibraryReadyAsync(Boolean ok) {
-                //FontFileParser.init();
+                //FontConfig.init();
             }
 
             @Override

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
@@ -5,10 +5,15 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
 
 import okhttp3.Call;
@@ -40,6 +45,43 @@ public class DefaultHttpHandler implements HttpHandler {
                 .connectTimeout(10, TimeUnit.SECONDS)
                 .writeTimeout(10, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.SECONDS);
+
+
+        builder.socketFactory(new SocketFactory() {
+            SocketFactory factory = SocketFactory.getDefault();
+
+            @Override
+            public Socket createSocket() throws IOException {
+                Socket s = factory.createSocket();
+                try {
+                    //Log.d("Tangram", "Patching socket nodelay: " + s.getTcpNoDelay());
+                    s.setTcpNoDelay(true);
+                } catch (SocketException e) {
+                    // empty
+                }
+                return s;
+            }
+
+            @Override
+            public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
+                return null;
+            }
+
+            @Override
+            public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException, UnknownHostException {
+                return null;
+            }
+
+            @Override
+            public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+                return null;
+            }
+
+            @Override
+            public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
+                return null;
+            }
+        });
 
         configureClient(builder);
 

--- a/platforms/common/urlClient.cpp
+++ b/platforms/common/urlClient.cpp
@@ -53,10 +53,10 @@ UrlClient::~UrlClient() {
     }
 }
 
-UrlRequestHandle UrlClient::addRequest(const std::string& url, UrlCallback onComplete) {
+UrlRequestId UrlClient::addRequest(const std::string& url, Callback onComplete) {
     // Create a new request.
-    m_requestCount++;
-    Request request = {url, onComplete, m_requestCount, false};
+    auto id = ++m_requestCount;
+    Request request = {url, onComplete, id, false};
     // Add the request to our list.
     {
         // Lock the mutex to prevent concurrent modification of the list by the curl loop thread.
@@ -65,18 +65,18 @@ UrlRequestHandle UrlClient::addRequest(const std::string& url, UrlCallback onCom
     }
     // Notify a thread to start the transfer.
     m_requestCondition.notify_one();
-    return m_requestCount;
+    return id;
 }
 
-void UrlClient::cancelRequest(UrlRequestHandle handle) {
-    UrlCallback callback;
+void UrlClient::cancelRequest(UrlRequestId id) {
+    Callback callback;
     // First check the pending request list.
     {
         // Lock the mutex to prevent concurrent modification of the list by the curl loop thread.
         std::lock_guard<std::mutex> lock(m_requestMutex);
         for (auto it = m_requests.begin(), end = m_requests.end(); it != end; ++it) {
             auto& request = *it;
-            if (request.handle == handle) {
+            if (request.id == id) {
                 // Found the request! Now run its callback and remove it.
                 callback = std::move(request.callback);
                 m_requests.erase(it);
@@ -92,7 +92,7 @@ void UrlClient::cancelRequest(UrlRequestHandle handle) {
 
     // Next check the active request list.
     for (auto& task : m_tasks) {
-        if (task.request.handle == handle) {
+        if (task.request.id == id) {
             task.request.canceled = true;
         }
     }

--- a/platforms/common/urlClient.cpp
+++ b/platforms/common/urlClient.cpp
@@ -143,6 +143,8 @@ void UrlClient::curlLoop(uint32_t index) {
     curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, m_options.requestTimeoutMs);
     curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(handle, CURLOPT_MAXREDIRS, 20);
+    curl_easy_setopt(handle, CURLOPT_TCP_NODELAY, 1);
+
     // Loop until the session is destroyed.
     while (m_keepRunning) {
         bool haveRequest = false;

--- a/platforms/common/urlClient.cpp
+++ b/platforms/common/urlClient.cpp
@@ -53,7 +53,7 @@ UrlClient::~UrlClient() {
     }
 }
 
-UrlRequestId UrlClient::addRequest(const std::string& url, Callback onComplete) {
+UrlClient::RequestId UrlClient::addRequest(const std::string& url, Callback onComplete) {
     // Create a new request.
     auto id = ++m_requestCount;
     Request request = {url, onComplete, id, false};
@@ -68,7 +68,7 @@ UrlRequestId UrlClient::addRequest(const std::string& url, Callback onComplete) 
     return id;
 }
 
-void UrlClient::cancelRequest(UrlRequestId id) {
+void UrlClient::cancelRequest(UrlClient::RequestId id) {
     Callback callback;
     // First check the pending request list.
     {

--- a/platforms/common/urlClient.cpp
+++ b/platforms/common/urlClient.cpp
@@ -53,7 +53,7 @@ UrlClient::~UrlClient() {
     }
 }
 
-UrlClient::RequestId UrlClient::addRequest(const std::string& url, Callback onComplete) {
+UrlClient::RequestId UrlClient::addRequest(const std::string& url, UrlCallback onComplete) {
     // Create a new request.
     auto id = ++m_requestCount;
     Request request = {url, onComplete, id, false};
@@ -69,7 +69,7 @@ UrlClient::RequestId UrlClient::addRequest(const std::string& url, Callback onCo
 }
 
 void UrlClient::cancelRequest(UrlClient::RequestId id) {
-    Callback callback;
+    UrlCallback callback;
     // First check the pending request list.
     {
         // Lock the mutex to prevent concurrent modification of the list by the curl loop thread.

--- a/platforms/common/urlClient.h
+++ b/platforms/common/urlClient.h
@@ -24,17 +24,18 @@ public:
     ~UrlClient();
 
     using Callback = std::function<void(UrlResponse&&)>;
+    using RequestId = uint64_t;
 
-    UrlRequestId addRequest(const std::string& url, Callback cb);
+    RequestId addRequest(const std::string& url, Callback cb);
 
-    void cancelRequest(UrlRequestId request);
+    void cancelRequest(RequestId request);
 
 private:
 
     struct Request {
         std::string url;
         Callback callback;
-        UrlRequestId id;
+        RequestId id;
         bool canceled;
     };
 

--- a/platforms/common/urlClient.h
+++ b/platforms/common/urlClient.h
@@ -23,10 +23,9 @@ public:
     UrlClient(Options options);
     ~UrlClient();
 
-    using Callback = std::function<void(UrlResponse&&)>;
     using RequestId = uint64_t;
 
-    RequestId addRequest(const std::string& url, Callback cb);
+    RequestId addRequest(const std::string& url, UrlCallback cb);
 
     void cancelRequest(RequestId request);
 
@@ -34,7 +33,7 @@ private:
 
     struct Request {
         std::string url;
-        Callback callback;
+        UrlCallback callback;
         RequestId id;
         bool canceled;
     };

--- a/platforms/common/urlClient.h
+++ b/platforms/common/urlClient.h
@@ -23,16 +23,18 @@ public:
     UrlClient(Options options);
     ~UrlClient();
 
-    UrlRequestHandle addRequest(const std::string& url, UrlCallback onComplete);
+    using Callback = std::function<void(UrlResponse&&)>;
 
-    void cancelRequest(UrlRequestHandle request);
+    UrlRequestId addRequest(const std::string& url, Callback cb);
+
+    void cancelRequest(UrlRequestId request);
 
 private:
 
     struct Request {
         std::string url;
-        UrlCallback callback;
-        UrlRequestHandle handle;
+        Callback callback;
+        UrlRequestId id;
         bool canceled;
     };
 

--- a/platforms/ios/framework/src/iosPlatform.h
+++ b/platforms/ios/framework/src/iosPlatform.h
@@ -16,8 +16,8 @@ public:
     void setContinuousRendering(bool _isContinuous) override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
-    UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;
-    void cancelUrlRequest(UrlRequestHandle _request) override;
+    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
+    void urlRequestCanceled(UrlRequestId _id) override;
 
 private:
 

--- a/platforms/ios/framework/src/iosPlatform.h
+++ b/platforms/ios/framework/src/iosPlatform.h
@@ -11,6 +11,7 @@ class iOSPlatform : public Platform {
 public:
 
     iOSPlatform(__weak TGMapView* _mapView);
+    void shutdown() override {}
     void requestRender() const override;
     void setContinuousRendering(bool _isContinuous) override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;

--- a/platforms/ios/framework/src/iosPlatform.h
+++ b/platforms/ios/framework/src/iosPlatform.h
@@ -16,8 +16,8 @@ public:
     void setContinuousRendering(bool _isContinuous) override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
-    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
-    void urlRequestCanceled(UrlRequestId _id) override;
+    bool startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) override;
+    void cancelUrlRequestImpl(const UrlRequestId _id) override;
 
 private:
 

--- a/platforms/ios/framework/src/iosPlatform.mm
+++ b/platforms/ios/framework/src/iosPlatform.mm
@@ -138,7 +138,7 @@ FontSourceHandle iOSPlatform::systemFont(const std::string& _name, const std::st
     return FontSourceHandle(std::string(font.fontName.UTF8String));
 }
 
-UrlRequestId iOSPlatform::startUrlRequest(Url _url, UrlRequestHandle _request) {
+Platform::UrlRequestId iOSPlatform::startUrlRequest(Url _url, UrlRequestHandle _request) {
     __strong TGMapView* mapView = m_mapView;
 
     UrlResponse errorResponse;
@@ -201,7 +201,7 @@ UrlRequestId iOSPlatform::startUrlRequest(Url _url, UrlRequestHandle _request) {
     return taskIdentifier;
 }
 
-void iOSPlatform::urlRequestCanceled(UrlRequestId _id) {
+void iOSPlatform::urlRequestCanceled(Platform::UrlRequestId _id) {
     __strong TGMapView* mapView = m_mapView;
 
     if (!mapView) {

--- a/platforms/linux/src/linuxPlatform.cpp
+++ b/platforms/linux/src/linuxPlatform.cpp
@@ -25,10 +25,8 @@ void logMsg(const char* fmt, ...) {
     va_end(args);
 }
 
-LinuxPlatform::LinuxPlatform() {
-    m_urlClient = std::make_unique<UrlClient>(UrlClient::Options{});
-    m_fcConfig = FcInitLoadConfigAndFonts();
-}
+LinuxPlatform::LinuxPlatform()
+    : LinuxPlatform(UrlClient::Options{}) {}
 
 LinuxPlatform::LinuxPlatform(UrlClient::Options urlClientOptions) :
     m_urlClient(std::make_unique<UrlClient>(urlClientOptions)) {

--- a/platforms/linux/src/linuxPlatform.cpp
+++ b/platforms/linux/src/linuxPlatform.cpp
@@ -79,30 +79,30 @@ FontSourceHandle LinuxPlatform::systemFont(const std::string& _name,
     return FontSourceHandle(Url(fontFile));
 }
 
-Platform::UrlRequestId LinuxPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
-    UrlRequestId id = UrlRequestNotCancelable;
+bool LinuxPlatform::startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) {
 
     if (_url.hasHttpScheme()) {
-        id = m_urlClient->addRequest(_url.string(),
-             [this, _handle](UrlResponse&& response) {
-                 onUrlResponse(_handle, std::move(response));
+        _id = m_urlClient->addRequest(_url.string(),
+             [this, _request](UrlResponse&& response) {
+                 onUrlResponse(_request, std::move(response));
              });
-    } else {
-        m_fileWorker.enqueue([this, path = _url.path(), _handle](){
-             UrlResponse response;
-             auto allocator = [&](size_t size) {
-                 response.content.resize(size);
-                 return response.content.data();
-             };
-
-             Platform::bytesFromFileSystem(path.c_str(), allocator);
-             onUrlResponse(_handle, std::move(response));
-        });
+        return true;
     }
-    return id;
+
+    m_fileWorker.enqueue([this, path = _url.path(), _request](){
+        UrlResponse response;
+        auto allocator = [&](size_t size) {
+                             response.content.resize(size);
+                             return response.content.data();
+                         };
+
+        Platform::bytesFromFileSystem(path.c_str(), allocator);
+        onUrlResponse(_request, std::move(response));
+    });
+    return false;
 }
 
-void LinuxPlatform::urlRequestCanceled(Platform::UrlRequestId _id) {
+void LinuxPlatform::cancelUrlRequestImpl(const UrlRequestId _id) {
     if (m_urlClient) {
         m_urlClient->cancelRequest(_id);
     }

--- a/platforms/linux/src/linuxPlatform.cpp
+++ b/platforms/linux/src/linuxPlatform.cpp
@@ -88,8 +88,6 @@ Platform::UrlRequestId LinuxPlatform::startUrlRequest(Url _url, UrlRequestHandle
                  onUrlResponse(_handle, std::move(response));
              });
     } else {
-        //UrlRequestId id = static_cast<UrlRequestHandle>(--m_urlRequestCount);
-
         m_fileWorker.enqueue([this, path = _url.path(), _handle](){
              UrlResponse response;
              auto allocator = [&](size_t size) {
@@ -105,7 +103,9 @@ Platform::UrlRequestId LinuxPlatform::startUrlRequest(Url _url, UrlRequestHandle
 }
 
 void LinuxPlatform::urlRequestCanceled(Platform::UrlRequestId _id) {
-    m_urlClient->cancelRequest(_id);
+    if (m_urlClient) {
+        m_urlClient->cancelRequest(_id);
+    }
 }
 
 void setCurrentThreadPriority(int priority) {

--- a/platforms/linux/src/linuxPlatform.cpp
+++ b/platforms/linux/src/linuxPlatform.cpp
@@ -79,7 +79,7 @@ FontSourceHandle LinuxPlatform::systemFont(const std::string& _name,
     return FontSourceHandle(Url(fontFile));
 }
 
-UrlRequestId LinuxPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
+Platform::UrlRequestId LinuxPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
     UrlRequestId id = UrlRequestNotCancelable;
 
     if (_url.hasHttpScheme()) {
@@ -104,7 +104,7 @@ UrlRequestId LinuxPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) 
     return id;
 }
 
-void LinuxPlatform::urlRequestCanceled(UrlRequestId _id) {
+void LinuxPlatform::urlRequestCanceled(Platform::UrlRequestId _id) {
     m_urlClient->cancelRequest(_id);
 }
 

--- a/platforms/linux/src/linuxPlatform.h
+++ b/platforms/linux/src/linuxPlatform.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <fontconfig/fontconfig.h>
+#include <atomic>
 
 #include "platform.h"
 #include "urlClient.h"
+#include "util/asyncWorker.h"
 
 namespace Tangram {
 
@@ -23,7 +25,8 @@ public:
 protected:
     FcConfig* m_fcConfig = nullptr;
     std::unique_ptr<UrlClient> m_urlClient;
-    bool m_shutdown = false;
+    AsyncWorker m_fileWorker;
+    std::atomic<bool> m_shutdown{false};
 };
 
 } // namespace Tangram

--- a/platforms/linux/src/linuxPlatform.h
+++ b/platforms/linux/src/linuxPlatform.h
@@ -27,7 +27,6 @@ protected:
     FcConfig* m_fcConfig = nullptr;
     std::unique_ptr<UrlClient> m_urlClient;
     AsyncWorker m_fileWorker;
-    std::atomic_int_fast64_t m_urlRequestCount = {0};
 
 };
 

--- a/platforms/linux/src/linuxPlatform.h
+++ b/platforms/linux/src/linuxPlatform.h
@@ -20,8 +20,8 @@ public:
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight,
                                 const std::string& _face) const override;
 
-    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _handle) override;
-    void urlRequestCanceled(UrlRequestId _id) override;
+    bool startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) override;
+    void cancelUrlRequestImpl(const UrlRequestId _id) override;
 
 protected:
     FcConfig* m_fcConfig = nullptr;

--- a/platforms/linux/src/linuxPlatform.h
+++ b/platforms/linux/src/linuxPlatform.h
@@ -8,25 +8,22 @@
 namespace Tangram {
 
 class LinuxPlatform : public Platform {
-
 public:
-
     LinuxPlatform();
-    LinuxPlatform(UrlClient::Options urlClientOptions);
+    explicit LinuxPlatform(UrlClient::Options urlClientOptions);
     ~LinuxPlatform() override;
+    void shutdown() override;
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight,
-            const std::string& _face) const override;
+                                const std::string& _face) const override;
     UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;
     void cancelUrlRequest(UrlRequestHandle _request) override;
 
 protected:
-
-
     FcConfig* m_fcConfig = nullptr;
-    UrlClient m_urlClient;
-
+    std::unique_ptr<UrlClient> m_urlClient;
+    bool m_shutdown = false;
 };
 
 } // namespace Tangram

--- a/platforms/linux/src/linuxPlatform.h
+++ b/platforms/linux/src/linuxPlatform.h
@@ -19,14 +19,16 @@ public:
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight,
                                 const std::string& _face) const override;
-    UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;
-    void cancelUrlRequest(UrlRequestHandle _request) override;
+
+    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _handle) override;
+    void urlRequestCanceled(UrlRequestId _id) override;
 
 protected:
     FcConfig* m_fcConfig = nullptr;
     std::unique_ptr<UrlClient> m_urlClient;
     AsyncWorker m_fileWorker;
-    std::atomic<bool> m_shutdown{false};
+    std::atomic_int_fast64_t m_urlRequestCount = {0};
+
 };
 
 } // namespace Tangram

--- a/platforms/osx/src/osxPlatform.h
+++ b/platforms/osx/src/osxPlatform.h
@@ -13,6 +13,7 @@ public:
 
     OSXPlatform();
     ~OSXPlatform() override;
+    void shutdown() override {}
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;

--- a/platforms/osx/src/osxPlatform.h
+++ b/platforms/osx/src/osxPlatform.h
@@ -16,8 +16,8 @@ public:
     void shutdown() override {}
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
-    UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;
-    void cancelUrlRequest(UrlRequestHandle _request) override;
+    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
+    void urlRequestCanceled(UrlRequestId _id) override;
 
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
 

--- a/platforms/osx/src/osxPlatform.h
+++ b/platforms/osx/src/osxPlatform.h
@@ -16,8 +16,8 @@ public:
     void shutdown() override {}
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
-    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
-    void urlRequestCanceled(UrlRequestId _id) override;
+    bool startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) override;
+    void cancelUrlRequestImpl(const UrlRequestId _id) override;
 
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight, const std::string& _face) const override;
 

--- a/platforms/osx/src/osxPlatform.mm
+++ b/platforms/osx/src/osxPlatform.mm
@@ -181,7 +181,7 @@ Platform::UrlRequestId OSXPlatform::startUrlRequest(Url _url, UrlRequestHandle _
 
 }
 
-void OSXPlatform::cancelUrlRequest(Platform::UrlRequestId id) {
+void OSXPlatform::urlRequestCanceled(Platform::UrlRequestId id) {
 
     [m_urlSession getTasksWithCompletionHandler:^(NSArray* dataTasks, NSArray* uploadTasks, NSArray* downloadTasks) {
         for (NSURLSessionTask* task in dataTasks) {

--- a/platforms/osx/src/osxPlatform.mm
+++ b/platforms/osx/src/osxPlatform.mm
@@ -138,7 +138,7 @@ FontSourceHandle OSXPlatform::systemFont(const std::string& _name, const std::st
     return FontSourceHandle(std::string(font.fontName.UTF8String));
 }
 
-Platform::UrlRequestId OSXPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
+bool OSXPlatform::startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) {
 
     void (^handler)(NSData*, NSURLResponse*, NSError*) = ^void (NSData* data, NSURLResponse* response, NSError* error) {
 
@@ -169,7 +169,7 @@ Platform::UrlRequestId OSXPlatform::startUrlRequest(Url _url, UrlRequestHandle _
         }];
 
         // Run the callback from the requester.
-        onUrlResponse(_handle, std::move(urlResponse));
+        onUrlResponse(_request, std::move(urlResponse));
     };
 
     NSURL* nsUrl = [NSURL URLWithString:[NSString stringWithUTF8String:_url.string().c_str()]];
@@ -181,11 +181,11 @@ Platform::UrlRequestId OSXPlatform::startUrlRequest(Url _url, UrlRequestHandle _
 
 }
 
-void OSXPlatform::urlRequestCanceled(Platform::UrlRequestId id) {
+void OSXPlatform::cancelUrlRequestImpl(const UrlRequestId _id) {
 
     [m_urlSession getTasksWithCompletionHandler:^(NSArray* dataTasks, NSArray* uploadTasks, NSArray* downloadTasks) {
         for (NSURLSessionTask* task in dataTasks) {
-            if ([task taskIdentifier] == id) {
+            if ([task taskIdentifier] == _id) {
                 [task cancel];
                 break;
             }

--- a/platforms/osx/src/osxPlatform.mm
+++ b/platforms/osx/src/osxPlatform.mm
@@ -172,6 +172,7 @@ UrlRequestHandle OSXPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
         if (_callback) {
             _callback(std::move(urlResponse));
         }
+        requestRender();
     };
 
     NSURL* nsUrl = [NSURL URLWithString:[NSString stringWithUTF8String:_url.string().c_str()]];

--- a/platforms/osx/src/osxPlatform.mm
+++ b/platforms/osx/src/osxPlatform.mm
@@ -138,7 +138,7 @@ FontSourceHandle OSXPlatform::systemFont(const std::string& _name, const std::st
     return FontSourceHandle(std::string(font.fontName.UTF8String));
 }
 
-UrlRequestHandle OSXPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
+UrlRequestId OSXPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
 
     void (^handler)(NSData*, NSURLResponse*, NSError*) = ^void (NSData* data, NSURLResponse* response, NSError* error) {
 
@@ -169,10 +169,7 @@ UrlRequestHandle OSXPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
         }];
 
         // Run the callback from the requester.
-        if (_callback) {
-            _callback(std::move(urlResponse));
-        }
-        requestRender();
+        onUrlResponse(_handle, std::move(urlResponse));
     };
 
     NSURL* nsUrl = [NSURL URLWithString:[NSString stringWithUTF8String:_url.string().c_str()]];
@@ -184,11 +181,11 @@ UrlRequestHandle OSXPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
 
 }
 
-void OSXPlatform::cancelUrlRequest(UrlRequestHandle handle) {
+void OSXPlatform::cancelUrlRequest(UrlRequestId id) {
 
     [m_urlSession getTasksWithCompletionHandler:^(NSArray* dataTasks, NSArray* uploadTasks, NSArray* downloadTasks) {
         for (NSURLSessionTask* task in dataTasks) {
-            if ([task taskIdentifier] == handle) {
+            if ([task taskIdentifier] == id) {
                 [task cancel];
                 break;
             }

--- a/platforms/osx/src/osxPlatform.mm
+++ b/platforms/osx/src/osxPlatform.mm
@@ -138,7 +138,7 @@ FontSourceHandle OSXPlatform::systemFont(const std::string& _name, const std::st
     return FontSourceHandle(std::string(font.fontName.UTF8String));
 }
 
-UrlRequestId OSXPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
+Platform::UrlRequestId OSXPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
 
     void (^handler)(NSData*, NSURLResponse*, NSError*) = ^void (NSData* data, NSURLResponse* response, NSError* error) {
 
@@ -181,7 +181,7 @@ UrlRequestId OSXPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
 
 }
 
-void OSXPlatform::cancelUrlRequest(UrlRequestId id) {
+void OSXPlatform::cancelUrlRequest(Platform::UrlRequestId id) {
 
     [m_urlSession getTasksWithCompletionHandler:^(NSArray* dataTasks, NSArray* uploadTasks, NSArray* downloadTasks) {
         for (NSURLSessionTask* task in dataTasks) {

--- a/platforms/osx/src/osxPlatform.mm
+++ b/platforms/osx/src/osxPlatform.mm
@@ -177,7 +177,9 @@ bool OSXPlatform::startUrlRequestImpl(const Url& _url, const UrlRequestHandle _r
 
     [dataTask resume];
 
-    return [dataTask taskIdentifier];
+    _id = [dataTask taskIdentifier];
+
+    return true;
 
 }
 

--- a/tests/src/mockPlatform.cpp
+++ b/tests/src/mockPlatform.cpp
@@ -31,7 +31,7 @@ std::vector<FontSourceHandle> MockPlatform::systemFontFallbacksHandle() const {
     return handles;
 }
 
-UrlRequestId MockPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
+Platform::UrlRequestId MockPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
 
     UrlResponse response;
 
@@ -47,7 +47,7 @@ UrlRequestId MockPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
     return 0;
 }
 
-void MockPlatform::urlRequestCanceled(UrlRequestId _id) {}
+void MockPlatform::urlRequestCanceled(Platform::UrlRequestId _id) {}
 
 void MockPlatform::putMockUrlContents(Url url, std::string contents) {
     m_files[url].assign(contents.begin(), contents.end());

--- a/tests/src/mockPlatform.cpp
+++ b/tests/src/mockPlatform.cpp
@@ -31,7 +31,7 @@ std::vector<FontSourceHandle> MockPlatform::systemFontFallbacksHandle() const {
     return handles;
 }
 
-Platform::UrlRequestId MockPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
+bool MockPlatform::startUrlRequestImpl(const Url& _url, const UrlRequestHandle _handle, UrlRequestId& _id) {
 
     UrlResponse response;
 
@@ -44,10 +44,10 @@ Platform::UrlRequestId MockPlatform::startUrlRequest(Url _url, UrlRequestHandle 
 
     onUrlResponse(_handle, std::move(response));
 
-    return 0;
+    return false;
 }
 
-void MockPlatform::urlRequestCanceled(Platform::UrlRequestId _id) {}
+void MockPlatform::cancelUrlRequestImpl(const UrlRequestId _id) {}
 
 void MockPlatform::putMockUrlContents(Url url, std::string contents) {
     m_files[url].assign(contents.begin(), contents.end());

--- a/tests/src/mockPlatform.cpp
+++ b/tests/src/mockPlatform.cpp
@@ -31,7 +31,7 @@ std::vector<FontSourceHandle> MockPlatform::systemFontFallbacksHandle() const {
     return handles;
 }
 
-UrlRequestHandle MockPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
+UrlRequestId MockPlatform::startUrlRequest(Url _url, UrlRequestHandle _handle) {
 
     UrlResponse response;
 
@@ -42,12 +42,12 @@ UrlRequestHandle MockPlatform::startUrlRequest(Url _url, UrlCallback _callback) 
         response.error = "Url contents could not be found!";
     }
 
-    _callback(std::move(response));
+    onUrlResponse(_handle, std::move(response));
 
     return 0;
 }
 
-void MockPlatform::cancelUrlRequest(UrlRequestHandle _request) {}
+void MockPlatform::urlRequestCanceled(UrlRequestId _id) {}
 
 void MockPlatform::putMockUrlContents(Url url, std::string contents) {
     m_files[url].assign(contents.begin(), contents.end());

--- a/tests/src/mockPlatform.h
+++ b/tests/src/mockPlatform.h
@@ -13,8 +13,8 @@ public:
     void shutdown() override {}
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
-    UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;
-    void cancelUrlRequest(UrlRequestHandle _request) override;
+    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
+    void urlRequestCanceled(UrlRequestHandle _request) override;
 
     // Put content at a URL to be retrieved by startUrlRequest.
     void putMockUrlContents(Url url, std::string contents);

--- a/tests/src/mockPlatform.h
+++ b/tests/src/mockPlatform.h
@@ -13,8 +13,8 @@ public:
     void shutdown() override {}
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
-    UrlRequestId startUrlRequest(Url _url, UrlRequestHandle _request) override;
-    void urlRequestCanceled(UrlRequestHandle _request) override;
+    bool startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) override;
+    void cancelUrlRequestImpl(const UrlRequestId _id) override;
 
     // Put content at a URL to be retrieved by startUrlRequest.
     void putMockUrlContents(Url url, std::string contents);

--- a/tests/src/mockPlatform.h
+++ b/tests/src/mockPlatform.h
@@ -10,6 +10,7 @@ class MockPlatform : public Platform {
 
 public:
 
+    void shutdown() override {}
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
     UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;


### PR DESCRIPTION
- Add Platform::shutdown() to allow stopping workers before going to delete Map. 
- Keep track of all url requests in Platform to allow synchronous cancellation on shutdown. This also ensures that no UrlCallbacks come in while Map is destructing itself on all platforms.

- Linux: 
  - Don't let http requests block reading local files: Since there is a fixed amount of UrlClient workers all of them can be busy waiting for network responses. This blocks reading local files until network calls completed.
- Android:
  - Call into java from less threads, enqueues async calls on single thread. TileWorker don't need to attach/detach their thread for each tile just to call requestRender()
  - Load files asynchronously
  - ￼Use WeakGlobalRef for android MapController instance
