### PR TITLE
Apply view constraint immediately when setting position or zoom

### DIFF
--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -38,7 +38,7 @@ void View::setPixelScale(float _pixelsPerPoint) {
     m_pixelScale = _pixelsPerPoint;
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
-    m_dirtyConstraint = true;
+    m_dirtyWorldBoundsMinZoom = true;
 
 }
 
@@ -70,7 +70,7 @@ void View::setSize(int _width, int _height) {
     m_aspect = (float)m_vpWidth/ (float)m_vpHeight;
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
-    m_dirtyConstraint = true;
+    m_dirtyWorldBoundsMinZoom = true;
 
     // Screen space orthographic projection matrix, top left origin, y pointing down
     m_orthoViewport = glm::ortho(0.f, (float)m_vpWidth, (float)m_vpHeight, 0.f, -1.f, 1.f);
@@ -167,10 +167,10 @@ float View::getMaxPitch() const {
 
 void View::setConstrainToWorldBounds(bool constrainToWorldBounds) {
 
-    m_constraintMinZoom = 0.f;
+    m_worldBoundsMinZoom = 0.f;
     m_constrainToWorldBounds = constrainToWorldBounds;
     if (m_constrainToWorldBounds) {
-        applyConstraint();
+        applyWorldBounds();
     }
 
 }
@@ -182,12 +182,7 @@ void View::setPosition(double _x, double _y) {
     m_pos.y = glm::clamp(_y, -MapProjection::EARTH_HALF_CIRCUMFERENCE_METERS, MapProjection::EARTH_HALF_CIRCUMFERENCE_METERS);
     m_dirtyTiles = true;
     if (m_constrainToWorldBounds) {
-        if (m_dirtyConstraint) {
-            applyConstraint();
-        } else {
-            m_pos.x = m_constraint.getConstrainedX(m_pos.x);
-            m_pos.y = m_constraint.getConstrainedY(m_pos.y);
-        }
+        applyWorldBounds();
     }
 }
 
@@ -202,11 +197,7 @@ void View::setZoom(float _z) {
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
     if (m_constrainToWorldBounds) {
-        if (m_dirtyConstraint) {
-            applyConstraint();
-        } else if (m_zoom < m_constraintMinZoom) {
-            m_zoom = m_constraintMinZoom;
-        }
+        applyWorldBounds();
     }
 }
 
@@ -255,19 +246,21 @@ LngLat View::getCenterCoordinates() const {
     return center;
 }
 
-void View::applyConstraint() {
+void View::applyWorldBounds() {
     // Approximate the view diameter in pixels by taking the maximum dimension.
     double viewDiameterPixels = std::fmax(getWidth(), getHeight()) / pixelScale();
-    // Approximate the minimum zoom that keeps with view span within the drawable projection area. [1]
-    m_constraintMinZoom = std::log(viewDiameterPixels / MapProjection::tileSize() + 2) / std::log(2);
-    if (m_zoom < m_constraintMinZoom) {
-        m_zoom = m_constraintMinZoom;
+    if (m_dirtyWorldBoundsMinZoom) {
+        // Approximate the minimum zoom that keeps with view span within the drawable projection area. [1]
+        m_worldBoundsMinZoom = static_cast<float>(std::log(viewDiameterPixels / MapProjection::tileSize() + 2) / std::log(2));
+        m_dirtyWorldBoundsMinZoom = false;
+    }
+    if (m_zoom < m_worldBoundsMinZoom) {
+        m_zoom = m_worldBoundsMinZoom;
     }
     // Constrain by moving map center to keep view in bounds.
     m_constraint.setRadius(0.5 * viewDiameterPixels / pixelsPerMeter());
     m_pos.x = m_constraint.getConstrainedX(m_pos.x);
     m_pos.y = m_constraint.getConstrainedY(m_pos.y);
-    m_dirtyConstraint = false;
 }
 
 void View::update() {

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -163,12 +163,24 @@ float View::getMaxPitch() const {
 
 }
 
+void View::setConstrainToWorldBounds(bool constrainToWorldBounds) {
+
+    m_constrainToWorldBounds = constrainToWorldBounds;
+    if (m_constrainToWorldBounds) {
+        applyConstraint();
+    }
+
+}
+
 void View::setPosition(double _x, double _y) {
     // Wrap horizontal position around the 180th meridian, which corresponds to +/- HALF_CIRCUMFERENCE meters.
     m_pos.x = _x - std::round(_x / MapProjection::EARTH_CIRCUMFERENCE_METERS) * MapProjection::EARTH_CIRCUMFERENCE_METERS;
     // Clamp vertical position to the span of the map, which is +/- HALF_CIRCUMFERENCE meters.
     m_pos.y = glm::clamp(_y, -MapProjection::EARTH_HALF_CIRCUMFERENCE_METERS, MapProjection::EARTH_HALF_CIRCUMFERENCE_METERS);
     m_dirtyTiles = true;
+    if (m_constrainToWorldBounds) {
+        applyConstraint();
+    }
 }
 
 void View::setCenterCoordinates(Tangram::LngLat center) {
@@ -181,6 +193,9 @@ void View::setZoom(float _z) {
     m_zoom = glm::clamp(_z, m_minZoom, m_maxZoom);
     m_dirtyMatrices = true;
     m_dirtyTiles = true;
+    if (m_constrainToWorldBounds) {
+        applyConstraint();
+    }
 }
 
 void View::setRoll(float _roll) {
@@ -228,23 +243,23 @@ LngLat View::getCenterCoordinates() const {
     return center;
 }
 
-void View::update(bool _constrainToWorldBounds) {
+void View::applyConstraint() {
+    // Approximate the view diameter in pixels by taking the maximum dimension.
+    double viewDiameterPixels = std::fmax(getWidth(), getHeight()) / pixelScale();
+    // Approximate the minimum zoom that keeps with view span within the drawable projection area. [1]
+    double minZoom = std::log(viewDiameterPixels / MapProjection::tileSize() + 2) / std::log(2);
+    if (m_zoom < minZoom) {
+        m_zoom = static_cast<float>(minZoom);
+    }
+    // Constrain by moving map center to keep view in bounds.
+    m_constraint.setRadius(0.5 * viewDiameterPixels / pixelsPerMeter());
+    m_pos.x = m_constraint.getConstrainedX(m_pos.x);
+    m_pos.y = m_constraint.getConstrainedY(m_pos.y);
+}
+
+void View::update() {
 
     m_changed = false;
-
-    if (_constrainToWorldBounds) {
-        // Approximate the view diameter in pixels by taking the maximum dimension.
-        double viewDiameterPixels = std::fmax(getWidth(), getHeight()) / pixelScale();
-        // Approximate the minimum zoom that keeps with view span within the drawable projection area. [1]
-        double minZoom = std::log(viewDiameterPixels / MapProjection::tileSize() + 2) / std::log(2);
-        if (m_zoom < minZoom) {
-            m_zoom = static_cast<float>(minZoom);
-        }
-        // Constrain by moving map center to keep view in bounds.
-        m_constraint.setRadius(0.5 * viewDiameterPixels / pixelsPerMeter());
-        m_pos.x = m_constraint.getConstrainedX(m_pos.x);
-        m_pos.y = m_constraint.getConstrainedY(m_pos.y);
-    }
 
     // Ensure valid pitch angle.
     {

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -96,6 +96,9 @@ public:
     // Get the maximum pitch angle for the current zoom, in degrees.
     float getMaxPitch() const;
 
+    // Whether to constrain visible area to the projected bounds of the world.
+    void setConstrainToWorldBounds(bool constrainToWorldBounds);
+
     /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
      * If unset, default is 1.0
      */
@@ -145,7 +148,7 @@ public:
     float getPitch() const { return m_pitch; }
 
     /* Updates the view and projection matrices if properties have changed */
-    void update(bool _constrainToWorldBounds = true);
+    void update();
 
     /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
     const glm::dvec3& getPosition() const { return m_pos; }
@@ -217,6 +220,8 @@ protected:
 
     void updateMatrices();
 
+    void applyConstraint();
+
     double screenToGroundPlaneInternal(double& _screenX, double& _screenY) const;
 
     std::shared_ptr<Stops> m_fovStops;
@@ -259,6 +264,7 @@ protected:
     bool m_dirtyMatrices;
     bool m_dirtyTiles;
     bool m_changed;
+    bool m_constrainToWorldBounds = true;
 
 };
 

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -243,6 +243,7 @@ protected:
     float m_pitch = 0.f;
 
     float m_zoom = 0.f;
+    float m_constraintMinZoom = 0.f;
 
     float m_width;
     float m_height;
@@ -260,6 +261,7 @@ protected:
 
     bool m_dirtyMatrices;
     bool m_dirtyTiles;
+    bool m_dirtyConstraint;
     bool m_changed;
     bool m_constrainToWorldBounds = true;
 

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -31,11 +31,10 @@ struct ViewState {
     float tileSize;
 };
 
-/* View
- * 1. Stores a representation of the current view into the map world
- * 2. Determines which tiles are visible in the current view
- * 3. Tracks changes in the view state to determine when new rendering is needed
-*/
+// View
+// 1. Stores a representation of the current view into the map world
+// 2. Determines which tiles are visible in the current view
+// 3. Tracks changes in the view state to determine when new rendering is needed
 
 class View {
 
@@ -99,101 +98,99 @@ public:
     // Whether to constrain visible area to the projected bounds of the world.
     void setConstrainToWorldBounds(bool constrainToWorldBounds);
 
-    /* Sets the ratio of hardware pixels to logical pixels (for high-density screens)
-     * If unset, default is 1.0
-     */
+    // Set the ratio of hardware pixels to logical pixels. Default is 1.0.
     void setPixelScale(float _pixelsPerPoint);
 
-    /* Sets the size of the viewable area in pixels */
+    // Set the size of the viewable area in pixel.
     void setSize(int _width, int _height);
 
-    /* Sets the position of the view within the world (in projection units) */
+    // Set the position of the view within the world in projected meters.
     void setPosition(double _x, double _y);
     void setPosition(const glm::dvec3 pos) { setPosition(pos.x, pos.y); }
     void setPosition(const glm::dvec2 pos) { setPosition(pos.x, pos.y); }
 
     void setCenterCoordinates(LngLat center);
 
-    /* Sets the zoom level of the view */
+    // Set the zoom level of the view.
     void setZoom(float _z);
 
-    /* Sets the roll angle of the view in radians (default is 0) */
+    // Set the roll angle of the view in radians. Default is 0.
     void setRoll(float _rad);
 
-    /* Sets the pitch angle of the view in radians (default is 0) */
+    // Set the pitch angle of the view in radians. Default is 0.
     void setPitch(float _rad);
 
-    /* Moves the position of the view */
+    // Move the position of the view in projected meters.
     void translate(double _dx, double _dy);
 
-    /* Changes zoom by the given amount */
+    // Change zoom by the given amount.
     void zoom(float _dz);
 
-    /* Changes the roll angle by the given amount in radians */
+    // Change the roll angle by the given amount in radians.
     void roll(float _drad);
 
-    /* Changes the pitch angle by the given amount in radians */
+    // Change the pitch angle by the given amount in radians.
     void pitch(float _drad);
 
-    /* Gets the current zoom */
+    // Get the current zoom.
     float getZoom() const { return m_zoom; }
 
-    /* Get the current zoom truncated to an integer. This is the zoom used to determine visible tiles. */
+    // Get the current zoom truncated to an integer. This is the zoom used to determine visible tiles.
     int getIntegerZoom() const { return static_cast<int>(m_zoom); }
 
-    /* Get the current roll angle in radians */
+    // Get the current roll angle in radians.
     float getRoll() const { return m_roll; }
 
-    /* Get the current pitch angle in radians */
+    // Get the current pitch angle in radians.
     float getPitch() const { return m_pitch; }
 
-    /* Updates the view and projection matrices if properties have changed */
+    // Update the view and projection matrices if properties have changed.
     void update();
 
-    /* Gets the position of the view in projection units (z is the effective 'height' determined from zoom) */
+    // Get the position of the view in projection units (z is the effective 'height' determined from zoom).
     const glm::dvec3& getPosition() const { return m_pos; }
 
+    // Get the coordinates of the point at the center of the view.
     LngLat getCenterCoordinates() const;
 
-    /* Gets the transformation from global space into view (camera) space; Due to precision limits, this
-       does not contain the translation of the view from the global origin (you must apply that separately) */
+    // Get the transformation from global space into view (camera) space; Due to precision limits, this
+    // does not contain the translation of the view from the global origin (you must apply that separately).
     const glm::mat4& getViewMatrix() const { return m_view; }
 
-    /* Gets the transformation from view space into screen space */
+    // Get the transformation from view space into screen space.
     const glm::mat4& getProjectionMatrix() const { return m_proj; }
 
-    /* Gets the combined view and projection transformation */
+    // Get the combined view and projection transformation.
     const glm::mat4 getViewProjectionMatrix() const { return m_viewProj; }
 
-    /* Gets the normal matrix; transforms surface normals from model space to camera space */
+    // Get the normal matrix; transforms surface normals from model space to camera space.
     const glm::mat3& getNormalMatrix() const { return m_normalMatrix; }
 
     const glm::mat3& getInverseNormalMatrix() const { return m_invNormalMatrix; }
 
-    /* Returns the eye position in world space */
+    // Get the eye position in world space.
     const glm::vec3& getEye() const { return m_eye; }
 
-    /* Returns the window coordinates [0,1], lower left corner of the window is (0, 0) */
+    // Get the window coordinates [0,1], lower left corner of the window is (0, 0).
     glm::vec2 normalizedWindowCoordinates(float _x, float _y) const;
 
     ViewState state() const;
 
-    /* Returns a rectangle of the current view range as [[x_min, y_min], [x_max, y_max]] */
+    // Get a rectangle of the current view range as [[x_min, y_min], [x_max, y_max]].
     glm::dmat2 getBoundsRect() const;
 
     float getWidth() const { return m_vpWidth; }
 
     float getHeight() const { return m_vpHeight; }
 
-    /* Calculate the position on the ground plane (z = 0) under the given screen space coordinates,
-     * replacing the input coordinates with world-space coordinates
-     * @return the un-normalized distance 'into the screen' to the ground plane
-     * (if < 0, intersection is behind the screen)
-     */
+    // Calculate the position on the ground plane (z = 0) under the given screen space coordinates,
+    // replacing the input coordinates with world-space coordinates.
+    // Returns the un-normalized distance 'into the screen' to the ground plane
+    // (if < 0, intersection is behind the screen).
     double screenToGroundPlane(float& _screenX, float& _screenY);
     double screenToGroundPlane(double& _screenX, double& _screenY);
 
-    /* Gets the screen position from a latitude/longitude */
+    // Get the screen position from a latitude/longitude.
     glm::vec2 lngLatToScreenPosition(double lng, double lat, bool& clipped);
 
     LngLat screenPositionToLngLat(float x, float y, bool& intersection);
@@ -202,10 +199,10 @@ public:
     // position, accounting for wrapping around the 180th meridian to get the smallest magnitude displacement.
     glm::dvec2 getRelativeMeters(glm::dvec2 projectedMeters) const;
 
-    /* Returns the set of all tiles visible at the current position and zoom */
+    // Get the set of all tiles visible at the current position and zoom.
     void getVisibleTiles(const std::function<void(TileID)>& _tileCb) const;
 
-    /* Returns true if the view properties have changed since the last call to update() */
+    // Returns true if the view properties have changed since the last call to update().
     bool changedOnLastUpdate() const { return m_changed; }
 
     const glm::mat4& getOrthoViewportMatrix() const { return m_orthoViewport; };

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -217,7 +217,7 @@ protected:
 
     void updateMatrices();
 
-    void applyConstraint();
+    void applyWorldBounds();
 
     double screenToGroundPlaneInternal(double& _screenX, double& _screenY) const;
 
@@ -243,7 +243,7 @@ protected:
     float m_pitch = 0.f;
 
     float m_zoom = 0.f;
-    float m_constraintMinZoom = 0.f;
+    float m_worldBoundsMinZoom = 0.f;
 
     float m_width;
     float m_height;
@@ -261,7 +261,7 @@ protected:
 
     bool m_dirtyMatrices;
     bool m_dirtyTiles;
-    bool m_dirtyConstraint;
+    bool m_dirtyWorldBoundsMinZoom;
     bool m_changed;
     bool m_constrainToWorldBounds = true;
 

--- a/tests/unit/flyToTest.cpp
+++ b/tests/unit/flyToTest.cpp
@@ -10,9 +10,10 @@ const static double nearZero = 0.00000001;
 
 View getView() {
     View view(1000, 1000);
+    view.setConstrainToWorldBounds(false);
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update(false);
+    view.update();
     return view;
 }
 

--- a/tests/unit/labelTests.cpp
+++ b/tests/unit/labelTests.cpp
@@ -43,10 +43,10 @@ TextLabel makeLabel(glm::vec2 _transform, Label::Type _type) {
 
 View makeView() {
     View view(256, 256);
-
+    view.setConstrainToWorldBounds(false);
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update(false);
+    view.update();
 
     return view;
 }

--- a/tests/unit/labelsTests.cpp
+++ b/tests/unit/labelsTests.cpp
@@ -104,9 +104,10 @@ TEST_CASE("Test getFeaturesAtPoint", "[Labels][FeaturePicking]") {
 TEST_CASE( "Test anchor fallback behavior", "[Labels][AnchorFallback]" ) {
 
     View view(256, 256);
+    view.setConstrainToWorldBounds(false);
     view.setPosition(0, 0);
     view.setZoom(0);
-    view.update(false);
+    view.update();
 
     Tile tile({0,0,0});
     tile.update(0, view);


### PR DESCRIPTION
See also https://github.com/tangrams/tangram-es/pull/1996

Previously a View could have a position/zoom assigned that violated the world bounds constraint until the subsequent `update()` call. This change ensures that the position and zoom of the view always satisfy the constraint preference. 