### PR TITLE
Add support for QuadKeys in tile URL templates

### DIFF
--- a/core/src/data/networkDataSource.cpp
+++ b/core/src/data/networkDataSource.cpp
@@ -27,6 +27,13 @@ std::string NetworkDataSource::tileCoordinatesToQuadKey(const TileID &tile) {
     return quadKey;
 }
 
+bool NetworkDataSource::urlHasTilePattern(const std::string &url) {
+    return (url.find("{x}") != std::string::npos &&
+            url.find("{y}") != std::string::npos &&
+            url.find("{z}") != std::string::npos) ||
+           (url.find("{q}") != std::string::npos);
+}
+
 std::string NetworkDataSource::buildUrlForTile(const TileID& tile, const std::string& urlTemplate, const UrlOptions& options, int subdomainIndex) {
 
     std::string url = urlTemplate;

--- a/core/src/data/networkDataSource.h
+++ b/core/src/data/networkDataSource.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "data/tileSource.h"
-#include "platform.h"
 
 #include <unordered_map>
 
@@ -24,6 +23,9 @@ public:
     void cancelLoadingTile(TileTask& _task) override;
 
     static std::string tileCoordinatesToQuadKey(const TileID& tile);
+
+    /// Returns true if the URL either contains 'x', 'y', and 'z' placeholders or contains a 'q' placeholder.
+    static bool urlHasTilePattern(const std::string& url);
 
     static std::string buildUrlForTile(const TileID& tile, const std::string& urlTemplate, const UrlOptions& options, int subdomainIndex);
 

--- a/core/src/data/networkDataSource.h
+++ b/core/src/data/networkDataSource.h
@@ -12,24 +12,30 @@ class Platform;
 class NetworkDataSource : public TileSource::DataSource {
 public:
 
-    NetworkDataSource(Platform& _platform, const std::string& _urlTemplate,
-                      std::vector<std::string>&& _urlSubdomains, bool _isTms);
+    struct UrlOptions {
+        std::vector<std::string> subdomains;
+        bool isTms = false;
+    };
+
+    NetworkDataSource(Platform& _platform, std::string url, UrlOptions options);
 
     bool loadTileData(std::shared_ptr<TileTask> _task, TileTaskCb _cb) override;
 
     void cancelLoadingTile(TileTask& _task) override;
 
+    static std::string tileCoordinatesToQuadKey(const TileID& tile);
+
+    static std::string buildUrlForTile(const TileID& tile, const std::string& urlTemplate, const UrlOptions& options, int subdomainIndex);
+
 private:
-    // Build the URL of a tile using our URL template.
-    std::string buildUrlForTile(const TileID& _tile, size_t _subdomainIndex) const;
 
     Platform& m_platform;
 
-    // URL template for requesting tiles from a network or filesystem
     std::string m_urlTemplate;
-    std::vector<std::string> m_urlSubdomains;
-    size_t m_urlSubdomainIndex = 0;
-    bool m_isTms = false;
+
+    UrlOptions m_options;
+
+    int m_urlSubdomainIndex = 0;
 };
 
 }

--- a/core/src/scene/sceneLoader.cpp
+++ b/core/src/scene/sceneLoader.cpp
@@ -698,12 +698,11 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
     std::string type;
     std::string url;
     std::string mbtiles;
-    std::vector<std::string> subdomains;
 
-    int32_t minDisplayZoom = -1;
-    int32_t maxDisplayZoom = -1;
-    int32_t maxZoom = 18;
-    int32_t zoomBias = 0;
+    NetworkDataSource::UrlOptions urlOptions{};
+
+    TileSource::ZoomOptions zoomOptions{};
+
     int32_t zoomOffset = 0;
 
     if (auto typeNode = _source["type"]) {
@@ -713,13 +712,13 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
         url = urlNode.Scalar();
     }
     if (auto minDisplayZoomNode = _source["min_display_zoom"]) {
-        YamlUtil::getInt(minDisplayZoomNode, minDisplayZoom);
+        YamlUtil::getInt(minDisplayZoomNode, zoomOptions.minDisplayZoom);
     }
     if (auto maxDisplayZoomNode = _source["max_display_zoom"]) {
-        YamlUtil::getInt(maxDisplayZoomNode, maxDisplayZoom);
+        YamlUtil::getInt(maxDisplayZoomNode, zoomOptions.maxDisplayZoom);
     }
     if (auto maxZoomNode = _source["max_zoom"]) {
-        YamlUtil::getInt(maxZoomNode, maxZoom);
+        YamlUtil::getInt(maxZoomNode, zoomOptions.maxZoom);
     }
     if (auto zoomOffsetNode = _source["zoom_offset"]) {
         YamlUtil::getInt(zoomOffsetNode, zoomOffset);
@@ -727,12 +726,12 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
     if (auto tileSizeNode = _source["tile_size"]) {
         int tileSize = 0;
         if (YamlUtil::getInt(tileSizeNode, tileSize)) {
-            zoomBias = TileSource::zoomBiasFromTileSize(tileSize);
+            zoomOptions.zoomBias = TileSource::zoomBiasFromTileSize(tileSize);
         }
     }
 
     if (zoomOffset >= 0) {
-        zoomBias += zoomOffset;
+        zoomOptions.zoomBias += zoomOffset;
     }
 
     // Parse and append any URL parameters.
@@ -767,7 +766,7 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
         if (subDomainNode.IsSequence()) {
             for (const auto& domain : subDomainNode) {
                 if (domain.IsScalar()) {
-                    subdomains.push_back(domain.Scalar());
+                    urlOptions.subdomains.push_back(domain.Scalar());
                 }
             }
         }
@@ -775,20 +774,22 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
 
     // Check whether the URL template and subdomains make sense together, and warn if not.
     bool hasSubdomainPlaceholder = (url.find("{s}") != std::string::npos);
-    if (hasSubdomainPlaceholder && subdomains.empty()) {
+    if (hasSubdomainPlaceholder && urlOptions.subdomains.empty()) {
         LOGW("The URL for source '%s' includes the subdomain placeholder '{s}'," \
              " but no subdomains were given.", _name.c_str());
     }
-    if (!hasSubdomainPlaceholder && !subdomains.empty()) {
+    if (!hasSubdomainPlaceholder && !urlOptions.subdomains.empty()) {
         LOGW("The URL for source '%s' has subdomains specified, but does not" \
              " include the subdomain placeholder '{s}'.", _name.c_str());
     }
 
-    // distinguish tiled and non-tiled sources by url
-    bool tiled = url.size() > 0 &&
-        url.find("{x}") != std::string::npos &&
-        url.find("{y}") != std::string::npos &&
-        url.find("{z}") != std::string::npos;
+    // A data source is considered 'tiled' if it has a URL that either contains 'x', 'y', and 'z' placeholders or
+    // contains a 'q' placeholder.
+    bool tiled = (!url.empty()) && (
+            (url.find("{x}") != std::string::npos &&
+             url.find("{y}") != std::string::npos &&
+             url.find("{z}") != std::string::npos) ||
+            (url.find("{q}") != std::string::npos));
 
     bool isMBTilesFile = false;
     {
@@ -798,9 +799,8 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
         isMBTilesFile = urlLength > extLength && (url.compare(urlLength - extLength, extLength, extStr) == 0);
     }
 
-    bool isTms = false;
     if (const Node& tmsNode = _source["tms"]) {
-        YamlUtil::getBool(tmsNode, isTms);
+        YamlUtil::getBool(tmsNode, urlOptions.isTms);
     }
 
     std::unique_ptr<TileSource::DataSource> rawSources;
@@ -823,7 +823,7 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
             rawSources = std::move(cache);
         }
 
-        auto s = std::make_unique<NetworkDataSource>(_platform, url, std::move(subdomains), isTms);
+        auto s = std::make_unique<NetworkDataSource>(_platform, url, urlOptions);
         if (rawSources) {
             rawSources->next = std::move(s);
         } else {
@@ -832,8 +832,6 @@ std::shared_ptr<TileSource> SceneLoader::loadSource(const Node& _source, const s
     }
 
     std::shared_ptr<TileSource> sourcePtr;
-
-    TileSource::ZoomOptions zoomOptions = { minDisplayZoom, maxDisplayZoom, maxZoom, zoomBias };
 
     if (type == "GeoJSON" && !tiled) {
         bool generateCentroids = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_SOURCES
   unit/lngLatTests.cpp
   unit/mapProjectionTests.cpp
   unit/meshTests.cpp
+  unit/networkDataSourceTests.cpp
   unit/sceneImportTests.cpp
   unit/sceneLoaderTests.cpp
   unit/sceneUpdateTests.cpp

--- a/tests/unit/networkDataSourceTests.cpp
+++ b/tests/unit/networkDataSourceTests.cpp
@@ -1,0 +1,4 @@
+//
+// Created by Matt Blair on 2/17/20.
+//
+

--- a/tests/unit/networkDataSourceTests.cpp
+++ b/tests/unit/networkDataSourceTests.cpp
@@ -1,4 +1,52 @@
-//
-// Created by Matt Blair on 2/17/20.
-//
+#include "catch.hpp"
 
+#include "data/networkDataSource.h"
+
+using namespace Tangram;
+
+#define TAGS "[NetworkDataSource]"
+
+TEST_CASE("Convert tile coordinates to QuadKey", TAGS) {
+    CHECK(NetworkDataSource::tileCoordinatesToQuadKey(TileID(0, 0, 0)) == "");
+    CHECK(NetworkDataSource::tileCoordinatesToQuadKey(TileID(0, 0, 1)) == "0");
+    CHECK(NetworkDataSource::tileCoordinatesToQuadKey(TileID(0, 0, 10)) == "0000000000");
+    CHECK(NetworkDataSource::tileCoordinatesToQuadKey(TileID(3, 5, 3)) == "213");
+    CHECK(NetworkDataSource::tileCoordinatesToQuadKey(TileID(5, 3, 4)) == "0123");
+}
+
+TEST_CASE("Build URL for tile from template", TAGS) {
+
+    SECTION("Template with x/y/z") {
+        std::string url = "https://some.domain/tiles/{z}/{x}/{y}.json";
+        NetworkDataSource::UrlOptions urlOptions;
+
+        CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 1, 2), url, urlOptions, 0) == "https://some.domain/tiles/2/0/1.json");
+        CHECK(NetworkDataSource::buildUrlForTile(TileID(12345, 54321, 20), url, urlOptions, 0) == "https://some.domain/tiles/20/12345/54321.json");
+    }
+
+    SECTION("Template with x/y/z in TMS mode") {
+        std::string url = "https://some.domain/tiles/{z}/{x}/{y}.json";
+        NetworkDataSource::UrlOptions urlOptions;
+        urlOptions.isTms = true;
+
+        CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 1, 2), url, urlOptions, 0) == "https://some.domain/tiles/2/0/2.json");
+        CHECK(NetworkDataSource::buildUrlForTile(TileID(12345, 54321, 20), url, urlOptions, 0) == "https://some.domain/tiles/20/12345/994254.json");
+    }
+
+    SECTION("Template with subdomains") {
+        std::string url = "https://{s}.some.domain/tiles/{z}/{x}/{y}.json";
+        NetworkDataSource::UrlOptions urlOptions;
+        urlOptions.subdomains = { "zero", "one" };
+
+        CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 1, 2), url, urlOptions, 0) == "https://zero.some.domain/tiles/2/0/1.json");
+        CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 1, 2), url, urlOptions, 1) == "https://one.some.domain/tiles/2/0/1.json");
+    }
+
+    SECTION("Template with quadkey") {
+        std::string url = "file://tiles/{q}.blah";
+        NetworkDataSource::UrlOptions urlOptions;
+
+        CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 0, 1), url, urlOptions, 0) == "file://tiles/0.blah");
+        CHECK(NetworkDataSource::buildUrlForTile(TileID(3, 5, 3), url, urlOptions, 0) == "file://tiles/213.blah");
+    }
+}

--- a/tests/unit/networkDataSourceTests.cpp
+++ b/tests/unit/networkDataSourceTests.cpp
@@ -14,11 +14,20 @@ TEST_CASE("Convert tile coordinates to QuadKey", TAGS) {
     CHECK(NetworkDataSource::tileCoordinatesToQuadKey(TileID(5, 3, 4)) == "0123");
 }
 
+TEST_CASE("Distinguish URLs that contain tile patterns", TAGS) {
+    CHECK(NetworkDataSource::urlHasTilePattern("https://some.domain/{z}/{x}/{y}.stuff"));
+    CHECK(NetworkDataSource::urlHasTilePattern("some.domain/{q}.thing"));
+
+    CHECK_FALSE(NetworkDataSource::urlHasTilePattern("file://{s}.tile.town"));
+    CHECK_FALSE(NetworkDataSource::urlHasTilePattern("file://tile.town/{x}/{y}"));
+}
+
 TEST_CASE("Build URL for tile from template", TAGS) {
+
+    NetworkDataSource::UrlOptions urlOptions;
 
     SECTION("Template with x/y/z") {
         std::string url = "https://some.domain/tiles/{z}/{x}/{y}.json";
-        NetworkDataSource::UrlOptions urlOptions;
 
         CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 1, 2), url, urlOptions, 0) == "https://some.domain/tiles/2/0/1.json");
         CHECK(NetworkDataSource::buildUrlForTile(TileID(12345, 54321, 20), url, urlOptions, 0) == "https://some.domain/tiles/20/12345/54321.json");
@@ -26,7 +35,6 @@ TEST_CASE("Build URL for tile from template", TAGS) {
 
     SECTION("Template with x/y/z in TMS mode") {
         std::string url = "https://some.domain/tiles/{z}/{x}/{y}.json";
-        NetworkDataSource::UrlOptions urlOptions;
         urlOptions.isTms = true;
 
         CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 1, 2), url, urlOptions, 0) == "https://some.domain/tiles/2/0/2.json");
@@ -35,7 +43,6 @@ TEST_CASE("Build URL for tile from template", TAGS) {
 
     SECTION("Template with subdomains") {
         std::string url = "https://{s}.some.domain/tiles/{z}/{x}/{y}.json";
-        NetworkDataSource::UrlOptions urlOptions;
         urlOptions.subdomains = { "zero", "one" };
 
         CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 1, 2), url, urlOptions, 0) == "https://zero.some.domain/tiles/2/0/1.json");
@@ -44,7 +51,6 @@ TEST_CASE("Build URL for tile from template", TAGS) {
 
     SECTION("Template with quadkey") {
         std::string url = "file://tiles/{q}.blah";
-        NetworkDataSource::UrlOptions urlOptions;
 
         CHECK(NetworkDataSource::buildUrlForTile(TileID(0, 0, 1), url, urlOptions, 0) == "file://tiles/0.blah");
         CHECK(NetworkDataSource::buildUrlForTile(TileID(3, 5, 3), url, urlOptions, 0) == "file://tiles/213.blah");


### PR DESCRIPTION
Resolves https://github.com/tangrams/tangram-es/issues/2041

- Tile source URLs can include a `{q}` placeholder that will be replaced with a [QuadKey](https://docs.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system#tile-coordinates-and-quadkeys) for the tile.
- Refactors parts of `NetworkDataSource` for improved composition and testing.
- Adds tests for `NetworkDataSource` URL operations