### PR TITLE
Update macOS CI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run: cd platforms/android && ./gradlew uploadArchives
   build-ios:
     macos:
-      xcode: "11.4.1"
+      xcode: "11.7.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -48,7 +48,7 @@ jobs:
       - run: make ios-swift-sim BUILD_TYPE=Debug
   build-deploy-ios-snapshot:
     macos:
-      xcode: "11.4.1"
+      xcode: "11.7.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -76,7 +76,7 @@ jobs:
           path: ~/pod.zip
   build-deploy-macos-snapshot:
     macos:
-      xcode: "11.4.1"
+      xcode: "11.7.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -93,7 +93,7 @@ jobs:
           path: ~/demo.zip
   build-deploy-ios-release:
     macos:
-      xcode: "11.4.1"
+      xcode: "11.7.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,9 @@ jobs:
   build-ios:
     macos:
       xcode: "11.7.0"
-    environment:
+    environment: # Disable some unnecessary homebrew operations to save time.
       HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
       # Check out repository with submodules.
       - checkout
@@ -49,8 +50,9 @@ jobs:
   build-deploy-ios-snapshot:
     macos:
       xcode: "11.7.0"
-    environment:
+    environment: # Disable some unnecessary homebrew operations to save time.
       HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
       # Check out repository with submodules.
       - checkout
@@ -77,8 +79,9 @@ jobs:
   build-deploy-macos-snapshot:
     macos:
       xcode: "11.7.0"
-    environment:
+    environment: # Disable some unnecessary homebrew operations to save time.
       HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
       # Check out repository with submodules.
       - checkout
@@ -94,8 +97,9 @@ jobs:
   build-deploy-ios-release:
     macos:
       xcode: "11.7.0"
-    environment:
+    environment: # Disable some unnecessary homebrew operations to save time.
       HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
       # Check out repository with submodules.
       - checkout


### PR DESCRIPTION
Newer images will have more recent CMake releases in the homebrew cache, which will let us work around recent issues with iOS configuration on CMake 3.17. 