### PR TITLE
Add TANGRAM_MBTILES_DATASOURCE and TANGRAM_USE_SYSTEM_SQLITE_LIBS build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ option(TANGRAM_USE_JSCORE_STATIC "Build with pre-compiled static libraries for J
 
 option(TANGRAM_USE_SYSTEM_FONT_LIBS "Use system libraries Freetype, ICU and Harfbuzz via pkgconfig" OFF)
 option(TANGRAM_USE_SYSTEM_GLFW_LIBS "Use system libraries for GLFW3 via pkgconfig" OFF)
+option(TANGRAM_USE_SYSTEM_SQLITE_LIBS "Use system libraries for SQLite via pkgconfig" OFF)
+option(TANGRAM_MBTILES_DATASOURCE "Build MBTiles Datasource" ON)
 
 option(TANGRAM_BUILD_TESTS "Build unit tests" OFF)
 option(TANGRAM_BUNDLE_TESTS "Compile all tests into a single binary" ON)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,11 +3,6 @@ project(tangram-core)
 # Build core library dependencies.
 add_subdirectory(deps)
 
-if (TANGRAM_MBTILES_DATASOURCE)
-  set(MBTILES_SOURCES src/data/mbtilesDataSource.cpp)
-  set(MBTILES_LIBS SQLiteCpp sqlite3)
-endif()
-
 add_library(tangram-core
   src/map.cpp
   src/platform.cpp
@@ -100,7 +95,6 @@ add_library(tangram-core
   src/view/flyTo.cpp
   src/view/view.cpp
   src/view/viewConstraint.cpp
-  ${MBTILES_SOURCES}
 )
 
 # Include headers from core library and dependencies.
@@ -131,6 +125,17 @@ target_include_directories(tangram-core
   deps/double-conversion/include
 )
 
+# Link core library dependencies.
+target_link_libraries(tangram-core
+  PRIVATE
+  css-color-parser-cpp
+  yaml-cpp
+  alfons
+  double-conversion
+  miniz
+  z
+)
+
 # Add JavaScript implementation.
 if(TANGRAM_JSCORE_ENABLED)
   target_sources(tangram-core PRIVATE src/js/JSCoreContext.cpp)
@@ -145,18 +150,12 @@ else()
   target_link_libraries(tangram-core PRIVATE duktape)
 endif()
 
-# Link core library dependencies.
-target_link_libraries(tangram-core
-  PRIVATE
-  ${MBTILES_LIBS}
-  css-color-parser-cpp
-  yaml-cpp
-  alfons
-  double-conversion
-  miniz
-  z
-)
-
+# Add MBTiles implementation.
+if(TANGRAM_MBTILES_DATASOURCE)
+  target_sources(tangram-core PRIVATE src/data/mbtilesDataSource.cpp)
+  target_link_libraries(tangram-core PRIVATE SQLiteCpp sqlite3)
+  target_compile_definitions(tangram-core PRIVATE TANGRAM_MBTILES_DATASOURCE=1)
+endif()
 
 if(UNIX AND NOT APPLE)
   # SQLite needs dl dynamic library loader when Linux
@@ -167,12 +166,6 @@ if(TANGRAM_WARN_ON_RULE_CONFLICT)
   target_compile_definitions(tangram-core
     PRIVATE
     TANGRAM_WARN_ON_RULE_CONFLICT)
-endif()
-
-if (TANGRAM_MBTILES_DATASOURCE)
-  target_compile_definitions(tangram-core
-    PRIVATE
-    TANGRAM_MBTILES_DATASOURCE)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,11 +3,16 @@ project(tangram-core)
 # Build core library dependencies.
 add_subdirectory(deps)
 
+if (TANGRAM_MBTILES_DATASOURCE)
+  set(MBTILES_SOURCES src/data/mbtilesDataSource.cpp)
+  set(MBTILES_LIBS SQLiteCpp sqlite3)
+  add_definitions(-DTANGRAM_MBTILES_DATASOURCE)
+endif()
+
 add_library(tangram-core
   src/map.cpp
   src/platform.cpp
   src/data/clientGeoJsonSource.cpp
-  src/data/mbtilesDataSource.cpp
   src/data/memoryCacheDataSource.cpp
   src/data/networkDataSource.cpp
   src/data/properties.cpp
@@ -96,6 +101,7 @@ add_library(tangram-core
   src/view/flyTo.cpp
   src/view/view.cpp
   src/view/viewConstraint.cpp
+  ${MBTILES_SOURCES}
 )
 
 # Include headers from core library and dependencies.
@@ -143,11 +149,10 @@ endif()
 # Link core library dependencies.
 target_link_libraries(tangram-core
   PRIVATE
+  ${MBTILES_LIBS}
   css-color-parser-cpp
   yaml-cpp
   alfons
-  SQLiteCpp
-  sqlite3
   double-conversion
   miniz
   z

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,7 +6,6 @@ add_subdirectory(deps)
 if (TANGRAM_MBTILES_DATASOURCE)
   set(MBTILES_SOURCES src/data/mbtilesDataSource.cpp)
   set(MBTILES_LIBS SQLiteCpp sqlite3)
-  add_definitions(-DTANGRAM_MBTILES_DATASOURCE)
 endif()
 
 add_library(tangram-core
@@ -168,6 +167,12 @@ if(TANGRAM_WARN_ON_RULE_CONFLICT)
   target_compile_definitions(tangram-core
     PRIVATE
     TANGRAM_WARN_ON_RULE_CONFLICT)
+endif()
+
+if (TANGRAM_MBTILES_DATASOURCE)
+  target_compile_definitions(tangram-core
+    PRIVATE
+    TANGRAM_MBTILES_DATASOURCE)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/core/deps/CMakeLists.txt
+++ b/core/deps/CMakeLists.txt
@@ -59,23 +59,29 @@ endif()
 set(GLM_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/glm)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/alfons)
 
-## SQLiteCpp ##
-###############
-set(SQLITECPP_RUN_CPPLINT OFF CACHE BOOL "")
-set(SQLITECPP_RUN_CPPCHECK OFF CACHE BOOL "")
-set(SQLITE_ENABLE_COLUMN_METADATA OFF CACHE BOOL "")
+if (TANGRAM_MBTILES_DATASOURCE)
+  ## SQLiteCpp ##
+  ###############
+  set(SQLITECPP_RUN_CPPLINT OFF CACHE BOOL "")
+  set(SQLITECPP_RUN_CPPCHECK OFF CACHE BOOL "")
+  set(SQLITE_ENABLE_COLUMN_METADATA OFF CACHE BOOL "")
 
-add_subdirectory(SQLiteCpp)
+  if (TANGRAM_USE_SYSTEM_SQLITE_LIBS)
+    set(SQLITECPP_INTERNAL_SQLITE OFF CACHE BOOL "")
+  endif()
 
-# Extensions aren't needed for MBTiles and aren't available in older versions of sqlite3.
-target_compile_definitions(SQLiteCpp PRIVATE SQLITE_OMIT_LOAD_EXTENSION)
+  add_subdirectory(SQLiteCpp)
 
-# needed for sqlite3 to work for ndk15c+ and android api level < 21
-# refer:
-# https://github.com/android-ndk/ndk/issues/477 and
-# https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
-if (ANDROID)
+  # Extensions aren't needed for MBTiles and aren't available in older versions of sqlite3.
+  target_compile_definitions(SQLiteCpp PRIVATE SQLITE_OMIT_LOAD_EXTENSION)
+
+  # needed for sqlite3 to work for ndk15c+ and android api level < 21
+  # refer:
+  # https://github.com/android-ndk/ndk/issues/477 and
+  # https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
+  if (ANDROID)
     target_compile_definitions(sqlite3 PRIVATE _FILE_OFFSET_BITS=32)
+  endif()
 endif()
 
 ## double-conversion ##

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -363,8 +363,12 @@ SceneID Map::updateSceneAsync(const std::vector<SceneUpdate>& _sceneUpdates) {
 }
 
 void Map::setMBTiles(const char* _dataSourceName, const char* _mbtilesFilePath) {
+#ifdef TANGRAM_MBTILES_DATASOURCE
     std::string scenePath = std::string("sources.") + _dataSourceName + ".mbtiles";
     updateSceneAsync({SceneUpdate{scenePath.c_str(), _mbtilesFilePath}});
+#else
+    LOGE("MBTiles support is disabled. This source will be ignored: %s", _dataSourceName);
+#endif
 }
 
 void Map::resize(int _newWidth, int _newHeight) {

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1038,10 +1038,15 @@ void SceneLoader::loadSource(const std::shared_ptr<Platform>& platform, const st
     rawSources->setCacheSize(CACHE_SIZE);
 
     if (isMBTilesFile) {
+#ifdef TANGRAM_MBTILES_DATASOURCE
         // If we have MBTiles, we know the source is tiled.
         tiled = true;
         // Create an MBTiles data source from the file at the url and add it to the source chain.
         rawSources->setNext(std::make_unique<MBTilesDataSource>(platform, name, url, ""));
+#else
+        LOGE("MBTiles support is disabled. This source will be ignored: %s", name.c_str());
+        return;
+#endif
     } else if (tiled) {
         rawSources->setNext(std::make_unique<NetworkDataSource>(platform, url, std::move(subdomains), isTms));
     }

--- a/platforms/android/config.cmake
+++ b/platforms/android/config.cmake
@@ -13,13 +13,13 @@ add_library(tangram SHARED
   platforms/common/platform_gl.cpp
   platforms/android/tangram/src/main/cpp/jniExports.cpp
   platforms/android/tangram/src/main/cpp/androidPlatform.cpp
-  platforms/android/tangram/src/main/cpp/sqlite3ndk.cpp
 )
 
-target_include_directories(tangram
-  PRIVATE
-  core/deps/SQLiteCpp/sqlite3 # sqlite3ndk.cpp needs sqlite3.h
-)
+if(TANGRAM_MBTILES_DATASOURCE)
+  target_sources(tangram PRIVATE platforms/android/tangram/src/main/cpp/sqlite3ndk.cpp)
+  target_include_directories(tangram PRIVATE core/deps/SQLiteCpp/sqlite3) # sqlite3ndk.cpp needs sqlite3.h
+  target_compile_definitions(tangram PRIVATE TANGRAM_MBTILES_DATASOURCE=1)
+endif()
 
 target_link_libraries(tangram
   PRIVATE

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -39,7 +39,10 @@ android {
                  '-Wignored-qualifiers',
                  '-Wtype-limits',
                  '-Wmissing-field-initializers',
-                 '-Wno-format-pedantic'
+                 '-Wno-format-pedantic',
+                 '-Wno-gnu-statement-expression',
+                 '-Wgnu-anonymous-struct',
+                 '-Wno-nested-anon-types'
 
         if (abi == 'all') {
           abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'

--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -23,8 +23,9 @@
 #include <codecvt>
 #include <locale>
 
+#ifdef TANGRAM_MBTILES_DATASOURCE
 #include "sqlite3ndk.h"
-
+#endif
 
 PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT = 0;
 PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
@@ -182,7 +183,9 @@ AndroidPlatform::AndroidPlatform(JNIEnv* _jniEnv, jobject _assetManager, jobject
         return;
     }
 
+#ifdef TANGRAM_MBTILES_DATASOURCE
     sqlite3_ndk_init(m_assetManager);
+#endif
 }
 
 void AndroidPlatform::dispose(JNIEnv* _jniEnv) {

--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -15,10 +15,10 @@ set(NEXTZEN_API_KEY $ENV{NEXTZEN_API_KEY})
 configure_file(${PROJECT_SOURCE_DIR}/platforms/ios/demo/Info.plist.in ${PROJECT_BINARY_DIR}/Info.plist)
 
 # Tell SQLiteCpp to not build its own copy of SQLite, we will use the system library instead.
+set(SQLITECPP_INTERNAL_SQLITE OFF CACHE BOOL "")
 if (IOS_SDK_VERSION VERSION_LESS 11.0)
   set(SQLITE_USE_LEGACY_STRUCT ON CACHE BOOL "")
 endif()
-set(SQLITECPP_INTERNAL_SQLITE OFF CACHE BOOL "")
 
 # Headers must be absolute paths for the copy_if_different command on the
 # static library target, relative paths cause it to fail with an error.
@@ -149,13 +149,15 @@ set(TANGRAM_STATIC_DEPENDENCIES "\
   $<TARGET_FILE:harfbuzz>
   $<TARGET_FILE:freetype>
   $<TARGET_FILE:icucommon>
-  $<TARGET_FILE:SQLiteCpp>
   $<TARGET_FILE:double-conversion>
   $<TARGET_FILE:miniz>
   "
 )
-if (NOT TANGRAM_USE_JSCORE)
+if(NOT TANGRAM_USE_JSCORE)
   set(TANGRAM_STATIC_DEPENDENCIES "${TANGRAM_STATIC_DEPENDENCIES} $<TARGET_FILE:duktape>")
+endif()
+if(TANGRAM_MBTILES_DATASOURCE)
+  set(TANGRAM_STATIC_DEPENDENCIES "${TANGRAM_STATIC_DEPENDENCIES} $<TARGET_FILE:SQLiteCpp>")
 endif()
 
 set_target_properties(tangram-static PROPERTIES

--- a/platforms/linux/config.cmake
+++ b/platforms/linux/config.cmake
@@ -19,8 +19,6 @@ check_unsupported_compiler_version()
 
 add_definitions(-DTANGRAM_LINUX)
 
-get_nextzen_api_key(NEXTZEN_API_KEY)
-add_definitions(-DNEXTZEN_API_KEY="${NEXTZEN_API_KEY}")
 
 find_package(OpenGL REQUIRED)
 
@@ -74,5 +72,11 @@ target_compile_options(tangram
   -Wtype-limits
   -Wmissing-field-initializers
 )
+
+get_nextzen_api_key(NEXTZEN_API_KEY)
+target_compile_definitions(tangram
+  PRIVATE
+  NEXTZEN_API_KEY="${NEXTZEN_API_KEY}")
+
 
 add_resources(tangram "${PROJECT_SOURCE_DIR}/scenes" "res")


### PR DESCRIPTION
This PR allows Tangram to be build without MBTiles support. This enables users of our library to not include the large SQLite dependency when they don't need it. It's also handy to turn off for faster build times during development.