### PR TITLE
Add optional 'alpha' draw parameter

### DIFF
--- a/core/src/scene/styleContext.cpp
+++ b/core/src/scene/styleContext.cpp
@@ -301,8 +301,12 @@ bool StyleContext::evalStyle(FunctionID _id, StyleParamKey _key, StyleParam::Val
                 _val = StyleParam::Width{static_cast<float>(number)};
                 break;
             }
+            case StyleParamKey::alpha:
             case StyleParamKey::angle:
+            case StyleParamKey::outline_alpha:
             case StyleParamKey::priority:
+            case StyleParamKey::text_font_alpha:
+            case StyleParamKey::text_font_stroke_alpha:
             case StyleParamKey::text_priority:
             case StyleParamKey::text_font_stroke_width:
             case StyleParamKey::placement_min_length_ratio: {

--- a/core/src/scene/styleParam.cpp
+++ b/core/src/scene/styleParam.cpp
@@ -23,6 +23,7 @@
 namespace Tangram {
 
 const std::map<std::string, StyleParamKey> s_StyleParamMap = {
+    {"alpha", StyleParamKey::alpha},
     {"align", StyleParamKey::text_align},
     {"anchor", StyleParamKey::anchor},
     {"angle", StyleParamKey::angle},
@@ -47,6 +48,7 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"none", StyleParamKey::none},
     {"offset", StyleParamKey::offset},
     {"order", StyleParamKey::order},
+    {"outline:alpha", StyleParamKey::outline_alpha},
     {"outline:cap", StyleParamKey::outline_cap},
     {"outline:color", StyleParamKey::outline_color},
     {"outline:join", StyleParamKey::outline_join},
@@ -69,9 +71,11 @@ const std::map<std::string, StyleParamKey> s_StyleParamMap = {
     {"text:anchor", StyleParamKey::text_anchor},
     {"text:buffer", StyleParamKey::text_buffer},
     {"text:collide", StyleParamKey::text_collide},
+    {"text:font:alpha", StyleParamKey::text_font_alpha},
     {"text:font:family", StyleParamKey::text_font_family},
     {"text:font:fill", StyleParamKey::text_font_fill},
     {"text:font:size", StyleParamKey::text_font_size},
+    {"text:font:stroke:alpha", StyleParamKey::text_font_stroke_alpha},
     {"text:font:stroke:color", StyleParamKey::text_font_stroke_color},
     {"text:font:stroke:width", StyleParamKey::text_font_stroke_width},
     {"text:font:style", StyleParamKey::text_font_style},
@@ -348,6 +352,10 @@ StyleParam::Value StyleParam::parseNode(StyleParamKey key, const YAML::Node& nod
         LOGW("Invalid angle value: %s", Dump(node).c_str());
         break;
     }
+    case StyleParamKey::alpha:
+    case StyleParamKey::outline_alpha:
+    case StyleParamKey::text_font_alpha:
+    case StyleParamKey::text_font_stroke_alpha:
     case StyleParamKey::priority:
     case StyleParamKey::text_priority:
     case StyleParamKey::miter_limit:
@@ -358,7 +366,7 @@ StyleParam::Value StyleParam::parseNode(StyleParamKey key, const YAML::Node& nod
         if (YamlUtil::getFloat(node, floatValue, true)) {
             return floatValue;
         } else {
-            LOGW("Invalid width value: %s", Dump(node).c_str());
+            LOGW("Invalid numeric value: %s", Dump(node).c_str());
         }
         break;
     }
@@ -491,6 +499,10 @@ std::string StyleParam::toString() const {
     case StyleParamKey::outline_join:
         if (!value.is<uint32_t>()) break;
         return k + std::to_string(value.get<uint32_t>());
+    case StyleParamKey::alpha:
+    case StyleParamKey::outline_alpha:
+    case StyleParamKey::text_font_alpha:
+    case StyleParamKey::text_font_stroke_alpha:
     case StyleParamKey::priority:
     case StyleParamKey::text_priority:
     case StyleParamKey::miter_limit:

--- a/core/src/scene/styleParam.h
+++ b/core/src/scene/styleParam.h
@@ -19,6 +19,7 @@ struct Color;
 struct Stops;
 
 enum class StyleParamKey : uint8_t {
+    alpha,
     anchor,
     angle,
     buffer,
@@ -33,6 +34,7 @@ enum class StyleParamKey : uint8_t {
     none,
     offset,
     order,
+    outline_alpha,
     outline_cap,
     outline_color,
     outline_join,
@@ -56,9 +58,11 @@ enum class StyleParamKey : uint8_t {
     text_anchor,
     text_buffer,
     text_collide,
+    text_font_alpha,
     text_font_family,
     text_font_fill,
     text_font_size,
+    text_font_stroke_alpha,
     text_font_stroke_color,
     text_font_stroke_width,
     text_font_style,

--- a/core/src/style/pointStyleBuilder.cpp
+++ b/core/src/style/pointStyleBuilder.cpp
@@ -127,6 +127,11 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule) const -> Parameters {
     Parameters p;
 
     _rule.get(StyleParamKey::color, p.color);
+    float alpha = 1;
+    if (_rule.get(StyleParamKey::alpha, alpha)) {
+        p.color = Color(p.color).withAlpha(alpha).abgr;
+    }
+
     _rule.get(StyleParamKey::sprite, p.sprite);
     _rule.get(StyleParamKey::offset, p.labelOptions.offset);
     _rule.get(StyleParamKey::buffer, p.labelOptions.buffer);
@@ -193,14 +198,16 @@ auto PointStyleBuilder::applyRule(const DrawRule& _rule) const -> Parameters {
 
     auto& strokeWidth = _rule.findParameter(StyleParamKey::outline_width);
 
-    if (_rule.get(StyleParamKey::outline_color, p.outlineColor) &&
-        strokeWidth.value.is<StyleParam::Width>()) {
-
-        auto& widthParam = strokeWidth.value.get<StyleParam::Width>();
-
-        p.outlineWidth = widthParam.value * m_style.pixelScale();
+    if (_rule.get(StyleParamKey::outline_color, p.outlineColor)) {
+        if (strokeWidth.value.is<StyleParam::Width>()) {
+            auto& widthParam = strokeWidth.value.get<StyleParam::Width>();
+            p.outlineWidth = widthParam.value * m_style.pixelScale();
+        }
     }
-
+    float outlineAlpha = 1;
+    if (_rule.get(StyleParamKey::outline_alpha, outlineAlpha)) {
+        p.outlineColor = Color(p.outlineColor).withAlpha(outlineAlpha).abgr;
+    }
 
     std::hash<Parameters> hash;
     p.labelOptions.paramHash = hash(p);

--- a/core/src/style/polygonStyle.cpp
+++ b/core/src/style/polygonStyle.cpp
@@ -9,6 +9,7 @@
 #include "scene/drawRule.h"
 #include "tile/tile.h"
 #include "util/builders.h"
+#include "util/color.h"
 #include "util/extrude.h"
 
 #include "glm/vec2.hpp"
@@ -153,6 +154,11 @@ template <class V>
 auto PolygonStyleBuilder<V>::parseRule(const DrawRule& _rule, const Properties& _props) -> Parameters {
     Parameters p;
     _rule.get(StyleParamKey::color, p.color);
+    float alpha = 1;
+    if (_rule.get(StyleParamKey::alpha, alpha)) {
+        p.color = Color(p.color).withAlpha(alpha).abgr;
+    }
+
     _rule.get(StyleParamKey::extrude, p.extrude);
     _rule.get(StyleParamKey::order, p.order);
     _rule.get(StyleParamKey::tile_edges, p.keepTileEdges);

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -291,7 +291,14 @@ auto PolylineStyleBuilder<V>::parseRule(const DrawRule& _rule, const Properties&
         return p;
     }
     fill.slope -= fill.width;
-    _rule.get(StyleParamKey::color, p.fill.color);
+
+    if (_rule.get(StyleParamKey::color, p.fill.color)) {
+        float alpha;
+        if (_rule.get(StyleParamKey::alpha, alpha)) {
+            p.fill.color = Color(p.fill.color).withAlpha(alpha).abgr;
+        }
+    }
+
     _rule.get(StyleParamKey::cap, cap);
     _rule.get(StyleParamKey::join, join);
     _rule.get(StyleParamKey::order, fill.order);
@@ -328,7 +335,15 @@ auto PolylineStyleBuilder<V>::parseRule(const DrawRule& _rule, const Properties&
             p.stroke.cap = static_cast<CapTypes>(cap);
             p.stroke.join = static_cast<JoinTypes>(join);
 
-            if (!_rule.get(StyleParamKey::outline_color, p.stroke.color)) { return p; }
+            if (_rule.get(StyleParamKey::outline_color, p.stroke.color)) {
+                float outlineAlpha;
+                if (_rule.get(StyleParamKey::outline_alpha, outlineAlpha)) {
+                    p.stroke.color = Color(p.stroke.color).withAlpha(outlineAlpha).abgr;
+                }
+            } else {
+                return p;
+            }
+
             if (!evalWidth(strokeWidth, stroke.width, stroke.slope)) {
                 return p;
             }

--- a/core/src/style/textStyleBuilder.cpp
+++ b/core/src/style/textStyleBuilder.cpp
@@ -11,6 +11,7 @@
 #include "selection/featureSelection.h"
 #include "scene/drawRule.h"
 #include "tile/tile.h"
+#include "util/color.h"
 #include "util/geom.h"
 #include "util/mapProjection.h"
 #include "util/lineSampler.h"
@@ -609,8 +610,17 @@ TextStyle::Parameters TextStyleBuilder::applyRule(const DrawRule& _rule,
         return p;
     }
     _rule.get(StyleParamKey::text_font_fill, p.fill);
+    float alpha = 1;
+    if (_rule.get(StyleParamKey::text_font_alpha, alpha)) {
+        p.fill = Color(p.fill).withAlpha(alpha).abgr;
+    }
 
     _rule.get(StyleParamKey::text_font_stroke_color, p.strokeColor);
+    float strokeAlpha = 1;
+    if (_rule.get(StyleParamKey::text_font_stroke_alpha, strokeAlpha)) {
+        p.strokeColor = Color(p.strokeColor).withAlpha(strokeAlpha).abgr;
+    }
+
     _rule.get(StyleParamKey::text_font_stroke_width, p.strokeWidth);
     p.strokeWidth *= m_style.pixelScale();
 

--- a/core/src/util/color.h
+++ b/core/src/util/color.h
@@ -34,6 +34,12 @@ struct Color {
 
     inline ColorF toColorF();
 
+    Color withAlpha(float alpha) {
+        Color result(abgr);
+        result.a = static_cast<uint8_t>(alpha * 255.f);
+        return result;
+    }
+
     static Color mix(const Color& _x, const Color& _y, float _a) {
         return Color(
             _x.r * (1 - _a) + _y.r * _a,

--- a/scenes/scene.yaml
+++ b/scenes/scene.yaml
@@ -84,16 +84,13 @@ styles:
         base: lines
         blend: overlay
         blend_order: -2
-        shaders:
-            blocks:
-                filter: |
-                    color.rgb *= 1.25; // pump up the colors
-                    color.a = 0.5;     // translucent
         draw: # default draw parameters
             color: function() { return feature.colour || 'gray'; }
+            alpha: 0.25
             width: 6px
             outline:
                 color: [.8, .8, .8]
+                alpha: 0.25
                 width: 1px
             interactive: true
 


### PR DESCRIPTION
Enables specifying a numeric 'alpha' value next to 'color' parameters in draw groups. If present, the 'alpha' parameter takes precedence over the alpha component of the 'color' parameter. See https://github.com/tangrams/tangram/pull/740 for more discussion.

Resolves https://github.com/tangrams/tangram-es/issues/2123