### PR TITLE
Fix iOS build errors with Xcode 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
       GRADLE_OPTS: -Xmx2048m
   macos-executor:
     macos:
-      xcode: "11.7.0"
+      xcode: "12.2.0"
     environment: # Disable some unnecessary homebrew operations to save time.
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ ios-framework: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramMap -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-framework-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramMap -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramMap -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
 
 ios-framework-universal: ios-framework ios-framework-sim
 	@mkdir -p ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal
@@ -228,13 +228,13 @@ ios-static: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-static-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
 
 ios-static-lib: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-static-lib-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
 
 ios-static-lib-universal: ios-static-lib ios-static-lib-sim
 	@mkdir -p ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal

--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -46,6 +46,20 @@ if (IOS_SDK_VERSION VERSION_LESS 11.0)
   set(SQLITE_USE_LEGACY_STRUCT ON CACHE BOOL "")
 endif()
 
+# Some 3rd-party dependencies (SQLiteCpp and Freetype) have CMake scripts that
+# use find_package() to locate and link libraries that they depend on.
+# find_package() successfully sets paths for these library files, but the paths
+# are only valid for the *configured* sysroot. For iOS, this means that the 
+# library paths use the device SDK, not the simulator. See:
+# https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#switching-between-device-and-simulator
+# To allow switching between device and simulator builds, we need to use linker
+# flags so that the final library path can be determined by the linker. If the
+# *_LIBRARY variable is already set when find_package() runs, it will keep the
+# current value. This lets us force dependencies to use linker flags instead of
+# paths to libraries.
+set(ZLIB_LIBRARY "-lz" CACHE STRING "Override zlib library location on iOS")
+set(SQLite3_LIBRARY "-lsqlite3" CACHE STRING "Override sqlite3 library location on iOS")
+
 # Headers must be absolute paths for the copy_if_different command on the
 # static library target, relative paths cause it to fail with an error.
 set(TANGRAM_FRAMEWORK_HEADERS

--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -119,7 +119,6 @@ add_library(TangramMap SHARED
 
 target_link_libraries(TangramMap PRIVATE
   tangram-core
-  sqlite3
   # Frameworks: use quotes so "-framework X" is treated as a single linker flag.
   "-framework CoreFoundation"
   "-framework CoreGraphics"
@@ -157,7 +156,6 @@ add_library(tangram-static STATIC
 
 target_link_libraries(tangram-static PRIVATE
   tangram-core
-  sqlite3
   # Frameworks: use quotes so "-framework X" is treated as a single linker flag.
   "-framework CoreFoundation"
   "-framework CoreGraphics"


### PR DESCRIPTION
Xcode 12 has some subtly different behavior from previous versions of Xcode that caused several build errors for Tangram ES on iOS.
- `xcodebuild` targets the `arm64` architecture by default when using `-sdk iphonesimulator` (maybe because this is the native arch for new macs?). I fixed this by adding an explicit `-arch x86_64` to the commands targeting the simulator in our Makefile.
- It is now an error for a build targeting the iOS simulator to link to a library path in the iOS device SDK (I'm not certain, but I *think* this was allowed before). CMake scripts using `find_package()` will end up linking to library paths in the SDK that is used during the CMake configuration phase, which is the iOS device SDK. This created errors when switching to a simulator build. I fixed this by sneakily forcing the 3rd-party scripts using `find_package()` to link with flags instead of library paths (see diff for details).

Resolves https://github.com/tangrams/tangram-es/issues/2205
Resolves https://github.com/tangrams/tangram-es/issues/2193