### PR TITLE
Tangram does not support recursive raster sources

### DIFF
--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -160,9 +160,6 @@ void RasterSource::addRasterTask(TileTask& _task) {
     auto rasterTask = createRasterTask(subTileID, true);
 
     _task.subTasks().push_back(rasterTask);
-
-    // Needed? Do we support recursive raster-source inclusion?
-    addRasterTasks(_task);
 }
 
 std::shared_ptr<RasterTileTask> RasterSource::createRasterTask(TileID _tileId, bool subTask) {


### PR DESCRIPTION
Simple One.

tangram as an engine does not support recursive raster sources as raster samplers.