### PR TITLE
Ensure onRegionDidChange gets called after an immediate camera update

### DIFF
--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -473,6 +473,11 @@ void Map::updateCameraPosition(const CameraUpdate& _update, float _duration, Eas
 
     if (_duration == 0.f) {
         setCameraPosition(camera);
+        // The animation listener needs to be called even when the update has no animation duration
+        // because this is how our Android MapController passes updates to its MapChangeListener.
+        if (impl->cameraAnimationListener) {
+            impl->cameraAnimationListener(true);
+        }
     } else {
         setCameraPositionEased(camera, _duration, _e);
     }


### PR DESCRIPTION
Resolves https://github.com/tangrams/tangram-es/issues/2129

Need to:
- [x] Add code comments explaining what this fixes
- [x] Ensure that other behavior isn't changed on Android
- [x] Ensure that iOS callback behavior isn't changed

