### PR TITLE
Prevent overshoot on fling damping

### DIFF
--- a/core/src/util/inputHandler.cpp
+++ b/core/src/util/inputHandler.cpp
@@ -35,10 +35,10 @@ bool InputHandler::update(float _dt) {
 
     if (isFlinging) {
 
-        m_velocityPan -= _dt * DAMPING_PAN * m_velocityPan;
+        m_velocityPan -= min(_dt * DAMPING_PAN, 1.f) * m_velocityPan;
         m_view.translate(_dt * m_velocityPan.x, _dt * m_velocityPan.y);
 
-        m_velocityZoom -= _dt * DAMPING_ZOOM * m_velocityZoom;
+        m_velocityZoom -= min(_dt * DAMPING_ZOOM, 1.f) * m_velocityZoom;
         m_view.zoom(m_velocityZoom * _dt);
     }
 


### PR DESCRIPTION
For unclear reasons, the update timestep on Android is sometimes unreasonably large (I've observed a _dt_ value of 30 seconds for an app that had been idle for less than 1 second). This caused the "damping" behavior for gesture "flings" to dramatically overshoot, creating a high-speed change in the opposite direction of the gesture. 

Though I don't fully understand the cause, the fix for this is simple and robust: the amount of velocity subtracted for damping is clamped to at most the magnitude of the current velocity.

Possibly related to https://github.com/tangrams/tangram-es/issues/2207