### PR TITLE
Update Android build tools and configuration

### DIFF
--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -5,7 +5,7 @@ allprojects {
       jcenter()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:3.0.1'
+      classpath 'com.android.tools.build:gradle:3.2.1'
       classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
   }

--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-  compile 'com.squareup.okio:okio:2.1.0'
+  implementation 'com.squareup.okio:okio:2.1.0'
   implementation project(path: ':tangram')
   implementation 'com.android.support:design:27.1.1'
 }

--- a/platforms/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platforms/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 22 15:30:42 CEST 2018
+#Fri Dec 14 12:46:19 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -27,7 +27,6 @@ android {
       cmake {
         targets 'tangram'
         arguments '-DTANGRAM_PLATFORM=android',
-                  '-DANDROID_TOOLCHAIN=clang',
                   '-DANDROID_STL=c++_shared'
         cppFlags '-std=c++14',
                  '-pedantic',


### PR DESCRIPTION
- Upgrade Android Gradle plugin from 3.0.1 to 3.2.1
- Upgrade Gradle from 4.4 to 4.6
- Replace deprecated 'compile' declaration with 'implementation'
- Remove 'clang' toolchain CMake argument, it's now the default

We've been down this road before: https://github.com/tangrams/tangram-es/pull/1818 

The newest version of the Gradle plugin still omits the 'res' folder from the AAR, but now I think the issues with Buck have been resolved.