### PR TITLE
Benchmark and Test fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ if(TANGRAM_BUILD_BENCHMARKS OR TANGRAM_BUILD_TESTS)
   target_include_directories(platform_mock PUBLIC tests/src)
   target_compile_definitions(platform_mock PUBLIC -DUNIT_TESTS)
   target_link_libraries(platform_mock PUBLIC tangram-core)
+  set_target_properties(platform_mock PROPERTIES CXX_STANDARD 14)
 endif()
 
 if(TANGRAM_BUILD_TESTS)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -41,6 +41,7 @@ foreach(_src_file_path ${BENCH_SOURCES})
   set_target_properties(${EXECUTABLE_NAME}
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bench"
+    CXX_STANDARD 14
   )
 
   if(TANGRAM_JSCORE_ENABLED)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -12,6 +12,12 @@ set(BENCH_SOURCES
   src/template.cpp
 )
 
+add_custom_target(benchmark_resources
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/scenes ${CMAKE_BINARY_DIR}/res
+  COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/bench/test_tile_10_301_384.mvt ${CMAKE_BINARY_DIR}/res/tile.mvt
+  COMMENT "Copying benchmark resources into build directory."
+)
+
 # create an executable per bench
 foreach(_src_file_path ${BENCH_SOURCES})
   string(REPLACE ".cpp" "" bench ${_src_file_path})
@@ -48,11 +54,7 @@ foreach(_src_file_path ${BENCH_SOURCES})
     target_compile_definitions(${EXECUTABLE_NAME} PRIVATE TANGRAM_USE_JSCORE=1)
   endif()
 
-  add_custom_command(TARGET ${EXECUTABLE_NAME}
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/scenes ${CMAKE_BINARY_DIR}/res
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/bench/test_tile_10_301_384.mvt ${CMAKE_BINARY_DIR}/res/tile.mvt
-  )
+  add_dependencies(${EXECUTABLE_NAME} benchmark_resources)
 
 endforeach()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,11 @@ target_include_directories(platform_test
   ${CMAKE_CURRENT_SOURCE_DIR}/catch
 )
 
+set_target_properties(platform_test
+  PROPERTIES
+  CXX_STANDARD 14
+)
+
 set(TEST_SOURCES
   unit/curlTests.cpp
   unit/drawRuleTests.cpp
@@ -61,6 +66,7 @@ if(TANGRAM_BUNDLE_TESTS)
   set_target_properties(${EXECUTABLE_NAME}
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+    CXX_STANDARD 14
   )
 
   # Copy resources into output directory (only needs to be performed for one target)
@@ -88,6 +94,7 @@ else()
     set_target_properties(${EXECUTABLE_NAME}
       PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+      CXX_STANDARD 14
     )
     # Copy resources into output directory (only needs to be performed for one target)
     add_resources(${EXECUTABLE_NAME} "${PROJECT_SOURCE_DIR}/scenes" "res")


### PR DESCRIPTION
- Benchmarks and tests were unable to build or run on macOS because several targets were not being built as C++14. Now C++14 is explicitly specified via CMake.
- lineWrapTests was crashing with a segfault related to static initialization of harfbuzz data structures. I re-structured this test to avoid static global initialization.
- The Linux builds on CircleCI have been occasionally failing at the step where benchmark resources are copied into the build folder (https://circleci.com/gh/tangrams/tangram-es/7749). I split this step into a separate target that will run once before the benchmark targets are built - hopefully this avoids those failures (may be difficult immediately whether it is fixed).