### PR TITLE
Fix RasterSource cache

### DIFF
--- a/core/include/tangram/data/clientGeoJsonSource.h
+++ b/core/include/tangram/data/clientGeoJsonSource.h
@@ -34,7 +34,7 @@ public:
     void generateLabelCentroidFeature();
 
     virtual void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
-    std::shared_ptr<TileTask> createTask(TileID _tileId, int _subTask) override;
+    std::shared_ptr<TileTask> createTask(TileID _tileId) override;
 
     virtual void cancelLoadingTile(TileTask& _task) override {};
     virtual void clearData() override;

--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -136,7 +136,9 @@ public:
     const auto& rasterSources() const { return m_rasterSources; }
 
     bool generateGeometry() const { return m_generateGeometry; }
-    void generateGeometry(bool generateGeometry) { m_generateGeometry = generateGeometry; }
+    virtual void generateGeometry(bool _generateGeometry) {
+        m_generateGeometry = _generateGeometry;
+    }
 
     /* Avoid RTTI by adding a boolean check on the data source object */
     virtual bool isRaster() const { return false; }

--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -12,6 +12,7 @@ namespace Tangram {
 struct TileData;
 struct TileID;
 struct Raster;
+class RasterSource;
 class Tile;
 class TileManager;
 struct RawCache;
@@ -110,7 +111,7 @@ public:
 
     const std::string& name() const { return m_name; }
 
-    virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask = -1);
+    virtual std::shared_ptr<TileTask> createTask(TileID _tile);
 
     /* ID of this TileSource instance */
     int32_t id() const { return m_id; }
@@ -144,7 +145,7 @@ public:
 
 protected:
 
-    void createSubTasks(std::shared_ptr<TileTask> _task);
+    void addRasterTasks(TileTask& _task);
 
     // This datasource is used to generate actual tile geometry
     // Is set true for any source assigned in a Scene Layer and when the layer is not disabled
@@ -165,7 +166,7 @@ protected:
     Format m_format = Format::GeoJson;
 
     /* vector of raster sources (as raster samplers) referenced by this datasource */
-    std::vector<std::shared_ptr<TileSource>> m_rasterSources;
+    std::vector<RasterSource*> m_rasterSources;
 
     std::unique_ptr<DataSource> m_sources;
 };

--- a/core/include/tangram/tile/tileTask.h
+++ b/core/include/tangram/tile/tileTask.h
@@ -22,7 +22,7 @@ class TileTask {
 
 public:
 
-    TileTask(TileID& _tileId, std::shared_ptr<TileSource> _source, int _subTask);
+    TileTask(TileID& _tileId, std::shared_ptr<TileSource> _source);
 
     // No copies
     TileTask(const TileTask& _other) = delete;
@@ -64,8 +64,6 @@ public:
     bool isProxy() const { return m_proxyState; }
 
     auto& subTasks() { return m_subTasks; }
-    int subTaskId() const { return m_subTaskId; }
-    bool isSubTask() const { return m_subTaskId >= 0; }
 
     // running on worker thread
     virtual void process(TileBuilder& _tileBuilder);
@@ -91,8 +89,6 @@ protected:
 
     const TileID m_tileId;
 
-    const int m_subTaskId;
-
     // Save shared reference to Datasource while building tile
     std::weak_ptr<TileSource> m_source;
 
@@ -115,8 +111,8 @@ protected:
 
 class BinaryTileTask : public TileTask {
 public:
-    BinaryTileTask(TileID& _tileId, std::shared_ptr<TileSource> _source, int _subTask)
-        : TileTask(_tileId, _source, _subTask) {}
+    BinaryTileTask(TileID& _tileId, std::shared_ptr<TileSource> _source)
+        : TileTask(_tileId, _source) {}
 
     virtual bool hasData() const override {
         return rawTileData && !rawTileData->empty();

--- a/core/src/data/clientGeoJsonSource.cpp
+++ b/core/src/data/clientGeoJsonSource.cpp
@@ -40,8 +40,8 @@ struct ClientGeoJsonData {
     std::vector<Properties> properties;
 };
 
-std::shared_ptr<TileTask> ClientGeoJsonSource::createTask(TileID _tileId, int _subTask) {
-    return std::make_shared<TileTask>(_tileId, shared_from_this(), _subTask);
+std::shared_ptr<TileTask> ClientGeoJsonSource::createTask(TileID _tileId) {
+    return std::make_shared<TileTask>(_tileId, shared_from_this());
 }
 
 

--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -68,12 +68,11 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
         if (task->isCanceled()) {
             return;
         }
+
         if (response.error) {
             LOGD("URL request '%s': %s", url.string().c_str(), response.error);
-            return;
-        }
 
-        if (!response.content.empty()) {
+        } else if (!response.content.empty()) {
             auto& dlTask = static_cast<BinaryTileTask&>(*task);
             dlTask.rawTileData = std::make_shared<std::vector<char>>(std::move(response.content));
         }

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -50,7 +50,7 @@ public:
         auto source = rasterSource();
         if (!source) { return; }
 
-        auto raster = source->getRaster(*this);
+        auto raster = source->addRaster(*this);
         assert(raster.isValid());
 
         m_tile->rasters().push_back(std::move(raster));
@@ -65,7 +65,7 @@ public:
         auto source = rasterSource();
         if (!source) { return; }
 
-        auto raster = source->getRaster(*this);
+        auto raster = source->addRaster(*this);
         assert(raster.isValid());
 
         _mainTask.tile()->rasters().push_back(std::move(raster));
@@ -150,7 +150,7 @@ std::shared_ptr<TileTask> RasterSource::createTask(TileID _tileId, int _subTask)
     return task;
 }
 
-Raster RasterSource::getRaster(const RasterTileTask& _task) {
+Raster RasterSource::addRaster(const RasterTileTask& _task) {
     const auto& tileId = _task.tileId();
     TileID id(tileId.x, tileId.y, tileId.z);
 

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -196,7 +196,7 @@ std::shared_ptr<Texture> RasterSource::cacheTexture(const TileID& _tileId, std::
     auto& textureEntry = (*m_textures)[id];
     auto texture = textureEntry.lock();
     if (texture) {
-        LOG("%d - drop duplicate %s", m_textures->size(), id.toString().c_str());
+        LOGD("%d - drop duplicate %s", m_textures->size(), id.toString().c_str());
         // The same texture has been loaded in the meantime: Reuse it and drop _texture..
         return texture;
     }
@@ -205,13 +205,13 @@ std::shared_ptr<Texture> RasterSource::cacheTexture(const TileID& _tileId, std::
                                        [c = std::weak_ptr<Cache>(m_textures), id](auto t) {
                                            if (auto cache = c.lock()) {
                                                cache->erase(id);
-                                               LOG("%d - remove %s", cache->size(), id.toString().c_str());
+                                               LOGD("%d - remove %s", cache->size(), id.toString().c_str());
                                            }
                                            delete t;
                                        });
     // Add to cache
     textureEntry = texture;
-    LOG("%d - added %s", m_textures->size(), id.toString().c_str());
+    LOGD("%d - added %s", m_textures->size(), id.toString().c_str());
 
     return texture;
 }

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -98,21 +98,27 @@ RasterSource::RasterSource(const std::string& _name, std::unique_ptr<DataSource>
     GLubyte pixel[4] = { 0, 0, 0, 0 };
     auto bpp = _options.bytesPerPixel();
     m_emptyTexture->setPixelData(1, 1, bpp, pixel, bpp);
+}
 
-    Feature rasterFeature;
-    rasterFeature.geometryType = GeometryType::polygons;
-    rasterFeature.polygons = { { {
-                {0.0f, 0.0f},
-                {1.0f, 0.0f},
-                {1.0f, 1.0f},
-                {0.0f, 1.0f},
-                {0.0f, 0.0f}
-            } } };
-    rasterFeature.props = Properties();
+void RasterSource::generateGeometry(bool _generateGeometry) {
+    m_generateGeometry = _generateGeometry;
 
-    m_tileData = std::make_shared<TileData>();
-    m_tileData->layers.emplace_back("");
-    m_tileData->layers.back().features.push_back(rasterFeature);
+    if (m_generateGeometry) {
+        Feature rasterFeature;
+        rasterFeature.geometryType = GeometryType::polygons;
+        rasterFeature.polygons = { { {
+                    {0.0f, 0.0f},
+                    {1.0f, 0.0f},
+                    {1.0f, 1.0f},
+                    {0.0f, 1.0f},
+                    {0.0f, 0.0f}
+                } } };
+        rasterFeature.props = Properties();
+
+        m_tileData = std::make_shared<TileData>();
+        m_tileData->layers.emplace_back("");
+        m_tileData->layers.back().features.push_back(rasterFeature);
+    }
 }
 
 std::unique_ptr<Texture> RasterSource::createTexture(TileID _tile, const std::vector<char>& _rawTileData) {

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -99,20 +99,22 @@ RasterSource::RasterSource(const std::string& _name, std::unique_ptr<DataSource>
     auto bpp = _options.bytesPerPixel();
     m_emptyTexture->setPixelData(1, 1, bpp, pixel, bpp);
 
-    Feature rasterFeature;
-    rasterFeature.geometryType = GeometryType::polygons;
-    rasterFeature.polygons = { { {
-                {0.0f, 0.0f},
-                {1.0f, 0.0f},
-                {1.0f, 1.0f},
-                {0.0f, 1.0f},
-                {0.0f, 0.0f}
-            } } };
-    rasterFeature.props = Properties();
+    if (m_generateGeometry) {
+        Feature rasterFeature;
+        rasterFeature.geometryType = GeometryType::polygons;
+        rasterFeature.polygons = { { {
+                    {0.0f, 0.0f},
+                    {1.0f, 0.0f},
+                    {1.0f, 1.0f},
+                    {0.0f, 1.0f},
+                    {0.0f, 0.0f}
+                } } };
+        rasterFeature.props = Properties();
 
-    m_tileData = std::make_shared<TileData>();
-    m_tileData->layers.emplace_back("");
-    m_tileData->layers.back().features.push_back(rasterFeature);
+        m_tileData = std::make_shared<TileData>();
+        m_tileData->layers.emplace_back("");
+        m_tileData->layers.back().features.push_back(rasterFeature);
+    }
 }
 
 std::unique_ptr<Texture> RasterSource::createTexture(TileID _tile, const std::vector<char>& _rawTileData) {

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -99,22 +99,20 @@ RasterSource::RasterSource(const std::string& _name, std::unique_ptr<DataSource>
     auto bpp = _options.bytesPerPixel();
     m_emptyTexture->setPixelData(1, 1, bpp, pixel, bpp);
 
-    if (m_generateGeometry) {
-        Feature rasterFeature;
-        rasterFeature.geometryType = GeometryType::polygons;
-        rasterFeature.polygons = { { {
-                    {0.0f, 0.0f},
-                    {1.0f, 0.0f},
-                    {1.0f, 1.0f},
-                    {0.0f, 1.0f},
-                    {0.0f, 0.0f}
-                } } };
-        rasterFeature.props = Properties();
+    Feature rasterFeature;
+    rasterFeature.geometryType = GeometryType::polygons;
+    rasterFeature.polygons = { { {
+                {0.0f, 0.0f},
+                {1.0f, 0.0f},
+                {1.0f, 1.0f},
+                {0.0f, 1.0f},
+                {0.0f, 0.0f}
+            } } };
+    rasterFeature.props = Properties();
 
-        m_tileData = std::make_shared<TileData>();
-        m_tileData->layers.emplace_back("");
-        m_tileData->layers.back().features.push_back(rasterFeature);
-    }
+    m_tileData = std::make_shared<TileData>();
+    m_tileData->layers.emplace_back("");
+    m_tileData->layers.back().features.push_back(rasterFeature);
 }
 
 std::unique_ptr<Texture> RasterSource::createTexture(TileID _tile, const std::vector<char>& _rawTileData) {

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -154,6 +154,10 @@ Raster RasterSource::getRaster(const RasterTileTask& _task) {
     const auto& tileId = _task.tileId();
     TileID id(tileId.x, tileId.y, tileId.z);
 
+    if (_task.m_texture == m_emptyTexture) {
+        return Raster{id, m_emptyTexture};
+    }
+
     auto entry = m_textures.emplace(id, _task.m_texture);
     std::shared_ptr<Texture> texture = entry.first->second;
     LOGD("Cache: add %d/%d/%d - reused: %d", id.x, id.y, id.z, !entry.second);

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -15,8 +15,8 @@ class RasterTileTask;
 
 class RasterSource : public TileSource {
 
-    using Cache = std::map<TileID, std::shared_ptr<Texture>>;
-    Cache m_textures;
+    using Cache = std::map<TileID, std::weak_ptr<Texture>>;
+    std::shared_ptr<Cache> m_textures;
 
     TextureOptions m_texOptions;
 
@@ -33,9 +33,11 @@ protected:
 
     void addRasterTask(TileTask& _tileTask);
 
-    std::shared_ptr<Texture> createTexture(TileID _tile, const std::vector<char>& _rawTileData);
+    std::unique_ptr<Texture> createTexture(TileID _tile, const std::vector<char>& _rawTileData);
 
-    Raster addRaster(const TileID& _tileId, std::shared_ptr<Texture> _texture);
+    std::shared_ptr<Texture> cacheTexture(const TileID& _tileId, std::unique_ptr<Texture> _texture);
+
+    std::shared_ptr<Texture> emptyTexture() { return m_emptyTexture; }
 
 public:
 

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -42,7 +42,7 @@ public:
 
     std::shared_ptr<Texture> createTexture(TileID _tile, const std::vector<char>& _rawTileData);
 
-    Raster getRaster(const RasterTileTask& _task);
+    Raster addRaster(const RasterTileTask& _task);
 
 };
 

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -45,13 +45,15 @@ public:
                  TextureOptions _options, TileSource::ZoomOptions _zoomOptions = {});
 
     // TODO Is this always PNG or can it also be JPEG?
-    virtual const char* mimeType() const override { return "image/png"; };
+    const char* mimeType() const override { return "image/png"; };
 
     void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
-    virtual std::shared_ptr<TileTask> createTask(TileID _tile) override;
+    std::shared_ptr<TileTask> createTask(TileID _tile) override;
 
-    virtual bool isRaster() const override { return true; }
+    bool isRaster() const override { return true; }
+
+    void generateGeometry(bool _generateGeometry) override;
 
 };
 

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -22,9 +22,20 @@ class RasterSource : public TileSource {
 
     std::shared_ptr<Texture> m_emptyTexture;
 
+    friend class RasterTileTask;
+    friend class TileSource;
 protected:
+    std::shared_ptr<TileData> m_tileData;
 
     std::shared_ptr<TileData> parse(const TileTask& _task) const override;
+
+    std::shared_ptr<RasterTileTask> createRasterTask(TileID _tileId, bool subTask);
+
+    void addRasterTask(TileTask& _tileTask);
+
+    std::shared_ptr<Texture> createTexture(TileID _tile, const std::vector<char>& _rawTileData);
+
+    Raster addRaster(const TileID& _tileId, std::shared_ptr<Texture> _texture);
 
 public:
 
@@ -36,13 +47,9 @@ public:
 
     void loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
-    virtual std::shared_ptr<TileTask> createTask(TileID _tile, int _subTask) override;
+    virtual std::shared_ptr<TileTask> createTask(TileID _tile) override;
 
     virtual bool isRaster() const override { return true; }
-
-    std::shared_ptr<Texture> createTexture(TileID _tile, const std::vector<char>& _rawTileData);
-
-    Raster addRaster(const RasterTileTask& _task);
 
 };
 

--- a/core/src/data/rasterSource.h
+++ b/core/src/data/rasterSource.h
@@ -15,8 +15,8 @@ class RasterTileTask;
 
 class RasterSource : public TileSource {
 
-    using Cache = std::map<TileID, std::weak_ptr<Texture>>;
-    std::shared_ptr<Cache> m_textures;
+    using Cache = std::map<TileID, std::shared_ptr<Texture>>;
+    Cache m_textures;
 
     TextureOptions m_texOptions;
 
@@ -42,7 +42,7 @@ public:
 
     std::shared_ptr<Texture> createTexture(TileID _tile, const std::vector<char>& _rawTileData);
 
-    Raster getRaster(const TileTask& _task);
+    Raster getRaster(const RasterTileTask& _task);
 
 };
 

--- a/core/src/data/tileSource.cpp
+++ b/core/src/data/tileSource.cpp
@@ -4,6 +4,7 @@
 #include "data/formats/mvt.h"
 #include "data/formats/topoJson.h"
 #include "data/tileData.h"
+#include "data/rasterSource.h"
 #include "platform.h"
 #include "tile/tileID.h"
 #include "tile/tile.h"
@@ -55,26 +56,18 @@ const char* TileSource::mimeType() const {
     return "";
 }
 
-std::shared_ptr<TileTask> TileSource::createTask(TileID _tileId, int _subTask) {
-    auto task = std::make_shared<BinaryTileTask>(_tileId, shared_from_this(), _subTask);
+std::shared_ptr<TileTask> TileSource::createTask(TileID _tileId) {
+    auto task = std::make_shared<BinaryTileTask>(_tileId, shared_from_this());
 
-    createSubTasks(task);
+    addRasterTasks(*task);
 
     return task;
 }
 
-void TileSource::createSubTasks(std::shared_ptr<TileTask> _task) {
-    size_t index = 0;
+void TileSource::addRasterTasks(TileTask& _task) {
 
-    for (auto& subSource : m_rasterSources) {
-        TileID subTileID = _task->tileId();
-
-        // get tile for lower zoom if we are past max zoom
-        if (subTileID.z > subSource->maxZoom()) {
-            subTileID = subTileID.withMaxSourceZoom(subSource->maxZoom());
-        }
-
-        _task->subTasks().push_back(subSource->createTask(subTileID, index++));
+    for (auto& source : m_rasterSources) {
+        source->addRasterTask(_task);
     }
 }
 
@@ -122,9 +115,12 @@ void TileSource::cancelLoadingTile(TileTask& _task) {
 }
 
 void TileSource::addRasterSource(std::shared_ptr<TileSource> _rasterSource) {
-    /*
-     * We limit the parent source by any attached raster source's min/max.
-     */
+    auto rasterSource = dynamic_cast<RasterSource*>(_rasterSource.get());
+    if (!rasterSource) {
+        assert(false);
+        return;
+    }
+    // We limit the parent source by any attached raster source's min/max.
     int32_t rasterMinDisplayZoom = _rasterSource->minDisplayZoom();
     int32_t rasterMaxDisplayZoom = _rasterSource->maxDisplayZoom();
     if (rasterMinDisplayZoom > m_zoomOptions.minDisplayZoom) {
@@ -133,7 +129,8 @@ void TileSource::addRasterSource(std::shared_ptr<TileSource> _rasterSource) {
     if (rasterMaxDisplayZoom < m_zoomOptions.maxDisplayZoom) {
         m_zoomOptions.maxDisplayZoom = rasterMaxDisplayZoom;
     }
-    m_rasterSources.push_back(_rasterSource);
+
+    m_rasterSources.push_back(rasterSource);
 }
 
 }

--- a/core/src/data/tileSource.cpp
+++ b/core/src/data/tileSource.cpp
@@ -115,9 +115,13 @@ void TileSource::cancelLoadingTile(TileTask& _task) {
 }
 
 void TileSource::addRasterSource(std::shared_ptr<TileSource> _rasterSource) {
+    if (!_rasterSource) {
+        LOGE("No raster source");
+        return;
+    }
     auto rasterSource = dynamic_cast<RasterSource*>(_rasterSource.get());
     if (!rasterSource) {
-        assert(false);
+        LOGE("Not a raster source: %s", _rasterSource->name().c_str());
         return;
     }
     // We limit the parent source by any attached raster source's min/max.

--- a/core/src/gl/texture.cpp
+++ b/core/src/gl/texture.cpp
@@ -174,17 +174,7 @@ void Texture::resize(int width, int height) {
 }
 
 size_t Texture::bpp() const {
-    switch (m_options.pixelFormat) {
-    case PixelFormat::ALPHA:
-    case PixelFormat::LUMINANCE:
-        return 1;
-    case PixelFormat::LUMINANCE_ALPHA:
-        return 2;
-    case PixelFormat::RGB:
-        return 3;
-    default:
-        return 4;
-    }
+    return m_options.bytesPerPixel();
 }
 
 bool Texture::sanityCheck(size_t _width, size_t _height, size_t _bytesPerPixel,

--- a/core/src/gl/texture.h
+++ b/core/src/gl/texture.h
@@ -46,6 +46,21 @@ struct TextureOptions {
     PixelFormat pixelFormat = PixelFormat::RGBA;
     float displayScale = 1.f; // 0.5 for a "@2x" image.
     bool generateMipmaps = false;
+
+    int bytesPerPixel() const {
+        switch (pixelFormat) {
+        case PixelFormat::ALPHA:
+        case PixelFormat::LUMINANCE:
+            return 1;
+        case PixelFormat::LUMINANCE_ALPHA:
+            return 2;
+        case PixelFormat::RGB:
+            return 3;
+        default:
+            break;
+        }
+        return 4;
+    }
 };
 
 class Texture {

--- a/core/src/tile/tileTask.cpp
+++ b/core/src/tile/tileTask.cpp
@@ -8,9 +8,8 @@
 
 namespace Tangram {
 
-TileTask::TileTask(TileID& _tileId, std::shared_ptr<TileSource> _source, int _subTask) :
+TileTask::TileTask(TileID& _tileId, std::shared_ptr<TileSource> _source) :
     m_tileId(_tileId),
-    m_subTaskId(_subTask),
     m_source(_source),
     m_sourceId(_source->id()),
     m_sourceGeneration(_source->generation()),

--- a/tests/unit/tileManagerTests.cpp
+++ b/tests/unit/tileManagerTests.cpp
@@ -76,8 +76,8 @@ struct TestTileSource : TileSource {
     public:
         bool gotData = false;
 
-        Task(TileID& _tileId, std::shared_ptr<TileSource> _source, bool _subTask)
-            : TileTask(_tileId, _source, _subTask) {}
+        Task(TileID& _tileId, std::shared_ptr<TileSource> _source)
+            : TileTask(_tileId, _source) {}
 
         bool hasData() const override { return gotData; }
     };
@@ -103,8 +103,8 @@ struct TestTileSource : TileSource {
 
     void clearData() override {}
 
-    std::shared_ptr<TileTask> createTask(TileID _tileId, int _subTask) override {
-        return std::make_shared<Task>(_tileId, shared_from_this(), _subTask);
+    std::shared_ptr<TileTask> createTask(TileID _tileId) override {
+        return std::make_shared<Task>(_tileId, shared_from_this());
     }
 };
 


### PR DESCRIPTION
In createTexture() Textures that may not be added to the
  cache later (in getRaster) held a deleter which removed
  their tileId from the cache, leading to invalid rasters. 

Instead now it clears the cache by checking whether the cache
  is the only one holding references to a texture in getRaster()

`Style::draw()`:
  - fix: when tile->rasters are empty uniforms should be set accordingly
  - cleanup: Rasters must be valid - asserted in ´RasterTileTask::complete()´ 
 
Edit: The flickering of hillshade happened from a combination of wrongly invalidated Rasters
and not unsetting the style uniforms.

Edit: The RasterSource cache can still be improved, ~currently it does not remove entries for emptyTexture~. I'll work on this in a follow up PR.
