### PR TITLE
Don't dereference null fonts in FontContext::releaseFonts

### DIFF
--- a/core/src/text/fontContext.cpp
+++ b/core/src/text/fontContext.cpp
@@ -294,6 +294,7 @@ void FontContext::releaseFonts() {
     // those are 'weak' resources (would be automatically reloaded by alfons from
     // its URI or source callback.
     for (auto& font : m_font) {
+        if (!font) { continue; }
         for (auto& face : font->faces()) {
             alfons::InputSource& fontSource = face->descriptor().source;
 


### PR DESCRIPTION
Resolves #1968 

Credit to @Developers-Here-Mobility for finding the crash here and the fix. I've just made the same fix with a slightly smaller diff.