### PR TITLE
Make sure correct gl context is set before rendering

### DIFF
--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -104,17 +104,15 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeState) {
 
 - (void)dealloc
 {
+    [self validateContext];
     if (_map) {
         delete _map;
-    }
-
-    if ([EAGLContext currentContext] == _context) {
-        [EAGLContext setCurrentContext:nil];
     }
 
     if (_displayLink) {
         [_displayLink invalidate];
     }
+    [self invalidateContext];
 }
 
 - (void)setup
@@ -192,6 +190,20 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeState) {
     _displayLink.paused = NO;
 }
 
+- (void)validateContext
+{
+    if (![[EAGLContext currentContext] isEqual:_context]) {
+        [EAGLContext setCurrentContext:_context];
+    }
+}
+
+- (void)invalidateContext
+{
+    if ([[EAGLContext currentContext] isEqual:_context]) {
+        [EAGLContext setCurrentContext:nil];
+    }
+}
+
 - (void)setupGL
 {
     _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
@@ -211,8 +223,8 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeState) {
     _glView.delegate = self;
     _glView.autoresizingMask = self.autoresizingMask;
 
+    [self validateContext];
 
-    [EAGLContext setCurrentContext:self.context];
     [_glView bindDrawable];
 
     [self insertSubview:_glView atIndex:0];
@@ -368,6 +380,8 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeState) {
     if (_viewInBackground) {
         return;
     }
+
+    [self validateContext];
 
     BOOL cameraEasing = self.map->render();
     if (cameraEasing) {

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -381,8 +381,6 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeState) {
         return;
     }
 
-    [self validateContext];
-
     BOOL cameraEasing = self.map->render();
     if (cameraEasing) {
         [self setMapRegionChangeState:TGMapRegionAnimating];


### PR DESCRIPTION
It is possible there are multiple instances of MapView active, in such scenarios we have to make sure EAGLContext is aptly set with the appropriate context before calling any gl calls.

Also dealloc needs to set apt EAGLContext because map deallocation requires cleaning of gl resources and hence requires context to be aptly set.

This PR addresses these concerns by making sure a validate and invalidate gl context calls are aptly placed before calling any gl function calls (within map->draw or other places in the native code).