### PR TITLE
Use CMake source_group function to organize tangram-core files in Xcode

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -81,32 +81,6 @@ function(check_and_link_libraries TARGET)
     endforeach()
 endfunction(check_and_link_libraries)
 
-macro(group_recursive_sources CURDIR CURGROUP)
-    file(GLOB children ${CURDIR}/*)
-
-    foreach(child ${children})
-        if(IS_DIRECTORY ${child})
-            file(GLOB FOUND_HEADERS ${child}/*.h)
-            file(GLOB FOUND_SOURCES ${child}/*.cpp)
-            string(REGEX MATCH "([^/]+)$" group ${child})
-
-            if("${CURGROUP}" STREQUAL "")
-                source_group(${group} FILES ${FOUND_HEADERS} ${FOUND_SOURCES})
-            else()
-                source_group(${CURGROUP}/${group} FILES ${FOUND_HEADERS} ${FOUND_SOURCES})
-                set(group ${CURGROUP}/${group})
-            endif()
-
-            group_recursive_sources(${child} ${group})
-        endif()
-    endforeach()
-
-    # add files from top level group
-    file(GLOB FOUND_HEADERS ${CURGROUP}/*.h)
-    file(GLOB FOUND_SOURCES ${CURGROUP}/*.cpp)
-    source_group(${CURGROUP} FILES ${FOUND_HEADERS} ${FOUND_SOURCES})
-endmacro()
-
 macro(add_bundle_resources RESOURCE_LIST RESOURCE_DIR RESOURCE_BASE)
 
     file(GLOB_RECURSE FULL_RESOURCE_PATHS "${RESOURCE_DIR}/[^.]**")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,96 +4,194 @@ project(tangram-core)
 add_subdirectory(deps)
 
 add_library(tangram-core
+  include/tangram/log.h
+  include/tangram/map.h
+  include/tangram/platform.h
+  include/tangram/tangram.h
+  include/tangram/data/clientGeoJsonSource.h
+  include/tangram/data/properties.h
+  include/tangram/data/propertyItem.h
+  include/tangram/data/tileSource.h
+  include/tangram/tile/tileID.h
+  include/tangram/tile/tileTask.h
+  include/tangram/util/types.h
+  include/tangram/util/url.h
+  include/tangram/util/variant.h
   src/map.cpp
   src/platform.cpp
   src/data/clientGeoJsonSource.cpp
+  src/data/memoryCacheDataSource.h
   src/data/memoryCacheDataSource.cpp
+  src/data/networkDataSource.h
   src/data/networkDataSource.cpp
   src/data/properties.cpp
+  src/data/rasterSource.h
   src/data/rasterSource.cpp
   src/data/tileSource.cpp
+  src/data/formats/geoJson.h
   src/data/formats/geoJson.cpp
+  src/data/formats/mvt.h
   src/data/formats/mvt.cpp
+  src/data/formats/topoJson.h
   src/data/formats/topoJson.cpp
+  src/debug/frameInfo.h
   src/debug/frameInfo.cpp
+  src/debug/textDisplay.h
   src/debug/textDisplay.cpp
+  src/gl/framebuffer.h
   src/gl/framebuffer.cpp
+  src/gl/glError.h
   src/gl/glError.cpp
+  src/gl/glyphTexture.h
   src/gl/glyphTexture.cpp
+  src/gl/hardware.h
   src/gl/hardware.cpp
+  src/gl/mesh.h
   src/gl/mesh.cpp
+  src/gl/primitives.h
   src/gl/primitives.cpp
+  src/gl/renderState.h
   src/gl/renderState.cpp
+  src/gl/shaderProgram.h
   src/gl/shaderProgram.cpp
+  src/gl/shaderSource.h
   src/gl/shaderSource.cpp
+  src/gl/texture.h
   src/gl/texture.cpp
+  src/gl/vao.h
   src/gl/vao.cpp
+  src/gl/vertexLayout.h
   src/gl/vertexLayout.cpp
+  src/js/JavaScript.h
+  src/js/JavaScriptFwd.h
+  src/labels/curvedLabel.h
   src/labels/curvedLabel.cpp
+  src/labels/label.h
   src/labels/label.cpp
+  src/labels/labelCollider.h
   src/labels/labelCollider.cpp
+  src/labels/labelProperty.h
   src/labels/labelProperty.cpp
+  src/labels/labelSet.h
   src/labels/labelSet.cpp
+  src/labels/labels.h
   src/labels/labels.cpp
+  src/labels/spriteLabel.h
   src/labels/spriteLabel.cpp
+  src/labels/textLabel.h
   src/labels/textLabel.cpp
+  src/marker/marker.h
   src/marker/marker.cpp
+  src/marker/markerManager.h
   src/marker/markerManager.cpp
+  src/scene/ambientLight.h
   src/scene/ambientLight.cpp
+  src/scene/dataLayer.h
   src/scene/dataLayer.cpp
+  src/scene/directionalLight.h
   src/scene/directionalLight.cpp
+  src/scene/drawRule.h
   src/scene/drawRule.cpp
+  src/scene/filters.h
   src/scene/filters.cpp
+  src/scene/importer.h
   src/scene/importer.cpp
+  src/scene/light.h
   src/scene/light.cpp
+  src/scene/pointLight.h
   src/scene/pointLight.cpp
+  src/scene/scene.h
   src/scene/scene.cpp
+  src/scene/sceneLayer.h
   src/scene/sceneLayer.cpp
+  src/scene/sceneLoader.h
   src/scene/sceneLoader.cpp
+  src/scene/spotLight.h
   src/scene/spotLight.cpp
+  src/scene/spriteAtlas.h
   src/scene/spriteAtlas.cpp
+  src/scene/stops.h
   src/scene/stops.cpp
+  src/scene/styleContext.h
   src/scene/styleContext.cpp
+  src/scene/styleMixer.h
   src/scene/styleMixer.cpp
+  src/scene/styleParam.h
   src/scene/styleParam.cpp
+  src/selection/featureSelection.h
   src/selection/featureSelection.cpp
+  src/selection/selectionQuery.h
   src/selection/selectionQuery.cpp
+  src/style/debugStyle.h
   src/style/debugStyle.cpp
+  src/style/debugTextStyle.h
   src/style/debugTextStyle.cpp
+  src/style/material.h
   src/style/material.cpp
+  src/style/pointStyle.h
   src/style/pointStyle.cpp
+  src/style/pointStyleBuilder.h
   src/style/pointStyleBuilder.cpp
+  src/style/polygonStyle.h
   src/style/polygonStyle.cpp
+  src/style/polylineStyle.h
   src/style/polylineStyle.cpp
+  src/style/rasterStyle.h
   src/style/rasterStyle.cpp
+  src/style/style.h
   src/style/style.cpp
+  src/style/textStyle.h
   src/style/textStyle.cpp
+  src/style/textStyleBuilder.h
   src/style/textStyleBuilder.cpp
+  src/text/fontContext.h
   src/text/fontContext.cpp
+  src/text/textUtil.h
   src/text/textUtil.cpp
+  src/tile/tile.h
   src/tile/tile.cpp
+  src/tile/tileBuilder.h
   src/tile/tileBuilder.cpp
+  src/tile/tileManager.h
   src/tile/tileManager.cpp
   src/tile/tileTask.cpp
+  src/tile/tileWorker.h
   src/tile/tileWorker.cpp
+  src/util/builders.h
   src/util/builders.cpp
+  src/util/dashArray.h
   src/util/dashArray.cpp
+  src/util/extrude.h
   src/util/extrude.cpp
+  src/util/floatFormatter.h
   src/util/floatFormatter.cpp
+  src/util/geom.h
   src/util/geom.cpp
+  src/util/inputHandler.h
   src/util/inputHandler.cpp
+  src/util/jobQueue.h
   src/util/jobQueue.cpp
+  src/util/json.h
   src/util/json.cpp
+  src/util/mapProjection.h
   src/util/mapProjection.cpp
+  src/util/rasterize.h
   src/util/rasterize.cpp
   src/util/stbImage.cpp
   src/util/url.cpp
+  src/util/yamlPath.h
   src/util/yamlPath.cpp
+  src/util/yamlUtil.h
   src/util/yamlUtil.cpp
+  src/util/zipArchive.h
   src/util/zipArchive.cpp
+  src/util/zlibHelper.h
   src/util/zlibHelper.cpp
+  src/view/flyTo.h
   src/view/flyTo.cpp
+  src/view/view.h
   src/view/view.cpp
+  src/view/viewConstraint.h
   src/view/viewConstraint.cpp
 )
 
@@ -138,7 +236,7 @@ target_link_libraries(tangram-core
 
 # Add JavaScript implementation.
 if(TANGRAM_JSCORE_ENABLED)
-  target_sources(tangram-core PRIVATE src/js/JSCoreContext.cpp)
+  target_sources(tangram-core PRIVATE src/js/JSCoreContext.cpp src/js/JSCoreContext.h)
   if (TANGRAM_USE_JSCORE_STATIC)
     target_link_libraries(tangram-core PRIVATE jscore-static)
   else()
@@ -146,7 +244,7 @@ if(TANGRAM_JSCORE_ENABLED)
   endif()
   target_compile_definitions(tangram-core PRIVATE TANGRAM_USE_JSCORE=1)
 else()
-  target_sources(tangram-core PRIVATE src/js/DuktapeContext.cpp)
+  target_sources(tangram-core PRIVATE src/js/DuktapeContext.cpp src/js/DuktapeContext.h)
   target_link_libraries(tangram-core PRIVATE duktape)
 endif()
 
@@ -183,9 +281,6 @@ endif()
 target_compile_options(tangram-core
   PUBLIC -std=c++14
 )
-
-# make groups for xcode
-group_recursive_sources(src "src")
 
 # We include GLSL shader sources into the library by generating header files with the source text
 # printed into a string constant. A CMake script generates one of these headers for each shader source
@@ -231,3 +326,7 @@ foreach(_shader ${SHADER_FILES})
 endforeach()
 add_custom_target(shader-headers DEPENDS ${SHADER_OUTPUT_FILES})
 add_dependencies(tangram-core shader-headers)
+
+# Create source groups for Xcode.
+get_target_property(TANGRAM_CORE_SOURCES tangram-core SOURCES)
+source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${TANGRAM_CORE_SOURCES})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -327,6 +327,8 @@ endforeach()
 add_custom_target(shader-headers DEPENDS ${SHADER_OUTPUT_FILES})
 add_dependencies(tangram-core shader-headers)
 
-# Create source groups for Xcode.
-get_target_property(TANGRAM_CORE_SOURCES tangram-core SOURCES)
-source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${TANGRAM_CORE_SOURCES})
+if(CMAKE_VERSION VERSION_GREATER "3.8")
+  # Create source groups for Xcode - this source_group syntax requires version >=3.8
+  get_target_property(TANGRAM_CORE_SOURCES tangram-core SOURCES)
+  source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${TANGRAM_CORE_SOURCES})
+endif()


### PR DESCRIPTION
Requires listing all headers in tangram-core, but now Xcode can index header contents and match them with their cpp counterparts!