### PR TITLE
Fix osx benchmark and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ endif()
 
 include(cmake/utils.cmake)
 
+if(NOT TANGRAM_CXX_STANDARD)
+    message(STATUS "CXX STANDARD NOT SET. Setting to c++14")
+    set(TANGRAM_CXX_STANDARD 14)
+endif()
+
 # If target platform isn't specified, use the local platform.
 if(NOT TANGRAM_PLATFORM)
   message(STATUS "No platform target specified. Choose a target with -DTANGRAM_PLATFORM=platform.")
@@ -83,6 +88,7 @@ if(TANGRAM_BUILD_BENCHMARKS OR TANGRAM_BUILD_TESTS)
     tests/src/mockPlatform.cpp
     tests/src/gl_mock.cpp
   )
+  set_property(TARGET platform_mock PROPERTY CXX_STANDARD ${TANGRAM_CXX_STANDARD})
   target_include_directories(platform_mock PUBLIC tests/src)
   target_compile_definitions(platform_mock PUBLIC -DUNIT_TESTS)
   target_link_libraries(platform_mock PUBLIC tangram-core)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -41,6 +41,7 @@ foreach(_src_file_path ${BENCH_SOURCES})
   set_target_properties(${EXECUTABLE_NAME}
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bench"
+    CXX_STANDARD ${TANGRAM_CXX_STANDARD}
   )
 
   if(TANGRAM_JSCORE_ENABLED)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -277,7 +277,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # C++14 is required for compiling tangram-core and for using the interface headers.
-set_property(TARGET tangram-core PROPERTY CXX_STANDARD 14)
+set_property(TARGET tangram-core PROPERTY CXX_STANDARD ${TANGRAM_CXX_STANDARD})
 
 # We include GLSL shader sources into the library by generating header files with the source text
 # printed into a string constant. A CMake script generates one of these headers for each shader source

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,8 @@ target_link_libraries(platform_test
   -lpthread
 )
 
+set_property(TARGET platform_test PROPERTY CXX_STANDARD ${TANGRAM_CXX_STANDARD})
+
 target_include_directories(platform_test
   PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/catch
@@ -61,6 +63,7 @@ if(TANGRAM_BUNDLE_TESTS)
   set_target_properties(${EXECUTABLE_NAME}
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+    CXX_STANDARD ${TANGRAM_CXX_STANDARD}
   )
 
   # Copy resources into output directory (only needs to be performed for one target)
@@ -88,6 +91,7 @@ else()
     set_target_properties(${EXECUTABLE_NAME}
       PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+      CXX_STANDARD ${TANGRAM_CXX_STANDARD}
     )
     # Copy resources into output directory (only needs to be performed for one target)
     add_resources(${EXECUTABLE_NAME} "${PROJECT_SOURCE_DIR}/scenes" "res")


### PR DESCRIPTION
- were missing c++14 build flag!
- Includes a Tangram cmake variable to control cxx_standard