### PR TITLE
Fix build errors for RaspberryPi target

### DIFF
--- a/platforms/rpi/config.cmake
+++ b/platforms/rpi/config.cmake
@@ -1,7 +1,3 @@
-# options
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_CXX_FLAGS} -L/opt/vc/lib/")
-set(CXX_FLAGS_DEBUG "-g -O0")
-
 add_definitions(-DTANGRAM_RPI)
 
 check_unsupported_compiler_version()
@@ -12,8 +8,6 @@ add_definitions(-DNEXTZEN_API_KEY="${NEXTZEN_API_KEY}")
 # System font config
 include(FindPkgConfig)
 pkg_check_modules(FONTCONFIG REQUIRED "fontconfig")
-
-add_subdirectory(platforms/common/duktape)
 
 add_executable(tangram
   platforms/rpi/src/context.cpp
@@ -39,13 +33,13 @@ target_link_libraries(tangram
   tangram-core
   ${FONTCONFIG_LDFLAGS}
   curl
-  EGL
-  GLESv2
   pthread
-  bcm_host
-  vchiq_arm
-  vcos
   rt
+  /opt/vc/lib/libbcm_host.so
+  /opt/vc/lib/libbrcmEGL.so
+  /opt/vc/lib/libbrcmGLESv2.so
+  /opt/vc/lib/libvchiq_arm.so
+  /opt/vc/lib/libvcos.so
 )
 
 target_compile_options(tangram
@@ -55,4 +49,4 @@ target_compile_options(tangram
   -fpermissive
 )
 
-add_resources(tangram "${PROJECT_SOURCE_DIR}/scenes")
+add_resources(tangram "${PROJECT_SOURCE_DIR}/scenes" "res")

--- a/platforms/rpi/src/rpiPlatform.cpp
+++ b/platforms/rpi/src/rpiPlatform.cpp
@@ -63,13 +63,17 @@ FontSourceHandle RpiPlatform::systemFont(const std::string& _name, const std::st
     return FontSourceHandle(Url(fontFile));
 }
 
-UrlRequestHandle RpiPlatform::startUrlRequest(Url _url, UrlCallback _callback) {
+bool RpiPlatform::startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) {
 
-    return m_urlClient.addRequest(_url.string(), _callback);
+    _id = m_urlClient.addRequest(_url.string(),
+                                 [this, _request](UrlResponse&& response) {
+                                     onUrlResponse(_request, std::move(response));
+                                 });
+    return true;
 }
 
-void RpiPlatform::cancelUrlRequest(UrlRequestHandle _request) {
-    m_urlClient.cancelRequest(_request);
+void RpiPlatform::cancelUrlRequestImpl(const UrlRequestId _id) {
+    m_urlClient.cancelRequest(_id);
 }
 
 RpiPlatform::~RpiPlatform() {}

--- a/platforms/rpi/src/rpiPlatform.h
+++ b/platforms/rpi/src/rpiPlatform.h
@@ -12,14 +12,15 @@ class RpiPlatform : public Platform {
 public:
 
     RpiPlatform();
-    RpiPlatform(UrlClient::Options urlClientOptions);
+    explicit RpiPlatform(UrlClient::Options urlClientOptions);
     ~RpiPlatform() override;
     void requestRender() const override;
     std::vector<FontSourceHandle> systemFontFallbacksHandle() const override;
-    UrlRequestHandle startUrlRequest(Url _url, UrlCallback _callback) override;
-    void cancelUrlRequest(UrlRequestHandle _url) override;
     FontSourceHandle systemFont(const std::string& _name, const std::string& _weight,
             const std::string& _face) const override;
+
+    bool startUrlRequestImpl(const Url& _url, const UrlRequestHandle _request, UrlRequestId& _id) override;
+    void cancelUrlRequestImpl(const UrlRequestId _id) override;
 
 protected:
 


### PR DESCRIPTION
- update CMake config for core and dependency changes
- link to RPi host libraries with explicit paths
- update RpiPlatform Url interface and UrlClient usage
- use unique_ptr for platform and map in main.cpp

Resolves https://github.com/tangrams/tangram-es/issues/2096

Still don't have a solution for automated RPi builds, so this was manually tested on my Raspberry Pi 3 running Raspbian Stretch.