### PR TITLE
Set text_source to to empty string when js function fails to evaluate

### DIFF
--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -176,6 +176,8 @@ bool getTextSource(const StyleParamKey _key, const DrawRule& _rule, const Proper
     } else if (textSource.value.is<std::string>()) {
         // From function evaluation
         _text = textSource.value.get<std::string>();
+    } else if (textSource.value.is<Undefined>()) {
+        _text = "";
     } else {
         return false;
     }


### PR DESCRIPTION
- jsFunction evaluation can result in an "Undefined" value when it fails
to evaluate. Example when trying to return a feature property which is
not present, "name:short". In such scenarios we do not want the
text_source to fall back to "name" feature property.
- NOTE: feature filtering in the style sheet should be written such that
this above described "Undefined" JS value never happens, but still
tangram-es should be more graceful and lenient about this.