### PR TITLE
Ensure full bitcode for iOS framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,14 +58,17 @@ jobs:
       # Install dependencies.
       - run: sudo gem install jazzy --no-document --version 0.10.0
       - run: brew install cmake
-      # Build the framework in debug mode and package it into pod.zip
-      - run: make ios-framework-universal BUILD_TYPE=Debug
+      # Build the framework and package it into pod.zip.
+      - run: make ios-framework-universal BUILD_TYPE=Release
+      # Check that bitcode is included for required archs.
+      - run: source scripts/check_bitcode.sh build/ios/Release-universal/TangramMap.framework/TangramMap armv7 arm64
+      # Build the docs and package them into docs.zip.
       - run: make ios-docs
       - run: cd build/ios-docs && zip -r ~/docs.zip .
       - store_artifacts:
           path: ~/docs.zip
       # To produce the intended structure within the zip archive, we must cd to each file's location.
-      - run: cd build/ios/Debug-universal && zip -r ~/pod.zip TangramMap.framework
+      - run: cd build/ios/Release-universal && zip -r ~/pod.zip TangramMap.framework
       # Add the readme and license files.
       - run: cd platforms/ios/framework && zip ~/pod.zip README.md
       - run: zip ~/pod.zip LICENSE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ jobs:
       - run: brew install cmake jfrog-cli-go
       # Build the framework in release mode and package it into pod.zip
       - run: make ios-framework-universal BUILD_TYPE=Release
+      # Check that bitcode is included for required archs.
+      - run: source scripts/check_bitcode.sh build/ios/Release-universal/TangramMap.framework/TangramMap armv7 arm64
       - run: make ios-docs
       - run: cd build/ios-docs && zip -r ~/docs.zip .
       - store_artifacts:

--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -7,6 +7,9 @@ set(TANGRAM_BUNDLE_IDENTIFIER "com.mapzen.TangramMap")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "9.3") # Applies to iOS even though the variable name says OSX.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
 execute_process(COMMAND xcrun --sdk iphoneos --show-sdk-version OUTPUT_VARIABLE IOS_SDK_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+# Set the global BITCODE_GENERATION_MODE value to 'bitcode' for Release builds.
+# This is for generating full bitcode outside of the "archive" command.
+set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "$<$<CONFIG:Release>:bitcode>")
 
 # Copy necessary workspace settings into a user-specific location in the iOS workspace.
 # See platforms/ios/DEVELOPING.md for details.

--- a/scripts/check_bitcode.sh
+++ b/scripts/check_bitcode.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eo pipefail
+# USAGE
+#   check_bitcode.sh input_file [archs]
+#
+if [[ ${2} ]]; then
+	# Take all args after input_file as archs.
+	archs=${@:2}
+else
+	# If archs not given in args, use lipo to list all archs in file.
+	archs=$(lipo -archs ${1})
+fi
+
+echo "Checking bitcode in file=${1} archs=${archs}"
+
+missing_bitcode=0
+
+for arch in ${archs}; do
+	# The otool command prints object file data for the given arch in the input file.
+	# The awk command prints the 'size' value following a 'segname' value equal to '__LLVM' (the bitcode segment).
+	bitcode_size=$(otool -l -arch ${arch} ${1} | awk '/ segname/ { SEGNAME = $2 }; / size/ { if(SEGNAME == "__LLVM") print $2 }')
+	echo "arch=${arch} bitcode_size=${bitcode_size}"
+	# Sometimes bitcode exists but is just a stub, so check for segments that are too small.
+	# This check also covers bitcode_size being empty.
+	if [[ ${bitcode_size} -lt 0x10 ]]; then
+		((missing_bitcode++))
+	fi
+done
+
+if [[ $missing_bitcode -gt 0 ]]; then
+	echo "Some archs are missing bitcode."
+	exit 1
+fi


### PR DESCRIPTION
Resolves https://github.com/tangrams/tangram-es/issues/2056

- Adds a script that checks whether iOS binary files have "full" bitcode segments. As far as I can tell there isn't an official way to do this, so I automated the inspection of the `otool` output that _should_ indicate bitcode. This may not be the ideal method but it has worked correctly in all my tests.
- Enables full bitcode generation for iOS builds in Release config. This adds a little time and a lot of size to the release binaries. Bitcode gets stripped on installation, so this won't impact the installed size of any downstream apps. If the added build time becomes noticeable, I might instead create a separate flag for building with bitcode and use it only where necessary.
- iOS snapshot builds use Release config and run bitcode check. Snapshot builds previously used the Debug config because its a bit faster and makes it easier to debug the built framework, but as far as I know this hasn't been used in a while. Checking bitcode generation seems more useful.