### PR TITLE
Workaround for missing gcc 7.4 support in GLM

### DIFF
--- a/core/deps/glm/glm/simd/platform.h
+++ b/core/deps/glm/glm/simd/platform.h
@@ -285,6 +285,8 @@
 #		define GLM_COMPILER (GLM_COMPILER_GCC72)
 #	elif (__GNUC__ == 7) && (__GNUC_MINOR__ == 3)
 #		define GLM_COMPILER (GLM_COMPILER_GCC72)
+#	elif (__GNUC__ == 7) && (__GNUC_MINOR__ == 4)
+#		define GLM_COMPILER (GLM_COMPILER_GCC72)
 #	elif (__GNUC__ >= 8)
 #		define GLM_COMPILER (GLM_COMPILER_GCC80)
 #	else


### PR DESCRIPTION
Resolves #2074 