### PR TITLE
Add options to build without MBTiles/SQLite and Debug Renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ option(TANGRAM_MBTILES_DATASOURCE "Build MBTiles Datasource" ON)
 option(TANGRAM_BUILD_TESTS "Build unit tests" OFF)
 option(TANGRAM_BUNDLE_TESTS "Compile all tests into a single binary" ON)
 option(TANGRAM_BUILD_BENCHMARKS "Build benchmarks" OFF)
+
 option(TANGRAM_DEV_MODE "For developers only: Don't omit the frame pointer" OFF)
+option(TANGRAM_DEV_DEBUG_RENDERER "Build debug TextDisplay, RenderLayers and other things to toggle via DebugFlags" OFF)
 
 message(STATUS "Build type configuration: ${CMAKE_BUILD_TYPE}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(tangram)
 # Options
 option(TANGRAM_USE_SYSTEM_FONT_LIBS "Use system libraries Freetype, ICU and Harfbuzz via pkgconfig" OFF)
 option(TANGRAM_USE_SYSTEM_GLFW_LIBS "Use system libraries for GLFW3 via pkgconfig" OFF)
+option(TANGRAM_USE_SYSTEM_SQLITE_LIBS "Use system libraries for SQLite via pkgconfig" OFF)
+option(TANGRAM_MBTILES_DATASOURCE "Build MBTiles Datasource" ON)
 
 option(TANGRAM_BUILD_TESTS "Build unit tests" OFF)
 option(TANGRAM_BUNDLE_TESTS "Compile all tests into a single binary" ON)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -32,6 +32,7 @@ foreach(_src_file_path ${BENCH_SOURCES})
   )
 
   target_link_libraries(${EXECUTABLE_NAME}
+  PRIVATE
     tangram-core
     benchmark
     platform_mock

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,11 +3,16 @@ project(tangram-core)
 # Build core library dependencies.
 add_subdirectory(deps)
 
+if (TANGRAM_MBTILES_DATASOURCE)
+  set(MBTILES_SOURCES src/data/mbtilesDataSource.cpp)
+  set(MBTILES_LIBS SQLiteCpp sqlite3)
+  add_definitions(-DTANGRAM_MBTILES_DATASOURCE)
+endif()
+
 add_library(tangram-core
   src/map.cpp
   src/platform.cpp
   src/data/clientGeoJsonSource.cpp
-  src/data/mbtilesDataSource.cpp
   src/data/memoryCacheDataSource.cpp
   src/data/networkDataSource.cpp
   src/data/properties.cpp
@@ -94,6 +99,7 @@ add_library(tangram-core
   src/view/flyTo.cpp
   src/view/view.cpp
   src/view/viewConstraint.cpp
+  ${MBTILES_SOURCES}
 )
 
 # Include headers from core library and dependencies.
@@ -127,12 +133,11 @@ target_include_directories(tangram-core
 # Link core library dependencies.
 target_link_libraries(tangram-core
   PRIVATE
+  ${MBTILES_LIBS}
   duktape
   css-color-parser-cpp
   yaml-cpp
   alfons
-  SQLiteCpp
-  sqlite3
   double-conversion
   miniz
   z

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,7 +6,6 @@ add_subdirectory(deps)
 if (TANGRAM_MBTILES_DATASOURCE)
   set(MBTILES_SOURCES src/data/mbtilesDataSource.cpp)
   set(MBTILES_LIBS SQLiteCpp sqlite3)
-  add_definitions(-DTANGRAM_MBTILES_DATASOURCE)
 endif()
 
 add_library(tangram-core
@@ -149,7 +148,15 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(TANGRAM_WARN_ON_RULE_CONFLICT)
-  add_definitions(-DTANGRAM_WARN_ON_RULE_CONFLICT)
+  target_compile_definitions(tangram-core
+    PRIVATE
+    TANGRAM_WARN_ON_RULE_CONFLICT)
+endif()
+
+if (TANGRAM_MBTILES_DATASOURCE)
+  target_compile_definitions(tangram-core
+    PRIVATE
+    TANGRAM_MBTILES_DATASOURCE)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,6 +8,15 @@ if (TANGRAM_MBTILES_DATASOURCE)
   set(MBTILES_LIBS SQLiteCpp sqlite3)
 endif()
 
+if(TANGRAM_DEV_MODE AND TANGRAM_DEV_DEBUG_RENDERER)
+  set(DEBUG_SOURCES
+    src/debug/frameInfo.cpp
+    src/debug/textDisplay.cpp
+    src/style/debugStyle.cpp
+    src/style/debugTextStyle.cpp
+    src/gl/primitives.cpp)
+endif()
+
 add_library(tangram-core
   src/map.cpp
   src/platform.cpp
@@ -20,13 +29,10 @@ add_library(tangram-core
   src/data/formats/geoJson.cpp
   src/data/formats/mvt.cpp
   src/data/formats/topoJson.cpp
-  src/debug/frameInfo.cpp
-  src/debug/textDisplay.cpp
   src/gl/framebuffer.cpp
   src/gl/glError.cpp
   src/gl/hardware.cpp
   src/gl/mesh.cpp
-  src/gl/primitives.cpp
   src/gl/renderState.cpp
   src/gl/shaderProgram.cpp
   src/gl/shaderSource.cpp
@@ -62,8 +68,6 @@ add_library(tangram-core
   src/scene/styleParam.cpp
   src/selection/featureSelection.cpp
   src/selection/selectionQuery.cpp
-  src/style/debugStyle.cpp
-  src/style/debugTextStyle.cpp
   src/style/material.cpp
   src/style/pointStyle.cpp
   src/style/pointStyleBuilder.cpp
@@ -99,6 +103,7 @@ add_library(tangram-core
   src/view/view.cpp
   src/view/viewConstraint.cpp
   ${MBTILES_SOURCES}
+  ${DEBUG_SOURCES}
 )
 
 # Include headers from core library and dependencies.
@@ -151,6 +156,18 @@ if(TANGRAM_WARN_ON_RULE_CONFLICT)
   target_compile_definitions(tangram-core
     PRIVATE
     TANGRAM_WARN_ON_RULE_CONFLICT)
+endif()
+
+if(TANGRAM_DEV_MODE)
+  target_compile_definitions(tangram-core
+    PRIVATE
+    TANGRAM_DEV_MODE)
+
+  if(TANGRAM_DEV_DEBUG_RENDERER)
+  target_compile_definitions(tangram-core
+    PRIVATE
+    TANGRAM_DEBUG_RENDERER)
+  endif()
 endif()
 
 if (TANGRAM_MBTILES_DATASOURCE)

--- a/core/deps/CMakeLists.txt
+++ b/core/deps/CMakeLists.txt
@@ -69,23 +69,29 @@ endif()
 set(GLM_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/glm)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/alfons)
 
-## SQLiteCpp ##
-###############
-set(SQLITECPP_RUN_CPPLINT OFF CACHE BOOL "")
-set(SQLITECPP_RUN_CPPCHECK OFF CACHE BOOL "")
-set(SQLITE_ENABLE_COLUMN_METADATA OFF CACHE BOOL "")
+if (TANGRAM_MBTILES_DATASOURCE)
+  ## SQLiteCpp ##
+  ###############
+  set(SQLITECPP_RUN_CPPLINT OFF CACHE BOOL "")
+  set(SQLITECPP_RUN_CPPCHECK OFF CACHE BOOL "")
+  set(SQLITE_ENABLE_COLUMN_METADATA OFF CACHE BOOL "")
 
-add_subdirectory(SQLiteCpp)
+  if (TANGRAM_USE_SYSTEM_SQLITE_LIBS)
+    set(SQLITECPP_INTERNAL_SQLITE OFF CACHE BOOL "")
+  endif()
 
-# Extensions aren't needed for MBTiles and aren't available in older versions of sqlite3.
-target_compile_definitions(SQLiteCpp PRIVATE SQLITE_OMIT_LOAD_EXTENSION)
+  add_subdirectory(SQLiteCpp)
 
-# needed for sqlite3 to work for ndk15c+ and android api level < 21
-# refer:
-# https://github.com/android-ndk/ndk/issues/477 and
-# https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
-if (ANDROID)
+  # Extensions aren't needed for MBTiles and aren't available in older versions of sqlite3.
+  target_compile_definitions(SQLiteCpp PRIVATE SQLITE_OMIT_LOAD_EXTENSION)
+
+  # needed for sqlite3 to work for ndk15c+ and android api level < 21
+  # refer:
+  # https://github.com/android-ndk/ndk/issues/477 and
+  # https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
+  if (ANDROID)
     target_compile_definitions(sqlite3 PRIVATE _FILE_OFFSET_BITS=32)
+  endif()
 endif()
 
 ## double-conversion ##

--- a/core/src/debug/frameInfo.cpp
+++ b/core/src/debug/frameInfo.cpp
@@ -18,6 +18,7 @@
 #define DEBUG_STATS_MAX_SIZE 128
 
 namespace Tangram {
+namespace Debug {
 
 static float s_lastUpdateTime = 0.0;
 
@@ -153,4 +154,5 @@ void FrameInfo::draw(RenderState& rs, const View& _view, TileManager& _tileManag
     }
 }
 
+}
 }

--- a/core/src/debug/frameInfo.h
+++ b/core/src/debug/frameInfo.h
@@ -6,14 +6,20 @@ class RenderState;
 class TileManager;
 class View;
 
-struct FrameInfo {
+namespace Debug {
 
+struct FrameInfo {
+#ifdef TANGRAM_DEBUG_RENDERER
     static void beginUpdate();
     static void beginFrame();
-
     static void endUpdate();
-
     static void draw(RenderState& rs, const View& _view, TileManager& _tileManager);
+#else
+    static void beginUpdate(){}
+    static void beginFrame(){}
+    static void endUpdate(){}
+    static void draw(RenderState&, const View&, TileManager&){}
+#endif
 };
-
+}
 }

--- a/core/src/debug/textDisplay.cpp
+++ b/core/src/debug/textDisplay.cpp
@@ -12,6 +12,7 @@
 #include "stb_easy_font.h"
 
 namespace Tangram {
+namespace Debug {
 
 TextDisplay::TextDisplay() : m_textDisplayResolution(350.0), m_initialized(false) {
     m_vertexBuffer = new char[VERTEX_BUFFER_SIZE];
@@ -142,7 +143,6 @@ void TextDisplay::draw(RenderState& rs, const std::vector<std::string>& _infos) 
     rs.culling(GL_TRUE);
     rs.vertexBuffer(boundbuffer);
 }
-
 }
-
+}
 

--- a/core/src/debug/textDisplay.h
+++ b/core/src/debug/textDisplay.h
@@ -19,6 +19,8 @@ namespace Tangram {
 typedef int FontID;
 class RenderState;
 
+namespace Debug {
+
 template <typename T>
 std::string to_string_with_precision(const T a_value, const int n = 6) {
     std::ostringstream out;
@@ -36,8 +38,9 @@ public:
         return instance;
     }
 
-    ~TextDisplay();
 
+#ifdef TANGRAM_DEBUG_RENDERER
+    ~TextDisplay();
     void setResolution(glm::vec2 _textDisplayResolution) { m_textDisplayResolution = _textDisplayResolution; }
 
     void init();
@@ -45,14 +48,11 @@ public:
 
     /* Draw stacked messages added through log and draw _infos string list */
     void draw(RenderState& rs, const std::vector<std::string>& _infos);
-
     /* Stack the log message to be displayed in the screen log */
     void log(const char* fmt, ...);
 
 private:
-
     TextDisplay();
-
     void draw(RenderState& rs, const std::string& _text, int _posx, int _posy);
 
     glm::vec2 m_textDisplayResolution;
@@ -64,10 +64,24 @@ private:
 
     UniformLocation m_uOrthoProj{"u_orthoProj"};
     UniformLocation m_uColor{"u_color"};
-
+#else
+    ~TextDisplay() {}
+    void setResolution(glm::vec2) {}
+    void init() {}
+    void deinit() {}
+    void draw(RenderState&, const std::vector<std::string>&) {}
+    void log(const char* fmt, ...) {}
+private:
+    TextDisplay(){}
+#endif
 };
+}
 
+#ifdef TANGRAM_DEBUG_RENDERER
 #define LOGS(fmt, ...) \
-do { Tangram::TextDisplay::Instance().log(fmt, ## __VA_ARGS__); } while(0)
+    do { Tangram::Debug::TextDisplay::Instance().log(fmt, ## __VA_ARGS__); } while(0)
+#else
+#define LOGS(...)
+#endif
 
 }

--- a/core/src/gl/framebuffer.cpp
+++ b/core/src/gl/framebuffer.cpp
@@ -175,7 +175,7 @@ FrameBuffer::~FrameBuffer() {
 void FrameBuffer::drawDebug(RenderState& _rs, glm::vec2 _dim) {
 
     if (m_texture) {
-        Primitives::drawTexture(_rs, *m_texture, glm::vec2{}, _dim);
+        Debug::Primitives::drawTexture(_rs, *m_texture, glm::vec2{}, _dim);
     }
 }
 

--- a/core/src/gl/primitives.cpp
+++ b/core/src/gl/primitives.cpp
@@ -16,8 +16,7 @@
 #include "debugTexture_fs.h"
 
 namespace Tangram {
-
-namespace Primitives {
+namespace Debug {
 
 static bool s_initialized;
 static std::unique_ptr<ShaderProgram> s_shader;
@@ -32,7 +31,7 @@ static std::unique_ptr<VertexLayout> s_textureLayout;
 
 static UniformLocation s_uTextureProj{"u_proj"};
 
-void init() {
+void Primitives::init() {
 
     // lazy init
     if (!s_initialized) {
@@ -60,7 +59,7 @@ void init() {
     }
 }
 
-void deinit() {
+void Primitives::deinit() {
 
     s_shader.reset(nullptr);
     s_layout.reset(nullptr);
@@ -70,7 +69,7 @@ void deinit() {
 
 }
 
-void drawLine(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination) {
+void Primitives::drawLine(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination) {
 
     init();
 
@@ -94,14 +93,14 @@ void drawLine(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _desti
     rs.vertexBuffer(boundBuffer);
 }
 
-void drawRect(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination) {
+void Primitives::drawRect(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination) {
     drawLine(rs, _origin, {_destination.x, _origin.y});
     drawLine(rs, {_destination.x, _origin.y}, _destination);
     drawLine(rs, _destination, {_origin.x, _destination.y});
     drawLine(rs, {_origin.x,_destination.y}, _origin);
 }
 
-void drawPoly(RenderState& rs, const glm::vec2* _polygon, size_t _n) {
+void Primitives::drawPoly(RenderState& rs, const glm::vec2* _polygon, size_t _n) {
     init();
 
     if (!s_shader->use(rs)) { return; }
@@ -119,7 +118,7 @@ void drawPoly(RenderState& rs, const glm::vec2* _polygon, size_t _n) {
     rs.vertexBuffer(boundBuffer);
 }
 
-void drawTexture(RenderState& rs, Texture& _tex, glm::vec2 _pos, glm::vec2 _dim) {
+void Primitives::drawTexture(RenderState& rs, Texture& _tex, glm::vec2 _pos, glm::vec2 _dim) {
     init();
 
     if (!s_textureShader->use(rs)) { return; }
@@ -156,7 +155,7 @@ void drawTexture(RenderState& rs, Texture& _tex, glm::vec2 _pos, glm::vec2 _dim)
     rs.vertexBuffer(boundBuffer);
 }
 
-void setColor(RenderState& rs, unsigned int _color) {
+void Primitives::setColor(RenderState& rs, unsigned int _color) {
     init();
 
     float r = (_color >> 16 & 0xff) / 255.0;
@@ -166,7 +165,7 @@ void setColor(RenderState& rs, unsigned int _color) {
     s_shader->setUniformf(rs, s_uColor, r, g, b);
 }
 
-void setResolution(RenderState& rs, float _width, float _height) {
+void Primitives::setResolution(RenderState& rs, float _width, float _height) {
     init();
 
     glm::mat4 proj = glm::ortho(0.f, _width, _height, 0.f, -1.f, 1.f);
@@ -175,5 +174,5 @@ void setResolution(RenderState& rs, float _width, float _height) {
 }
 
 }
-
 }
+

--- a/core/src/gl/primitives.h
+++ b/core/src/gl/primitives.h
@@ -7,28 +7,39 @@ namespace Tangram {
 class RenderState;
 class Texture;
 
-namespace Primitives {
+namespace Debug {
 
-void init();
-void deinit();
+struct Primitives {
+#ifdef TANGRAM_DEBUG_RENDERER
+static void init();
+static void deinit();
 
 /* Setup the debug resolution size */
-void setResolution(RenderState& rs, float _width, float _height);
+static void setResolution(RenderState& rs, float _width, float _height);
 
 /* Sets the current primitive color */
-void setColor(RenderState& rs, unsigned int _color);
+static void setColor(RenderState& rs, unsigned int _color);
 
 /* Draws a line from _origin to _destination for the screen resolution _resolution */
-void drawLine(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination);
+static void drawLine(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination);
 
 /* Draws a rect from _origin to _destination for the screen resolution _resolution */
-void drawRect(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination);
+static void drawRect(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination);
 
 /* Draws a polyon of containing _n points in screen space for the screen resolution _resolution */
-void drawPoly(RenderState& rs, const glm::vec2* _polygon, size_t _n);
+static void drawPoly(RenderState& rs, const glm::vec2* _polygon, size_t _n);
 
-void drawTexture(RenderState& rs, Texture& _tex, glm::vec2 _pos, glm::vec2 _dim);
-
+static void drawTexture(RenderState& rs, Texture& _tex, glm::vec2 _pos, glm::vec2 _dim);
+#else
+static void init(){}
+static void deinit(){}
+static void setResolution(RenderState& rs, float _width, float _height){}
+static void setColor(RenderState& rs, unsigned int _color){}
+static void drawLine(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination){}
+static void drawRect(RenderState& rs, const glm::vec2& _origin, const glm::vec2& _destination){}
+static void drawPoly(RenderState& rs, const glm::vec2* _polygon, size_t _n){}
+static void drawTexture(RenderState& rs, Texture& _tex, glm::vec2 _pos, glm::vec2 _dim){}
+#endif
+};
 }
-
 }

--- a/core/src/labels/labels.cpp
+++ b/core/src/labels/labels.cpp
@@ -496,7 +496,9 @@ void Labels::updateLabelSet(const ViewState& _viewState, float _dt,
     }
 }
 
+#ifdef TAGRAM_DEBUG_RENDERER
 void Labels::drawDebug(RenderState& rs, const View& _view) {
+    using Primitives = Debug::Primitives;
 
     if (!Tangram::getDebugFlag(Tangram::DebugFlags::labels)) {
         return;
@@ -625,5 +627,8 @@ void Labels::drawDebug(RenderState& rs, const View& _view) {
         }
     }
 }
+#else
+void Labels::drawDebug(RenderState& rs, const View& _view) {}
+#endif
 
 }

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -363,8 +363,12 @@ SceneID Map::updateSceneAsync(const std::vector<SceneUpdate>& _sceneUpdates) {
 }
 
 void Map::setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath) {
+#ifdef TANGRAM_MBTILES_DATASOURCE
     std::string scenePath = std::string("sources.") + _dataSourceName + ".mbtiles";
     updateSceneAsync({SceneUpdate{scenePath.c_str(), _mbtilesFilePath}});
+#else
+    LOGE("MBTiles support is disabled. This source will be ignored: %s", _dataSourceName);
+#endif
 }
 
 void Map::resize(int _newWidth, int _newHeight) {

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -126,8 +126,8 @@ Map::~Map() {
     // All jobs will be executed immediately on add() afterwards.
     impl->jobQueue.stop();
 
-    TextDisplay::Instance().deinit();
-    Primitives::deinit();
+    Debug::TextDisplay::Instance().deinit();
+    Debug::Primitives::deinit();
 }
 
 void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
@@ -382,7 +382,7 @@ void Map::resize(int _newWidth, int _newHeight) {
 
     impl->selectionBuffer = std::make_unique<FrameBuffer>(_newWidth/2, _newHeight/2);
 
-    Primitives::setResolution(impl->renderState, _newWidth, _newHeight);
+    Debug::Primitives::setResolution(impl->renderState, _newWidth, _newHeight);
 }
 
 bool Map::update(float _dt) {
@@ -395,7 +395,7 @@ bool Map::update(float _dt) {
         return false;
     }
 
-    FrameInfo::beginUpdate();
+    Debug::FrameInfo::beginUpdate();
 
     impl->scene->updateTime(_dt);
 
@@ -451,7 +451,7 @@ bool Map::update(float _dt) {
         }
     }
 
-    FrameInfo::endUpdate();
+    Debug::FrameInfo::endUpdate();
 
     bool viewChanged = impl->view.changedOnLastUpdate();
     bool tilesChanged = impl->tileManager.hasTileSetChanged();
@@ -504,7 +504,7 @@ bool Map::render() {
     // Cache default framebuffer handle used for rendering
     impl->renderState.cacheDefaultFramebuffer();
 
-    FrameInfo::beginFrame();
+    Debug::FrameInfo::beginFrame();
 
     // Invalidate render states for new frame
     if (!impl->cacheGlState) {
@@ -555,7 +555,7 @@ bool Map::render() {
 
     if (drawSelectionBuffer) {
         impl->selectionBuffer->drawDebug(impl->renderState, viewport);
-        FrameInfo::draw(impl->renderState, impl->view, impl->tileManager);
+        Debug::FrameInfo::draw(impl->renderState, impl->view, impl->tileManager);
         return impl->isCameraEasing;
     }
 
@@ -583,7 +583,7 @@ bool Map::render() {
 
     impl->labels.drawDebug(impl->renderState, impl->view);
 
-    FrameInfo::draw(impl->renderState, impl->view, impl->tileManager);
+    Debug::FrameInfo::draw(impl->renderState, impl->view, impl->tileManager);
 
     return impl->isCameraEasing;
 }
@@ -1077,7 +1077,7 @@ void Map::setupGL() {
     }
 
     // Set default primitive render color
-    Primitives::setColor(impl->renderState, 0xffffff);
+    Debug::Primitives::setColor(impl->renderState, 0xffffff);
 
     // Load GL extensions and capabilities
     Hardware::loadExtensions();

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -184,11 +184,14 @@ bool SceneLoader::applyConfig(const std::shared_ptr<Platform>& _platform, const 
     // Instantiate built-in styles
     _scene->styles().emplace_back(new PolygonStyle("polygons"));
     _scene->styles().emplace_back(new PolylineStyle("lines"));
-    _scene->styles().emplace_back(new DebugTextStyle("debugtext", _scene->fontContext(), true));
     _scene->styles().emplace_back(new TextStyle("text", _scene->fontContext(), true));
-    _scene->styles().emplace_back(new DebugStyle("debug"));
     _scene->styles().emplace_back(new PointStyle("points", _scene->fontContext()));
     _scene->styles().emplace_back(new RasterStyle("raster"));
+
+#ifdef TANGRAM_DEBUG_RENDERER
+    _scene->styles().emplace_back(new DebugTextStyle("debugtext", _scene->fontContext(), true));
+    _scene->styles().emplace_back(new DebugStyle("debug"));
+#endif
 
     if (config["global"]) {
         applyGlobals(config, *_scene);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1038,10 +1038,15 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
     rawSources->setCacheSize(CACHE_SIZE);
 
     if (isMBTilesFile) {
+#ifdef TANGRAM_MBTILES_DATASOURCE
         // If we have MBTiles, we know the source is tiled.
         tiled = true;
         // Create an MBTiles data source from the file at the url and add it to the source chain.
         rawSources->setNext(std::make_unique<MBTilesDataSource>(platform, name, url, ""));
+#else
+        LOGE("MBTiles support is disabled. This source will be ignored: %s", name.c_str());
+        return;
+#endif
     } else if (tiled) {
         rawSources->setNext(std::make_unique<NetworkDataSource>(platform, url, std::move(subdomains), isTms));
     }

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -39,7 +39,10 @@ android {
                  '-Wignored-qualifiers',
                  '-Wtype-limits',
                  '-Wmissing-field-initializers',
-                 '-Wno-format-pedantic'
+                 '-Wno-format-pedantic',
+                 '-Wno-gnu-statement-expression',
+                 '-Wgnu-anonymous-struct',
+                 '-Wno-nested-anon-types'
 
         if (abi == 'all') {
           abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'

--- a/platforms/linux/config.cmake
+++ b/platforms/linux/config.cmake
@@ -19,8 +19,6 @@ check_unsupported_compiler_version()
 
 add_definitions(-DTANGRAM_LINUX)
 
-get_nextzen_api_key(NEXTZEN_API_KEY)
-add_definitions(-DNEXTZEN_API_KEY="${NEXTZEN_API_KEY}")
 
 find_package(OpenGL REQUIRED)
 
@@ -74,5 +72,11 @@ target_compile_options(tangram
   -Wtype-limits
   -Wmissing-field-initializers
 )
+
+get_nextzen_api_key(NEXTZEN_API_KEY)
+target_compile_definitions(tangram
+  PRIVATE
+  NEXTZEN_API_KEY="${NEXTZEN_API_KEY}")
+
 
 add_resources(tangram "${PROJECT_SOURCE_DIR}/scenes" "res")


### PR DESCRIPTION
I think we could enable the `TANGRAM_DEV_*` options by default on linus and osx for now