### PR TITLE
Apply pixel density to Marker bitmaps

### DIFF
--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -87,6 +87,7 @@ bool MarkerManager::setBitmap(MarkerID markerID, int width, int height, const un
     m_dirty = true;
 
     TextureOptions options;
+    options.displayScale = 1.f / m_scene->pixelScale();
     auto texture = std::make_unique<Texture>(options);
     texture->setPixelData(width, height, sizeof(GLuint),
                           reinterpret_cast<const GLubyte*>(bitmapData),

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -420,7 +420,7 @@ extern "C" {
                 if (a != 0) {
                     auto alphaInv = 255.f/a;
                     rgba[0] = static_cast<uint8_t>(rgba[0] * alphaInv);
-                    rgba[1] = static_cast<uint8_t>(rgba[1] * alphaInv );
+                    rgba[1] = static_cast<uint8_t>(rgba[1] * alphaInv);
                     rgba[2] = static_cast<uint8_t>(rgba[2] * alphaInv);
                 }
                 pixelOutput[flippedRow + col] = pixel;


### PR DESCRIPTION
Similar fix as https://github.com/tangrams/tangram-es/pull/1927 just with a smaller diff.

Resolves https://github.com/tangrams/tangram-es/issues/1925