### PR TITLE
Add shader define to distinguish Tangram implementation

### DIFF
--- a/core/src/gl/shaderSource.cpp
+++ b/core/src/gl/shaderSource.cpp
@@ -48,6 +48,7 @@ std::string ShaderSource::applySourceBlocks(const std::string& _source, bool _fr
 
     out.append("#define TANGRAM_EPSILON 0.00001\n");
     out.append("#define TANGRAM_WORLD_POSITION_WRAP 100000.\n");
+    out.append("#define TANGRAM_IS_ES\n");
 
     if (_fragShader) {
         out.append("#define TANGRAM_FRAGMENT_SHADER\n");


### PR DESCRIPTION
Resolves #2154 

All shader sources will now include the line
```glsl
#define TANGRAM_IS_ES
```
in the preamble of all vertex and fragment shaders. This allows style authors to enable shader code conditionally based on the engine platform ("ES" or "JS").