### PR TITLE
Fix NPE for MapView.onTouchEvent

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -237,7 +237,10 @@ public class MapView extends FrameLayout {
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        return mapController.handleGesture(this, ev);
+        if (mapController != null) {
+            return mapController.handleGesture(this, ev);
+        }
+        return false;
     }
 
     protected MapController getMapInstance() {


### PR DESCRIPTION
Client code could call MapView.onTouchEvent or its extension in its
own MapView class, when MapController has not been set. To avoid this it
makes sense to check for nullability of MapController in
MapView.onTouchEvent.