### PR TITLE
Fix: old bug in clearTileSets() / TileManager shutdown

### DIFF
--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -59,12 +59,12 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
     }
 
     UrlCallback onRequestFinish = [callback, task, url](UrlResponse&& response) {
-        if (task->isCanceled()) {
-            return;
-        }
         auto source = task->source();
         if (!source) {
             LOGW("URL Callback for deleted TileSource '%s'", url.string().c_str());
+            return;
+        }
+        if (task->isCanceled()) {
             return;
         }
         if (response.error) {

--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -59,13 +59,12 @@ bool NetworkDataSource::loadTileData(std::shared_ptr<TileTask> task, TileTaskCb 
     }
 
     UrlCallback onRequestFinish = [callback, task, url](UrlResponse&& response) {
-
+        if (task->isCanceled()) {
+            return;
+        }
         auto source = task->source();
         if (!source) {
             LOGW("URL Callback for deleted TileSource '%s'", url.string().c_str());
-            return;
-        }
-        if (task->isCanceled()) {
             return;
         }
         if (response.error) {

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -118,6 +118,9 @@ Map::Map(std::shared_ptr<Platform> _platform) : platform(_platform) {
 }
 
 Map::~Map() {
+
+    impl->tileManager.clearTileSets();
+
     // The unique_ptr to Impl will be automatically destroyed when Map is destroyed.
     impl->tileWorker.stop();
     impl->asyncWorker.reset();

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -78,6 +78,7 @@ protected:
     struct TileSet {
         TileSet(std::shared_ptr<TileSource> _source, bool _clientSource);
         ~TileSet();
+        void cancelTasks();
 
         std::shared_ptr<TileSource> source;
 


### PR DESCRIPTION
- cancel fetching of TileTasks in progress
- no more warnings about callback for deleted DataSource