### PR TITLE
Try new target SDK to fix Android CI failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: source scripts/run_bench.sh build/linux
   build-android:
     docker:
-      - image: circleci/android:api-28-ndk-r17b
+      - image: circleci/android:api-28-ndk
     environment:
       GRADLE_OPTS: -Xmx2048m
     steps:
@@ -22,7 +22,7 @@ jobs:
       - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=armeabi-v7a
   build-deploy-android-snapshot:
     docker:
-      - image: circleci/android:api-28-ndk-r17b
+      - image: circleci/android:api-28-ndk
     environment:
       GRADLE_OPTS: -Xmx2048m
     steps:

--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 27
+  compileSdkVersion 28
 
   def apiKey = project.hasProperty('nextzenApiKey') ? nextzenApiKey : System.getenv('NEXTZEN_API_KEY')
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 27
+    targetSdkVersion 28
     buildConfigField 'String', 'NEXTZEN_API_KEY', '"' + apiKey + '"'
   }
 

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -7,7 +7,7 @@ version = VERSION_NAME
 apply from: 'versioning.gradle'
 
 android {
-  compileSdkVersion 27
+  compileSdkVersion 28
 
   // Specific ABI targets can be chosen with the 'abis' property as a comma-separated list of ABIs.
   // From the command line, add '-Ptangram.abis=armeabi-v7a,x86,...' to only build those ABIs.
@@ -19,7 +19,7 @@ android {
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 27
+    targetSdkVersion 28
     versionCode buildVersionCode()
     versionName VERSION_NAME
     consumerProguardFiles 'tangram-proguard-rules.txt'


### PR DESCRIPTION
CircleCI config uses the `circleci/android:api-28-ndk-r17b` image