### PR TITLE
Build only x86_64 for ios-sim and ios-swift-sim make rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,13 +189,13 @@ ios: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
 
 ios-swift: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemoSwift -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-swift-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemoSwift -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemoSwift -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
 
 ios-xcode: cmake-ios
 	open platforms/ios/Tangram.xcworkspace


### PR DESCRIPTION
Makes these consistent with ios-framework-sim, ios-static-sim, and ios-static-lib-sim. Should speed up CI builds.