### PR TITLE
Optimize shader source

### DIFF
--- a/core/src/gl/shaderSource.cpp
+++ b/core/src/gl/shaderSource.cpp
@@ -116,6 +116,7 @@ std::string ShaderSource::applySourceBlocks(const std::string& _source, bool _fr
         }
     }
 
+    // printf("overalloc'd: %d\n",  shaderLength - int(out.length()));
     // for (auto& block : m_sourceBlocks) {
     //     if (pragmas.find(block.first) == pragmas.end()) {
     //         logMsg("Warning: expected pragma '%s' in shader source\n",

--- a/core/src/gl/shaderSource.cpp
+++ b/core/src/gl/shaderSource.cpp
@@ -3,6 +3,7 @@
 
 #include <set>
 #include <sstream>
+#include <tuple>
 
 #include "selection_fs.h"
 
@@ -42,45 +43,53 @@ void ShaderSource::addSourceBlock(const std::string& _tagName, const std::string
 
 std::string ShaderSource::applySourceBlocks(const std::string& _source, bool _fragShader, bool _selection) const {
 
-    std::stringstream sourceOut;
+    std::string out;
     std::set<std::string> pragmas;
 
-    sourceOut << "#define TANGRAM_EPSILON 0.00001\n";
-    sourceOut << "#define TANGRAM_WORLD_POSITION_WRAP 100000.\n";
+    out.append("#define TANGRAM_EPSILON 0.00001\n");
+    out.append("#define TANGRAM_WORLD_POSITION_WRAP 100000.\n");
 
     if (_fragShader) {
-        sourceOut << "#define TANGRAM_FRAGMENT_SHADER\n";
+        out.append("#define TANGRAM_FRAGMENT_SHADER\n");
     } else {
-        sourceOut << "#define TANGRAM_DEPTH_DELTA 0.00003052\n"; // 2^-15
-        sourceOut << "#define TANGRAM_VERTEX_SHADER\n";
+        out.append("#define TANGRAM_DEPTH_DELTA 0.00003052\n"); // 2^-15
+        out.append("#define TANGRAM_VERTEX_SHADER\n");
     }
-
     if (_selection) {
-        sourceOut <<  "#define TANGRAM_FEATURE_SELECTION\n";
+        out.append("#define TANGRAM_FEATURE_SELECTION\n");
     }
 
-    std::string line;
+    size_t shaderLength = out.length() + _source.length();
+    for (auto& block : m_sourceBlocks) {
+        for (auto& s : block.second) {
+            shaderLength += s.length() + 1;
+        }
+        shaderLength += 1;
+    }
+    out.reserve(shaderLength);
+
     size_t end = 0;
+    size_t start = 0;
+    size_t pos = 0;
+    const char* str = _source.c_str();
 
     while(end < _source.length()) {
-        size_t pos = end;
-        end = _source.find('\n', pos);
+        auto pragma = _source.find("#pragma ", pos);
+        if (pragma == std::string::npos) {
+            // Write appendix and done
+            out.append(str + start);
+            break;
+        }
+
+        // find end of #pragma line
+        end = _source.find('\n', pragma);
         if (end == std::string::npos) {
             end = _source.length();
         }
-        // Skip empty lines
-        if (end == pos) {
-            end++;
-            continue;
-        }
-        line = _source.substr(pos, end - pos);
-        end++;
-
-        sourceOut << line << '\n';
+        pos = end;
 
         char pragmaName[128];
-        // NB: The initial whitespace is to skip any number of whitespace chars
-        if (sscanf(line.c_str(), " #pragma tangram:%127s", pragmaName) == 0) {
+        if (sscanf(str + pragma + 8, " tangram:%127s", pragmaName) == 0) {
             continue;
         }
 
@@ -95,9 +104,15 @@ std::string ShaderSource::applySourceBlocks(const std::string& _source, bool _fr
             continue;
         }
 
+        // Write everything to end of #pragma tangram line
+        out.append(str + start, end - start);
+        out.append("\n");
+        start = end;
+
         // insert blocks
         for (auto& s : block->second) {
-            sourceOut << s << '\n';
+            out.append(s);
+            out.append("\n");
         }
     }
 
@@ -107,7 +122,7 @@ std::string ShaderSource::applySourceBlocks(const std::string& _source, bool _fr
     //                block.first.c_str());
     //     }
     // }
-    return sourceOut.str();
+    return out;
 }
 
 void ShaderSource::addExtensionDeclaration(const std::string& _extension) {

--- a/core/src/style/debugStyle.cpp
+++ b/core/src/style/debugStyle.cpp
@@ -25,7 +25,9 @@ struct PosColVertex {
 
 
 DebugStyle::DebugStyle(std::string _name, Blending _blendMode, GLenum _drawMode)
-    : Style(_name, _blendMode, _drawMode, false) {}
+    : Style(_name, _blendMode, _drawMode, false) {
+    m_type = StyleType::debug;
+}
 
 void DebugStyle::constructVertexLayout() {
 

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -20,6 +20,7 @@ PointStyle::PointStyle(std::string _name, std::shared_ptr<FontContext> _fontCont
                        Blending _blendMode, GLenum _drawMode, bool _selection)
     : Style(_name, _blendMode, _drawMode, _selection) {
 
+    m_type = StyleType::point;
     m_textStyle = std::make_unique<TextStyle>(_name, _fontContext, true, _blendMode, _drawMode);
 }
 

--- a/core/src/style/pointStyle.cpp
+++ b/core/src/style/pointStyle.cpp
@@ -21,6 +21,8 @@ PointStyle::PointStyle(std::string _name, std::shared_ptr<FontContext> _fontCont
     : Style(_name, _blendMode, _drawMode, _selection) {
 
     m_type = StyleType::point;
+    m_lightingType = LightingType::none;
+
     m_textStyle = std::make_unique<TextStyle>(_name, _fontContext, true, _blendMode, _drawMode);
 }
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -50,8 +50,9 @@ struct PolygonVertex : PolygonVertexNoUVs {
 };
 
 PolygonStyle::PolygonStyle(std::string _name, Blending _blendMode, GLenum _drawMode, bool _selection)
-    : Style(_name, _blendMode, _drawMode, _selection)
-{}
+    : Style(_name, _blendMode, _drawMode, _selection) {
+    m_type = StyleType::polygon;
+}
 
 void PolygonStyle::constructVertexLayout() {
 

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -52,6 +52,7 @@ struct PolygonVertex : PolygonVertexNoUVs {
 PolygonStyle::PolygonStyle(std::string _name, Blending _blendMode, GLenum _drawMode, bool _selection)
     : Style(_name, _blendMode, _drawMode, _selection) {
     m_type = StyleType::polygon;
+    m_material.material = std::make_shared<Material>();
 }
 
 void PolygonStyle::constructVertexLayout() {

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -68,6 +68,7 @@ struct PolylineVertex : PolylineVertexNoUVs {
 PolylineStyle::PolylineStyle(std::string _name, Blending _blendMode, GLenum _drawMode, bool _selection)
     : Style(_name, _blendMode, _drawMode, _selection) {
     m_type = StyleType::polyline;
+    m_material.material = std::make_shared<Material>();
 }
 
 void PolylineStyle::constructVertexLayout() {

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -66,8 +66,9 @@ struct PolylineVertex : PolylineVertexNoUVs {
 };
 
 PolylineStyle::PolylineStyle(std::string _name, Blending _blendMode, GLenum _drawMode, bool _selection)
-    : Style(_name, _blendMode, _drawMode, _selection)
-{}
+    : Style(_name, _blendMode, _drawMode, _selection) {
+    m_type = StyleType::polyline;
+}
 
 void PolylineStyle::constructVertexLayout() {
 

--- a/core/src/style/rasterStyle.cpp
+++ b/core/src/style/rasterStyle.cpp
@@ -6,8 +6,8 @@
 namespace Tangram {
 
 RasterStyle::RasterStyle(std::string _name, Blending _blendMode, GLenum _drawMode)
-    : PolygonStyle(_name, _blendMode, _drawMode, false)
-{
+    : PolygonStyle(_name, _blendMode, _drawMode, false) {
+    m_type = StyleType::raster;
     m_rasterType = RasterType::color;
 }
 

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -75,7 +75,26 @@ void Style::build(const Scene& _scene) {
         }
     }
 
-    setupRasters(_scene.tileSources());
+    if (m_rasterType != RasterType::none) {
+        int numRasterSource = 0;
+        for (const auto& source : _scene.tileSources()) {
+            if (source->isRaster()) { numRasterSource++; }
+        }
+        if (numRasterSource > 0) {
+            // Inject shader defines for raster sampling and uniforms
+            if (m_rasterType == RasterType::normal) {
+                m_shaderSource->addSourceBlock("defines", "#define TANGRAM_RASTER_TEXTURE_NORMAL\n", false);
+            } else if (m_rasterType == RasterType::color) {
+                m_shaderSource->addSourceBlock("defines", "#define TANGRAM_RASTER_TEXTURE_COLOR\n", false);
+            }
+
+            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_NUM_RASTER_SOURCES "
+                                           + std::to_string(numRasterSource) + "\n", false);
+            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_MODEL_POSITION_BASE_ZOOM_VARYING\n", false);
+
+            m_shaderSource->addSourceBlock("raster", rasters_glsl);
+        }
+    }
 
     const auto& blocks = m_shaderSource->getSourceBlocks();
     if (blocks.find("color") != blocks.end() ||
@@ -184,37 +203,6 @@ void Style::setupSceneShaderUniforms(RenderState& rs, Scene& _scene, UniformBloc
         }
     }
 }
-
-void Style::setupRasters(const std::vector<std::shared_ptr<TileSource>>& _sources) {
-    if (!hasRasters()) {
-        return;
-    }
-
-    int numRasterSource = 0;
-    for (const auto& source : _sources) {
-        if (source->isRaster()) {
-            numRasterSource++;
-        }
-    }
-
-    if (numRasterSource == 0) {
-        return;
-    }
-
-    // Inject shader defines for raster sampling and uniforms
-    if (m_rasterType == RasterType::normal) {
-        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_RASTER_TEXTURE_NORMAL\n", false);
-    } else if (m_rasterType == RasterType::color) {
-        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_RASTER_TEXTURE_COLOR\n", false);
-    }
-
-    m_shaderSource->addSourceBlock("defines", "#define TANGRAM_NUM_RASTER_SOURCES "
-            + std::to_string(numRasterSource) + "\n", false);
-    m_shaderSource->addSourceBlock("defines", "#define TANGRAM_MODEL_POSITION_BASE_ZOOM_VARYING\n", false);
-
-    m_shaderSource->addSourceBlock("raster", rasters_glsl);
-}
-
 
 void Style::setupShaderUniforms(RenderState& rs, ShaderProgram& _program, const View& _view,
                                 Scene& _scene, UniformBlock& _uniforms) {

--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -24,9 +24,7 @@ Style::Style(std::string _name, Blending _blendMode, GLenum _drawMode, bool _sel
     m_shaderSource(std::make_unique<ShaderSource>()),
     m_blend(_blendMode),
     m_drawMode(_drawMode),
-    m_selection(_selection) {
-    m_material.material = std::make_shared<Material>();
-}
+    m_selection(_selection) {}
 
 Style::~Style() {}
 

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -315,8 +315,6 @@ public:
 
     virtual bool hasRasters() const { return m_rasterType != RasterType::none; }
 
-    void setupRasters(const std::vector<std::shared_ptr<TileSource>>& _sources);
-
     std::vector<StyleUniform>& styleUniforms() { return m_mainUniforms.styleUniforms; }
 
     void setDefaultDrawRule(std::unique_ptr<DrawRuleData>&& _rule);

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -161,8 +161,6 @@ protected:
 
     StyleType m_type = StyleType::none;
 
-private:
-
     struct UniformBlock {
         UniformLocation uTime{"u_time"};
         // View uniforms

--- a/core/src/style/style.h
+++ b/core/src/style/style.h
@@ -31,6 +31,16 @@ struct DrawRule;
 struct LightUniforms;
 struct MaterialUniforms;
 
+enum class StyleType : uint8_t {
+    none,
+    debug,
+    point,
+    polygon,
+    polyline,
+    raster,
+    text,
+};
+
 enum class LightingType : uint8_t {
     none,
     vertex,
@@ -149,6 +159,8 @@ protected:
 
     bool m_selection;
 
+    StyleType m_type = StyleType::none;
+
 private:
 
     struct UniformBlock {
@@ -201,6 +213,8 @@ public:
     Style(std::string _name, Blending _blendMode, GLenum _drawMode, bool _selection);
 
     virtual ~Style();
+
+    StyleType type() { return m_type; }
 
     static bool compare(std::unique_ptr<Style>& a, std::unique_ptr<Style>& b) {
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -19,7 +19,9 @@ namespace Tangram {
 TextStyle::TextStyle(std::string _name, std::shared_ptr<FontContext> _fontContext,
                      bool _sdf, Blending _blendMode, GLenum _drawMode, bool _selection)
     : Style(_name, _blendMode, _drawMode, _selection), m_sdf(_sdf),
-      m_context(_fontContext) {}
+      m_context(_fontContext) {
+    m_type = StyleType::text;
+  }
 
 TextStyle::~TextStyle() {}
 

--- a/core/src/style/textStyle.cpp
+++ b/core/src/style/textStyle.cpp
@@ -20,8 +20,10 @@ TextStyle::TextStyle(std::string _name, std::shared_ptr<FontContext> _fontContex
                      bool _sdf, Blending _blendMode, GLenum _drawMode, bool _selection)
     : Style(_name, _blendMode, _drawMode, _selection), m_sdf(_sdf),
       m_context(_fontContext) {
+
     m_type = StyleType::text;
-  }
+    m_lightingType = LightingType::none;
+}
 
 TextStyle::~TextStyle() {}
 


### PR DESCRIPTION
Further optimize applySourceBlocks() ￼
- write everything between #pragma: tangram in one batch
- preallocate shader source out with appropriate size

Don't add Light and Material shader blocks to Point- and TextStyles￼
- there is just no #pragma for them, so unnecessary to add these blocks
- now buildShaderSource usually overallocates nothing and always less than 1k in my tests

Cleanup: Move setupRaster function into Style::build()
- This 'setup' function was a bit out-of-line with the other 'setup' functions
  which do setup the style for rendering a frame - If we want to keep
  this as a separate function addRasterShaderBlocks would fit better

@matteblair I've added your commit just to avoid solving some merge conflicts again 