### PR TITLE
Android publishing refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: cd platforms/android && ./gradlew uploadArchives
+      - run: cd platforms/android && ./gradlew publish
   build-ios:
     executor: macos-executor
     steps:

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 
 group = GROUP
 version = VERSION_NAME

--- a/platforms/android/tangram/gradle.properties
+++ b/platforms/android/tangram/gradle.properties
@@ -7,14 +7,14 @@ POM_NAME=Tangram ES
 POM_PACKAGING=aar
 POM_DESCRIPTION=Tangram Android SDK
 
-POM_URL=http://github.com/tangrams/tangram-es
-POM_SCM_URL=http://github.com/tangrams/tangram-es
-POM_SCM_CONNECTION=scm:git:git://github.com/tangrams/tangram-es.git
+POM_URL=https://github.com/tangrams/tangram-es
+POM_SCM_URL=https://github.com/tangrams/tangram-es
+POM_SCM_CONNECTION=scm:git:https://github.com/tangrams/tangram-es.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/tangrams/tangram-es.git
 
-POM_LICENCE_NAME=The MIT License (MIT)
-POM_LICENCE_URL=http://opensource.org/licenses/MIT
-POM_LICENCE_DIST=repo
+POM_LICENSE_NAME=The MIT License (MIT)
+POM_LICENSE_URL=https://opensource.org/licenses/MIT
+POM_LICENSE_DIST=repo
 
 POM_DEVELOPER_ID=Mapzen
 POM_DEVELOPER_NAME=Mapzen

--- a/platforms/android/tangram/publishing.gradle
+++ b/platforms/android/tangram/publishing.gradle
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013 Chris Banes
- * Copyright 2018 Matt Blair
+ * Copyright 2020 Matt Blair
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,92 +15,96 @@
  * limitations under the License.
  */
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
-def isReleaseBuild() {
-  return VERSION_NAME.contains('SNAPSHOT') == false
-}
-
-def getRepositoryUsername() {
-  return project.hasProperty('bintrayUsername') ? bintrayUsername : System.env.BINTRAY_USERNAME
-}
-
-def getRepositoryPassword() {
-  return project.hasProperty('bintrayApiKey') ? bintrayApiKey : System.env.BINTRAY_API_KEY
-}
-
+// Components from the Android Gradle plugin are only created during the afterEvaluate phase, so
+// configure publications using the afterEvaluate() lifecycle method.
+// https://developer.android.com/studio/build/maven-publish-plugin
 afterEvaluate { project ->
-  uploadArchives {
-    repositories {
-      mavenDeployer {
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
 
-        repository(url: 'https://api.bintray.com/maven/tangrams/maven/tangram/') {
-          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-        }
-        snapshotRepository(url: 'https://oss.jfrog.org/artifactory/oss-snapshot-local/') {
-          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-        }
-
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
-
-          scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
-          }
-
+  publishing {
+    publications {
+      // Create a publication named 'maven'.
+      maven(MavenPublication) {
+        // Configure package information.
+        groupId = GROUP
+        artifactId = POM_ARTIFACT_ID
+        version = VERSION_NAME
+        pom {
+          name = POM_NAME
+          description = POM_DESCRIPTION
+          url = POM_URL
           licenses {
             license {
-              name POM_LICENCE_NAME
-              url POM_LICENCE_URL
-              distribution POM_LICENCE_DIST
+              name = POM_LICENSE_NAME
+              url = POM_LICENSE_URL
+              distribution = POM_LICENSE_DIST
             }
           }
-
           developers {
             developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
+              name = POM_DEVELOPER_NAME
             }
           }
+          scm {
+            connection = POM_SCM_CONNECTION
+            developerConnection = POM_SCM_DEV_CONNECTION
+            url = POM_SCM_URL
+          }
+        }
+
+        // Apply the component for the 'release' build variant.
+        from components.release
+
+        // Apply the sources and javadoc jars.
+        artifact androidSourcesJar
+        artifact androidJavadocsJar
+      }
+    }
+
+    repositories {
+      maven {
+        // Publish releases to Bintray and snapshots to OJO.
+        def releaseUrl = 'https://api.bintray.com/maven/tangrams/maven/tangram/'
+        def snapshotUrl = 'https://oss.jfrog.org/artifactory/oss-snapshot-local/'
+        url = VERSION_NAME.contains('SNAPSHOT') ? snapshotUrl : releaseUrl
+        credentials {
+          username = project.hasProperty('bintrayUsername') ? bintrayUsername : System.env.BINTRAY_USERNAME
+          password = project.hasProperty('bintrayApiKey') ? bintrayApiKey : System.env.BINTRAY_API_KEY
         }
       }
     }
   }
+}
 
-  task androidJavadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    failOnError = false
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    exclude '**/*.kt'
-    exclude 'com/almeros/android/multitouch'
+// Configure tasks for javadoc and sources jars.
 
-    if (JavaVersion.current().isJava8Compatible()) {
-      allprojects {
-        tasks.withType(Javadoc) {
-          options.addStringOption('Xdoclint:none', '-quiet')
-        }
-      }
+task androidJavadocs(type: Javadoc) {
+  source = android.sourceSets.main.java.srcDirs
+  // TODO: Fix errors caused by Android dependencies not on classpath for javadoc task.
+  failOnError = false
+  // Add Android SDK to classpath.
+  classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+  // Exclude internal dependency classes.
+  exclude 'com/almeros/android/multitouch'
+}
+
+task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+  from androidJavadocs.destinationDir
+  // Add archiveClassifier so that the publishing task correctly resolves names of jar artifacts.
+  archiveClassifier = 'javadoc'
+}
+
+task androidSourcesJar(type: Jar) {
+  from android.sourceSets.main.java.sourceFiles
+  // Add archiveClassifier so that the publishing task correctly resolves names of jar artifacts.
+  archiveClassifier = 'sources'
+}
+
+if (JavaVersion.current().isJava8Compatible()) {
+  allprojects {
+    tasks.withType(Javadoc) {
+      options.addStringOption('Xdoclint:none', '-quiet')
     }
-  }
-
-  task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    from androidJavadocs.destinationDir
-  }
-
-  task androidSourcesJar(type: Jar) {
-    from android.sourceSets.main.java.sourceFiles
-  }
-
-  artifacts {
-    archives androidSourcesJar
-    archives androidJavadocsJar
   }
 }


### PR DESCRIPTION
Using Gradle's "publications" feature works mostly the same as the plugin we were previously using, but with greater flexibility. In particular, this approach makes it simple to publish to your local Maven repository, which is very useful for inspecting the package contents before publishing it to a server.

Publishing plugin documentation: https://developer.android.com/studio/build/maven-publish-plugin

I used the OkHTTP publishing configuration for reference: https://github.com/square/okhttp/blob/000bb666529148595f91ecad822baf7ae07fbcc5/build.gradle#L285-L342