### PR TITLE
Add x86_64 to 'all' ABI Android builds

### DIFF
--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -49,7 +49,7 @@ android {
                  '-Wno-unknown-warning-option'
 
         if (abi == 'all') {
-          abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'
+          abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
         } else {
           abiFilters abi.split(',')
         }


### PR DESCRIPTION
Resolves https://github.com/tangrams/tangram-es/issues/2044

This ensures that AARs of the Tangram Android SDK have 64-bit versions of each supported 32-bit ABI, as required by the new Google Play Store rules.