### PR TITLE
Fix duplicate, non-cyclic scene imports

### DIFF
--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -75,6 +75,9 @@ Node Importer::applySceneImports(Platform& platform) {
         });
     }
 
+    if (m_importedScenes.size() == 1) {
+        return m_importedScenes.begin()->second;
+    }
     Node root;
 
     LOGD("Processing scene import Stack:");
@@ -212,7 +215,7 @@ void Importer::mergeMapFields(Node& target, const Node& import) {
                  Dump(target).c_str(), Dump(import).c_str());
         }
 
-        target = import;
+        target = YAML::Clone(import);
 
     } else {
         for (const auto& entry : import) {

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -179,11 +179,17 @@ void Importer::importScenesRecursive(Node& root, const Url& sceneUrl, std::unord
 
     auto& sceneNode = m_sceneNodes[sceneUrl];
 
+    // If an import URL is already in the imported set that means it is imported by a "parent" scene file to this one.
+    // The parent import will assign the same values, so we can safely skip importing it here. This saves some work and
+    // also prevents import cycles.
+    //
+    // It is important that we don't merge the same YAML node more than once. YAML node assignment is by reference, so
+    // merging mutates the original input nodes.
     auto it = std::remove_if(sceneNode.imports.begin(), sceneNode.imports.end(),
                              [&](auto& i){ return imported.find(i) != imported.end(); });
 
     if (it != sceneNode.imports.end()) {
-        LOGD("Remove duplicate import");
+        LOGD("Skipping redundant import(s)");
         sceneNode.imports.erase(it, sceneNode.imports.end());
     }
 

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -135,7 +135,7 @@ void Importer::addSceneYaml(const Url& sceneUrl, const char* sceneYaml, size_t l
 
     for (const auto& url : sceneNode.imports) {
         // Check if this scene URL has been (or is going to be) imported already
-        if (m_sceneNodes.find(url) == std::end(m_sceneNodes)) {
+        if (m_sceneNodes.find(url) == m_sceneNodes.end()) {
             m_sceneQueue.push_back(url);
         }
     }
@@ -177,15 +177,15 @@ void Importer::importScenesRecursive(Node& root, const Url& sceneUrl, std::unord
 
     auto& sceneNode = m_sceneNodes[sceneUrl];
 
-    auto it = std::remove_if(std::begin(sceneNode.imports), std::end(sceneNode.imports),
-                             [&](auto& i){ return imported.find(i) != std::end(imported); });
+    auto it = std::remove_if(sceneNode.imports.begin(), sceneNode.imports.end(),
+                             [&](auto& i){ return imported.find(i) != imported.end(); });
 
-    if (it != std::end(sceneNode.imports)) {
+    if (it != sceneNode.imports.end()) {
         LOGD("Remove duplicate import");
-        sceneNode.imports.erase(it, std::end(sceneNode.imports));
+        sceneNode.imports.erase(it, sceneNode.imports.end());
     }
 
-    imported.insert(std::begin(sceneNode.imports), std::end(sceneNode.imports));
+    imported.insert(sceneNode.imports.begin(), sceneNode.imports.end());
 
     for (const auto& url : sceneNode.imports) {
         importScenesRecursive(root, url, imported);

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -211,7 +211,7 @@ void Importer::mergeMapFields(Node& target, const Node& import) {
                  Dump(target).c_str(), Dump(import).c_str());
         }
 
-        target = YAML::Clone(import);
+        target = import;
 
     } else {
         for (const auto& entry : import) {

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -133,6 +133,9 @@ void Importer::addSceneYaml(const Url& sceneUrl, const char* sceneYaml, size_t l
 
     sceneNode.imports = getResolvedImportUrls(sceneNode.yaml, sceneUrl);
 
+    // Remove 'import' values so they don't get merged.
+    sceneNode.yaml.remove("import");
+
     for (const auto& url : sceneNode.imports) {
         // Check if this scene URL has been (or is going to be) imported already
         if (m_sceneNodes.find(url) == m_sceneNodes.end()) {
@@ -161,7 +164,6 @@ std::vector<Url> Importer::getResolvedImportUrls(const Node& sceneNode, const Ur
                     }
                 }
             }
-            Node(sceneNode).remove("import");
         }
     }
 

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -74,9 +74,6 @@ Node Importer::applySceneImports(Platform& platform) {
         });
     }
 
-    // if (m_importedScenes.size() == 1) {
-    //     return m_importedScenes.begin()->second;
-    // }
     Node root;
 
     LOGD("Processing scene import Stack:");

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace Tangram {
@@ -50,7 +51,8 @@ protected:
     std::vector<Url> getResolvedImportUrls(const Node& sceneNode, const Url& base);
 
     // loads all the imported scenes and the master scene and returns a unified YAML root node.
-    void importScenesRecursive(Node& root, const Url& sceneUrl, std::vector<Url>& sceneStack);
+    void importScenesRecursive(Node& root, const Url& sceneUrl, std::vector<Url>& sceneStack,
+                               std::unordered_set<Url>& imported);
 
     void mergeMapFields(Node& target, const Node& import);
 

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -58,10 +58,14 @@ protected:
     // Importer holds a pointer to the scene it is operating on.
     std::shared_ptr<Scene> m_scene;
 
-    // Imported scenes must be parsed into YAML nodes to find further imports.
+    // Scene files must be parsed into YAML nodes to find further imports.
     // The parsed scenes are stored in a map with their URLs to be merged once
     // all imports are found and parsed.
-    std::unordered_map<Url, std::pair<Node, std::vector<Url>>> m_importedScenes = {};
+    struct SceneNode {
+        Node yaml{};
+        std::vector<Url> imports;
+    };
+    std::unordered_map<Url, SceneNode> m_sceneNodes = {};
 
     std::vector<Url> m_sceneQueue;
 };

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -60,7 +60,7 @@ protected:
     // Imported scenes must be parsed into YAML nodes to find further imports.
     // The parsed scenes are stored in a map with their URLs to be merged once
     // all imports are found and parsed.
-    std::unordered_map<Url, Node> m_importedScenes;
+    std::unordered_map<Url, std::pair<Node, std::vector<Url>>> m_importedScenes = {};
 
     std::vector<Url> m_sceneQueue;
 };

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -51,8 +51,7 @@ protected:
     std::vector<Url> getResolvedImportUrls(const Node& sceneNode, const Url& base);
 
     // loads all the imported scenes and the master scene and returns a unified YAML root node.
-    void importScenesRecursive(Node& root, const Url& sceneUrl, std::vector<Url>& sceneStack,
-                               std::unordered_set<Url>& imported);
+    void importScenesRecursive(Node& root, const Url& sceneUrl, std::unordered_set<Url>& imported);
 
     void mergeMapFields(Node& target, const Node& import);
 


### PR DESCRIPTION
The current scene import process can behave incorrectly when a scene file is imported more than once in the recursive import graph.

TODO:
- [x] Add a test to demonstrate the existing problem with imports - test should fail currently
- [x] Apply a fix to the scene merge process and check that test passes