### PR TITLE
TileManager removes tile sources that are not enabled.

### DIFF
--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -168,7 +168,7 @@ void Map::Impl::setScene(std::shared_ptr<Scene>& _scene) {
     }
 
     inputHandler.setView(view);
-    tileManager.setTileSources(_scene->tileSources());
+    tileManager.setTileSourcesFromScene(_scene);
     tileWorker.setScene(_scene);
     markerManager.setScene(_scene);
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -2,6 +2,7 @@
 
 #include "data/tileData.h"
 #include "data/tileSource.h"
+#include "scene/scene.h"
 #include "tile/tile.h"
 #include "tile/tileID.h"
 #include "tile/tileTask.h"
@@ -38,8 +39,8 @@ public:
 
     virtual ~TileManager();
 
-    /* Sets the tile TileSources */
-    void setTileSources(const std::vector<std::shared_ptr<TileSource>>& _sources);
+    /* Sets the tile TileSources from the scene */
+    void setTileSourcesFromScene(const std::shared_ptr<Scene> _scene);
 
     /* Updates visible tile set and load missing tiles */
     void updateTileSets(const View& _view);


### PR DESCRIPTION
Made TileManager remove tile sources that are not referenced by enabled layers.

Fixes #1973 

I'm not sure if this is the way to go, but it solved my problem, and with Scene Updates as well.
Looks like the TileManager adds/removes tile sources on setScene (which happens on updateScene).
So, I made it remove tile sources that are not enabled by the scene.