### PR TITLE
Fixing Crash on memory warning call

### DIFF
--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -294,11 +294,14 @@ void FontContext::releaseFonts() {
     // those are 'weak' resources (would be automatically reloaded by alfons from
     // its URI or source callback.
     for (auto& font : m_font) {
-        for (auto& face : font->faces()) {
-            alfons::InputSource& fontSource = face->descriptor().source;
+        // Validating font reference
+        if (font) {
+            for (auto& face : font->faces()) {
+                alfons::InputSource& fontSource = face->descriptor().source;
 
-            if (fontSource.isUri() || fontSource.hasSourceCallback()) {
-                fontSource.clearData();
+                if (fontSource.isUri() || fontSource.hasSourceCallback()) {
+                    fontSource.clearData();
+                }
             }
         }
     }


### PR DESCRIPTION
When memory warning notification is invoked by OS, best practice is to call Map::OnMemoryWarning.
when doing so, m_font might not be set yet (FontContext::loadFonts()), causing a crash at:
"for (auto& face : font->faces()) {..." in function FontContext::releaseFonts().

this crash can be easily reproduced in iOS/XCode by using
1.  "Simulate Memory Warnings" option in Simulator
2. An application that uses TGMapView
3. add observer for : UIApplicationDidReceiveMemoryWarningNotification in TGMapView.
3. Invoke "Simulate Memory Warnings" in transition to Map view controller (that uses TGMapView).

The fix was to validate font pointer before accessing it:
void FontContext::releaseFonts() {

    std::lock_guard<std::mutex> lock(m_fontMutex);
    // Unload Freetype and Harfbuzz resources for all font faces
    m_alfons.unload();

    // Release system font fallbacks input source data from default fonts, since
    // those are 'weak' resources (would be automatically reloaded by alfons from
    // its URI or source callback.
    for (auto& font : m_font) {
        // Validating font reference
        if (font) {
            for (auto& face : font->faces()) {
                alfons::InputSource& fontSource = face->descriptor().source;

                if (fontSource.isUri() || fontSource.hasSourceCallback()) {
                    fontSource.clearData();
                }
            }
        }
    }
}

Crash report (relevant part):
Crashed: com.apple.main-thread
0  HereSDKMapKit                  0x1051d50f4 Tangram::FontContext::releaseFonts() + 28
1  CoreFoundation                 0x21858e928 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 20
2  CoreFoundation                 0x21858e8f4 ___CFXRegistrationPost_block_invoke + 64
3  CoreFoundation                 0x21858dde4 _CFXRegistrationPost + 392
4  CoreFoundation                 0x21858da90 ___CFXNotificationPost_block_invoke + 96
5  CoreFoundation                 0x218505d70 -[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1404
6  CoreFoundation                 0x21858d51c _CFXNotificationPost + 696
7  Foundation                     0x218f9dc10 -[NSNotificationCenter postNotificationName:object:userInfo:] + 68
8  UIKitCore                      0x2457fff7c -[UIApplication _performMemoryWarning] + 152
9  UIKitCore                      0x245800168 -[UIApplication _receivedMemoryNotification] + 140