### PR TITLE
Don't throw when native pointers have long values < 0

### DIFF
--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -670,7 +670,7 @@ public class MapController {
             return mapData;
         }
         final long pointer = nativeMap.addClientDataSource(name, generateCentroid);
-        if (pointer <= 0) {
+        if (pointer == 0) {
             throw new RuntimeException("Unable to create new data source");
         }
         mapData = new MapData(name, pointer, this);
@@ -684,7 +684,9 @@ public class MapController {
      */
     void removeDataLayer(@NonNull final MapData mapData) {
         clientTileSources.remove(mapData.name);
-        checkPointer(mapData.pointer);
+        if (mapData.pointer == 0) {
+            throw new RuntimeException("Tried to remove a MapData that was already disposed");
+        }
         nativeMap.removeClientDataSource(mapData.pointer);
     }
 
@@ -1081,14 +1083,6 @@ public class MapController {
 
     void onLowMemory() {
         nativeMap.onLowMemory();
-    }
-
-    void checkPointer(final long ptr) {
-        if (ptr <= 0) {
-            throw new RuntimeException("Tried to perform an operation on an invalid pointer!"
-                    + " This means you may have used an object that has been disposed and is no"
-                    + " longer valid.");
-        }
     }
 
     void checkId(final long id) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -92,7 +92,7 @@ public class MapData {
     }
 
     private void checkPointer(final long ptr) {
-        if (ptr <= 0) {
+        if (ptr == 0) {
             throw new RuntimeException("Tried to perform an operation on an invalid pointer!"
                     + " This means you may have used a MapData that has already been removed.");
         }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
@@ -9,7 +9,7 @@ class NativeMap {
 
     NativeMap(MapController mapController, AssetManager assetManager) {
         nativePointer = init(mapController, assetManager);
-        if (nativePointer <= 0) {
+        if (nativePointer == 0) {
             throw new RuntimeException("Unable to create a native Map object! There may be insufficient memory available.");
         }
     }


### PR DESCRIPTION
Android 11 and certain ROMs use "tagged pointers" that set the high bits on pointers, causing them to become negative as a long.

See https://github.com/tangrams/tangram-es/issues/2215