### PR TITLE
Exclusive and Priority for SceneLayer

### DIFF
--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -148,6 +148,9 @@ bool DrawRuleMergeSet::match(const Feature& _feature, const SceneLayer& _layer, 
 
             if (sublayer.filter().eval(_feature, _ctx)) {
                 m_queuedLayers.push_back(&sublayer);
+                if (sublayer.exclusive()) {
+                    break;
+                }
             }
         }
     }

--- a/core/src/scene/sceneLayer.cpp
+++ b/core/src/scene/sceneLayer.cpp
@@ -10,12 +10,16 @@ static_assert(std::is_move_constructible<SceneLayer>::value, "check");
 SceneLayer::SceneLayer(std::string _name, Filter _filter,
                        std::vector<DrawRuleData> _rules,
                        std::vector<SceneLayer> _sublayers,
-                       bool _enabled) :
+                       int _priority,
+                       bool _enabled,
+                       bool _exclusive) :
     m_filter(std::move(_filter)),
     m_name(_name),
     m_rules(_rules),
     m_sublayers(std::move(_sublayers)),
-    m_enabled(_enabled) {
+    m_priority(_priority),
+    m_enabled(_enabled),
+    m_exclusive(_exclusive) {
 
     setDepth(1);
 
@@ -29,6 +33,23 @@ void SceneLayer::setDepth(size_t _d) {
         layer.setDepth(m_depth + 1);
     }
 
+}
+
+void SceneLayer::sortSublayers() {
+
+    if (m_subLayersSorted) { return; }
+    m_subLayersSorted = true;
+
+    std::sort(m_sublayers.begin(), m_sublayers.end(),
+            [&](const SceneLayer& a, const SceneLayer& b) {
+                if (a.exclusive() && !b.exclusive()) {
+                    return true;
+                } else if (!a.exclusive() && b.exclusive()) {
+                    return false;
+                } else {
+                    return a.priority() <= b.priority();
+                }
+            });
 }
 
 }

--- a/core/src/scene/sceneLayer.h
+++ b/core/src/scene/sceneLayer.h
@@ -18,23 +18,31 @@ class SceneLayer {
     std::vector<DrawRuleData> m_rules;
     std::vector<SceneLayer> m_sublayers;
     size_t m_depth = 0;
+    int m_priority = std::numeric_limits<int>::max();
     bool m_enabled = true;
+    bool m_exclusive = false;
+    mutable bool m_subLayersSorted = false;
 
 public:
 
     SceneLayer(std::string _name, Filter _filter,
                std::vector<DrawRuleData> _rules,
                std::vector<SceneLayer> _sublayers,
-               bool _enabled);
+               int _priority,
+               bool _enabled,
+               bool _exclusive);
 
     const auto& name() const { return m_name; }
     const auto& filter() const { return m_filter; }
     const auto& rules() const { return m_rules; }
     const auto& sublayers() const { return m_sublayers; }
     const auto& depth() const { return m_depth; }
+    const auto& priority() const { return m_priority; }
     const auto& enabled() const { return m_enabled; }
+    const auto& exclusive() const { return m_exclusive; }
 
     void setDepth(size_t _d);
+    void sortSublayers();
 };
 
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1526,6 +1526,7 @@ std::vector<DataLayer> SceneLoader::applyLayers(const Node& _node,  SceneFunctio
 
             auto sublayer = loadSublayer(layer.second, name, _functions, _stops, _ruleNames);
 
+
             if (const Node& data = layer.second["data"]) {
 
                 const Node& data_source = data["source"];
@@ -1551,6 +1552,7 @@ std::vector<DataLayer> SceneLoader::applyLayers(const Node& _node,  SceneFunctio
                 collections.push_back(name);
             }
             dataLayers.emplace_back(std::move(sublayer), source, collections);
+            dataLayers.back().sortSublayers();
 
         }
         catch (const YAML::RepresentationException& e) {
@@ -1567,6 +1569,8 @@ SceneLayer SceneLoader::loadSublayer(const Node& _layer, const std::string& _lay
     std::vector<DrawRuleData> rules;
     Filter filter;
     bool enabled = true;
+    bool exclusive = false;
+    int priority = std::numeric_limits<int>::max();
 
     for (const auto& member : _layer) {
 
@@ -1588,7 +1592,7 @@ SceneLayer SceneLoader::loadSublayer(const Node& _layer, const std::string& _lay
             filter = generateFilter(_functions, member.second);
             if (!filter.isValid()) {
                 LOGNode("Invalid 'filter' in layer '%s'", member.second, _layerName.c_str());
-                return { _layerName, {}, {}, {}, false };
+                return { _layerName, {}, {}, {}, priority, false, exclusive};
             }
         } else if (key == "visible") {
             if (!_layer["enabled"].IsDefined()) {
@@ -1596,13 +1600,18 @@ SceneLayer SceneLoader::loadSublayer(const Node& _layer, const std::string& _lay
             }
         } else if (key == "enabled") {
             YAML::convert<bool>::decode(member.second, enabled);
+        } else if (key == "exclusive") {
+            YAML::convert<bool>::decode(member.second, exclusive);
+        } else if (key == "priority") {
+            priority = YamlUtil::getIntOrDefault(member.second, priority);
         } else {
             // Member is a sublayer
             sublayers.push_back(loadSublayer(member.second, (_layerName + DELIMITER + key),
                                              _functions, _stops, _ruleNames));
+            sublayers.back().sortSublayers();
         }
     }
-    return { _layerName, std::move(filter), rules, std::move(sublayers), enabled };
+    return { _layerName, std::move(filter), rules, std::move(sublayers), priority, enabled, exclusive };
 }
 
 void printFilters(const SceneLayer& layer, int indent){


### PR DESCRIPTION
- Sort SceneLayers such that all exclusive layers come before
non-exclusive layers and in order of increasing priority

TODO: 
- [ ] Add unit test covering `priority` and `exclusive` properties.
Addresses #2036 
