### PR TITLE
Fix possible dereference of IOSPlatform instance after deletion

### DIFF
--- a/platforms/ios/framework/src/iosPlatform.mm
+++ b/platforms/ios/framework/src/iosPlatform.mm
@@ -156,9 +156,10 @@ bool iOSPlatform::startUrlRequestImpl(const Url& _url, const UrlRequestHandle _r
         return false;
     }
 
+    __weak TGMapView* weakMapView = m_mapView;
     TGDownloadCompletionHandler handler = ^void (NSData* data, NSURLResponse* response, NSError* error) {
 
-        __strong TGMapView* mapView = m_mapView;
+        __strong TGMapView* mapView = weakMapView;
         if (!mapView) {
             // Map was disposed before the request completed, so abort the completion handler.
             return;


### PR DESCRIPTION
Capturing 'm_mapView' implicitly captures 'this' and dereferences it in the block.

If a TGURLHandler outlives its TGMapView it can invoke this callback after the IOSPlatform is deleted, causing an access error.

With this change we can safely check whether the TGMapView is deleted and exit the block early if so.