### PR TITLE
Fix subclassing DefaultHttpHandler in Kotlin

### DIFF
--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -5,7 +5,7 @@ allprojects {
       jcenter()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:3.5.2'
+      classpath 'com.android.tools.build:gradle:3.5.3'
       classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
   }

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -5,7 +5,7 @@ allprojects {
       jcenter()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:3.5.3'
+      classpath 'com.android.tools.build:gradle:3.6.1'
       classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
   }

--- a/platforms/android/demo/build.gradle
+++ b/platforms/android/demo/build.gradle
@@ -32,5 +32,5 @@ android {
 dependencies {
   implementation 'com.squareup.okio:okio:2.1.0'
   implementation project(path: ':tangram')
-  implementation 'com.android.support:design:27.1.1'
+  implementation 'com.android.support:design:28.0.0'
 }

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -206,7 +206,7 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
     }
 
     HttpHandler getHttpHandler() {
-        OkHttpClient.Builder builder = DefaultHttpHandler.GetClientBuilder();
+        OkHttpClient.Builder builder = DefaultHttpHandler.getClientBuilder();
         File cacheDir = getExternalCacheDir();
         if (cacheDir != null && cacheDir.exists()) {
             builder.cache(new Cache(cacheDir, 16 * 1024 * 1024));

--- a/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
+++ b/platforms/android/demo/src/main/java/com/mapzen/tangram/android/MainActivity.java
@@ -28,9 +28,6 @@ import com.mapzen.tangram.TouchInput;
 import com.mapzen.tangram.TouchInput.DoubleTapResponder;
 import com.mapzen.tangram.TouchInput.LongPressResponder;
 import com.mapzen.tangram.TouchInput.TapResponder;
-import com.mapzen.tangram.geometry.Geometry;
-import com.mapzen.tangram.geometry.Polygon;
-import com.mapzen.tangram.geometry.Polyline;
 import com.mapzen.tangram.networking.DefaultHttpHandler;
 import com.mapzen.tangram.networking.HttpHandler;
 
@@ -209,14 +206,13 @@ public class MainActivity extends AppCompatActivity implements MapController.Sce
     }
 
     HttpHandler getHttpHandler() {
-        return new DefaultHttpHandler() {
-            @Override
-            protected void configureClient(OkHttpClient.Builder builder) {
-                File cacheDir = getExternalCacheDir();
-                if (cacheDir != null && cacheDir.exists()) {
-                    builder.cache(new Cache(cacheDir, 16 * 1024 * 1024));
-                }
-            }
+        OkHttpClient.Builder builder = DefaultHttpHandler.GetClientBuilder();
+        File cacheDir = getExternalCacheDir();
+        if (cacheDir != null && cacheDir.exists()) {
+            builder.cache(new Cache(cacheDir, 16 * 1024 * 1024));
+        }
+
+        return new DefaultHttpHandler(builder) {
             CacheControl tileCacheControl = new CacheControl.Builder().maxStale(7, TimeUnit.DAYS).build();
             @Override
             protected void configureRequest(HttpUrl url, Request.Builder builder) {

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2048m
+android.useAndroidX=true

--- a/platforms/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platforms/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 14 12:46:19 EST 2018
+#Mon Mar 23 02:10:46 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
@@ -31,7 +31,7 @@ public class DefaultHttpHandler implements HttpHandler {
     /**
      * @return OkHttp client builder with recommended settings for Tangram.
      */
-    public static OkHttpClient.Builder GetClientBuilder() {
+    public static OkHttpClient.Builder getClientBuilder() {
         return new OkHttpClient.Builder()
                 .followRedirects(true)
                 .followSslRedirects(true)
@@ -43,15 +43,15 @@ public class DefaultHttpHandler implements HttpHandler {
 
     /**
      * Construct an {@code DefaultHttpHandler} with default options.
-     * Uses an OkHttp client from {@link #GetClientBuilder()}.
+     * Uses an OkHttp client from {@link #getClientBuilder()}.
      */
     public DefaultHttpHandler() {
-        this(GetClientBuilder());
+        this(getClientBuilder());
     }
 
     /**
      * Construct a {@code DefaultHttpHandler} with a custom OkHttp client builder.
-     * In most cases you should start with a builder from {@link #GetClientBuilder()}.
+     * In most cases you should start with a builder from {@link #getClientBuilder()}.
      * @param builder Custom OkHttp client builder
      */
     public DefaultHttpHandler(@NonNull final OkHttpClient.Builder builder) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/DefaultHttpHandler.java
@@ -29,14 +29,61 @@ public class DefaultHttpHandler implements HttpHandler {
 
     private OkHttpClient okClient;
 
+    /**
+     * Construct an {@code DefaultHttpHandler} with default options.
+     */
+    public DefaultHttpHandler() {
+        final OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .followRedirects(true)
+                .followSslRedirects(true)
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS);
+
+
+        builder.socketFactory(new SocketFactory() {
+            SocketFactory factory = SocketFactory.getDefault();
+
+            @Override
+            public Socket createSocket() throws IOException {
+                Socket s = factory.createSocket();
+                try {
+                    //Log.d("Tangram", "Patching socket nodelay: " + s.getTcpNoDelay());
+                    s.setTcpNoDelay(true);
+                } catch (SocketException e) {
+                    // empty
+                }
+                return s;
+            }
+
+            @Override
+            public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
+                return null;
+            }
+
+            @Override
+            public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException, UnknownHostException {
+                return null;
+            }
+
+            @Override
+            public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+                return null;
+            }
+
+            @Override
+            public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
+                return null;
+            }
+        });
+
+        configureClient(builder);
+
+        okClient = builder.build();
+    }
+
     @Override
     public Object startRequest(@NonNull final String url, @NonNull final HttpHandler.Callback cb) {
-        // Build the OkHttpClient lazily. If we run configureClient() in the constructor then
-        // subclasses in Kotlin won't yet be initialized.
-        if (okClient == null) {
-            okClient = buildClient();
-        }
-
         final HttpUrl httpUrl = HttpUrl.parse(url);
         if (httpUrl == null) {
             cb.onFailure(new IOException("Failed to parse URL: " + url));
@@ -86,20 +133,6 @@ public class DefaultHttpHandler implements HttpHandler {
         }
     }
 
-    private OkHttpClient buildClient() {
-        final OkHttpClient.Builder builder = new OkHttpClient.Builder()
-                .followRedirects(true)
-                .followSslRedirects(true)
-                .socketFactory(new CustomSocketFactory())
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .writeTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS);
-
-        configureClient(builder);
-
-        return builder.build();
-    }
-
     /**
      * Override this method to customize the OkHTTP client
      * @param builder OkHTTP client builder to customize
@@ -113,43 +146,6 @@ public class DefaultHttpHandler implements HttpHandler {
      * @param builder Request builder to customize
      */
     protected void configureRequest(HttpUrl url, Request.Builder builder) {
-    }
-
-    private class CustomSocketFactory extends SocketFactory {
-
-        SocketFactory factory = SocketFactory.getDefault();
-
-        @Override
-        public Socket createSocket() throws IOException {
-            Socket s = factory.createSocket();
-            try {
-                //Log.d("Tangram", "Patching socket nodelay: " + s.getTcpNoDelay());
-                s.setTcpNoDelay(true);
-            } catch (SocketException e) {
-                // empty
-            }
-            return s;
-        }
-
-        @Override
-        public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
-            return null;
-        }
-
-        @Override
-        public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException, UnknownHostException {
-            return null;
-        }
-
-        @Override
-        public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
-            return null;
-        }
-
-        @Override
-        public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
-            return null;
-        }
     }
 
 }


### PR DESCRIPTION
Resolves #2145 

As suggested in the reported issue, this change makes `DefaultHttpHandler` instantiate its `OkHttpClient` lazily during the first call to `startRequest`, so that a subclass in Kotlin will be fully initialized when `configureClient` is called.

I also considered other ways of resolving this, such as replacing the override-able `configureClient` and `configureRequest` methods with delegate objects. The lazy-instantiation approach has the smallest impact on existing user code, so I've opted for this until it shows problems.