### PR TITLE
Fix Bitmap density for Markers added at startup

### DIFF
--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -324,7 +324,7 @@ public:
     // Set a bitmap to use as the image for a point marker; _data is a buffer of RGBA pixel data with
     // length of _width * _height; pixels are in row-major order beginning from the bottom-left of the
     // image; returns true if the marker ID was found and successfully updated, otherwise returns false.
-    bool markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data);
+    bool markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data, float _density = 1.f);
 
     // Set the geometry of a marker to a point at the given coordinates; markers can have their
     // geometry set multiple times with possibly different geometry types; returns true if the

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -1005,8 +1005,8 @@ bool Map::markerSetStylingFromPath(MarkerID _marker, const char* _path) {
     return success;
 }
 
-bool Map::markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data) {
-    bool success = impl->markerManager.setBitmap(_marker, _width, _height, impl->view.pixelScale(), _data);
+bool Map::markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data, float _density) {
+    bool success = impl->markerManager.setBitmap(_marker, _width, _height, _density, _data);
     platform->requestRender();
     return success;
 }

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -1006,7 +1006,7 @@ bool Map::markerSetStylingFromPath(MarkerID _marker, const char* _path) {
 }
 
 bool Map::markerSetBitmap(MarkerID _marker, int _width, int _height, const unsigned int* _data) {
-    bool success = impl->markerManager.setBitmap(_marker, _width, _height, _data);
+    bool success = impl->markerManager.setBitmap(_marker, _width, _height, impl->view.pixelScale(), _data);
     platform->requestRender();
     return success;
 }

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -80,14 +80,14 @@ bool MarkerManager::setStyling(MarkerID markerID, const char* styling, bool isPa
     return true;
 }
 
-bool MarkerManager::setBitmap(MarkerID markerID, int width, int height, const unsigned int* bitmapData) {
+bool MarkerManager::setBitmap(MarkerID markerID, int width, int height, float density, const unsigned int* bitmapData) {
     Marker* marker = getMarkerOrNull(markerID);
     if (!marker) { return false; }
 
     m_dirty = true;
 
     TextureOptions options;
-    options.displayScale = 1.f / m_scene->pixelScale();
+    options.displayScale = 1.f / density;
     auto texture = std::make_unique<Texture>(options);
     texture->setPixelData(width, height, sizeof(GLuint),
                           reinterpret_cast<const GLubyte*>(bitmapData),

--- a/core/src/marker/markerManager.h
+++ b/core/src/marker/markerManager.h
@@ -42,7 +42,7 @@ public:
         return setStyling(markerID, path, true);
     }
 
-    bool setBitmap(MarkerID markerID, int width, int height, const unsigned int* bitmapData);
+    bool setBitmap(MarkerID markerID, int width, int height, float density, const unsigned int* bitmapData);
 
     // Set whether a marker should be visible; returns true if the marker was found and updated.
     bool setVisible(MarkerID markerID, bool visible);

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -389,7 +389,7 @@ extern "C" {
         return static_cast<jboolean>(result);
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetBitmap(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jobject jbitmap) {
+    JNIEXPORT jboolean JNICALL Java_com_mapzen_tangram_MapController_nativeMarkerSetBitmap(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong markerID, jobject jbitmap, jfloat density) {
         assert(mapPtr > 0);
         auto map = reinterpret_cast<Tangram::Map*>(mapPtr);
 
@@ -427,7 +427,7 @@ extern "C" {
             }
         }
         AndroidBitmap_unlockPixels(jniEnv, jbitmap);
-        auto result = map->markerSetBitmap(static_cast<unsigned int>(markerID), width, height, pixelOutput);
+        auto result = map->markerSetBitmap(static_cast<unsigned int>(markerID), width, height, pixelOutput, density);
         delete[] pixelOutput;
         return static_cast<jboolean>(result);
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -1209,10 +1209,10 @@ public class MapController implements Renderer {
         return nativeMarkerSetStylingFromPath(mapPointer, markerId, path);
     }
 
-    boolean setMarkerBitmap(final long markerId, Bitmap bitmap) {
+    boolean setMarkerBitmap(final long markerId, Bitmap bitmap, float density) {
         checkPointer(mapPointer);
         checkId(markerId);
-        return nativeMarkerSetBitmap(mapPointer, markerId, bitmap);
+        return nativeMarkerSetBitmap(mapPointer, markerId, bitmap, density);
     }
 
     boolean setMarkerPoint(final long markerId, final double lng, final double lat) {
@@ -1300,7 +1300,7 @@ public class MapController implements Renderer {
     private synchronized native boolean nativeMarkerRemove(long mapPtr, long markerID);
     private synchronized native boolean nativeMarkerSetStylingFromString(long mapPtr, long markerID, String styling);
     private synchronized native boolean nativeMarkerSetStylingFromPath(long mapPtr, long markerID, String path);
-    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, Bitmap bitmap);
+    private synchronized native boolean nativeMarkerSetBitmap(long mapPtr, long markerID, Bitmap bitmap, float density);
     private synchronized native boolean nativeMarkerSetPoint(long mapPtr, long markerID, double lng, double lat);
     private synchronized native boolean nativeMarkerSetPointEased(long mapPtr, long markerID, double lng, double lat, float duration, int ease);
     private synchronized native boolean nativeMarkerSetPolyline(long mapPtr, long markerID, double[] coordinates, int count);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/Marker.java
@@ -211,7 +211,8 @@ public class Marker {
     }
 
     private boolean setBitmap(@NonNull final Bitmap bitmap) {
-        return map.setMarkerBitmap(markerId, bitmap);
+        float density = context.getResources().getDisplayMetrics().density;
+        return map.setMarkerBitmap(markerId, bitmap, density);
     }
 
     void invalidate() {


### PR DESCRIPTION
Fixes crash when marker is created before scene finishes loading

This should fix #1979 but I need to test it concretely before merging.