### PR TITLE
Reduce allocations in JNI invocations

### DIFF
--- a/platforms/android/tangram/src/main/cpp/AndroidMap.h
+++ b/platforms/android/tangram/src/main/cpp/AndroidMap.h
@@ -11,8 +11,8 @@ class AndroidMap : public Map {
 public:
     AndroidMap(JNIEnv* env, jobject mapController, jobject assetManager);
     void pickFeature(float posX, float posY);
-    void pickMarker(float posX, float posY);
     void pickLabel(float posX, float posY);
+    void pickMarker(float posX, float posY);
 
     AndroidPlatform& androidPlatform();
 

--- a/platforms/android/tangram/src/main/cpp/JniHelpers.cpp
+++ b/platforms/android/tangram/src/main/cpp/JniHelpers.cpp
@@ -50,6 +50,9 @@ void JniHelpers::jniOnLoad(JavaVM* jvm, JNIEnv* jniEnv) {
 }
 
 std::string JniHelpers::stringFromJavaString(JNIEnv* jniEnv, jstring javaString) {
+    if (javaString == nullptr) {
+        return {};
+    }
     auto length = jniEnv->GetStringLength(javaString);
     std::u16string chars(length, char16_t());
     if(!chars.empty()) {
@@ -65,6 +68,9 @@ jstring JniHelpers::javaStringFromString(JNIEnv* jniEnv, const std::string& stri
 }
 
 void JniHelpers::cameraPositionToJava(JNIEnv* env, jobject javaCamera, const CameraPosition& camera) {
+    if (javaCamera == nullptr) {
+        return;
+    }
     env->SetDoubleField(javaCamera, cameraPositionLongitudeFID, camera.longitude);
     env->SetDoubleField(javaCamera, cameraPositionLatitudeFID, camera.latitude);
     env->SetFloatField(javaCamera, cameraPositionZoomFID, camera.zoom);
@@ -73,22 +79,34 @@ void JniHelpers::cameraPositionToJava(JNIEnv* env, jobject javaCamera, const Cam
 }
 
 void JniHelpers::vec2ToJava(JNIEnv* env, jobject javaPointF, float x, float y) {
+    if (javaPointF == nullptr) {
+        return;
+    }
     env->SetFloatField(javaPointF, pointFxFID, x);
     env->SetFloatField(javaPointF, pointFyFID, y);
 }
 
 void JniHelpers::lngLatToJava(JNIEnv* env, jobject javaLngLat, const LngLat& lngLat) {
+    if (javaLngLat == nullptr) {
+        return;
+    }
     env->SetDoubleField(javaLngLat, lngLatLongitudeFID, lngLat.longitude);
     env->SetDoubleField(javaLngLat, lngLatLatitudeFID, lngLat.latitude);
 }
 
 LngLat JniHelpers::lngLatFromJava(JNIEnv* env, jobject javaLngLat) {
+    if (javaLngLat == nullptr) {
+        return {};
+    }
     double longitude = env->GetDoubleField(javaLngLat, lngLatLongitudeFID);
     double latitude = env->GetDoubleField(javaLngLat, lngLatLatitudeFID);
     return LngLat{ longitude, latitude };
 }
 
 EdgePadding JniHelpers::edgePaddingFromJava(JNIEnv* env, jobject javaRect) {
+    if (javaRect == nullptr) {
+        return {};
+    }
     int left = env->GetIntField(javaRect, rectLeftFID);
     int top = env->GetIntField(javaRect, rectTopFID);
     int right = env->GetIntField(javaRect, rectRightFID);

--- a/platforms/android/tangram/src/main/cpp/JniHelpers.cpp
+++ b/platforms/android/tangram/src/main/cpp/JniHelpers.cpp
@@ -13,6 +13,17 @@ static jfieldID cameraPositionZoomFID = nullptr;
 static jfieldID cameraPositionRotationFID = nullptr;
 static jfieldID cameraPositionTiltFID = nullptr;
 
+static jfieldID lngLatLongitudeFID = nullptr;
+static jfieldID lngLatLatitudeFID = nullptr;
+
+static jfieldID pointFxFID = nullptr;
+static jfieldID pointFyFID = nullptr;
+
+static jfieldID rectLeftFID = nullptr;
+static jfieldID rectTopFID = nullptr;
+static jfieldID rectRightFID = nullptr;
+static jfieldID rectBottomFID = nullptr;
+
 void JniHelpers::jniOnLoad(JavaVM* jvm, JNIEnv* jniEnv) {
     s_jvm = jvm;
 
@@ -22,6 +33,20 @@ void JniHelpers::jniOnLoad(JavaVM* jvm, JNIEnv* jniEnv) {
     cameraPositionZoomFID = jniEnv->GetFieldID(cameraPositionClass, "zoom", "F");
     cameraPositionRotationFID = jniEnv->GetFieldID(cameraPositionClass, "rotation", "F");
     cameraPositionTiltFID = jniEnv->GetFieldID(cameraPositionClass, "tilt", "F");
+
+    jclass lngLatClass = jniEnv->FindClass("com/mapzen/tangram/LngLat");
+    lngLatLongitudeFID = jniEnv->GetFieldID(lngLatClass, "longitude", "D");
+    lngLatLatitudeFID = jniEnv->GetFieldID(lngLatClass, "latitude", "D");
+
+    jclass pointFClass = jniEnv->FindClass("android/graphics/PointF");
+    pointFxFID = jniEnv->GetFieldID(pointFClass, "x", "F");
+    pointFyFID = jniEnv->GetFieldID(pointFClass, "y", "F");
+
+    jclass rectClass = jniEnv->FindClass("android/graphics/Rect");
+    rectLeftFID = jniEnv->GetFieldID(rectClass, "left", "I");
+    rectTopFID = jniEnv->GetFieldID(rectClass, "top", "I");
+    rectRightFID = jniEnv->GetFieldID(rectClass, "right", "I");
+    rectBottomFID = jniEnv->GetFieldID(rectClass, "bottom", "I");
 }
 
 std::string JniHelpers::stringFromJavaString(JNIEnv* jniEnv, jstring javaString) {
@@ -45,6 +70,30 @@ void JniHelpers::cameraPositionToJava(JNIEnv* env, jobject javaCamera, const Cam
     env->SetFloatField(javaCamera, cameraPositionZoomFID, camera.zoom);
     env->SetFloatField(javaCamera, cameraPositionRotationFID, camera.rotation);
     env->SetFloatField(javaCamera, cameraPositionTiltFID, camera.tilt);
+}
+
+void JniHelpers::vec2ToJava(JNIEnv* env, jobject javaPointF, float x, float y) {
+    env->SetFloatField(javaPointF, pointFxFID, x);
+    env->SetFloatField(javaPointF, pointFyFID, y);
+}
+
+void JniHelpers::lngLatToJava(JNIEnv* env, jobject javaLngLat, const LngLat& lngLat) {
+    env->SetDoubleField(javaLngLat, lngLatLongitudeFID, lngLat.longitude);
+    env->SetDoubleField(javaLngLat, lngLatLatitudeFID, lngLat.latitude);
+}
+
+LngLat JniHelpers::lngLatFromJava(JNIEnv* env, jobject javaLngLat) {
+    double longitude = env->GetDoubleField(javaLngLat, lngLatLongitudeFID);
+    double latitude = env->GetDoubleField(javaLngLat, lngLatLatitudeFID);
+    return LngLat{ longitude, latitude };
+}
+
+EdgePadding JniHelpers::edgePaddingFromJava(JNIEnv* env, jobject javaRect) {
+    int left = env->GetIntField(javaRect, rectLeftFID);
+    int top = env->GetIntField(javaRect, rectTopFID);
+    int right = env->GetIntField(javaRect, rectRightFID);
+    int bottom = env->GetIntField(javaRect, rectBottomFID);
+    return EdgePadding{ left, top, right, bottom };
 }
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/JniHelpers.cpp
+++ b/platforms/android/tangram/src/main/cpp/JniHelpers.cpp
@@ -1,10 +1,28 @@
 #include "JniHelpers.h"
+#include "map.h"
 #include <codecvt>
 #include <locale>
 
 namespace Tangram {
 
 JavaVM* JniHelpers::s_jvm = nullptr;
+
+static jfieldID cameraPositionLongitudeFID = nullptr;
+static jfieldID cameraPositionLatitudeFID = nullptr;
+static jfieldID cameraPositionZoomFID = nullptr;
+static jfieldID cameraPositionRotationFID = nullptr;
+static jfieldID cameraPositionTiltFID = nullptr;
+
+void JniHelpers::jniOnLoad(JavaVM* jvm, JNIEnv* jniEnv) {
+    s_jvm = jvm;
+
+    jclass cameraPositionClass = jniEnv->FindClass("com/mapzen/tangram/CameraPosition");
+    cameraPositionLongitudeFID = jniEnv->GetFieldID(cameraPositionClass, "longitude", "D");
+    cameraPositionLatitudeFID = jniEnv->GetFieldID(cameraPositionClass, "latitude", "D");
+    cameraPositionZoomFID = jniEnv->GetFieldID(cameraPositionClass, "zoom", "F");
+    cameraPositionRotationFID = jniEnv->GetFieldID(cameraPositionClass, "rotation", "F");
+    cameraPositionTiltFID = jniEnv->GetFieldID(cameraPositionClass, "tilt", "F");
+}
 
 std::string JniHelpers::stringFromJavaString(JNIEnv* jniEnv, jstring javaString) {
     auto length = jniEnv->GetStringLength(javaString);
@@ -19,6 +37,14 @@ jstring JniHelpers::javaStringFromString(JNIEnv* jniEnv, const std::string& stri
     auto chars = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(string);
     auto s = reinterpret_cast<const jchar*>(chars.empty() ? u"" : chars.data());
     return jniEnv->NewString(s, chars.length());
+}
+
+void JniHelpers::cameraPositionToJava(JNIEnv* env, jobject javaCamera, const CameraPosition& camera) {
+    env->SetDoubleField(javaCamera, cameraPositionLongitudeFID, camera.longitude);
+    env->SetDoubleField(javaCamera, cameraPositionLatitudeFID, camera.latitude);
+    env->SetFloatField(javaCamera, cameraPositionZoomFID, camera.zoom);
+    env->SetFloatField(javaCamera, cameraPositionRotationFID, camera.rotation);
+    env->SetFloatField(javaCamera, cameraPositionTiltFID, camera.tilt);
 }
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/JniHelpers.h
+++ b/platforms/android/tangram/src/main/cpp/JniHelpers.h
@@ -5,15 +5,19 @@
 
 namespace Tangram {
 
+struct CameraPosition;
+
 class JniHelpers {
 
 public:
 
-    static void jniOnLoad(JavaVM* jvm) { s_jvm = jvm; }
+    static void jniOnLoad(JavaVM* jvm, JNIEnv* jniEnv);
     static JavaVM* getJVM() { return s_jvm; }
 
     static std::string stringFromJavaString(JNIEnv* jniEnv, jstring javaString);
     static jstring javaStringFromString(JNIEnv* jniEnv, const std::string& string);
+
+    static void cameraPositionToJava(JNIEnv* env, jobject javaCamera, const CameraPosition& camera);
 
 protected:
 

--- a/platforms/android/tangram/src/main/cpp/JniHelpers.h
+++ b/platforms/android/tangram/src/main/cpp/JniHelpers.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "map.h"
+
 #include <jni.h>
 #include <string>
 
 namespace Tangram {
-
-struct CameraPosition;
 
 class JniHelpers {
 
@@ -18,6 +18,14 @@ public:
     static jstring javaStringFromString(JNIEnv* jniEnv, const std::string& string);
 
     static void cameraPositionToJava(JNIEnv* env, jobject javaCamera, const CameraPosition& camera);
+
+    static void vec2ToJava(JNIEnv* env, jobject javaPointF, float x, float y);
+
+    static void lngLatToJava(JNIEnv* env, jobject javaLngLat, const LngLat& lngLat);
+
+    static LngLat lngLatFromJava(JNIEnv* env, jobject javaLngLat);
+
+    static EdgePadding edgePaddingFromJava(JNIEnv* env, jobject javaRect);
 
 protected:
 

--- a/platforms/android/tangram/src/main/cpp/JniOnLoad.cpp
+++ b/platforms/android/tangram/src/main/cpp/JniOnLoad.cpp
@@ -10,7 +10,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* javaVM, void*) {
         return -1;
     }
 
-    Tangram::JniHelpers::jniOnLoad(javaVM);
+    Tangram::JniHelpers::jniOnLoad(javaVM, jniEnv);
     Tangram::AndroidPlatform::jniOnLoad(javaVM, jniEnv);
     Tangram::AndroidMap::jniOnLoad(javaVM, jniEnv);
 

--- a/platforms/android/tangram/src/main/cpp/NativeMap.cpp
+++ b/platforms/android/tangram/src/main/cpp/NativeMap.cpp
@@ -136,21 +136,10 @@ void NATIVE_METHOD(captureSnapshot)(JNIEnv* env, jobject obj, jintArray buffer) 
     env->ReleaseIntArrayElements(buffer, ptr, 0);
 }
 
-void NATIVE_METHOD(getCameraPosition)(JNIEnv* env, jobject obj, jdoubleArray lonLat,
-                                      jfloatArray zoomRotationTilt) {
+void NATIVE_METHOD(getCameraPosition)(JNIEnv* env, jobject obj, jobject cameraPositionOut) {
     auto* map = androidMapFromJava(env, obj);
-    jdouble* pos = env->GetDoubleArrayElements(lonLat, nullptr);
-    jfloat* zrt = env->GetFloatArrayElements(zoomRotationTilt, nullptr);
-
-    auto camera = map->getCameraPosition();
-    pos[0] = camera.longitude;
-    pos[1] = camera.latitude;
-    zrt[0] = camera.zoom;
-    zrt[1] = camera.rotation;
-    zrt[2] = camera.tilt;
-
-    env->ReleaseDoubleArrayElements(lonLat, pos, 0);
-    env->ReleaseFloatArrayElements(zoomRotationTilt, zrt, 0);
+    CameraPosition cameraPosition = map->getCameraPosition();
+    JniHelpers::cameraPositionToJava(env, cameraPositionOut, cameraPosition);
 }
 
 void NATIVE_METHOD(updateCameraPosition)(JNIEnv* env, jobject obj,
@@ -185,7 +174,7 @@ void NATIVE_METHOD(updateCameraPosition)(JNIEnv* env, jobject obj,
 void NATIVE_METHOD(getEnclosingCameraPosition)(JNIEnv* env, jobject obj,
                                                jdouble aLng, jdouble aLat,
                                                jdouble bLng, jdouble bLat,
-                                               jintArray jpad, jdoubleArray lngLatZoom) {
+                                               jintArray jpad, jobject cameraPositionOut) {
     auto* map = androidMapFromJava(env, obj);
 
     EdgePadding padding;
@@ -195,11 +184,7 @@ void NATIVE_METHOD(getEnclosingCameraPosition)(JNIEnv* env, jobject obj,
         env->ReleaseIntArrayElements(jpad, jpadArray, JNI_ABORT);
     }
     CameraPosition camera = map->getEnclosingCameraPosition(LngLat{aLng,aLat}, LngLat{bLng,bLat}, padding);
-    jdouble* arr = env->GetDoubleArrayElements(lngLatZoom, nullptr);
-    arr[0] = camera.longitude;
-    arr[1] = camera.latitude;
-    arr[2] = camera.zoom;
-    env->ReleaseDoubleArrayElements(lngLatZoom, arr, 0);
+    JniHelpers::cameraPositionToJava(env, cameraPositionOut, camera);
 }
 
 void NATIVE_METHOD(flyTo)(JNIEnv* env, jobject obj, jdouble lon, jdouble lat,

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/CameraUpdate.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/CameraUpdate.java
@@ -1,5 +1,7 @@
 package com.mapzen.tangram;
 
+import android.graphics.Rect;
+
 public class CameraUpdate {
 
     final static int SET_LNGLAT = 1 << 0;
@@ -24,7 +26,7 @@ public class CameraUpdate {
     double boundsLat1;
     double boundsLon2;
     double boundsLat2;
-    int[] padding;
+    Rect padding;
     int set;
 
     CameraUpdate() {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/CameraUpdateFactory.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/CameraUpdateFactory.java
@@ -170,7 +170,7 @@ public class CameraUpdateFactory {
         update.boundsLat1 = sw.latitude;
         update.boundsLon2 = ne.longitude;
         update.boundsLat2 = ne.latitude;
-        update.padding = new int[]{padding.left, padding.top, padding.right, padding.bottom};
+        update.padding = padding;
         return update;
     }
 }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -530,8 +530,7 @@ public class MapController {
      */
     @NonNull
     public CameraPosition getEnclosingCameraPosition(@NonNull LngLat sw, @NonNull LngLat ne, @NonNull Rect padding, @NonNull final CameraPosition out) {
-        int[] pad = new int[]{padding.left, padding.top, padding.right, padding.bottom};
-        nativeMap.getEnclosingCameraPosition(sw.longitude, sw.latitude, ne.longitude, ne.latitude, pad, out);
+        nativeMap.getEnclosingCameraPosition(sw, ne, padding, out);
         return out;
     }
 
@@ -598,11 +597,22 @@ public class MapController {
      */
     @Nullable
     public LngLat screenPositionToLngLat(@NonNull final PointF screenPosition) {
-        final double[] tmp = { screenPosition.x, screenPosition.y };
-        if (nativeMap.screenPositionToLngLat(tmp)) {
-            return new LngLat(tmp[0], tmp[1]);
+        LngLat result = new LngLat();
+        if (screenPositionToLngLat(screenPosition, result)) {
+            return result;
         }
         return null;
+    }
+
+    /**
+     * Find the geographic coordinates corresponding to the given position on screen.
+     * @param screenPosition Position in pixels from the top-left corner of the map area.
+     * @param lngLatOut LngLat object to hold the result.
+     * @return True if a LngLat result was found, false if the screen position does not intersect
+     * a geographic location (this can happen at high tilt angles).
+     */
+    public boolean screenPositionToLngLat(@NonNull final PointF screenPosition, @NonNull final LngLat lngLatOut) {
+        return nativeMap.screenPositionToLngLat(screenPosition.x, screenPosition.y, lngLatOut);
     }
 
     /**
@@ -627,10 +637,7 @@ public class MapController {
      * @return True if the resulting point is inside the viewport, otherwise false.
      */
     public boolean lngLatToScreenPosition(@NonNull final LngLat lngLat, @NonNull final PointF screenPositionOut, boolean clipToViewport) {
-        final double[] tmp = { lngLat.longitude, lngLat.latitude };
-        boolean insideViewport = nativeMap.lngLatToScreenPosition(tmp, clipToViewport);
-        screenPositionOut.set((float)tmp[0], (float)tmp[1]);
-        return insideViewport;
+        return nativeMap.lngLatToScreenPosition(lngLat.longitude, lngLat.latitude, screenPositionOut, clipToViewport);
     }
 
     /**

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -497,14 +497,7 @@ public class MapController {
      */
     @NonNull
     public CameraPosition getCameraPosition(@NonNull final CameraPosition out) {
-        final double[] pos = { 0, 0 };
-        final float[] zrt = { 0, 0, 0 };
-        nativeMap.getCameraPosition(pos, zrt);
-        out.longitude = pos[0];
-        out.latitude = pos[1];
-        out.zoom = zrt[0];
-        out.rotation = zrt[1];
-        out.tilt = zrt[2];
+        nativeMap.getCameraPosition(out);
         return out;
     }
 
@@ -538,13 +531,7 @@ public class MapController {
     @NonNull
     public CameraPosition getEnclosingCameraPosition(@NonNull LngLat sw, @NonNull LngLat ne, @NonNull Rect padding, @NonNull final CameraPosition out) {
         int[] pad = new int[]{padding.left, padding.top, padding.right, padding.bottom};
-        double[] lngLatZoom = new double[3];
-        nativeMap.getEnclosingCameraPosition(sw.longitude, sw.latitude, ne.longitude, ne.latitude, pad, lngLatZoom);
-        out.longitude = lngLatZoom[0];
-        out.latitude = lngLatZoom[1];
-        out.zoom = (float)lngLatZoom[2];
-        out.rotation = 0.f;
-        out.tilt = 0.f;
+        nativeMap.getEnclosingCameraPosition(sw.longitude, sw.latitude, ne.longitude, ne.latitude, pad, out);
         return out;
     }
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
@@ -27,13 +27,13 @@ class NativeMap {
     native void render();
     native void captureSnapshot(int[] buffer);
 
-    native void getCameraPosition(double[] lonLatOut, float[] zoomRotationTiltOut);
+    native void getCameraPosition(CameraPosition cameraPositionOut);
     native void updateCameraPosition(int set, double lon, double lat, float zoom, float zoomBy,
                                                                 float rotation, float rotateBy, float tilt, float tiltBy,
                                                                 double b1lon, double b1lat, double b2lon, double b2lat, int[] padding,
                                                                 float duration, int ease);
     native void flyTo(double lon, double lat, float zoom, float duration, float speed);
-    native void getEnclosingCameraPosition(double aLng, double aLat, double bLng, double bLat, int[] buffer, double[] lngLatZoom);
+    native void getEnclosingCameraPosition(double aLng, double aLat, double bLng, double bLat, int[] buffer, CameraPosition cameraPositionOut);
     native void cancelCameraAnimation();
     native boolean screenPositionToLngLat(double[] coordinates);
     native boolean lngLatToScreenPosition(double[] coordinates, boolean clipToViewport);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
@@ -2,6 +2,8 @@ package com.mapzen.tangram;
 
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
+import android.graphics.PointF;
+import android.graphics.Rect;
 
 class NativeMap {
 
@@ -30,13 +32,13 @@ class NativeMap {
     native void getCameraPosition(CameraPosition cameraPositionOut);
     native void updateCameraPosition(int set, double lon, double lat, float zoom, float zoomBy,
                                                                 float rotation, float rotateBy, float tilt, float tiltBy,
-                                                                double b1lon, double b1lat, double b2lon, double b2lat, int[] padding,
+                                                                double b1lon, double b1lat, double b2lon, double b2lat, Rect padding,
                                                                 float duration, int ease);
     native void flyTo(double lon, double lat, float zoom, float duration, float speed);
-    native void getEnclosingCameraPosition(double aLng, double aLat, double bLng, double bLat, int[] buffer, CameraPosition cameraPositionOut);
+    native void getEnclosingCameraPosition(LngLat lngLatSE, LngLat lngLatNW, Rect padding, CameraPosition cameraPositionOut);
     native void cancelCameraAnimation();
-    native boolean screenPositionToLngLat(double[] coordinates);
-    native boolean lngLatToScreenPosition(double[] coordinates, boolean clipToViewport);
+    native boolean screenPositionToLngLat(float x, float y, LngLat lngLatOut);
+    native boolean lngLatToScreenPosition(double lng, double lat, PointF screenPositionOut, boolean clipToViewport);
     native void setPixelScale(float scale);
     native void setCameraType(int type);
     native int getCameraType();


### PR DESCRIPTION
While refactoring Tangram's JNI usage for the Android SDK a while ago, I noticed opportunities for avoiding a lot of temporary allocations for objects used exclusively to send data between Java and C++. The general pattern here is that rather than passing a Java object's data as primitives in a list of arguments, we can pass the Java objects into JNI methods and use field accessors to get or set the data directly in C++. This requires a bit more boilerplate code to set up field IDs in C++, but minimizing temporary allocations is important for performance and I think several methods are much easier to read now. 