### PR TITLE
Fix segv in TextStyleBuilder

### DIFF
--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -254,6 +254,7 @@ bool TextStyleBuilder::addFeature(const Feature& _feat, const DrawRule& _rule) {
     if (!checkRule(_rule)) { return false; }
 
     TextStyle::Parameters params = applyRule(_rule, _feat.props, false);
+    if (!params.font) { return false; }
 
     Label::Type labelType;
     if (_feat.geometryType == GeometryType::lines) {
@@ -578,9 +579,6 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         p.text = _props.getString(key_name);
     }
 
-
-    if (p.text.empty()) { return p; }
-
     auto fontFamily = _rule.get<std::string>(StyleParamKey::text_font_family);
     fontFamily = (!fontFamily) ? &defaultFamily : fontFamily;
 
@@ -594,7 +592,10 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
     p.fontSize *= m_style.pixelScale();
 
     p.font = m_style.context()->getFont(*fontFamily, *fontStyle, *fontWeight, p.fontSize);
-
+    if (!p.font) {
+        LOGW("Missing font for %s / %s / %s / %d", fontFamily->c_str(), fontStyle->c_str(), fontWeight->c_str(), p.fontSize);
+        return p;
+    }
     _rule.get(StyleParamKey::text_font_fill, p.fill);
 
     _rule.get(StyleParamKey::text_font_stroke_color, p.strokeColor);

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -54,7 +54,7 @@ public:
     void addCurvedTextLabels(const Line& _feature, const TextStyle::Parameters& _params,
                              const LabelAttributes& _attributes, const DrawRule& _rule);
 
-    bool handleBoundaryLabel(const Feature& _feat, const DrawRule& _rule,
+    void handleBoundaryLabel(const Feature& _feat, const DrawRule& _rule,
                              const TextStyle::Parameters& _params);
 
     bool checkRule(const DrawRule& _rule) const override;

--- a/core/src/style/textStyleBuilder.h
+++ b/core/src/style/textStyleBuilder.h
@@ -54,7 +54,7 @@ public:
     void addCurvedTextLabels(const Line& _feature, const TextStyle::Parameters& _params,
                              const LabelAttributes& _attributes, const DrawRule& _rule);
 
-    void handleBoundaryLabel(const Feature& _feat, const DrawRule& _rule,
+    bool handleBoundaryLabel(const Feature& _feat, const DrawRule& _rule,
                              const TextStyle::Parameters& _params);
 
     bool checkRule(const DrawRule& _rule) const override;

--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -29,17 +29,19 @@ void FontContext::setPixelScale(float _scale) {
 
 void FontContext::loadFonts() {
     auto fallbacks = m_platform->systemFontFallbacksHandle();
-
     for (size_t i = 0; i < s_fontRasterSizes.size(); i++) {
         m_font[i] = m_alfons.addFont("default", s_fontRasterSizes[i]);
     }
 
+    bool added = false;
     for (const auto& fallback : fallbacks) {
 
-        if (!fallback.isValid()) { continue; }
+        if (!fallback.isValid()) {
+            LOGD("Invalid fallback font");
+            continue;
+        }
 
         alfons::InputSource source;
-
         switch (fallback.tag) {
             case FontSourceHandle::FontPath:
                 source = alfons::InputSource(fallback.fontPath.path());
@@ -51,13 +53,18 @@ void FontContext::loadFonts() {
                 source = alfons::InputSource(fallback.fontLoader);
                 break;
             case FontSourceHandle::None:
-            default:
-                return;
+            default: {
+                LOGD("Invalid fallback font: FontSourceHandle::None");
+                continue;
+            }
         }
-
         for (size_t i = 0; i < s_fontRasterSizes.size(); i++) {
             m_font[i]->addFace(m_alfons.addFontFace(source, s_fontRasterSizes[i]));
         }
+        added = true;
+    }
+    if (!added) {
+        LOGW("No fallback fonts available!");
     }
 }
 
@@ -337,9 +344,7 @@ std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, c
     if (font->hasFaces()) { return font; }
 
     // First, try to load from the system fonts.
-
     bool useFallbackFont = false;
-
     auto systemFontHandle = m_platform->systemFont(_family, _weight, _style);
 
     alfons::InputSource source;
@@ -369,17 +374,13 @@ std::shared_ptr<alfons::Font> FontContext::getFont(const std::string& _family, c
 
     if (!useFallbackFont) {
         font->addFace(m_alfons.addFontFace(source, fontSize));
-        if (m_font[sizeIndex]) {
-            font->addFaces(*m_font[sizeIndex]);
-        }
     } else {
-        LOGD("Loading fallback font for Family: %s, Style: %s, Weight: %s, Size %f",
-            _family.c_str(), _style.c_str(), _weight.c_str(), _size);
-
-        // Add fallbacks from default font.
-        if (m_font[sizeIndex]) {
-            font->addFaces(*m_font[sizeIndex]);
-        }
+        LOGD("Using fallback font for Family: %s, Style: %s, Weight: %s, Size %f",
+             _family.c_str(), _style.c_str(), _weight.c_str(), _size);
+    }
+    // Add fallbacks from default font.
+    if (m_font[sizeIndex]) {
+        font->addFaces(*m_font[sizeIndex]);
     }
 
     return font;


### PR DESCRIPTION
- Early return on !params.text caused segv due to missing params.font
  for boundary labels
- Add safety check that TextStyle::Param::font exists
