### PR TITLE
Resolve named textures in imports using final merged scene

### DIFF
--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -90,7 +90,7 @@ Node Importer::loadSceneData(Platform& _platform, const Url& _sceneUrl, const st
     Node textures = root["textures"];
     for (auto& sceneNode : m_sceneNodes) {
         auto sceneUrl = sceneNode.first;
-        for (auto& node : sceneNode.second.unresolvedTextures) {
+        for (auto& node : sceneNode.second.pendingUrlNodes) {
             // If the node does not contain a named texture in the final scene, treat it as a URL relative to the scene
             // file where it was originally encountered.
             if (!textures[node.Scalar()]) {
@@ -198,7 +198,7 @@ void Importer::addSceneYaml(const Url& sceneUrl, const char* sceneYaml, size_t l
 
     sceneNode.imports = getResolvedImportUrls(sceneNode.yaml, sceneUrl);
 
-    sceneNode.unresolvedTextures = getTextureUrlNodes(sceneNode.yaml);
+    sceneNode.pendingUrlNodes = getTextureUrlNodes(sceneNode.yaml);
 
     // Remove 'import' values so they don't get merged.
     sceneNode.yaml.remove("import");
@@ -403,7 +403,6 @@ void Importer::resolveSceneUrls(Node& root, const Url& baseUrl) {
         for (auto texture : textures) {
             if (Node textureUrlNode = texture.second["url"]) {
                 if (nodeIsPotentialUrl(textureUrlNode)) {
-
                     textureUrlNode = base.resolve(Url(textureUrlNode.Scalar())).string();
                 }
             }

--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -86,6 +86,19 @@ Node Importer::loadSceneData(Platform& _platform, const Url& _sceneUrl, const st
     Node root;
     importScenesRecursive(root, _sceneUrl, imported);
 
+    // After merging all scenes, resolve texture nodes as named textures or URLs.
+    Node textures = root["textures"];
+    for (auto& sceneNode : m_sceneNodes) {
+        auto sceneUrl = sceneNode.first;
+        for (auto& node : sceneNode.second.unresolvedTextures) {
+            // If the node does not contain a named texture in the final scene, treat it as a URL relative to the scene
+            // file where it was originally encountered.
+            if (!textures[node.Scalar()]) {
+                node = sceneUrl.resolve(Url(node.Scalar())).string();
+            }
+        }
+    }
+
     m_sceneNodes.clear();
 
     return root;
@@ -184,6 +197,8 @@ void Importer::addSceneYaml(const Url& sceneUrl, const char* sceneYaml, size_t l
     }
 
     sceneNode.imports = getResolvedImportUrls(sceneNode.yaml, sceneUrl);
+
+    sceneNode.unresolvedTextures = getTextureUrlNodes(sceneNode.yaml);
 
     // Remove 'import' values so they don't get merged.
     sceneNode.yaml.remove("import");
@@ -303,7 +318,7 @@ bool nodeIsPotentialUrl(const Node& node) {
     return true;
 }
 
-bool nodeIsTextureUrl(const Node& node, const Node& textures) {
+bool nodeIsPotentialTextureUrl(const Node& node) {
 
     if (!nodeIsPotentialUrl(node)) { return false; }
 
@@ -313,10 +328,64 @@ bool nodeIsTextureUrl(const Node& node, const Node& textures) {
     if (YAML::convert<bool>::decode(node, booleanValue)) { return false; }
     if (YAML::convert<double>::decode(node, numberValue)) { return false; }
 
-    // Check that the node does not name a scene texture.
-    if (textures[node.Scalar()]) { return false; }
-
     return true;
+}
+
+std::vector<Node> Importer::getTextureUrlNodes(Node& root) {
+
+    std::vector<Node> nodes;
+
+    if (Node styles = root["styles"]) {
+
+        for (auto entry : styles) {
+
+            Node style = entry.second;
+            if (!style.IsMap()) { continue; }
+
+            //style->texture
+            if (Node texture = style["texture"]) {
+                if (nodeIsPotentialTextureUrl(texture)) {
+                    nodes.push_back(texture);
+                }
+            }
+
+            //style->material->texture
+            if (Node material = style["material"]) {
+                if (!material.IsMap()) { continue; }
+                for (auto& prop : {"emission", "ambient", "diffuse", "specular", "normal"}) {
+                    if (Node propNode = material[prop]) {
+                        if (!propNode.IsMap()) { continue; }
+                        if (Node matTexture = propNode["texture"]) {
+                            if (nodeIsPotentialTextureUrl(matTexture)) {
+                                nodes.push_back(matTexture);
+                            }
+                        }
+                    }
+                }
+            }
+
+            //style->shader->uniforms->texture
+            if (Node shaders = style["shaders"]) {
+                if (!shaders.IsMap()) { continue; }
+                if (Node uniforms = shaders["uniforms"]) {
+                    for (auto uniformEntry : uniforms) {
+                        Node uniformValue = uniformEntry.second;
+                        if (nodeIsPotentialTextureUrl(uniformValue)) {
+                            nodes.push_back(uniformValue);
+                        } else if (uniformValue.IsSequence()) {
+                            for (Node u : uniformValue) {
+                                if (nodeIsPotentialTextureUrl(u)) {
+                                    nodes.push_back(u);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return nodes;
 }
 
 void Importer::resolveSceneUrls(Node& root, const Url& baseUrl) {
@@ -334,59 +403,8 @@ void Importer::resolveSceneUrls(Node& root, const Url& baseUrl) {
         for (auto texture : textures) {
             if (Node textureUrlNode = texture.second["url"]) {
                 if (nodeIsPotentialUrl(textureUrlNode)) {
+
                     textureUrlNode = base.resolve(Url(textureUrlNode.Scalar())).string();
-                }
-            }
-        }
-    }
-
-    // Resolve inline texture URLs.
-
-    if (Node styles = root["styles"]) {
-
-        for (auto entry : styles) {
-
-            Node style = entry.second;
-            if (!style.IsMap()) { continue; }
-
-            //style->texture
-            if (Node texture = style["texture"]) {
-                if (nodeIsTextureUrl(texture, textures)) {
-                    texture = base.resolve(Url(texture.Scalar())).string();
-                }
-            }
-
-            //style->material->texture
-            if (Node material = style["material"]) {
-                if (!material.IsMap()) { continue; }
-                for (auto& prop : {"emission", "ambient", "diffuse", "specular", "normal"}) {
-                    if (Node propNode = material[prop]) {
-                        if (!propNode.IsMap()) { continue; }
-                        if (Node matTexture = propNode["texture"]) {
-                            if (nodeIsTextureUrl(matTexture, textures)) {
-                                matTexture = base.resolve(Url(matTexture.Scalar())).string();
-                            }
-                        }
-                    }
-                }
-            }
-
-            //style->shader->uniforms->texture
-            if (Node shaders = style["shaders"]) {
-                if (!shaders.IsMap()) { continue; }
-                if (Node uniforms = shaders["uniforms"]) {
-                    for (auto uniformEntry : uniforms) {
-                        Node uniformValue = uniformEntry.second;
-                        if (nodeIsTextureUrl(uniformValue, textures)) {
-                            uniformValue = base.resolve(Url(uniformValue.Scalar())).string();
-                        } else if (uniformValue.IsSequence()) {
-                            for (Node u : uniformValue) {
-                                if (nodeIsTextureUrl(u, textures)) {
-                                    u = base.resolve(Url(u.Scalar())).string();
-                                }
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -81,7 +81,7 @@ protected:
     struct SceneNode {
         Node yaml{};
         std::vector<Url> imports;
-        std::vector<Node> unresolvedTextures;
+        std::vector<Node> pendingUrlNodes;
     };
     std::unordered_map<Url, SceneNode> m_sceneNodes = {};
 

--- a/core/src/scene/importer.h
+++ b/core/src/scene/importer.h
@@ -43,6 +43,8 @@ public:
     // against the given base URL.
     static void resolveSceneUrls(Node& root, const Url& base);
 
+    static std::vector<Node> getTextureUrlNodes(Node& root);
+
     // Start an asynchronous request for the scene resource at the given URL.
     // In addition to the URL types supported by the platform instance, this
     // also supports a custom ZIP URL scheme. ZIP URLs are of the form:
@@ -79,6 +81,7 @@ protected:
     struct SceneNode {
         Node yaml{};
         std::vector<Url> imports;
+        std::vector<Node> unresolvedTextures;
     };
     std::unordered_map<Url, SceneNode> m_sceneNodes = {};
 

--- a/tests/unit/sceneImportTests.cpp
+++ b/tests/unit/sceneImportTests.cpp
@@ -172,8 +172,9 @@ TEST_CASE("Scene URLs are resolved against their parent during import", "[import
     auto uniformsB = styleB["shaders"]["uniforms"];
 
     CHECK(uniformsB["u_tex1"].Scalar() == "/root/imports/in_imports.png");
-    // Don't use global textures from importing scene
-    CHECK(uniformsB["u_tex2"].Scalar() == "/root/imports/tex2");
+
+    // Use global textures from importing scene
+    CHECK(uniformsB["u_tex2"].Scalar() == "tex2");
 
     // Check that data source URLs are resolved correctly.
 


### PR DESCRIPTION
Addresses the issue described in https://github.com/tangrams/tangram/issues/748. The linked issue is for Tangram JS, but Tangram ES exhibits the same behavior.