### PR TITLE
Fix dash color and background blending

### DIFF
--- a/core/shaders/polyline.fs
+++ b/core/shaders/polyline.fs
@@ -65,20 +65,20 @@ void main(void) {
     #endif
 
     #ifdef TANGRAM_LINE_TEXTURE
-        vec2 line_st = vec2(v_texcoord.x, fract(v_texcoord.y * TANGRAM_DASHLINE_TEX_SCALE / u_texture_ratio));
+        vec2 line_st = vec2(v_texcoord.x, fract(v_texcoord.y * TANGRAM_DASH_TEX_SCALE / u_texture_ratio));
         vec4 line_color = texture2D(u_texture, line_st);
 
-        if (line_color.a < TANGRAM_ALPHA_TEST) {
-            #ifdef TANGRAM_LINE_BACKGROUND_COLOR
-                color.rgb = TANGRAM_LINE_BACKGROUND_COLOR;
-            #elif !defined(TANGRAM_BLEND_OVERLAY) && !defined(TANGRAM_BLEND_INLAY)
-                discard;
-            #else
-                color.a = 0.0;
-            #endif
-        } else {
+        #if defined(TANGRAM_LINE_DASH)
+            color = mix(TANGRAM_LINE_BACKGROUND_COLOR, color, line_color.a);
+        #else
             color *= line_color;
-        }
+        #endif
+
+        #if defined(TANGRAM_BLEND_OPAQUE)
+            if (color.a < TANGRAM_ALPHA_TEST) {
+                discard;
+            }
+        #endif
     #endif
 
     #ifdef TANGRAM_RASTER_TEXTURE_NORMAL

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -107,7 +107,6 @@ void PolylineStyle::onBeginDrawFrame(RenderState& rs, const View& _view) {
 
 void PolylineStyle::setDashBackgroundColor(const glm::vec4 _dashBackgroundColor) {
     m_dashBackgroundColor = _dashBackgroundColor;
-    m_dashBackground = true;
 }
 
 void PolylineStyle::constructShaderProgram() {
@@ -126,22 +125,22 @@ void PolylineStyle::constructShaderProgram() {
                                 reinterpret_cast<GLubyte*>(pixels.data()),
                                 pixels.size() * sizeof(GLuint));
 
-        if (m_dashBackground) {
-            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_LINE_BACKGROUND_COLOR vec3(" +
-                ff::to_string(m_dashBackgroundColor.r) + ", " +
-                ff::to_string(m_dashBackgroundColor.g) + ", " +
-                ff::to_string(m_dashBackgroundColor.b) + ")\n");
-        }
+        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_LINE_BACKGROUND_COLOR vec4(" +
+                                                  ff::to_string(m_dashBackgroundColor.r) + ", " +
+                                                  ff::to_string(m_dashBackgroundColor.g) + ", " +
+                                                  ff::to_string(m_dashBackgroundColor.b) + ", " +
+                                                  ff::to_string(m_dashBackgroundColor.a) + ")\n");
     }
 
     if (m_dashArray.size() > 0 || m_texture) {
         m_shaderSource->addSourceBlock("defines", "#define TANGRAM_LINE_TEXTURE\n", false);
         m_shaderSource->addSourceBlock("defines", "#define TANGRAM_ALPHA_TEST 0.25\n", false);
         if (m_dashArray.size() > 0) {
-            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE " +
+            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_LINE_DASH");
+            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_DASH_TEX_SCALE " +
                                             ff::to_string(dash_scale) + "\n", false);
         } else {
-            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_DASHLINE_TEX_SCALE 1.0\n", false);
+            m_shaderSource->addSourceBlock("defines", "#define TANGRAM_DASH_TEX_SCALE 1.0\n", false);
         }
     }
 

--- a/core/src/style/polylineStyle.h
+++ b/core/src/style/polylineStyle.h
@@ -27,8 +27,7 @@ private:
 
     std::vector<float> m_dashArray;
     std::shared_ptr<Texture> m_texture;
-    bool m_dashBackground = false;
-    glm::vec4 m_dashBackgroundColor;
+    glm::vec4 m_dashBackgroundColor = {};
 
     UniformLocation m_uTexture{"u_texture"};
     UniformLocation m_uTextureRatio{"u_texture_ratio"};

--- a/core/src/util/yamlUtil.cpp
+++ b/core/src/util/yamlUtil.cpp
@@ -19,6 +19,9 @@ glm::vec4 getColorAsVec4(const YAML::Node& node) {
     if (node.IsSequence()) {
         glm::vec4 vec;
         if (parseVec(node, vec)) {
+            if (node.size() < 4) {
+                vec.w = 1.0;
+            }
             return vec;
         }
     }


### PR DESCRIPTION
Addresses the issue described in https://github.com/tangrams/tangram/issues/741 (this issue is for the JS engine, but the problem exists here too). This change applies the logic described in https://github.com/tangrams/tangram/pull/742 color in a dashed polyline. I also fixed a small bug  in parsing colors from YAML sequences.