### PR TITLE
Fix Jazzy install step on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
+      - run: sudo gem install jazzy --no-document --version 0.13.4
       # Check out repository with submodules.
       - checkout
       - run: git submodule update --init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - run: sudo gem install jazzy --no-document --version 0.13.4
       # Check out repository with submodules.
       - checkout
       - run: git submodule update --init
@@ -49,7 +48,7 @@ jobs:
       - run: make ios-swift-sim BUILD_TYPE=Debug
   build-deploy-ios-snapshot:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.4.1"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -74,7 +73,7 @@ jobs:
           path: ~/pod.zip
   build-deploy-macos-snapshot:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.4.1"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -91,7 +90,7 @@ jobs:
           path: ~/demo.zip
   build-deploy-ios-release:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.4.1"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run: cd platforms/android && ./gradlew uploadArchives
   build-ios:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.4.1"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:


### PR DESCRIPTION
-___-

Jazzy issue: https://github.com/realm/jazzy/issues/1120

Due to some inconsistency in Apple's distribution of the Ruby runtime and headers, the combination of macOS 10.14 and Xcode 11 causes building native extensions to fail.

Attempts and results:
- Update Jazzy to latest version (0.13.4): same error
- Use Xcode 11.4.1 image on CircleCI (which uses macOS 10.15) with latest Jazzy version: install succeeds, but takes over 3 minutes to build the native extensions!
- Use Xcode 11.4.1 image on CircleCI with original Jazzy version (0.10.0): install succeeds, no increase in build time