### PR TITLE
Tile fallback

### DIFF
--- a/core/include/tangram/data/clientDataSource.h
+++ b/core/include/tangram/data/clientDataSource.h
@@ -50,10 +50,16 @@ public:
 
     void addPointFeature(Properties&& properties, LngLat coordinates);
 
-    void addPolylineFeature(Properties&& properties, PolylineBuilder&& polyline);
+    uint64_t addPolylineFeature(Properties&& properties, PolylineBuilder&& polyline);
 
     void addPolygonFeature(Properties&& properties, PolygonBuilder
         && polygon);
+
+    void updatePolylineFeature(uint64_t id, const Coordinates& coordinates);
+
+    void updatePolylineFeature(uint64_t id, const Properties&& properties);
+
+    void removePolylineFeature(uint64_t id);
 
     // Transform added feature data into tiles.
     void generateTiles();

--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -54,6 +54,8 @@ public:
     struct DataSource {
         virtual ~DataSource() {}
 
+        virtual TileID getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) = 0;
+
         virtual bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) = 0;
 
         /* Stops any running I/O tasks pertaining to @_tile */
@@ -91,6 +93,8 @@ public:
      * @return the mime-type of the DataSource.
      */
     virtual const char* mimeType() const;
+
+    TileID getFallbackTileID(const TileID& _tileID);
 
     /* Fetches data for the map tile specified by @_tileID
      *

--- a/core/src/data/mbtilesDataSource.h
+++ b/core/src/data/mbtilesDataSource.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include "data/tileSource.h"
 
 namespace SQLite {
@@ -22,11 +23,14 @@ public:
 
     ~MBTilesDataSource();
 
+    TileID getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) override;
+
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
     void clear() override {}
 
 private:
+    bool hasTileData(const TileID& _tileId);
     bool getTileData(const TileID& _tileId, std::vector<char>& _data);
     void storeTileData(const TileID& _tileId, const std::vector<char>& _data);
     bool loadNextSource(std::shared_ptr<TileTask> _task, TileTaskCb _cb);
@@ -51,6 +55,9 @@ private:
     std::unique_ptr<SQLite::Database> m_db;
     std::unique_ptr<MBTilesQueries> m_queries;
     std::unique_ptr<AsyncWorker> m_worker;
+
+    // Cached has tile data
+    std::map<TileID, bool> m_HasTileDataCache;
 
     // Platform reference
     Platform& m_platform;

--- a/core/src/data/memoryCacheDataSource.cpp
+++ b/core/src/data/memoryCacheDataSource.cpp
@@ -22,8 +22,17 @@ struct RawCache {
 
     CacheMap m_cacheMap;
     CacheList m_cacheList;
-    int m_usage = 0;
-    int m_maxUsage = 0;
+    size_t m_usage = 0;
+    size_t m_maxUsage = 0;
+
+    bool has(const TileID& _tileID) {
+
+        if (m_maxUsage <= 0) { return false; }
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        return m_cacheMap.find(_tileID) != m_cacheMap.end();
+    }
 
     bool get(BinaryTileTask& _task) {
 
@@ -93,12 +102,53 @@ void MemoryCacheDataSource::setCacheSize(size_t _cacheSize) {
     m_cache->m_maxUsage = _cacheSize;
 }
 
+bool MemoryCacheDataSource::hasCache(const TileID& _tileID) {
+    return m_cache->has(_tileID);
+}
+
 bool MemoryCacheDataSource::cacheGet(BinaryTileTask& _task) {
     return m_cache->get(_task);
 }
 
 void MemoryCacheDataSource::cachePut(const TileID& _tileID, std::shared_ptr<std::vector<char>> _rawDataRef) {
     m_cache->put(_tileID, _rawDataRef);
+}
+
+TileID MemoryCacheDataSource::getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) {
+
+    TileID tileID(_tileID);
+    bool isCached = false;
+
+    while (!(isCached = hasCache(tileID)) && tileID.z > 0) {
+        tileID = tileID.getParent(_zoomBias);
+    }
+
+    if (tileID.z == _maxZoom) {
+        tileID = _tileID;
+    }
+    else {
+        tileID.s = _tileID.s;
+    }
+
+    if (next) {
+        TileID nextTileID = next->getFallbackTileID(_tileID, _maxZoom, _zoomBias);
+
+        if (nextTileID.z == _maxZoom) {
+            nextTileID = _tileID;
+        }
+        else {
+            nextTileID.s = _tileID.s;
+        }
+
+        if (isCached) {
+            return (tileID.z > nextTileID.z) ? tileID : nextTileID;
+        }
+        else {
+            return nextTileID;
+        }
+    }
+
+    return tileID;
 }
 
 bool MemoryCacheDataSource::loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) {

--- a/core/src/data/memoryCacheDataSource.h
+++ b/core/src/data/memoryCacheDataSource.h
@@ -10,6 +10,8 @@ public:
     MemoryCacheDataSource();
     ~MemoryCacheDataSource();
 
+    TileID getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) override;
+
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
     void clear() override;
@@ -20,6 +22,7 @@ public:
     void setCacheSize(size_t _cacheSize);
 
 private:
+    bool hasCache(const TileID& _tileID);
     bool cacheGet(BinaryTileTask& _task);
 
     void cachePut(const TileID& _tileID, std::shared_ptr<std::vector<char>> _rawDataRef);

--- a/core/src/data/networkDataSource.h
+++ b/core/src/data/networkDataSource.h
@@ -15,6 +15,8 @@ public:
     NetworkDataSource(Platform& _platform, const std::string& _urlTemplate,
                       std::vector<std::string>&& _urlSubdomains, bool _isTms);
 
+    TileID getFallbackTileID(const TileID& _tileID, int32_t _maxZoom, int32_t _zoomBias) override { return _tileID; }
+
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
     void cancelLoadingTile(TileTask& _task) override;

--- a/core/src/data/rasterSource.cpp
+++ b/core/src/data/rasterSource.cpp
@@ -150,19 +150,24 @@ std::shared_ptr<TileData> RasterSource::parse(const TileTask& _task) const {
 
 void RasterSource::addRasterTask(TileTask& _task) {
 
-    TileID subTileID = _task.tileId();
+    TileID fallbackTileID = getFallbackTileID(_task.tileId());
 
-    // apply apt downsampling for raster tiles depending on difference
-    // in zoomBias (which also takes zoom offset into account)
-    auto zoomDiff = m_zoomOptions.zoomBias - _task.source()->zoomBias();
+    if (fallbackTileID == _task.tileId()) {
+        // apply apt downsampling for raster tiles depending on difference
+        // in zoomBias (which also takes zoom offset into account)
+        auto zoomDiff = m_zoomOptions.zoomBias - _task.source()->zoomBias();
 
-    if (zoomDiff > 0) {
-        subTileID = subTileID.zoomBiasAdjusted(zoomDiff).withMaxSourceZoom(m_zoomOptions.maxZoom);
-    } else {
-        subTileID = subTileID.withMaxSourceZoom(m_zoomOptions.maxZoom);
+        if (zoomDiff > 0) {
+            fallbackTileID = fallbackTileID.zoomBiasAdjusted(zoomDiff).withMaxSourceZoom(m_zoomOptions.maxZoom);
+        } else {
+            fallbackTileID = fallbackTileID.withMaxSourceZoom(m_zoomOptions.maxZoom);
+        }
+    }
+    else if (fallbackTileID.s > (int8_t)_task.source()->maxZoom()) {
+        fallbackTileID.s = (int8_t)_task.source()->maxZoom();
     }
 
-    auto rasterTask = createRasterTask(subTileID, true);
+    auto rasterTask = createRasterTask(fallbackTileID, true);
 
     _task.subTasks().push_back(rasterTask);
 }

--- a/core/src/data/tileSource.cpp
+++ b/core/src/data/tileSource.cpp
@@ -78,6 +78,16 @@ void TileSource::clearData() {
     m_generation++;
 }
 
+TileID TileSource::getFallbackTileID(const TileID& _tileID) {
+
+    if (m_sources) {
+        return m_sources->getFallbackTileID(_tileID, maxZoom(), zoomBias());
+    }
+    else {
+        return _tileID;
+    }
+}
+
 void TileSource::loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) {
 
     if (m_sources) {

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -296,8 +296,16 @@ void TileManager::updateTileSets(const View& _view) {
                 auto zoomBias = tileSet.source->zoomBias();
                 auto maxZoom = tileSet.source->maxZoom();
 
-                // Insert scaled and maxZoom mapped tileID in the visible set
-                tileSet.visibleTiles.insert(_tileID.zoomBiasAdjusted(zoomBias).withMaxSourceZoom(maxZoom));
+                TileID fallbackTileID = tileSet.source->getFallbackTileID(_tileID);
+
+                if (fallbackTileID == _tileID) {
+                    fallbackTileID = fallbackTileID.zoomBiasAdjusted(zoomBias);
+                }
+                else if (fallbackTileID.s > (int8_t)maxZoom) {
+                    fallbackTileID.s = (int8_t)maxZoom;
+                }
+
+                tileSet.visibleTiles.insert(fallbackTileID.withMaxSourceZoom(maxZoom));
             }
         };
 


### PR DESCRIPTION
Add support for getting tile for lower zoom if tile for higher zoom is not available.

Use case and current state:
User has mbtiles tile source which for some areas has tile data let's say only for zoom 10. Then he zooms to zoom 15 and the current state is that on the map he does not see anything. In this case it would be better to see a tile from zoom 10 rather than nothing.

New behavior:
When user want to show some location on the map and tile is not available in mbtiles, it would search tile parents until mbtiles contain some parent which does exist in mbtiles and then return `TileID` of that parent.

I have implemented it for `MBTilesDataSource` and `MemoryCacheDataSource`.