### PR TITLE
Add support for zoom_offset for data sources

### DIFF
--- a/core/shaders/rasters.glsl
+++ b/core/shaders/rasters.glsl
@@ -10,7 +10,7 @@ uniform vec3 u_raster_offsets[TANGRAM_NUM_RASTER_SOURCES];
 
 #define currentRasterPixel(raster_index) (currentRasterUV(raster_index) * rasterPixelSize(raster_index))
 
-#define sampleRasterAtPixel(raster_index, pixel) (texture2D(u_rasters[raster_index], adjustRasterUV(raster_index, (pixel) / rasterPixelSize(raster_index))))
+#define sampleRasterAtPixel(raster_index, pixel) (texture2D(u_rasters[raster_index], (pixel) / rasterPixelSize(raster_index)))
 
 #define sampleRaster(raster_index) (texture2D(u_rasters[raster_index], currentRasterUV(raster_index)))
 

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -152,9 +152,14 @@ void RasterSource::addRasterTask(TileTask& _task) {
 
     TileID subTileID = _task.tileId();
 
-    // get tile for lower zoom if we are past max zoom
-    if (subTileID.z > maxZoom()) {
-        subTileID = subTileID.withMaxSourceZoom(maxZoom());
+    // apply apt downsampling for raster tiles depending on difference
+    // in zoomBias (which also takes zoom offset into account)
+    auto zoomDiff = m_zoomOptions.zoomBias - _task.source()->zoomBias();
+
+    if (zoomDiff > 0) {
+        subTileID = subTileID.zoomBiasAdjusted(zoomDiff).withMaxSourceZoom(m_zoomOptions.maxZoom);
+    } else {
+        subTileID = subTileID.withMaxSourceZoom(m_zoomOptions.maxZoom);
     }
 
     auto rasterTask = createRasterTask(subTileID, true);

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -945,6 +945,7 @@ void SceneLoader::loadSource(Platform& platform, const std::string& name,
     int32_t maxDisplayZoom = -1;
     int32_t maxZoom = 18;
     int32_t zoomBias = 0;
+    int32_t zoomOffset = 0;
     bool generateCentroids = false;
 
     if (auto typeNode = source["type"]) {
@@ -962,11 +963,18 @@ void SceneLoader::loadSource(Platform& platform, const std::string& name,
     if (auto maxZoomNode = source["max_zoom"]) {
         YamlUtil::getInt(maxZoomNode, maxZoom);
     }
+    if (auto zoomOffsetNode = source["zoom_offset"]) {
+        YamlUtil::getInt(zoomOffsetNode, zoomOffset);
+    }
     if (auto tileSizeNode = source["tile_size"]) {
         int tileSize = 0;
         if (YamlUtil::getInt(tileSizeNode, tileSize)) {
             zoomBias = TileSource::zoomBiasFromTileSize(tileSize);
         }
+    }
+
+    if (zoomOffset >= 0) {
+        zoomBias += zoomOffset;
     }
 
     // Parse and append any URL parameters.

--- a/scenes/raster-terrain-offset.yaml
+++ b/scenes/raster-terrain-offset.yaml
@@ -1,0 +1,33 @@
+global:
+    sdk_api_key: ''
+    sdk_landcover_api_key: ''
+
+sources:
+  nextzen:
+    type: MVT
+    url: https://tile.nextzen.org/tilezen/vector/v1/256/all/{z}/{x}/{y}.mvt
+    url_params:
+        api_key: global.sdk_api_key
+    rasters: ['terrain']
+  terrain:
+    type: Raster
+    url: https://d3gy1yxv8mxm7h.cloudfront.net/tilezen/landcover/v1/512/all/{z}/{x}/{y}.png
+    url_params:
+        api_key: global.sdk_landcover_api_key
+    zoom_offset: 1
+
+styles:
+  raster-test:
+    base: raster
+    shaders:
+      blocks:
+        color: 
+          "color.rgba = sampleRasterAtPixel(0, vec2(currentRasterPixel(0)));"
+
+layers:
+  earth:
+    data: { source: nextzen }
+    draw:
+      raster-test:
+        order: 1
+        color: white

--- a/scenes/raster-terrain-offset.yaml
+++ b/scenes/raster-terrain-offset.yaml
@@ -1,33 +1,5 @@
-global:
-    sdk_api_key: ''
-    sdk_landcover_api_key: ''
+import: raster-terrain.yaml
 
 sources:
-  nextzen:
-    type: MVT
-    url: https://tile.nextzen.org/tilezen/vector/v1/256/all/{z}/{x}/{y}.mvt
-    url_params:
-        api_key: global.sdk_api_key
-    rasters: ['terrain']
-  terrain:
-    type: Raster
-    url: https://d3gy1yxv8mxm7h.cloudfront.net/tilezen/landcover/v1/512/all/{z}/{x}/{y}.png
-    url_params:
-        api_key: global.sdk_landcover_api_key
-    zoom_offset: 1
-
-styles:
-  raster-test:
-    base: raster
-    shaders:
-      blocks:
-        color: 
-          "color.rgba = sampleRasterAtPixel(0, vec2(currentRasterPixel(0)));"
-
-layers:
-  earth:
-    data: { source: nextzen }
-    draw:
-      raster-test:
-        order: 1
-        color: white
+    terrain-normals:
+        zoom_offset: 1


### PR DESCRIPTION
Addresses #2019 

- Zoom offset behave exactly like zoom bias which gets calculated using
tile size. This can be useful when there are tilesources (unlike tilezen
tiles) which do not provide multiple sized tiles, in such senarios it
can be helpful to use zoom_offset to provide down sampled tiles,
specially when using dependent raster tiles.

- This also fixes the behavior when tile_size for a dependent raster source is greater than tile_size for the parent vector source.

TODO:
- [ ] It is possible in certain scenarios, different vector tiles, end up using the same raster tile. It is quite wasteful to make duplicate url requests for these "same" raster tiles. We might be able to rearchitect some of subTask management code to share subTasks between tasks, and once a "subtasks" is completed, it trickles this to all its master tasks. (cc. @hjanetzek for thoughts on this).