### PR TITLE
Synchronize access to shared NativeMap

### DIFF
--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -113,8 +113,10 @@ Map::~Map() {
     // In any case after shutdown Platform may not call back into Map!
     platform->shutdown();
 
-    // The unique_ptr to Impl will be automatically destroyed when Map is destroyed.
+    // Impl will be automatically destroyed by unique_ptr, but threads owned by AsyncWorker and
+    // Scene need to be destroyed before JobQueue stops.
     impl->asyncWorker.reset();
+    impl->scene.reset();
 
     // Make sure other threads are stopped before calling stop()!
     // All jobs will be executed immediately on add() afterwards.

--- a/core/src/map.cpp
+++ b/core/src/map.cpp
@@ -37,9 +37,9 @@ namespace Tangram {
 struct CameraEase {
     struct {
         glm::dvec2 pos;
-        float zoom;
-        float rotation;
-        float tilt;
+        float zoom = 0;
+        float rotation = 0;
+        float tilt = 0;
     } start, end;
 };
 
@@ -66,8 +66,6 @@ public:
     void syncClientTileSources(bool _firstUpdate);
     bool updateCameraEase(float _dt);
 
-    std::mutex sceneMutex;
-
     Platform& platform;
     RenderState renderState;
     JobQueue jobQueue;
@@ -79,7 +77,6 @@ public:
     std::unique_ptr<Ease> ease;
 
     std::shared_ptr<Scene> scene;
-    std::condition_variable blockUntilSceneReady;
 
     std::unique_ptr<FrameBuffer> selectionBuffer = std::make_unique<FrameBuffer>(0, 0);
 
@@ -105,7 +102,7 @@ static std::bitset<9> g_flags = 0;
 
 Map::Map(std::unique_ptr<Platform> _platform) : platform(std::move(_platform)) {
     LOGTOInit();
-    impl.reset(new Impl(*platform));
+    impl = std::make_unique<Impl>(*platform);
 }
 
 Map::~Map() {
@@ -120,7 +117,6 @@ Map::~Map() {
     impl->asyncWorker.reset();
 
     impl->scene.reset();
-    impl->blockUntilSceneReady.notify_all();
 
     // Make sure other threads are stopped before calling stop()!
     // All jobs will be executed immediately on add() afterwards.

--- a/platforms/android/tangram/src/main/cpp/NativeMap.cpp
+++ b/platforms/android/tangram/src/main/cpp/NativeMap.cpp
@@ -117,15 +117,11 @@ void NATIVE_METHOD(resize)(JNIEnv* env, jobject obj, jint width, jint height) {
     map->resize(width, height);
 }
 
-jint NATIVE_METHOD(update)(JNIEnv* env, jobject obj, jfloat dt) {
+jint NATIVE_METHOD(render)(JNIEnv* env, jobject obj, jfloat dt) {
     auto* map = androidMapFromJava(env, obj);
     auto result = map->update(dt);
-    return static_cast<jint>(result.flags);
-}
-
-void NATIVE_METHOD(render)(JNIEnv* env, jobject obj) {
-    auto* map = androidMapFromJava(env, obj);
     map->render();
+    return static_cast<jint>(result.flags);
 }
 
 void NATIVE_METHOD(captureSnapshot)(JNIEnv* env, jobject obj, jintArray buffer) {

--- a/platforms/android/tangram/src/main/cpp/NativeMap.cpp
+++ b/platforms/android/tangram/src/main/cpp/NativeMap.cpp
@@ -505,6 +505,8 @@ jlong NATIVE_METHOD(addClientDataSource)(JNIEnv* env, jobject obj,
 void NATIVE_METHOD(removeClientDataSource)(JNIEnv* env, jobject obj, jlong sourcePtr) {
     auto* map = androidMapFromJava(env, obj);
     auto* clientDataSource = reinterpret_cast<ClientDataSource*>(sourcePtr);
+    // Map holds the only reference of the shared_ptr to the ClientDataSource, so removing the
+    // reference in Map will also implicitly free the ClientDataSource.
     map->removeTileSource(*clientDataSource);
 }
 

--- a/platforms/android/tangram/src/main/cpp/NativeMap.cpp
+++ b/platforms/android/tangram/src/main/cpp/NativeMap.cpp
@@ -11,7 +11,7 @@ AndroidMap* androidMapFromJava(JNIEnv* env, jobject nativeMapObject) {
     static jclass nativeMapClass = env->FindClass("com/mapzen/tangram/NativeMap");
     static jfieldID nativePointerFID = env->GetFieldID(nativeMapClass, "nativePointer", "J");
     jlong nativePointer = env->GetLongField(nativeMapObject, nativePointerFID);
-    assert(nativePointer > 0);
+    assert(nativePointer != 0);
     return reinterpret_cast<AndroidMap*>(nativePointer);
 }
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -217,21 +217,18 @@ public class MapController {
         clientTileSources.clear();
         markers.clear();
 
-        // Acquire the lock to ensure mapRenderer is not currently accessing nativeMap.
-        synchronized (mapRenderer.nativeMapLock) {
-            // NativeMap dispose makes GL calls to free GPU resources so we _should_ call it on the
-            // render thread, where the GL context is active. However, it is possible for the render
-            // thread associated with GLSurfaceView to be stopped without running all of the queued
-            // events. This would cause the native memory to be leaked.
-            //
-            // To avoid this, we dispose the NativeMap on the UI thread. The GL calls produce an
-            // error in logcat, but otherwise have no effect. The GPU resources are eventually freed
-            // when the SurfaceView is destroyed, so nothing is leaked.
-            Log.v(BuildConfig.TAG, "Dispose NativeMap");
-            NativeMap disposingNativeMap = nativeMap;
-            nativeMap = null;
-            disposingNativeMap.dispose();
-        }
+        // NativeMap dispose makes GL calls to free GPU resources so we _should_ call it on the
+        // render thread, where the GL context is active. However, it is possible for the render
+        // thread associated with GLSurfaceView to be stopped without running all of the queued
+        // events. This would cause the native memory to be leaked.
+        //
+        // To avoid this, we dispose the NativeMap on the UI thread. The GL calls produce an
+        // error in logcat, but otherwise have no effect. The GPU resources are eventually freed
+        // when the SurfaceView is destroyed, so nothing is leaked.
+        Log.v(BuildConfig.TAG, "Dispose NativeMap");
+        NativeMap disposingNativeMap = nativeMap;
+        nativeMap = null;
+        disposingNativeMap.dispose();
 
         // Dispose all listener and callbacks associated with mapController
         // This will help prevent leaks of references from the client code, possibly used in these
@@ -293,11 +290,8 @@ public class MapController {
      */
     public int loadSceneFile(final String path, @Nullable final List<SceneUpdate> sceneUpdates) {
         final String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        final int sceneId;
-        synchronized (mapRenderer.nativeMapLock) {
-            sceneId = nativeMap.loadScene(path, updateStrings);
-            removeAllMarkers();
-        }
+        final int sceneId = nativeMap.loadScene(path, updateStrings);
+        removeAllMarkers();
         requestRender();
         return sceneId;
     }
@@ -314,11 +308,8 @@ public class MapController {
      */
     public int loadSceneFileAsync(final String path, @Nullable final List<SceneUpdate> sceneUpdates) {
         final String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        final int sceneId;
-        synchronized (mapRenderer.nativeMapLock) {
-            sceneId = nativeMap.loadSceneAsync(path, updateStrings);
-            removeAllMarkers();
-        }
+        final int sceneId = nativeMap.loadSceneAsync(path, updateStrings);
+        removeAllMarkers();
         requestRender();
         return sceneId;
     }
@@ -336,11 +327,8 @@ public class MapController {
     public int loadSceneYaml(final String yaml, final String resourceRoot,
                              @Nullable final List<SceneUpdate> sceneUpdates) {
         final String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        final int sceneId;
-        synchronized (mapRenderer.nativeMapLock) {
-            sceneId = nativeMap.loadSceneYaml(yaml, resourceRoot, updateStrings);
-            removeAllMarkers();
-        }
+        final int sceneId = nativeMap.loadSceneYaml(yaml, resourceRoot, updateStrings);
+        removeAllMarkers();
         requestRender();
         return sceneId;
     }
@@ -358,11 +346,8 @@ public class MapController {
     public int loadSceneYamlAsync(final String yaml, final String resourceRoot,
                                   @Nullable final List<SceneUpdate> sceneUpdates) {
         final String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        final int sceneId;
-        synchronized (mapRenderer.nativeMapLock) {
-            sceneId = nativeMap.loadSceneYamlAsync(yaml, resourceRoot, updateStrings);
-            removeAllMarkers();
-        }
+        final int sceneId = nativeMap.loadSceneYamlAsync(yaml, resourceRoot, updateStrings);
+        removeAllMarkers();
         requestRender();
         return sceneId;
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -293,8 +293,11 @@ public class MapController {
      */
     public int loadSceneFile(final String path, @Nullable final List<SceneUpdate> sceneUpdates) {
         final String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        final int sceneId = nativeMap.loadScene(path, updateStrings);
-        removeAllMarkers();
+        final int sceneId;
+        synchronized (mapRenderer.nativeMapLock) {
+            sceneId = nativeMap.loadScene(path, updateStrings);
+            removeAllMarkers();
+        }
         requestRender();
         return sceneId;
     }
@@ -311,8 +314,11 @@ public class MapController {
      */
     public int loadSceneFileAsync(final String path, @Nullable final List<SceneUpdate> sceneUpdates) {
         final String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        final int sceneId = nativeMap.loadSceneAsync(path, updateStrings);
-        removeAllMarkers();
+        final int sceneId;
+        synchronized (mapRenderer.nativeMapLock) {
+            sceneId = nativeMap.loadSceneAsync(path, updateStrings);
+            removeAllMarkers();
+        }
         requestRender();
         return sceneId;
     }
@@ -330,8 +336,11 @@ public class MapController {
     public int loadSceneYaml(final String yaml, final String resourceRoot,
                              @Nullable final List<SceneUpdate> sceneUpdates) {
         final String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        final int sceneId = nativeMap.loadSceneYaml(yaml, resourceRoot, updateStrings);
-        removeAllMarkers();
+        final int sceneId;
+        synchronized (mapRenderer.nativeMapLock) {
+            sceneId = nativeMap.loadSceneYaml(yaml, resourceRoot, updateStrings);
+            removeAllMarkers();
+        }
         requestRender();
         return sceneId;
     }
@@ -349,8 +358,11 @@ public class MapController {
     public int loadSceneYamlAsync(final String yaml, final String resourceRoot,
                                   @Nullable final List<SceneUpdate> sceneUpdates) {
         final String[] updateStrings = bundleSceneUpdates(sceneUpdates);
-        final int sceneId = nativeMap.loadSceneYamlAsync(yaml, resourceRoot, updateStrings);
-        removeAllMarkers();
+        final int sceneId;
+        synchronized (mapRenderer.nativeMapLock) {
+            sceneId = nativeMap.loadSceneYamlAsync(yaml, resourceRoot, updateStrings);
+            removeAllMarkers();
+        }
         requestRender();
         return sceneId;
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -211,7 +211,8 @@ public class MapController {
 
         Log.v(BuildConfig.TAG, "MapData instances to remove: " + clientTileSources.size());
         for (MapData mapData : clientTileSources.values()) {
-            mapData.remove();
+            nativeMap.removeClientDataSource(mapData.pointer);
+            mapData.dispose();
         }
         clientTileSources.clear();
         markers.clear();
@@ -686,6 +687,7 @@ public class MapController {
             throw new RuntimeException("Tried to remove a MapData that was already disposed");
         }
         nativeMap.removeClientDataSource(mapData.pointer);
+        mapData.dispose();
     }
 
     /**

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -76,7 +76,9 @@ public class MapData {
             return;
         }
         map.removeDataLayer(this);
+    }
 
+    void dispose() {
         mapController = null;
         pointer = 0;
     }

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapRenderer.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapRenderer.java
@@ -106,7 +106,12 @@ class MapRenderer implements GLSurfaceView.Renderer {
 
     @NonNull
     private Bitmap capture() {
-        View view = map.getGLViewHolder().getView();
+        GLViewHolder viewHolder = map.getGLViewHolder();
+        if (viewHolder == null) {
+            throw new IllegalStateException("MapController GLViewHolder is null");
+        }
+
+        View view = viewHolder.getView();
 
         final int w = view.getWidth();
         final int h = view.getHeight();

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
@@ -14,72 +14,71 @@ class NativeMap {
         }
     }
 
-    native long init(MapController mapController, AssetManager assetManager);
-    native void dispose();
-    native void shutdown();
-    native void onLowMemory();
-    native int loadScene(String path, String[] updateStrings);
-    native int loadSceneAsync(String path, String[] updateStrings);
-    native int loadSceneYaml(String yaml, String resourceRoot, String[] updateStrings);
-    native int loadSceneYamlAsync(String yaml, String resourceRoot, String[] updateStrings);
+    private native long init(MapController mapController, AssetManager assetManager);
+    native synchronized void dispose();
+    native synchronized void shutdown();
+    native synchronized void onLowMemory();
+    native synchronized int loadScene(String path, String[] updateStrings);
+    native synchronized int loadSceneAsync(String path, String[] updateStrings);
+    native synchronized int loadSceneYaml(String yaml, String resourceRoot, String[] updateStrings);
+    native synchronized int loadSceneYamlAsync(String yaml, String resourceRoot, String[] updateStrings);
 
-    native void setupGL();
-    native void resize(int width, int height);
-    native int update(float dt);
-    native void render();
-    native void captureSnapshot(int[] buffer);
+    native synchronized void setupGL();
+    native synchronized void resize(int width, int height);
+    native synchronized int render(float dt);
+    native synchronized void captureSnapshot(int[] buffer);
 
-    native void getCameraPosition(CameraPosition cameraPositionOut);
-    native void updateCameraPosition(int set, double lon, double lat, float zoom, float zoomBy,
+    native synchronized void getCameraPosition(CameraPosition cameraPositionOut);
+    native synchronized void updateCameraPosition(int set, double lon, double lat, float zoom, float zoomBy,
                                                                 float rotation, float rotateBy, float tilt, float tiltBy,
                                                                 double b1lon, double b1lat, double b2lon, double b2lat, Rect padding,
                                                                 float duration, int ease);
-    native void flyTo(double lon, double lat, float zoom, float duration, float speed);
-    native void getEnclosingCameraPosition(LngLat lngLatSE, LngLat lngLatNW, Rect padding, CameraPosition cameraPositionOut);
-    native void cancelCameraAnimation();
-    native boolean screenPositionToLngLat(float x, float y, LngLat lngLatOut);
-    native boolean lngLatToScreenPosition(double lng, double lat, PointF screenPositionOut, boolean clipToViewport);
-    native void setPixelScale(float scale);
-    native void setCameraType(int type);
-    native int getCameraType();
-    native float getMinZoom();
-    native void setMinZoom(float minZoom);
-    native float getMaxZoom();
-    native void setMaxZoom(float maxZoom);
-    native void handleTapGesture(float posX, float posY);
-    native void handleDoubleTapGesture(float posX, float posY);
-    native void handlePanGesture(float startX, float startY, float endX, float endY);
-    native void handleFlingGesture(float posX, float posY, float velocityX, float velocityY);
-    native void handlePinchGesture(float posX, float posY, float scale, float velocity);
-    native void handleRotateGesture(float posX, float posY, float rotation);
-    native void handleShoveGesture(float distance);
-    native void setPickRadius(float radius);
-    native void pickFeature(float posX, float posY);
-    native void pickLabel(float posX, float posY);
-    native void pickMarker(float posX, float posY);
-    native long markerAdd();
-    native boolean markerRemove(long markerID);
-    native boolean markerSetStylingFromString(long markerID, String styling);
-    native boolean markerSetStylingFromPath(long markerID, String path);
-    native boolean markerSetBitmap(long markerID, Bitmap bitmap, float density);
-    native boolean markerSetPoint(long markerID, double lng, double lat);
-    native boolean markerSetPointEased(long markerID, double lng, double lat, float duration, int ease);
-    native boolean markerSetPolyline(long markerID, double[] coordinates, int count);
-    native boolean markerSetPolygon(long markerID, double[] coordinates, int[] rings, int count);
-    native boolean markerSetVisible(long markerID, boolean visible);
-    native boolean markerSetDrawOrder(long markerID, int drawOrder);
-    native void markerRemoveAll();
-    native void useCachedGlState(boolean use);
-    native void setDefaultBackgroundColor(float r, float g, float b);
+    native synchronized void flyTo(double lon, double lat, float zoom, float duration, float speed);
+    native synchronized void getEnclosingCameraPosition(LngLat lngLatSE, LngLat lngLatNW, Rect padding, CameraPosition cameraPositionOut);
+    native synchronized void cancelCameraAnimation();
+    native synchronized boolean screenPositionToLngLat(float x, float y, LngLat lngLatOut);
+    native synchronized boolean lngLatToScreenPosition(double lng, double lat, PointF screenPositionOut, boolean clipToViewport);
+    native synchronized void setPixelScale(float scale);
+    native synchronized void setCameraType(int type);
+    native synchronized int getCameraType();
+    native synchronized float getMinZoom();
+    native synchronized void setMinZoom(float minZoom);
+    native synchronized float getMaxZoom();
+    native synchronized void setMaxZoom(float maxZoom);
+    native synchronized void handleTapGesture(float posX, float posY);
+    native synchronized void handleDoubleTapGesture(float posX, float posY);
+    native synchronized void handlePanGesture(float startX, float startY, float endX, float endY);
+    native synchronized void handleFlingGesture(float posX, float posY, float velocityX, float velocityY);
+    native synchronized void handlePinchGesture(float posX, float posY, float scale, float velocity);
+    native synchronized void handleRotateGesture(float posX, float posY, float rotation);
+    native synchronized void handleShoveGesture(float distance);
+    native synchronized void setPickRadius(float radius);
+    native synchronized void pickFeature(float posX, float posY);
+    native synchronized void pickLabel(float posX, float posY);
+    native synchronized void pickMarker(float posX, float posY);
+    native synchronized long markerAdd();
+    native synchronized boolean markerRemove(long markerID);
+    native synchronized boolean markerSetStylingFromString(long markerID, String styling);
+    native synchronized boolean markerSetStylingFromPath(long markerID, String path);
+    native synchronized boolean markerSetBitmap(long markerID, Bitmap bitmap, float density);
+    native synchronized boolean markerSetPoint(long markerID, double lng, double lat);
+    native synchronized boolean markerSetPointEased(long markerID, double lng, double lat, float duration, int ease);
+    native synchronized boolean markerSetPolyline(long markerID, double[] coordinates, int count);
+    native synchronized boolean markerSetPolygon(long markerID, double[] coordinates, int[] rings, int count);
+    native synchronized boolean markerSetVisible(long markerID, boolean visible);
+    native synchronized boolean markerSetDrawOrder(long markerID, int drawOrder);
+    native synchronized void markerRemoveAll();
+    native synchronized void useCachedGlState(boolean use);
+    native synchronized void setDefaultBackgroundColor(float r, float g, float b);
 
-    native long addClientDataSource(String name, boolean generateCentroid);
-    native void removeClientDataSource(long sourcePtr);
-    native void addClientDataFeature(long sourcePtr, double[] coordinates, int[] rings, String[] properties);
-    native void addClientDataGeoJson(long sourcePtr, String geoJson);
-    native void generateClientDataTiles(long sourcePtr);
-    native void clearClientDataFeatures(long sourcePtr);
+    native synchronized long addClientDataSource(String name, boolean generateCentroid);
+    native synchronized void removeClientDataSource(long sourcePtr);
+    native synchronized void addClientDataFeature(long sourcePtr, double[] coordinates, int[] rings, String[] properties);
+    native synchronized void addClientDataGeoJson(long sourcePtr, String geoJson);
+    native synchronized void generateClientDataTiles(long sourcePtr);
+    native synchronized void clearClientDataFeatures(long sourcePtr);
 
-    native void setDebugFlag(int flag, boolean on);
+    native synchronized void setDebugFlag(int flag, boolean on);
 
     native void onUrlComplete(long requestHandle, byte[] rawDataBytes, String errorMessage);
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
@@ -15,6 +15,10 @@ class NativeMap {
     }
 
     private native long init(MapController mapController, AssetManager assetManager);
+
+    // Declare all methods called by MapController and MapRenderer to be synchronized. These methods
+    // potentially have mutable access to shared native memory and can be called from different
+    // threads. If these calls interleave, it can lead to states that cause a segmentation fault.
     native synchronized void dispose();
     native synchronized void shutdown();
     native synchronized void onLowMemory();


### PR DESCRIPTION
Addresses https://github.com/tangrams/tangram-es/issues/2218

The change that resolved the crashes was to declare (almost) all the methods of `NativeMap` as `synchronized`. Earlier versions of these method declarations had been `synchronized`, but this was dropped in https://github.com/tangrams/tangram-es/pull/2187. The original reason for making these `synchronized` (which I have now rediscovered) is that `MapController` and `MapRenderer` both call methods with mutable access to native memory from separate threads. Occasionally, these method calls can interleave and lead to states that produce a crash. For example, `MapController` may add a marker to the map while `MapRenderer` is iterating over the list of markers, invalidating the iterator and causing a segmentation fault.

Forcing the UI thread and GL thread to synchronize on the same object is less than ideal because the GL thread can be blocked and drop frames, but avoiding these data races without synchronization would require significant refactoring.

Several other changes got rolled into this PR while I was trying various solutions:
- Resolves #2136 by refactoring disposal of `MapData`
- Changes `Map::Impl::scene` from `shared_ptr` to `unique_ptr`, for clearer ownership
- Fixes a lot of warnings from Android Studio