### PR TITLE
Add $meters_per_pixel keyword for filters and JS functions

### DIFF
--- a/bench/src/benchStyleContext.cpp
+++ b/bench/src/benchStyleContext.cpp
@@ -104,7 +104,7 @@ struct JSTileStyleFnFixture : public benchmark::Fixture {
     void SetUp(const ::benchmark::State& state) override {
         globalSetup();
         ctx.initFunctions(*scene);
-        ctx.setKeywordZoom(10);
+        ctx.setZoom(10);
     }
     void TearDown(const ::benchmark::State& state) override {
         LOG(">>> %d", evalCnt);

--- a/core/src/marker/markerManager.cpp
+++ b/core/src/marker/markerManager.cpp
@@ -407,7 +407,7 @@ bool MarkerManager::buildMesh(Marker& marker, int zoom) {
     // Apply defaul draw rules defined for this style
     styler->style().applyDefaultDrawRules(*rule);
 
-    m_styleContext->setKeywordZoom(zoom);
+    m_styleContext->setZoom(zoom);
 
     bool valid = marker.evaluateRuleForContext(*m_styleContext);
 

--- a/core/src/scene/drawRule.cpp
+++ b/core/src/scene/drawRule.cpp
@@ -191,7 +191,7 @@ bool DrawRuleMergeSet::evaluateRuleForContext(DrawRule& rule, StyleContext& ctx)
             m_evaluated[i] = *param;
             param = &m_evaluated[i];
 
-            Stops::eval(*param->stops, param->key, ctx.getKeywordZoom(), m_evaluated[i].value);
+            Stops::eval(*param->stops, param->key, ctx.getZoom(), m_evaluated[i].value);
         }
     }
 

--- a/core/src/scene/filters.cpp
+++ b/core/src/scene/filters.cpp
@@ -8,6 +8,26 @@
 
 namespace Tangram {
 
+static const char* keywordGeometryString = "$geometry";
+static const char* keywordZoomString = "$zoom";
+static const char* keywordMetersPerPixelString = "$meters_per_pixel";
+
+FilterKeyword stringToFilterKeyword(const std::string& _key) {
+    if (_key == keywordGeometryString) { return FilterKeyword::geometry; }
+    if (_key == keywordZoomString) { return  FilterKeyword::zoom; }
+    if (_key == keywordMetersPerPixelString) { return FilterKeyword::meters_per_pixel; }
+    return  FilterKeyword::undefined;
+}
+
+std::string filterKeywordToString(FilterKeyword keyword) {
+    switch (keyword) {
+        case FilterKeyword::geometry: return keywordGeometryString;
+        case FilterKeyword::zoom: return keywordZoomString;
+        case FilterKeyword::meters_per_pixel: return keywordMetersPerPixelString;
+        default: return {};
+    }
+}
+
 void Filter::print(int _indent) const {
 
     switch (data.which()) {

--- a/core/src/scene/filters.h
+++ b/core/src/scene/filters.h
@@ -14,7 +14,12 @@ enum class FilterKeyword : uint8_t {
     undefined,
     zoom,
     geometry,
+    meters_per_pixel,
 };
+
+FilterKeyword stringToFilterKeyword(const std::string& _key);
+
+std::string filterKeywordToString(FilterKeyword keyword);
 
 struct Filter {
     struct OperatorAll {
@@ -83,14 +88,14 @@ struct Filter {
     // Create an 'equality' filter
     inline static Filter MatchEquality(const std::string& k, const std::vector<Value>& vals) {
         if (vals.size() == 1) {
-            return { Equality{ k, vals[0], keywordType(k) }};
+            return { Equality{k, vals[0], stringToFilterKeyword(k) }};
         } else {
-            return { EqualitySet{ k, vals, keywordType(k) }};
+            return { EqualitySet{k, vals, stringToFilterKeyword(k) }};
         }
     }
     // Create a 'range' filter
     inline static Filter MatchRange(const std::string& k, float min, float max, bool sqA) {
-        return { Range{ k, min, max, keywordType(k), sqA }};
+        return { Range{k, min, max, stringToFilterKeyword(k), sqA }};
     }
     // Create an 'existence' filter
     inline static Filter MatchExistence(const std::string& k, bool ex) {
@@ -99,15 +104,6 @@ struct Filter {
     // Create an 'function' filter with reference to Scene function id
     inline static Filter MatchFunction(uint32_t id) {
         return { Function{ id }};
-    }
-
-    static FilterKeyword keywordType(const std::string& _key) {
-        if (_key == "$geometry") {
-            return FilterKeyword::geometry;
-        } else if (_key == "$zoom") {
-            return  FilterKeyword::zoom;
-        }
-        return  FilterKeyword::undefined;
     }
 
     /* Public for testing */

--- a/core/src/scene/styleContext.h
+++ b/core/src/scene/styleContext.h
@@ -2,13 +2,10 @@
 
 #include "js/JavaScriptFwd.h"
 #include "scene/styleParam.h"
-#include "util/fastmap.h"
 
 #include <array>
-#include <functional>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 namespace YAML {
     class Node;
@@ -34,54 +31,50 @@ public:
 
     ~StyleContext();
 
-    /*
-     * Set currently processed Feature
-     */
-    void setFeature(const Feature& _feature);
+    /// Set current Feature being evaluated.
+    void setFeature(const Feature& feature);
 
-    /*
-     * Set keyword for currently processed Tile
-     */
-    void setKeywordZoom(int _zoom);
+    /// Set current zoom level being evaluated.
+    void setZoom(double zoom);
 
-    /* Called from Filter::eval */
-    float getKeywordZoom() const { return m_keywordZoom; }
-
-    /* returns meters per pixels at current style zoom */
-    float getPixelAreaScale();
-
-    const Value& getKeyword(FilterKeyword _key) const {
-        return m_keywords[static_cast<uint8_t>(_key)];
+    double getZoom() const {
+        return m_zoom;
     }
 
-    /* Called from Filter::eval */
+    /// Squared meters per pixels at current zoom.
+    double getPixelAreaScale();
+
+    const Value& getKeyword(FilterKeyword keyword) const {
+        return m_keywordValues[static_cast<uint8_t>(keyword)];
+    }
+
+    /// Called from Filter::eval
     bool evalFilter(FunctionID id);
 
-    /* Called from DrawRule::eval */
-    bool evalStyle(FunctionID id, StyleParamKey _key, StyleParam::Value& _val);
+    /// Called from DrawRule::eval
+    bool evalStyle(FunctionID id, StyleParamKey key, StyleParam::Value& value);
 
-    /*
-     * Setup filter and style functions from @_scene
-     */
-    void initFunctions(const Scene& _scene);
+    /// Setup filter and style functions from a Scene.
+    void initFunctions(const Scene& scene);
 
-    /*
-     * Unset Feature handle
-     */
+    /// Unset the current Feature.
     void clear();
 
-    bool setFunctions(const std::vector<std::string>& _functions);
-    bool addFunction(const std::string& _function);
+    bool setFunctions(const std::vector<std::string>& functions);
+    bool addFunction(const std::string& function);
     void setSceneGlobals(const YAML::Node& sceneGlobals);
-
-    void setKeyword(const std::string& _key, Value _value);
-    const Value& getKeyword(const std::string& _key) const;
 
 private:
 
-    std::array<Value, 4> m_keywords;
-    int m_keywordGeom= -1;
-    int m_keywordZoom = -1;
+    void setKeyword(FilterKeyword keyword, Value value);
+
+    std::array<Value, 4> m_keywordValues;
+
+    // Cache zoom separately from keywords for easier access.
+    double m_zoom = -1;
+
+    // Geometry keyword is accessed as a string, but internally cached as an int.
+    int m_keywordGeometry = -1;
 
     int m_functionCount = 0;
 

--- a/core/src/tile/tileBuilder.cpp
+++ b/core/src/tile/tileBuilder.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<Tile> TileBuilder::build(TileID _tileID, const TileData& _tileDa
 
     tile->initGeometry(int(m_scene.styles().size()));
 
-    m_styleContext->setKeywordZoom(_tileID.s);
+    m_styleContext->setZoom(_tileID.s);
 
     for (auto& builder : m_styleBuilder) {
         if (builder.second) { builder.second->setup(*tile); }

--- a/tests/unit/dukTests.cpp
+++ b/tests/unit/dukTests.cpp
@@ -44,14 +44,25 @@ TEST_CASE( "Test evalFilterFn with feature and keywords", "[Duktape][evalFilterF
 
     StyleContext ctx;
     ctx.setFeature(feature);
-    ctx.setKeyword("$zoom", 5);
+    ctx.setZoom(5);
 
     REQUIRE(ctx.setFunctions({ R"(function() { return (feature.scalerank * .5) <= ($zoom - 4); })"}));
     REQUIRE(ctx.evalFilter(0) == true);
 
-    ctx.setKeyword("$zoom", 4);
+    ctx.setZoom(4);
+    REQUIRE(ctx.evalFilter(0) == false);
+}
+
+TEST_CASE( "Test $meters_per_pixel keyword in JS function", "[Duktape]") {
+    StyleContext ctx;
+
+    REQUIRE(ctx.setFunctions({ R"(function() { return $meters_per_pixel <= 100; })"}));
+
+    ctx.setZoom(10); // $meters_per_pixel should be 152.9
     REQUIRE(ctx.evalFilter(0) == false);
 
+    ctx.setZoom(11); // $meters_per_pixel should be 76.4
+    REQUIRE(ctx.evalFilter(0) == true);
 }
 
 TEST_CASE( "Test evalFilterFn with feature and keyword geometry", "[Duktape][evalFilterFn]") {
@@ -106,27 +117,6 @@ TEST_CASE( "Test evalFilterFn with different features", "[Duktape][evalFilterFn]
 
     ctx.setFeature(feat1);
     REQUIRE(ctx.evalFilter(0) == true);
-}
-
-TEST_CASE( "Test numeric keyword", "[Duktape][setKeyword]") {
-    StyleContext ctx;
-    ctx.setKeyword("$zoom", 10);
-    REQUIRE(ctx.setFunctions({ R"(function() { return $zoom === 10 })"}));
-    REQUIRE(ctx.evalFilter(0) == true);
-
-    ctx.setKeyword("$zoom", 0);
-    REQUIRE(ctx.evalFilter(0) == false);
-}
-
-TEST_CASE( "Test string keyword", "[Duktape][setKeyword]") {
-    StyleContext ctx;
-    ctx.setKeyword("$geometry", GeometryType::points);
-    REQUIRE(ctx.setFunctions({ R"(function() { return $geometry === point })"}));
-    REQUIRE(ctx.evalFilter(0) == true);
-
-    ctx.setKeyword("$geometry", "none");
-    REQUIRE(ctx.evalFilter(0) == false);
-
 }
 
 TEST_CASE( "Test evalStyleFn - StyleParamKey::order", "[Duktape][evalStyleFn]") {

--- a/tests/unit/yamlFilterTests.cpp
+++ b/tests/unit/yamlFilterTests.cpp
@@ -57,8 +57,7 @@ void init() {
     bike.props.set("check", "available");
     bike.props.set("serial", 4398046511105); // 2^42 + 1
 
-    ctx.setKeyword("$geometry", Value(1));
-    ctx.setKeyword("$zoom", Value("false"));
+    ctx.setZoom(10);
 }
 
 
@@ -164,7 +163,7 @@ TEST_CASE( "yaml-filter-tests: not", "[filters][core][yaml]") {
 //10. basic predicate with context
 TEST_CASE( "yaml-filter-tests: context filter", "[filters][core][yaml]") {
     init();
-    Filter filter = load("filter: {$geometry : 1}");
+    Filter filter = load("filter: {$zoom : 10}");
 
     REQUIRE(filter.eval(civic, ctx));
     REQUIRE(filter.eval(bmw1, ctx));
@@ -202,19 +201,9 @@ TEST_CASE( "yaml-filter-tests: boolean false filter as existence check", "[filte
 
 }
 
-TEST_CASE( "yaml-filter-tests: boolean true filter as existence check for keyword", "[filters][core][yaml]") {
-    init();
-    Filter filter = load("filter: {$geometry : 1}");
-
-    REQUIRE(filter.eval(civic, ctx));
-    REQUIRE(filter.eval(bmw1, ctx));
-    REQUIRE(filter.eval(bike, ctx));
-
-}
-
 TEST_CASE( "yaml-filter-tests: boolean false filter as existence check for keyword", "[filters][core][yaml]") {
     init();
-    Filter filter = load("filter: {$zoom : false}");
+    Filter filter = load("filter: { not_a_property : false}");
 
     REQUIRE(filter.eval(civic, ctx));
     REQUIRE(filter.eval(bmw1, ctx));


### PR DESCRIPTION
- Add the $meters_per_pixel keyword, determine its value from the current zoom in StyleContext, and make it accessible to filter expressions and JS functions.
- Clean up the logic for keywords in StyleContext - setting arbitrary keywords is no longer supported.
- Updated tests for changes to StyleContext and added a case using $meters_per_pixel in a JS function.

Resolves https://github.com/tangrams/tangram-es/issues/2138