### PR TITLE
Android pick callbacks revision

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/FeaturePickListener.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/FeaturePickListener.java
@@ -1,11 +1,10 @@
 package com.mapzen.tangram;
 
-import java.util.Map;
-
 import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
 
 /**
- * Interface for a callback to receive information about features picked from the map
+ * Callback to receive information about features picked from the map
  * Triggered after a call of {@link MapController#pickFeature(float, float)}
  * Listener should be set with {@link MapController#setFeaturePickListener(FeaturePickListener)}
  * The callback will be run on the main (UI) thread.
@@ -13,10 +12,8 @@ import androidx.annotation.Keep;
 @Keep
 public interface FeaturePickListener {
     /**
-     * Receive information about features found in a call to {@link MapController#pickFeature(float, float)}
-     * @param properties A mapping of string keys to string or number values
-     * @param positionX The horizontal screen coordinate of the picked location
-     * @param positionY The vertical screen coordinate of the picked location
+     * Called when a feature pick query is complete, whether or not a feature was found.
+     * @param result Info about the selected feature, or null if no feature was found.
      */
-    void onFeaturePick(final Map<String, String> properties, final float positionX, final float positionY);
+    void onFeaturePickComplete(@Nullable final FeaturePickResult result);
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/FeaturePickResult.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/FeaturePickResult.java
@@ -1,0 +1,30 @@
+package com.mapzen.tangram;
+
+import android.graphics.PointF;
+
+import java.util.Map;
+
+public class FeaturePickResult {
+
+    private Map<String, String> properties;
+    private PointF screenPosition;
+
+    FeaturePickResult(Map<String, String> properties, float screenX, float screenY) {
+        this.properties = properties;
+        this.screenPosition = new PointF(screenX, screenY);
+    }
+
+    /**
+     * @return Properties of the picked feature, as string key-value pairs.
+     */
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    /**
+     * @return Screen position of the query that produced this result.
+     */
+    public PointF getScreenPosition() {
+        return screenPosition;
+    }
+}

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/LabelPickListener.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/LabelPickListener.java
@@ -1,9 +1,10 @@
 package com.mapzen.tangram;
 
 import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
 
 /**
- * Interface for a callback to receive information about labels picked from the map
+ * Callback to receive information about labels picked from the map
  * Triggered after a call of {@link MapController#pickLabel(float, float)}
  * Listener should be set with {@link MapController#setLabelPickListener(LabelPickListener)}
  * The callback will be run on the main (UI) thread.
@@ -11,10 +12,8 @@ import androidx.annotation.Keep;
 @Keep
 public interface LabelPickListener {
     /**
-     * Receive information about labels found in a call to {@link MapController#pickLabel(float, float)}
-     * @param labelPickResult The {@link LabelPickResult} that has been selected
-     * @param positionX The horizontal screen coordinate of the picked location
-     * @param positionY The vertical screen coordinate of the picked location
+     * Called when a label pick query is complete, whether or not a label was found.
+     * @param result Info about the selected label, or null if no label was found.
      */
-    void onLabelPick(final LabelPickResult labelPickResult, final float positionX, final float positionY);
+    void onLabelPickComplete(@Nullable final LabelPickResult result);
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/LabelPickResult.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/LabelPickResult.java
@@ -1,8 +1,10 @@
 package com.mapzen.tangram;
 
-import java.util.Map;
+import android.graphics.PointF;
 
 import androidx.annotation.Keep;
+
+import java.util.Map;
 
 /**
  * {@code LabelPickResult} represents labels that can be selected on the screen
@@ -18,32 +20,45 @@ public class LabelPickResult {
         TEXT,
     }
 
-    private LngLat coordinates;
-    private LabelType type;
     private Map<String, String> properties;
+    private LngLat coordinates;
+    private PointF screenPosition;
+    private LabelType type;
 
-    LabelPickResult(final double longitude, final double latitude, final int type,
-                            final Map<String, String> properties) {
+
+    LabelPickResult(final Map<String, String> properties, final double longitude, final double latitude, final float screenX, final float screenY, final int type) {
         this.properties = properties;
         this.coordinates = new LngLat(longitude, latitude);
+        this.screenPosition = new PointF(screenX, screenY);
         this.type = LabelType.values()[type];
     }
 
-    public LabelType getType() {
-        return this.type;
+    /**
+     * @return Properties of the picked feature, as string key-value pairs.
+     */
+    public Map<String, String> getProperties() {
+        return this.properties;
     }
 
     /**
-     * @return The coordinate of the feature for which this label has been created
+     * @return Geographic coordinates of the feature associated with this label.
      */
     public LngLat getCoordinates() {
         return this.coordinates;
     }
 
     /**
-     * @return A mapping of string keys to string or number values
+     * @return Screen position of the query that produced this result.
      */
-    public Map<String, String> getProperties() {
-        return this.properties;
+    public PointF getScreenPosition() {
+        return screenPosition;
     }
+
+    /**
+     * @return Type of this label.
+     */
+    public LabelType getType() {
+        return this.type;
+    }
+
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -899,11 +899,11 @@ public class MapController {
     public void setLabelPickListener(@Nullable final LabelPickListener listener) {
         labelPickListener = (listener == null) ? null : new LabelPickListener() {
             @Override
-            public void onLabelPick(final LabelPickResult labelPickResult, final float positionX, final float positionY) {
+            public void onLabelPickComplete(final LabelPickResult labelPickResult) {
                 uiThreadHandler.post(new Runnable() {
                     @Override
                     public void run() {
-                        listener.onLabelPick(labelPickResult, positionX, positionY);
+                        listener.onLabelPickComplete(labelPickResult);
                     }
                 });
             }
@@ -917,11 +917,11 @@ public class MapController {
     public void setMarkerPickListener(@Nullable final MarkerPickListener listener) {
         markerPickListener = (listener == null) ? null : new MarkerPickListener() {
             @Override
-            public void onMarkerPick(final MarkerPickResult markerPickResult, final float positionX, final float positionY) {
+            public void onMarkerPickComplete(final MarkerPickResult markerPickResult) {
                 uiThreadHandler.post(new Runnable() {
                     @Override
                     public void run() {
-                        listener.onMarkerPick(markerPickResult, positionX, positionY);
+                        listener.onMarkerPickComplete(markerPickResult);
                     }
                 });
             }
@@ -1301,7 +1301,11 @@ public class MapController {
             uiThreadHandler.post(new Runnable() {
                 @Override
                 public void run() {
-                    listener.onFeaturePick(properties, x, y);
+                    FeaturePickResult result = null;
+                    if (properties != null) {
+                        result = new FeaturePickResult(properties, x, y);
+                    }
+                    listener.onFeaturePickComplete(result);
                 }
             });
         }
@@ -1316,9 +1320,9 @@ public class MapController {
                 public void run() {
                     LabelPickResult result = null;
                     if (properties != null) {
-                        result = new LabelPickResult(lng, lat, type, properties);
+                        result = new LabelPickResult(properties, lng, lat, x, y, type);
                     }
-                    listener.onLabelPick(result, x, y);
+                    listener.onLabelPickComplete(result);
                 }
             });
         }
@@ -1334,9 +1338,9 @@ public class MapController {
                     final Marker marker = markers.get(markerId);
                     MarkerPickResult result = null;
                     if (marker != null) {
-                        result = new MarkerPickResult(marker, lng, lat);
+                        result = new MarkerPickResult(marker, lng, lat, x, y);
                     }
-                    listener.onMarkerPick(result, x, y);
+                    listener.onMarkerPickComplete(result);
                 }
             });
         }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MarkerPickListener.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MarkerPickListener.java
@@ -1,6 +1,7 @@
 package com.mapzen.tangram;
 
 import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
 
 /**
  * Interface for a callback to receive the picked {@link Marker}
@@ -11,10 +12,8 @@ import androidx.annotation.Keep;
 @Keep
 public interface MarkerPickListener {
     /**
-     * Receive information about marker found in a call to {@link MapController#pickMarker(float, float)}
-     * @param markerPickResult The {@link MarkerPickResult} the marker that has been selected
-     * @param positionX The horizontal screen coordinate of the picked location
-     * @param positionY The vertical screen coordinate of the picked location
+     * Called when a marker pick query is complete, whether or not a marker was found.
+     * @param result Info about the selected marker, or null if no marker was found.
      */
-    void onMarkerPick(final MarkerPickResult markerPickResult, final float positionX, final float positionY);
+    void onMarkerPickComplete(@Nullable final MarkerPickResult result);
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MarkerPickResult.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MarkerPickResult.java
@@ -1,35 +1,47 @@
 package com.mapzen.tangram;
 
+import android.graphics.PointF;
+
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
 /**
- * {@code MarkerPickResult} represents labels that can be selected on the screen
+ * Result of a marker selection query.
  */
 @Keep
 public class MarkerPickResult {
 
     private Marker marker;
     private LngLat coordinates;
+    private PointF screenPosition;
 
-    MarkerPickResult(final Marker marker, final double longitude, final double latitude) {
+    MarkerPickResult(final Marker marker, final double longitude, final double latitude, final float screenX, final float screenY) {
         this.marker = marker;
         this.coordinates = new LngLat(longitude, latitude);
+        this.screenPosition = new PointF(screenX, screenY);
     }
 
     /**
-     * @return The marker associated with the selection
+     * @return Selected marker.
      */
     public Marker getMarker() {
-        return this.marker;
+        return marker;
     }
 
     /**
-     * @return The coordinate of the feature for which this label has been created
+     * @return Geographic coordinates of the selected marker.
      */
     @NonNull
     public LngLat getCoordinates() {
-        return this.coordinates;
+        return coordinates;
+    }
+
+    /**
+     * @return Screen position of the query that produced this result.
+     */
+    @NonNull
+    public PointF getScreenPosition() {
+        return screenPosition;
     }
 
 }

--- a/scenes/scene.yaml
+++ b/scenes/scene.yaml
@@ -63,6 +63,8 @@ styles:
     icons:
         base: points
         texture: pois
+        draw:
+            interactive: true
     heightglow:
         base: polygons
         blend: translucent


### PR DESCRIPTION
This clears up some confusion and ambiguity in the feature/label/marker picking interfaces in the Tangram Android SDK. 

- Updated documentation to clarify that pick calls will always result in a callback (when a listener is set). Success of the pick is expressed in the result object passed to the callback.
- `onFeaturePick` etc. have been renamed to `onFeaturePickComplete` to both distinguish the updated method signatures and to emphasize that the pick is _complete_, but not necessarily _successful_.
- Callback methods now take a single result object as their argument, which will be non-null if the pick call resulted in a feature/label/marker and will be null otherwise.