### PR TITLE
Fix label collider tile scale

### DIFF
--- a/core/src/labels/labelCollider.cpp
+++ b/core/src/labels/labelCollider.cpp
@@ -58,6 +58,21 @@ size_t LabelCollider::filterRepeatGroups(size_t startPos, size_t curPos) {
 
 void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tileSize) {
 
+    // Set view parameters so that the tile is rendererd at
+    // style-zoom-level + 2. (scaled up by factor 4). This
+    // filters out labels that are unlikely to become visible
+    // within the tiles zoom-range.
+    int overzoom = 2;
+    int tileScaleDiff = _tileID.s - _tileID.z + overzoom;
+
+    if (tileScaleDiff >= 6) {
+        return;
+    }
+
+    float tileScale = pow(2, tileScaleDiff);
+    glm::vec2 screenSize{ _tileSize * tileScale };
+    glm::vec2 screenSize128{screenSize.x / 128, screenSize.y / 128};
+    
     // Sort labels so that all labels of one repeat group are next to each other
     std::sort(m_labels.begin(), m_labels.end(),
               [](auto& e1, auto& e2) {
@@ -78,14 +93,6 @@ void LabelCollider::process(TileID _tileID, float _tileInverseScale, float _tile
 
                   return l1->hash() < l2->hash();
               });
-
-    // Set view parameters so that the tile is rendererd at
-    // style-zoom-level + 2. (scaled up by factor 4). This
-    // filters out labels that are unlikely to become visible
-    // within the tiles zoom-range.
-    int overzoom = 2;
-    float tileScale = pow(2, _tileID.s - _tileID.z + overzoom);
-    glm::vec2 screenSize{ _tileSize * tileScale };
 
     // Project tile to NDC (-1 to 1, y-up)
     glm::mat4 mvp{1};


### PR DESCRIPTION
While I was testing tile fallbacking feature I discovered that when tile fallback (there is a pull request for tile fallback here: https://github.com/tangrams/tangram-es/pull/2120) is from zoom 16 to zoom 0 there just occurred an int 32 overflow in allocation https://github.com/tangrams/isect2d/blob/2e1a75cee09d9949900e926c61c86505b09205b2/include/isect2d.h#L60  . So while trying it and profiling memory usage on Android device I came out with a solution to not process labels when tile scale difference is larger or equal to 6 so it won't much consume RAM and also it won't crash on bad alloc exception. I am not sure if this proposed solution is a right one.