### PR TITLE
Fix PolygonBuilder name collision

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(tangram-core
   include/tangram/map.h
   include/tangram/platform.h
   include/tangram/tangram.h
-  include/tangram/data/clientGeoJsonSource.h
+  include/tangram/data/clientDataSource.h
   include/tangram/data/properties.h
   include/tangram/data/propertyItem.h
   include/tangram/data/tileSource.h
@@ -19,7 +19,7 @@ add_library(tangram-core
   include/tangram/util/variant.h
   src/map.cpp
   src/platform.cpp
-  src/data/clientGeoJsonSource.cpp
+  src/data/clientDataSource.cpp
   src/data/memoryCacheDataSource.h
   src/data/memoryCacheDataSource.cpp
   src/data/networkDataSource.h

--- a/core/include/tangram/data/clientDataSource.h
+++ b/core/include/tangram/data/clientDataSource.h
@@ -11,38 +11,36 @@ class Platform;
 
 struct Properties;
 
-struct ClientGeoJsonData;
-
-struct PolylineBuilderData;
-
-struct PolylineBuilder {
-    PolylineBuilder();
-    ~PolylineBuilder();
-    void beginPolyline(size_t numberOfPoints);
-    void addPoint(LngLat point);
-    std::unique_ptr<PolylineBuilderData> data;
-};
-
-struct PolygonBuilderData;
-
-struct PolygonBuilder {
-    PolygonBuilder();
-    ~PolygonBuilder();
-    void beginPolygon(size_t numberOfRings);
-    void beginRing(size_t numberOfPoints);
-    void addPoint(LngLat point);
-    std::unique_ptr<PolygonBuilderData> data;
-};
-
-class ClientGeoJsonSource : public TileSource {
+class ClientDataSource : public TileSource {
 
 public:
 
-    ClientGeoJsonSource(Platform& _platform, const std::string& _name,
+    ClientDataSource(Platform& _platform, const std::string& _name,
                         const std::string& _url, bool generateCentroids = false,
                         TileSource::ZoomOptions _zoomOptions = {});
 
-    ~ClientGeoJsonSource() override;
+    ~ClientDataSource() override;
+
+    struct PolylineBuilderData;
+
+    struct PolylineBuilder {
+        PolylineBuilder();
+        ~PolylineBuilder();
+        void beginPolyline(size_t numberOfPoints);
+        void addPoint(LngLat point);
+        std::unique_ptr<PolylineBuilderData> data;
+    };
+
+    struct PolygonBuilderData;
+
+    struct PolygonBuilder {
+        PolygonBuilder();
+        ~PolygonBuilder();
+        void beginPolygon(size_t numberOfRings);
+        void beginRing(size_t numberOfPoints);
+        void addPoint(LngLat point);
+        std::unique_ptr<PolygonBuilderData> data;
+    };
 
     // http://www.iana.org/assignments/media-types/application/geo+json
     const char* mimeType() const override { return "application/geo+json"; };
@@ -54,7 +52,8 @@ public:
 
     void addPolylineFeature(Properties&& properties, PolylineBuilder&& polyline);
 
-    void addPolygonFeature(Properties&& properties, PolygonBuilder&& polygon);
+    void addPolygonFeature(Properties&& properties, PolygonBuilder
+        && polygon);
 
     // Transform added feature data into tiles.
     void generateTiles();
@@ -69,7 +68,8 @@ protected:
 
     std::shared_ptr<TileData> parse(const TileTask& _task) const override;
 
-    std::unique_ptr<ClientGeoJsonData> m_store;
+    struct Storage;
+    std::unique_ptr<Storage> m_store;
 
     mutable std::mutex m_mutexStore;
     bool m_hasPendingData = false;

--- a/core/include/tangram/tangram.h
+++ b/core/include/tangram/tangram.h
@@ -9,7 +9,7 @@
 #define TANGRAM_VERSION_MINOR 10
 #define TANGRAM_VERSION_PATCH 1
 
-#include "data/clientGeoJsonSource.h"
+#include "data/clientDataSource.h"
 #include "data/properties.h"
 #include "data/propertyItem.h"
 #include "data/tileSource.h"

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -1,6 +1,6 @@
 #include "scene/sceneLoader.h"
 
-#include "data/clientGeoJsonSource.h"
+#include "data/clientDataSource.h"
 #include "data/memoryCacheDataSource.h"
 #include "data/mbtilesDataSource.h"
 #include "data/networkDataSource.h"
@@ -840,8 +840,7 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
         if (auto genLabelCentroidsNode = _source["generate_label_centroids"]) {
             generateCentroids = true;
         }
-        sourcePtr = std::make_shared<ClientGeoJsonSource>(_platform, _name, url,
-                                                          generateCentroids, zoomOptions);
+        sourcePtr = std::make_shared<ClientDataSource>(_platform, _name, url, generateCentroids, zoomOptions);
     } else if (type == "Raster") {
         TextureOptions options;
         if (const Node& filtering = _source["filtering"]) {

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -1,5 +1,5 @@
 #include "androidPlatform.h"
-#include "data/clientGeoJsonSource.h"
+#include "data/clientDataSource.h"
 #include "map.h"
 
 #include <cassert>
@@ -36,7 +36,7 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
 #define FUNC(CLASS, NAME) JNIEXPORT JNICALL Java_com_mapzen_tangram_ ## CLASS ## _native ## NAME
 
 #define auto_map(ptr) assert(ptr); auto map = reinterpret_cast<Tangram::AndroidMap*>(mapPtr)
-#define auto_source(ptr) assert(ptr); auto source = reinterpret_cast<Tangram::ClientGeoJsonSource*>(ptr)
+#define auto_source(ptr) assert(ptr); auto source = reinterpret_cast<Tangram::ClientDataSource*>(ptr)
 
 
 #define MapRenderer(NAME) FUNC(MapRenderer, NAME)
@@ -534,7 +534,7 @@ jlong MapController(AddTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
     auto_map(mapPtr);
 
     auto sourceName = stringFromJString(jniEnv, name);
-    auto source = std::make_shared<Tangram::ClientGeoJsonSource>(map->getPlatform(),
+    auto source = std::make_shared<Tangram::ClientDataSource>(map->getPlatform(),
                                                                  sourceName, "",
                                                                  generateCentroid);
     map->addTileSource(source);
@@ -582,7 +582,7 @@ void MapData(AddFeature)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr, jdoubleAr
     if (nRings > 0) {
         // If rings are defined, this is a polygon feature.
         auto* rings = jniEnv->GetIntArrayElements(jrings, NULL);
-        Tangram::PolygonBuilder builder;
+        Tangram::ClientDataSource::PolygonBuilder builder;
         builder.beginPolygon(static_cast<size_t>(nRings));
         int offset = 0;
         for (int j = 0; j < nRings; j++) {
@@ -597,7 +597,7 @@ void MapData(AddFeature)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr, jdoubleAr
         jniEnv->ReleaseIntArrayElements(jrings, rings, JNI_ABORT);
     } else if (nPoints > 1) {
         // If no rings defined but multiple points, this is a polyline feature.
-        Tangram::PolylineBuilder builder;
+        Tangram::ClientDataSource::PolylineBuilder builder;
         builder.beginPolyline(static_cast<size_t>(nPoints));
         for (size_t i = 0; i < nPoints; i++) {
             builder.addPoint(LngLat(coordinates[2 * i], coordinates[2 * i + 1]));

--- a/platforms/ios/framework/src/TGMapData+Internal.h
+++ b/platforms/ios/framework/src/TGMapData+Internal.h
@@ -10,14 +10,14 @@
 #import "TGMapData.h"
 #import <Foundation/Foundation.h>
 
-#include "data/clientGeoJsonSource.h"
+#include "data/clientDataSource.h"
 #include <memory>
 
 @interface TGMapData ()
 
 NS_ASSUME_NONNULL_BEGIN
 
-- (instancetype)initWithMapView:(__weak TGMapView *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::ClientGeoJsonSource>)source;
+- (instancetype)initWithMapView:(__weak TGMapView *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::ClientDataSource>)source;
 
 NS_ASSUME_NONNULL_END
 

--- a/platforms/ios/framework/src/TGMapData.mm
+++ b/platforms/ios/framework/src/TGMapData.mm
@@ -27,7 +27,7 @@ static inline void TGFeaturePropertiesConvertToCoreProperties(TGFeaturePropertie
 }
 
 @interface TGMapData () {
-    std::shared_ptr<Tangram::ClientGeoJsonSource> dataSource;
+    std::shared_ptr<Tangram::ClientDataSource> dataSource;
 }
 
 @property (copy, nonatomic) NSString* name;
@@ -37,7 +37,7 @@ static inline void TGFeaturePropertiesConvertToCoreProperties(TGFeaturePropertie
 
 @implementation TGMapData
 
-- (instancetype)initWithMapView:(__weak TGMapView *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::ClientGeoJsonSource>)source
+- (instancetype)initWithMapView:(__weak TGMapView *)mapView name:(NSString *)name source:(std::shared_ptr<Tangram::ClientDataSource>)source
 {
     self = [super init];
 
@@ -67,7 +67,7 @@ static inline void TGFeaturePropertiesConvertToCoreProperties(TGFeaturePropertie
 
         } else if (TGGeoPolyline *polyline = [feature polyline]) {
 
-            Tangram::PolylineBuilder builder;
+            Tangram::ClientDataSource::PolylineBuilder builder;
             size_t numberOfPoints = polyline.count;
             builder.beginPolyline(numberOfPoints);
             for (size_t i = 0; i < numberOfPoints; i++) {
@@ -77,7 +77,7 @@ static inline void TGFeaturePropertiesConvertToCoreProperties(TGFeaturePropertie
 
         } else if (TGGeoPolygon *polygon = [feature polygon]) {
 
-            Tangram::PolygonBuilder builder;
+            Tangram::ClientDataSource::PolygonBuilder builder;
             builder.beginPolygon(polygon.rings.count);
             for (TGGeoPolyline *ring in polygon.rings) {
                 size_t numberOfPoints = ring.count;

--- a/platforms/ios/framework/src/TGMapView+Internal.h
+++ b/platforms/ios/framework/src/TGMapView+Internal.h
@@ -7,7 +7,6 @@
 
 #import "TGMapView.h"
 
-#include "data/clientGeoJsonSource.h"
 #include "map.h"
 #include <vector>
 #include <memory>

--- a/platforms/ios/framework/src/TGMapView.mm
+++ b/platforms/ios/framework/src/TGMapView.mm
@@ -24,6 +24,7 @@
 #import "TGTypes+Internal.h"
 #import <GLKit/GLKit.h>
 
+#include "data/clientDataSource.h"
 #include "data/propertyItem.h"
 #include "iosPlatform.h"
 #include "map.h"
@@ -477,7 +478,7 @@ typedef NS_ENUM(NSInteger, TGMapRegionChangeState) {
     if (!self.map) { return nil; }
 
     std::string dataLayerName = std::string([name UTF8String]);
-    auto source = std::make_shared<Tangram::ClientGeoJsonSource>(self.map->getPlatform(),
+    auto source = std::make_shared<Tangram::ClientDataSource>(self.map->getPlatform(),
                     dataLayerName, "", generateCentroid);
     self.map->addTileSource(source);
 


### PR DESCRIPTION
`Tangram::PolygonBuilder` in `core/include/data/clientGeoJsonSource.h` aliased an existing struct with the same fully-qualified name in `core/src/util/builders.h`. This resulted in undefined behavior because it breaks the one-definition rule. With clang, the linker chose an incorrect destructor for one of the instances, leading to a segfault when the Map is destructed.

To resolve this, I made the `PolygonBuilder` in `clientGeoJsonSource.h` into a nested class within `ClientGeoJsonSource`. This seemed reasonable because this class is the sole consumer of this `PolygonBuilder`.

While I was renaming things I also renamed `ClientGeoJsonSource` to `ClientDataSource`, since the "GeoJson" descriptor doesn't reflect the primary use of this class. 