### PR TITLE
Expose CADisplayLink property

### DIFF
--- a/platforms/ios/framework/src/TGMapView.h
+++ b/platforms/ios/framework/src/TGMapView.h
@@ -349,6 +349,14 @@ TG_EXPORT
 @property (assign, nonatomic) NSInteger preferredFramesPerSecond;
 
 /**
+ The CADisplayLink used by the renderer. Exposed mostly for the ability to pause/unpause rendering without having to initiate a scene update, as animations defined within the stylesheet force a continuous rendering regardless of the `continuous` setting defined in code.
+ 
+ @note This property is manipulated by the rendering subsystem depending on lifecycle events coming from the OS as well as certain events within Tangram itself. As such, do not expect your manipulation of individual settings (such as `paused`) to be long lived. An example of this is setting displayLink.paused to YES, then backgrounding and foregrounding the app. Tangram will respond to the OS lifecycle events and pause/unpause the map rendering, respectively, thereby overriding your setting. This is intended functionality and will not be changed.
+ @note This property, even though it is marked NS_ASSUME_NONNULL at the top of the header, *will be nil* until the view is added to some kind of view hierarchy (window or subview). In a future PR we should clean up this assumption, but until then, you have been warned :)
+ */
+@property (strong, nonatomic, readonly) CADisplayLink *displayLink;
+
+/**
  If `continuous` is `YES`, the map view will re-draw continuously. Otherwise, the map will re-draw only when an event
  changes the map view.
 

--- a/platforms/ios/framework/src/TGMapView.h
+++ b/platforms/ios/framework/src/TGMapView.h
@@ -349,10 +349,19 @@ TG_EXPORT
 @property (assign, nonatomic) NSInteger preferredFramesPerSecond;
 
 /**
- The CADisplayLink used by the renderer. Exposed mostly for the ability to pause/unpause rendering without having to initiate a scene update, as animations defined within the stylesheet force a continuous rendering regardless of the `continuous` setting defined in code.
+ The CADisplayLink used by the renderer. Exposed mostly for the ability to pause/unpause rendering without having to initiate
+ a scene update, as animations defined within the stylesheet force a continuous rendering regardless of the `continuous`
+ setting defined in code.
  
- @note This property is manipulated by the rendering subsystem depending on lifecycle events coming from the OS as well as certain events within Tangram itself. As such, do not expect your manipulation of individual settings (such as `paused`) to be long lived. An example of this is setting displayLink.paused to YES, then backgrounding and foregrounding the app. Tangram will respond to the OS lifecycle events and pause/unpause the map rendering, respectively, thereby overriding your setting. This is intended functionality and will not be changed.
- @note This property, even though it is marked NS_ASSUME_NONNULL at the top of the header, *will be nil* until the view is added to some kind of view hierarchy (window or subview). In a future PR we should clean up this assumption, but until then, you have been warned :)
+ @note This property is manipulated by the rendering subsystem depending on lifecycle events coming from the OS as well as
+ certain events within Tangram itself. As such, do not expect your manipulation of individual settings (such as `paused`) to
+ be long lived. An example of this is setting displayLink.paused to YES, then backgrounding and foregrounding the app. Tangram
+ will respond to the OS lifecycle events and pause/unpause the map rendering, respectively, thereby overriding your setting.
+ This is intended functionality and will not be changed.
+ 
+ @note This property, even though it is marked NS_ASSUME_NONNULL at the top of the header, *will be nil* until the view is
+ added to some kind of view hierarchy (window or subview). In a future PR we should clean up this assumption, but until then,
+ you have been warned :)
  */
 @property (strong, nonatomic, readonly) CADisplayLink *displayLink;
 

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -72,6 +72,8 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeState) {
 
 @implementation TGMapView
 
+@synthesize displayLink = _displayLink;
+
 #pragma mark Lifecycle Methods
 
 - (instancetype)initWithFrame:(CGRect)frame


### PR DESCRIPTION
@matteblair / @tallytalwar / @karimnaaji PTAL!

This exposes a read-only access to the underlying CADisplayLink property that the iOS Tangram-es SDK uses for synchronizing drawing to display refresh.

*Reasoning*

Currently, when an animation of some kind is defined in a stylesheet, tangram-es will render that animation continuously regardless of whether or not the `continuous` property is set to `NO`. Tangram currently correctly handles pausing/unpausing rendering for OS lifecycle events, but there are other times when developers might want to pause / unpause rendering, for example when a modal view is displayed over top of the map, or the need to respond to one of the iOS view controller lifecycle events such as `viewWillDisappear:`. 

In some of these scenarios, we could utilize a scene update to disable the animations, but that causes a re-render to occur and will cause the map to flicker twice, once when disabling and once when re-enabling.