### PR TITLE
Fix JNI reference overflow in AndroidPlatform::startUrlRequest

### DIFF
--- a/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
+++ b/platforms/android/tangram/src/main/cpp/androidPlatform.cpp
@@ -305,6 +305,7 @@ bool AndroidPlatform::startUrlRequestImpl(const Url& _url, const UrlRequestHandl
 
         // Call the MapController method to start the URL request.
         jniEnv->CallVoidMethod(m_tangramInstance, startUrlRequestMID, jUrl, jRequestHandle);
+        jniEnv->DeleteLocalRef(jUrl);
     });
 
     return true;


### PR DESCRIPTION
Resolves https://github.com/tangrams/tangram-es/issues/2050

The issue and fix were both reported by @vilinet - thanks!