### PR TITLE
Revert "fix: polygon vertex wraparound (#1776)"

### DIFF
--- a/core/src/marker/marker.cpp
+++ b/core/src/marker/marker.cpp
@@ -78,7 +78,7 @@ void Marker::setMesh(uint32_t styleId, uint32_t zoom, std::unique_ptr<StyledMesh
     if (m_feature && m_feature->geometryType == GeometryType::points) {
         scale = MapProjection::metersPerTileAtZoom(zoom);
     } else {
-        scale = modelScale();
+        scale = extent();
     }
     m_modelMatrix = glm::scale(glm::vec3(scale));
 }
@@ -134,10 +134,6 @@ uint32_t Marker::styleId() const {
 
 float Marker::extent() const {
     return glm::max(m_bounds.width(), m_bounds.height());
-}
-
-float Marker::modelScale() const {
-    return glm::max(extent(), 4096.0f);
 }
 
 Feature* Marker::feature() const {

--- a/core/src/marker/marker.h
+++ b/core/src/marker/marker.h
@@ -94,12 +94,9 @@ public:
     // Get the ordering of this marker relative to other markers.
     int drawOrder() const;
 
-    // Get the length of the maximum dimension of the bounds of this marker.
-    // This is used to calculate modelScale.
+    // Get the length of the maximum dimension of the bounds of this marker. This is used as
+    // the scale in the model matrix.
     float extent() const;
-
-    // Get the scale for the model matrix. Depends on extent().
-    float modelScale() const;
 
     StyledMesh* mesh() const;
 

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -169,7 +169,7 @@ bool MarkerManager::setPolyline(MarkerID markerID, LngLat* coordinates, int coun
     // Update the marker's bounds.
     marker->setBounds(bounds);
 
-    float scale = 1.f / marker->modelScale();
+    float scale = 1.f / marker->extent();
 
     // Project and offset the coordinates into the marker-local coordinate system.
     auto origin = marker->origin(); // SW corner.
@@ -222,7 +222,7 @@ bool MarkerManager::setPolygon(MarkerID markerID, LngLat* coordinates, int* coun
     // Update the marker's bounds.
     marker->setBounds(bounds);
 
-    float scale = 1.f / marker->modelScale();
+    float scale = 1.f / marker->extent();
 
     // Project and offset the coordinates into the marker-local coordinate system.
     auto origin = marker->origin(); // SW corner.

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -108,7 +108,7 @@ public:
 
     void setup(const Marker& _marker, int zoom) override {
         m_zoom = zoom;
-        m_tileUnitsPerMeter = 1.f / _marker.modelScale();
+        m_tileUnitsPerMeter = 1.f / _marker.extent();
         m_meshData.clear();
     }
 


### PR DESCRIPTION
This reverts commit eea679ccd65356e22e4abd8d3a135a4b53aa7e7e.

As discussed in #2038, we had a regression in marker API, where extent for PolyLine markers was not behaving correctly, Though #1776 was solving the case and introduced support for extruded polygon markers, it caused this regression in polyline marker handling which is more common usage for marker API. 

I have lost the context of the usage of `extent` and how it governs the behavior of marker scaling, so in order the fix the regression I am proposing to revert the change from #1776 and reopen #1639 (assigned to myself).

Fixes #2038 