### PR TITLE
modify dash:exchange width and heigh of m_texture

### DIFF
--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -122,7 +122,7 @@ void PolylineStyle::constructShaderProgram() {
         auto pixels = DashArray::render(m_dashArray, dash_scale);
 
         m_texture = std::make_shared<Texture>(options);
-        m_texture->setPixelData(pixels.size(), 1, sizeof(GLuint),
+        m_texture->setPixelData(1, pixels.size(), sizeof(GLuint),
                                 reinterpret_cast<GLubyte*>(pixels.data()),
                                 pixels.size() * sizeof(GLuint));
 


### PR DESCRIPTION
i think:
m_texture->setPixelData(pixels.size(), 1, sizeof(GLuint),
is wrong, i can not render dash
in old version,it is:
m_texture->resize(1, pixels.size());
m_texture->setPixelData(pixels.data(), pixels.size());