### PR TITLE
Move scene data

### DIFF
--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -40,10 +40,10 @@ public:
 protected:
 
     // Process and store data for an imported scene from a vector of bytes.
-    void addSceneData(const Url& sceneUrl, std::vector<char>& sceneContent);
+    void addSceneData(const Url& sceneUrl, std::vector<char>&& sceneContent);
 
     // Process and store data for an imported scene from a string of YAML.
-    void addSceneString(const Url& sceneUrl, const std::string& sceneString);
+    void addSceneYaml(const Url& sceneUrl, const char* sceneYaml, size_t length);
 
     // Get the sequence of scene names that are designated to be imported into the
     // input scene node by its 'import' fields.

--- a/core/src/util/zipArchive.cpp
+++ b/core/src/util/zipArchive.cpp
@@ -10,11 +10,11 @@ ZipArchive::~ZipArchive() {
     reset();
 }
 
-bool ZipArchive::loadFromMemory(std::vector<char> compressedArchiveData) {
+bool ZipArchive::loadFromMemory(std::vector<char>&& compressedArchiveData) {
     // Reset to an empty state.
     reset();
     // Initialize the buffer and archive with the input data.
-    buffer.swap(compressedArchiveData);
+    buffer = std::move(compressedArchiveData);
     if (!mz_zip_reader_init_mem(&minizData, buffer.data(), buffer.size(), 0)) {
         return false;
     }

--- a/core/src/util/zipArchive.h
+++ b/core/src/util/zipArchive.h
@@ -33,7 +33,7 @@ public:
     // archive is successfully loaded this returns true, otherwise returns
     // false. The data is moved out of the input vector and retained until other
     // data is loaded or the archive is destroyed.
-    bool loadFromMemory(std::vector<char> compressedArchiveData);
+    bool loadFromMemory(std::vector<char>&& compressedArchiveData);
 
     // Empty the archive.
     void reset();


### PR DESCRIPTION
With the added YAML::Load(const char* data, length) we can avoid a superfluous copy from vector<char> to std::string.