### PR TITLE
Set BITCODE_GENERATION_MODE to 'marker' when build config is not Release

### DIFF
--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -9,7 +9,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines
 execute_process(COMMAND xcrun --sdk iphoneos --show-sdk-version OUTPUT_VARIABLE IOS_SDK_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 # Set the global BITCODE_GENERATION_MODE value to 'bitcode' for Release builds.
 # This is for generating full bitcode outside of the "archive" command.
-set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "$<$<CONFIG:Release>:bitcode>")
+# Set 'marker' for other configs to make debug builds install-able on devices.
+set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "$<IF:$<CONFIG:Release>,bitcode,marker>")
 
 # Copy necessary workspace settings into a user-specific location in the iOS workspace.
 # See platforms/ios/DEVELOPING.md for details.


### PR DESCRIPTION
This is a follow-up to https://github.com/tangrams/tangram-es/pull/2174 that fixes an issue I discovered after merging it.

The behavior for Release builds is correct, but it looks like setting `BITCODE_GENERATION_MODE` to an empty string for other build configs makes the resulting builds unable to be installed on devices for debugging. I've surmised that this variable overrides Xcode's default behavior of embedding bitcode 'markers'. The simplest solution I saw for this was to re-instate this behavior using the same variable. Now the CMake config sets `BITCODE_GENERATION_MODE` to `marker` when the build config is not Release. As expected, this makes debug builds install-able again.