### PR TITLE
Fix iOS dynamic framework referencing its local build path

### DIFF
--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -120,6 +120,9 @@ set_target_properties(TangramMap PROPERTIES
   # This property is necessary for downstream consumers of the framework. Set it here for Xcode to
   # populate the 'Bundle Identifier' fields and substitute the placeholder value in our Info.plist.
   XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${TANGRAM_BUNDLE_IDENTIFIER}"
+  # This ensures that the dynamic linker loads the framework from its embedded path in an app, not
+  # from the location it was originally built.
+  XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
 )
 # Other properties that are common to dynamic and static framework targets are set below.
 


### PR DESCRIPTION
When INSTALL_PATH uses its default value, the framework stores a dependency to its local build path, causing the dynamic linker to fail when the framework is embedded on another device.

You can see this dependency using `otool`. Before this change:
```
> $ otool -L /Users/matt/Workspace/tangram-es/build/ios/Release-universal/TangramMap.framework/TangramMap
/Users/matt/Workspace/tangram-es/build/ios/Release-universal/TangramMap.framework/TangramMap:
	/Users/matt/Workspace/tangram-es/build/ios/Release-iphonesimulator/TangramMap.framework/TangramMap (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libsqlite3.dylib (compatibility version 9.0.0, current version 308.4.0)
	/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation (compatibility version 150.0.0, current version 1673.126.0)
	/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics (compatibility version 64.0.0, current version 1348.12.1)
	/System/Library/Frameworks/CoreLocation.framework/CoreLocation (compatibility version 1.0.0, current version 2388.0.21)
	/System/Library/Frameworks/CoreText.framework/CoreText (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/GLKit.framework/GLKit (compatibility version 1.0.0, current version 106.0.0)
	/System/Library/Frameworks/OpenGLES.framework/OpenGLES (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/QuartzCore.framework/QuartzCore (compatibility version 1.2.0, current version 1.11.0)
	/System/Library/Frameworks/UIKit.framework/UIKit (compatibility version 1.0.0, current version 61000.0.0)
	/System/Library/Frameworks/Foundation.framework/Foundation (compatibility version 300.0.0, current version 1673.126.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/usr/lib/libc++abi.dylib (compatibility version 1.0.0, current version 800.6.0)
```

After this change:
```
> $ otool -L /Users/matt/Workspace/tangram-es/build/ios/Release-universal/TangramMap.framework/TangramMap
/Users/matt/Workspace/tangram-es/build/ios/Release-universal/TangramMap.framework/TangramMap:
	@rpath/TangramMap.framework/TangramMap (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libsqlite3.dylib (compatibility version 9.0.0, current version 308.4.0)
	/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation (compatibility version 150.0.0, current version 1673.126.0)
	/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics (compatibility version 64.0.0, current version 1348.12.1)
	/System/Library/Frameworks/CoreLocation.framework/CoreLocation (compatibility version 1.0.0, current version 2388.0.21)
	/System/Library/Frameworks/CoreText.framework/CoreText (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/GLKit.framework/GLKit (compatibility version 1.0.0, current version 106.0.0)
	/System/Library/Frameworks/OpenGLES.framework/OpenGLES (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/QuartzCore.framework/QuartzCore (compatibility version 1.2.0, current version 1.11.0)
	/System/Library/Frameworks/UIKit.framework/UIKit (compatibility version 1.0.0, current version 61000.0.0)
	/System/Library/Frameworks/Foundation.framework/Foundation (compatibility version 300.0.0, current version 1673.126.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/usr/lib/libc++abi.dylib (compatibility version 1.0.0, current version 800.6.0)
```
Note that the first link dependency no longer includes a local path.

More details on dynamic linker behavior and `@rpath`:
- https://blog.krzyzanowskim.com/2018/12/05/rpath-what/
- https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/RunpathDependentLibraries.html
