### PR TITLE
Fix TGMarker bitmap channel swap

### DIFF
--- a/platforms/ios/framework/src/TGMarker.mm
+++ b/platforms/ios/framework/src/TGMarker.mm
@@ -170,7 +170,7 @@
 
     bitmap.resize(w * h);
 
-    CGColorSpaceRef colorSpace = CGImageGetColorSpace(cgImage);
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     // iOS only supports contexts with pre-multiplied alpha, so we transform it below.
     CGContextRef cgContext = CGBitmapContextCreate(bitmap.data(), w, h, 8, w * 4,
         colorSpace, kCGImageAlphaPremultipliedLast);

--- a/platforms/ios/framework/src/TGMarker.mm
+++ b/platforms/ios/framework/src/TGMarker.mm
@@ -182,20 +182,16 @@
     CGContextDrawImage(cgContext, CGRectMake(0, 0, w, h), cgImage);
     CGContextRelease(cgContext);
 
-    // For each pixel in the image, convert from BGRA to RGBA and if A != 0 then un-pre-multiply alpha.
+    // For each pixel in the image, if A != 0 then un-pre-multiply alpha.
     // TODO: This is wasteful! Instead we could ingest pre-multiplied data with a flag or enum and
     // alter the rendering mode for this texture appropriately. -MEB 3.30.18
     for (auto& pixel : bitmap) {
         auto* p = reinterpret_cast<unsigned char*>(&pixel);
         unsigned int a = p[3];
-        unsigned int b = p[0];
-        if (a == 0) {
-            p[0] = p[2];
-            p[2] = b;
-        } else {
-            p[0] = p[2] * 255 / a;
+        if (a != 0) {
+            p[0] = p[0] * 255 / a;
             p[1] = p[1] * 255 / a;
-            p[2] = b * 255 / a;
+            p[2] = p[2] * 255 / a;
         }
     }
 

--- a/platforms/ios/framework/src/TGMarker.mm
+++ b/platforms/ios/framework/src/TGMarker.mm
@@ -189,9 +189,11 @@
         auto* p = reinterpret_cast<unsigned char*>(&pixel);
         unsigned int a = p[3];
         if (a != 0) {
-            p[0] = p[0] * 255 / a;
-            p[1] = p[1] * 255 / a;
-            p[2] = p[2] * 255 / a;
+            // Add a '1/2' to account for rounding down during pre-multiply.
+            unsigned int half = a / 2;
+            p[0] = (p[0] * 255 + half) / a;
+            p[1] = (p[1] * 255 + half) / a;
+            p[2] = (p[2] * 255 + half) / a;
         }
     }
 


### PR DESCRIPTION
Addresses https://github.com/tangrams/tangram-es/issues/2167

For some reason, the code that processes bitmap data in `TGMarker` assumed that incoming bitmaps were in BGRA format, and so it swapped the channels to make it RGBA. This seems to be incorrect now, as it causes marker bitmaps to render with incorrect colors.

This PR removes the BGRA->RGBA conversion, while keeping the alpha un-pre-multiplication, which I believe is still necessary.