### PR TITLE
View's zoom should ALWAYS respect zoom constrain

### DIFF
--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -244,7 +244,7 @@ protected:
     float m_pitch = 0.f;
 
     float m_zoom = 0.f;
-    float m_constrainZoom = 0.f;
+    float m_constrainMinZoom = 0.f;
 
     float m_width;
     float m_height;

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -96,6 +96,9 @@ public:
     // Get the maximum pitch angle for the current zoom, in degrees.
     float getMaxPitch() const;
 
+    // Sets constrainToWorldBounds for view to aptly respect m_constrainToWorldBounds
+    void setConstrainToWorldBounds(bool constrainToWorldBounds);
+
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
      * If unset, default is 1.0
      */
@@ -145,7 +148,7 @@ public:
     float getPitch() const { return m_pitch; }
 
     /* Updates the view and projection matrices if properties have changed */
-    void update(bool _constrainToWorldBounds = true);
+    void update();
 
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
     const glm::dvec3& getPosition() const { return m_pos; }
@@ -241,6 +244,7 @@ protected:
     float m_pitch = 0.f;
 
     float m_zoom = 0.f;
+    float m_constrainZoom = 0.f;
 
     float m_width;
     float m_height;
@@ -258,7 +262,9 @@ protected:
 
     bool m_dirtyMatrices;
     bool m_dirtyTiles;
+    bool m_dirtyConstraint;
     bool m_changed;
+    bool m_constrainToWorldBounds = true;
 
 };
 

--- a/tests/unit/flyToTest.cpp
+++ b/tests/unit/flyToTest.cpp
@@ -11,8 +11,8 @@ const static double nearZero = 0.00000001;
 View getView() {
     View view(1000, 1000);
     view.setPosition(0, 0);
-    view.setZoom(0);
     view.setConstrainToWorldBounds(false);
+    view.setZoom(0);
     view.update();
     return view;
 }

--- a/tests/unit/flyToTest.cpp
+++ b/tests/unit/flyToTest.cpp
@@ -12,7 +12,8 @@ View getView() {
     View view(1000, 1000);
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update(false);
+    view.setConstrainToWorldBounds(false);
+    view.update();
     return view;
 }
 

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -45,8 +45,8 @@ View makeView() {
     View view(256, 256);
 
     view.setPosition(0, 0);
-    view.setZoom(0);
     view.setConstrainToWorldBounds(false);
+    view.setZoom(0);
     view.update();
 
     return view;

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -46,7 +46,8 @@ View makeView() {
 
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update(false);
+    view.setConstrainToWorldBounds(false);
+    view.update();
 
     return view;
 }

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -105,8 +105,8 @@ TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
 
     View view(256, 256);
     view.setPosition(0, 0);
-    view.setZoom(0);
     view.setConstrainToWorldBounds(false);
+    view.setZoom(0);
     view.update();
 
     Tile tile({0,0,0});

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -106,7 +106,8 @@ TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
     View view(256, 256);
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update(false);
+    view.setConstrainToWorldBounds(false);
+    view.update();
 
     Tile tile({0,0,0});
     tile.update(0, view);


### PR DESCRIPTION
- Previous a client could set a zoom (< constrained min zoom) which gets updated in the next update cycle. But any call to `getZoom` before this update cycle would result in unconstrained zoom value to be passed to client code.
- Only calculate constrained min zoom when view's aspect ratio changes
- Provide a setter for view constrained (removed parameterized view.update() method)

FYI @msmollin 