### PR TITLE
Fix ClientDataSource losing features after scene change

### DIFF
--- a/core/include/tangram/data/clientDataSource.h
+++ b/core/include/tangram/data/clientDataSource.h
@@ -55,6 +55,9 @@ public:
     void addPolygonFeature(Properties&& properties, PolygonBuilder
         && polygon);
 
+    // Remove all feature data.
+    void clearFeatures();
+
     // Transform added feature data into tiles.
     void generateTiles();
 
@@ -62,7 +65,6 @@ public:
     std::shared_ptr<TileTask> createTask(TileID _tileId) override;
 
     void cancelLoadingTile(TileTask& _task) override {};
-    void clearData() override;
 
 protected:
 

--- a/core/src/data/clientDataSource.cpp
+++ b/core/src/data/clientDataSource.cpp
@@ -212,15 +212,12 @@ void ClientDataSource::loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb 
     TileSource::loadTileData(_task, _cb);
 }
 
-void ClientDataSource::clearData() {
+void ClientDataSource::clearFeatures() {
 
     std::lock_guard<std::mutex> lock(m_mutexStore);
 
     m_store->features.clear();
     m_store->properties.clear();
-    m_store->tiles.reset();
-
-    m_generation++;
 }
 
 void ClientDataSource::addData(const std::string& _data) {

--- a/platforms/android/tangram/src/main/cpp/jniExports.cpp
+++ b/platforms/android/tangram/src/main/cpp/jniExports.cpp
@@ -529,7 +529,7 @@ void MapController(SetDefaultBackgroundColor)(JNIEnv* jnienv, jobject obj, jlong
     map->setDefaultBackgroundColor(r, g, b);
 }
 
-jlong MapController(AddTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
+jlong MapController(AddClientDataSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
                                    jstring name, jboolean generateCentroid) {
     auto_map(mapPtr);
 
@@ -541,18 +541,11 @@ jlong MapController(AddTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr,
     return reinterpret_cast<jlong>(source.get());
 }
 
-void MapController(RemoveTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
+void MapController(RemoveClientDataSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
     auto_map(mapPtr);
     auto_source(sourcePtr);
     map->removeTileSource(*source);
 }
-
-void MapController(ClearTileSource)(JNIEnv* jniEnv, jobject obj, jlong mapPtr, jlong sourcePtr) {
-    auto_map(mapPtr);
-    auto_source(sourcePtr);
-    map->clearTileSource(*source, true, true);
-}
-
 
 #define MapData(NAME) FUNC(MapData, NAME)
 
@@ -622,6 +615,12 @@ void MapData(GenerateTiles)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr) {
     auto_source(sourcePtr);
 
     source->generateTiles();
+}
+
+void MapData(ClearFeatures)(JNIEnv* jniEnv, jobject obj, jlong sourcePtr) {
+    auto_source(sourcePtr);
+
+    source->clearFeatures();
 }
 
 } // extern "C"

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -682,7 +682,7 @@ public class MapController {
             return mapData;
         }
         checkPointer(mapPointer);
-        final long pointer = nativeAddTileSource(mapPointer, name, generateCentroid);
+        final long pointer = nativeAddClientDataSource(mapPointer, name, generateCentroid);
         if (pointer <= 0) {
             throw new RuntimeException("Unable to create new data source");
         }
@@ -699,7 +699,7 @@ public class MapController {
         clientTileSources.remove(mapData.name);
         checkPointer(mapPointer);
         checkPointer(mapData.pointer);
-        nativeRemoveTileSource(mapPointer, mapData.pointer);
+        nativeRemoveClientDataSource(mapPointer, mapData.pointer);
     }
 
     /**
@@ -1107,19 +1107,6 @@ public class MapController {
         nativeOnLowMemory(mapPointer);
     }
 
-    void removeTileSource(final long sourcePtr) {
-        checkPointer(mapPointer);
-        checkPointer(sourcePtr);
-        nativeRemoveTileSource(mapPointer, sourcePtr);
-    }
-
-    void clearTileSource(final long sourcePtr) {
-        checkPointer(mapPointer);
-        checkPointer(sourcePtr);
-        nativeClearTileSource(mapPointer, sourcePtr);
-    }
-
-
     void checkPointer(final long ptr) {
         if (ptr <= 0) {
             throw new RuntimeException("Tried to perform an operation on an invalid pointer!"
@@ -1440,9 +1427,8 @@ public class MapController {
     private synchronized native void nativeUseCachedGlState(long mapPtr, boolean use);
     private synchronized native void nativeSetDefaultBackgroundColor(long mapPtr, float r, float g, float b);
 
-    private synchronized native long nativeAddTileSource(long mapPtr, String name, boolean generateCentroid);
-    private synchronized native void nativeRemoveTileSource(long mapPtr, long sourcePtr);
-    private synchronized native void nativeClearTileSource(long mapPtr, long sourcePtr);
+    private synchronized native long nativeAddClientDataSource(long mapPtr, String name, boolean generateCentroid);
+    private synchronized native void nativeRemoveClientDataSource(long mapPtr, long sourcePtr);
 
     private synchronized native void nativeSetDebugFlag(int flag, boolean on);
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -35,12 +35,8 @@ public class MapData {
      * @param features The features to assign
      */
     public void setFeatures(@NonNull final List<Geometry> features) {
-        final MapController map = mapController;
-        if (map == null) {
-            return;
-        }
         synchronized (this) {
-            map.clearTileSource(pointer);
+            nativeClearFeatures(pointer);
             for (Geometry feature : features) {
                 nativeAddFeature(pointer,
                         feature.getCoordinateArray(),
@@ -56,13 +52,10 @@ public class MapData {
      * @param data A string containing a <a href="http://geojson.org/">GeoJSON</a> FeatureCollection
      */
     public void setGeoJson(final String data) {
-        final MapController map = mapController;
-        if (map != null) {
-            synchronized (this) {
-                map.clearTileSource(pointer);
-                nativeAddGeoJson(pointer, data);
-                nativeGenerateTiles(pointer);
-            }
+        synchronized (this) {
+            nativeClearFeatures(pointer);
+            nativeAddGeoJson(pointer, data);
+            nativeGenerateTiles(pointer);
         }
     }
 
@@ -94,13 +87,13 @@ public class MapData {
      * Remove all features from this collection.
      */
     public void clear() {
-        final MapController map = mapController;
-        if (map != null) {
-            map.clearTileSource(pointer);
+        synchronized (this) {
+            nativeClearFeatures(pointer);
         }
     }
 
     private native void nativeAddFeature(long sourcePtr, double[] coordinates, int[] rings, String[] properties);
     private native void nativeAddGeoJson(long sourcePtr, String geoJson);
     private native void nativeGenerateTiles(long sourcePtr);
+    private native void nativeClearFeatures(long sourcePtr);
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -35,6 +35,7 @@ public class MapData {
      * @param features The features to assign
      */
     public void setFeatures(@NonNull final List<Geometry> features) {
+        checkPointer(pointer);
         nativeClearFeatures(pointer);
         for (Geometry feature : features) {
             nativeAddFeature(pointer,
@@ -50,6 +51,7 @@ public class MapData {
      * @param data A string containing a <a href="http://geojson.org/">GeoJSON</a> FeatureCollection
      */
     public void setGeoJson(final String data) {
+        checkPointer(pointer);
         nativeClearFeatures(pointer);
         nativeAddGeoJson(pointer, data);
         nativeGenerateTiles(pointer);
@@ -83,8 +85,16 @@ public class MapData {
      * Remove all features from this collection.
      */
     public void clear() {
+        checkPointer(pointer);
         nativeClearFeatures(pointer);
         nativeGenerateTiles(pointer);
+    }
+
+    private void checkPointer(final long ptr) {
+        if (ptr <= 0) {
+            throw new RuntimeException("Tried to perform an operation on an invalid pointer!"
+                    + " This means you may have used a MapData that has already been removed.");
+        }
     }
 
     private native void nativeAddFeature(long sourcePtr, double[] coordinates, int[] rings, String[] properties);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -84,6 +84,7 @@ public class MapData {
      */
     public void clear() {
         nativeClearFeatures(pointer);
+        nativeGenerateTiles(pointer);
     }
 
     private native void nativeAddFeature(long sourcePtr, double[] coordinates, int[] rings, String[] properties);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -35,16 +35,14 @@ public class MapData {
      * @param features The features to assign
      */
     public void setFeatures(@NonNull final List<Geometry> features) {
-        synchronized (this) {
-            nativeClearFeatures(pointer);
-            for (Geometry feature : features) {
-                nativeAddFeature(pointer,
-                        feature.getCoordinateArray(),
-                        feature.getRingArray(),
-                        feature.getPropertyArray());
-            }
-            nativeGenerateTiles(pointer);
+        nativeClearFeatures(pointer);
+        for (Geometry feature : features) {
+            nativeAddFeature(pointer,
+                    feature.getCoordinateArray(),
+                    feature.getRingArray(),
+                    feature.getPropertyArray());
         }
+        nativeGenerateTiles(pointer);
     }
 
     /**
@@ -52,11 +50,9 @@ public class MapData {
      * @param data A string containing a <a href="http://geojson.org/">GeoJSON</a> FeatureCollection
      */
     public void setGeoJson(final String data) {
-        synchronized (this) {
-            nativeClearFeatures(pointer);
-            nativeAddGeoJson(pointer, data);
-            nativeGenerateTiles(pointer);
-        }
+        nativeClearFeatures(pointer);
+        nativeAddGeoJson(pointer, data);
+        nativeGenerateTiles(pointer);
     }
 
     /**
@@ -87,9 +83,7 @@ public class MapData {
      * Remove all features from this collection.
      */
     public void clear() {
-        synchronized (this) {
-            nativeClearFeatures(pointer);
-        }
+        nativeClearFeatures(pointer);
     }
 
     private native void nativeAddFeature(long sourcePtr, double[] coordinates, int[] rings, String[] properties);

--- a/platforms/ios/framework/src/TGMapData.h
+++ b/platforms/ios/framework/src/TGMapData.h
@@ -81,6 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setGeoJson:(NSString *)data;
 
 /**
+ Clears the contents of this map data.
+ */
+- (void)clear;
+
+/**
  Permanently removes this map data from the map view.
 
  Any future use of this object will do nothing.

--- a/platforms/ios/framework/src/TGMapData.mm
+++ b/platforms/ios/framework/src/TGMapData.mm
@@ -105,6 +105,16 @@ static inline void TGFeaturePropertiesConvertToCoreProperties(TGFeaturePropertie
     dataSource->generateTiles();
 }
 
+- (void)clear
+{
+    if (!self.map) {
+        return;
+    }
+
+    dataSource->clearFeatures();
+    dataSource->generateTiles();
+}
+
 - (BOOL)remove
 {
     if (!self.map) {

--- a/platforms/ios/framework/src/TGMapData.mm
+++ b/platforms/ios/framework/src/TGMapData.mm
@@ -56,7 +56,7 @@ static inline void TGFeaturePropertiesConvertToCoreProperties(TGFeaturePropertie
         return;
     }
 
-    dataSource->clearData();
+    dataSource->clearFeatures();
     for (TGMapFeature *feature in features) {
         Tangram::Properties properties;
         TGFeaturePropertiesConvertToCoreProperties(feature.properties, properties);
@@ -100,7 +100,7 @@ static inline void TGFeaturePropertiesConvertToCoreProperties(TGFeaturePropertie
     }
 
     std::string sourceData = std::string([data UTF8String]);
-    dataSource->clearData();
+    dataSource->clearFeatures();
     dataSource->addData(sourceData);
     dataSource->generateTiles();
 }


### PR DESCRIPTION
When the current scene is changed, the `TileManager` instance used by the old scene runs `cancelTileTasks()` to stop pending asynchronous work. The implementation of this method also called `clearData()` on all of the managed `TileSource`s. `ClientDataSource::clearData()` not only removes the tiles generated from its stored features, but also removes the features themselves. This should definitely not happen when the scene changes. ~It's not clear why `clearData()` was used here at all, so I've simply removed the call.~

The behavior of `clearData()` (which is to clear caches) was mistakenly conflated with the need to clear the set of features added to a `ClientDataSource`. These two behaviors are both necessary, but should be separate. So I've given `ClientDataSource` a new method called `clearFeatures()` that removes added features, and made its `clearData()` implementation fall back to that of the base class. So now when a scene is reloaded and `clearData()` is invoked, the `ClientDataSource` features won't be cleared. But a client can explicitly clear the features through `MapData$clear`. 

This issue demonstrates how messy some of the `TileSource` abstraction is. A better, more complete solution would be to refactor these interfaces, but that will take more time.

Resolves #2117