### PR TITLE
Fix getEnclosingCameraPosition for very small bounds

### DIFF
--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -656,7 +656,7 @@ void Map::setCameraPositionEased(const CameraPosition& _camera, float _duration,
     e.end.pos = MapProjection::lngLatToProjectedMeters({lonEnd, latEnd});
 
     e.start.zoom = getZoom();
-    e.end.zoom = _camera.zoom;
+    e.end.zoom = glm::clamp(_camera.zoom, getMinZoom(), getMaxZoom());
 
     float radiansStart = getRotation();
 

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -806,16 +806,18 @@ CameraPosition Map::getEnclosingCameraPosition(LngLat _a, LngLat _b, EdgePadding
 
     // Take the value from the larger dimension to calculate the final zoom.
     double maxMetersPerPixel = std::max(metersPerPixel.x, metersPerPixel.y);
-    double zoom = -std::log2(maxMetersPerPixel * MapProjection::tileSize() / MapProjection::EARTH_CIRCUMFERENCE_METERS);
+    double zoom = MapProjection::zoomAtMetersPerPixel(maxMetersPerPixel);
+    double finalZoom = glm::clamp(zoom, (double)getMinZoom(), (double)getMaxZoom());
+    double finalMetersPerPixel = MapProjection::metersPerPixelAtZoom(finalZoom);
 
     // Adjust the center of the final visible region using the padding converted to Mercator meters.
-    glm::dvec2 paddingMeters = glm::dvec2(_pad.right - _pad.left, _pad.top - _pad.bottom) * maxMetersPerPixel;
+    glm::dvec2 paddingMeters = glm::dvec2(_pad.right - _pad.left, _pad.top - _pad.bottom) * finalMetersPerPixel;
     glm::dvec2 centerMeters = 0.5 * (aMeters + bMeters + paddingMeters);
 
     LngLat centerLngLat = MapProjection::projectedMetersToLngLat(centerMeters);
 
     CameraPosition camera;
-    camera.zoom = static_cast<float>(zoom);
+    camera.zoom = static_cast<float>(finalZoom);
     camera.longitude = centerLngLat.longitude;
     camera.latitude = centerLngLat.latitude;
     return camera;

--- a/core/src/util/mapProjection.cpp
+++ b/core/src/util/mapProjection.cpp
@@ -46,6 +46,14 @@ double MapProjection::metersPerTileAtZoom(int zoom) {
     return MapProjection::EARTH_CIRCUMFERENCE_METERS / (1 << zoom);
 }
 
+double MapProjection::metersPerPixelAtZoom(double zoom) {
+    return MapProjection::EARTH_CIRCUMFERENCE_METERS / (exp2(zoom) * tileSize());
+}
+
+double MapProjection::zoomAtMetersPerPixel(double metersPerPixel) {
+    return log2(MapProjection::EARTH_CIRCUMFERENCE_METERS / (metersPerPixel * tileSize()));
+}
+
 BoundingBox MapProjection::mapLngLatBounds() {
     // Reference: https://en.wikipedia.org/wiki/Mercator_projection#Truncation_and_aspect_ratio
     return { glm::dvec2(-180, -MAX_LATITUDE_DEGREES), glm::dvec2(180, MAX_LATITUDE_DEGREES) };

--- a/core/src/util/mapProjection.h
+++ b/core/src/util/mapProjection.h
@@ -77,6 +77,10 @@ public:
 
     static double metersPerTileAtZoom(int zoom);
 
+    static double metersPerPixelAtZoom(double zoom);
+
+    static double zoomAtMetersPerPixel(double metersPerPixel);
+
     // Bounds of the map projection in projected meters.
     static BoundingBox mapProjectedMetersBounds();
 

--- a/tests/unit/mapProjectionTests.cpp
+++ b/tests/unit/mapProjectionTests.cpp
@@ -32,3 +32,27 @@ TEST_CASE("MapProjection correctly converts between LngLat and ProjectedMeters",
     CHECK_THAT(convertedLngLat.latitude, Catch::WithinAbs(pair.lngLat.latitude, epsilonDegrees));
 
 }
+
+TEST_CASE("MapProjection correctly converts between zoom and metersPerPixel", "[projection]") {
+
+    double epsilon = 0.00001;
+
+    SECTION("zoom 0") {
+        auto metersPerPixel = MapProjection::metersPerPixelAtZoom(0.0);
+        auto expected = MapProjection::EARTH_CIRCUMFERENCE_METERS / MapProjection::tileSize();
+        CHECK_THAT(metersPerPixel, Catch::WithinAbs(expected, epsilon));
+    }
+
+    SECTION("zoom n + 1") {
+        auto zoom = GENERATE(0.0, 7.0, 16.0, 24.0);
+
+        auto metersPerPixel = MapProjection::metersPerPixelAtZoom(zoom);
+        auto metersPerPixelHalved = metersPerPixel * 0.5;
+        auto metersPerPixelAtNextZoom = MapProjection::metersPerPixelAtZoom(zoom + 1.0);
+        auto convertedZoom = MapProjection::zoomAtMetersPerPixel(metersPerPixel);
+
+        CHECK_THAT(convertedZoom, Catch::WithinAbs(zoom, epsilon));
+        CHECK_THAT(metersPerPixelAtNextZoom, Catch::WithinAbs(metersPerPixelHalved, epsilon));
+    }
+
+}


### PR DESCRIPTION
If the bounding points passed into `getEnclosingCameraPosition` are very close together or are equivalent, then the resulting zoom of the output is larger than the maximum applicable zoom of the map view - resulting in incorrect placement of the view.

To simplify the code a little I moved some functionality into `MapProjection` and wrote tests to check its correctness. 

I also addressed a similar problem in `setCameraPositionEased` that could lead to incorrect or unexpected interpolation. 

Resolves #1961 