### PR TITLE
Javadoc fixes

### DIFF
--- a/platforms/android/tangram/publishing.gradle
+++ b/platforms/android/tangram/publishing.gradle
@@ -22,6 +22,32 @@ apply plugin: 'maven-publish'
 // https://developer.android.com/studio/build/maven-publish-plugin
 afterEvaluate { project ->
 
+  // Configure tasks for javadoc and sources jars.
+
+  task androidJavadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    // Add Android SDK to classpath.
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    // Also add the classpath and files from a library variant (fixes Javadoc errors).
+    def libraryVariantCompile = android.libraryVariants.first().javaCompileProvider.get()
+    classpath += libraryVariantCompile.classpath
+    classpath += libraryVariantCompile.outputs.files
+    // Exclude internal dependency classes.
+    exclude 'com/almeros/android/multitouch'
+  }
+
+  task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    from androidJavadocs.destinationDir
+    // Add archiveClassifier so that the publishing task correctly resolves names of jar artifacts.
+    archiveClassifier = 'javadoc'
+  }
+
+  task androidSourcesJar(type: Jar) {
+    from android.sourceSets.main.java.sourceFiles
+    // Add archiveClassifier so that the publishing task correctly resolves names of jar artifacts.
+    archiveClassifier = 'sources'
+  }
+
   publishing {
     publications {
       // Create a publication named 'maven'.
@@ -75,30 +101,6 @@ afterEvaluate { project ->
       }
     }
   }
-}
-
-// Configure tasks for javadoc and sources jars.
-
-task androidJavadocs(type: Javadoc) {
-  source = android.sourceSets.main.java.srcDirs
-  // TODO: Fix errors caused by Android dependencies not on classpath for javadoc task.
-  failOnError = false
-  // Add Android SDK to classpath.
-  classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-  // Exclude internal dependency classes.
-  exclude 'com/almeros/android/multitouch'
-}
-
-task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-  from androidJavadocs.destinationDir
-  // Add archiveClassifier so that the publishing task correctly resolves names of jar artifacts.
-  archiveClassifier = 'javadoc'
-}
-
-task androidSourcesJar(type: Jar) {
-  from android.sourceSets.main.java.sourceFiles
-  // Add archiveClassifier so that the publishing task correctly resolves names of jar artifacts.
-  archiveClassifier = 'sources'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -96,8 +96,8 @@ public class MapController {
 
     /**
      * Interface for listening to scene load status information.
-     * Triggered after a call of {@link #loadSceneYamlAsync(String, String, List<SceneUpdate>)} or
-     * {@link #loadSceneFileAsync(String, List<SceneUpdate>)} or {@link #loadSceneFile(String, List<SceneUpdate>)}
+     * Triggered after a call of {@link #loadSceneYamlAsync(String, String, List)} or
+     * {@link #loadSceneFileAsync(String, List)} or {@link #loadSceneFile(String, List)}
      * Listener should be set with {@link #setSceneLoadListener(SceneLoadListener)}
      * The callbacks will be run on the main (UI) thread.
      */
@@ -105,8 +105,8 @@ public class MapController {
     public interface SceneLoadListener {
         /**
          * Received when a scene load or update finishes. If sceneError is not null then the operation did not succeed.
-         * @param sceneId The identifier returned by {@link #loadSceneYamlAsync(String, String, List<SceneUpdate>)} or
-         * {@link #loadSceneFileAsync(String, List<SceneUpdate>)}.
+         * @param sceneId The identifier returned by {@link #loadSceneYamlAsync(String, String, List)} or
+         * {@link #loadSceneFileAsync(String, List)}.
          * @param sceneError A {@link SceneError} holding error information, or null if no error occurred.
          */
         void onSceneReady(final int sceneId, final SceneError sceneError);

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapView.java
@@ -27,7 +27,7 @@ public class MapView extends FrameLayout {
 
     protected MapController mapController;
     protected GLViewHolder viewHolder;
-    protected AsyncTask loadLibraryTask;
+    protected AsyncTask<Void, Void, Boolean> loadLibraryTask;
     protected static boolean libraryLoaded = false;
 
     /**
@@ -105,7 +105,7 @@ public class MapView extends FrameLayout {
             return false;
         }
 
-        final WeakReference mapViewRef = new WeakReference<>(this);
+        final WeakReference<MapView> mapViewRef = new WeakReference<>(this);
 
         loadLibraryTask = loadNativeLibraryAsync(new NativeLibraryLoadCb() {
             @Override
@@ -115,7 +115,7 @@ public class MapView extends FrameLayout {
 
             @Override
             public void onLibraryReady(Boolean ok) {
-                MapView view = (MapView) mapViewRef.get();
+                MapView view = mapViewRef.get();
                 if (ok && view != null) {
                     readyCallback.onMapReady(view.initMapController(glViewHolderFactory, handler));
                 } else {
@@ -220,7 +220,7 @@ public class MapView extends FrameLayout {
      * Responsible for doing the native map library loading in an AsyncTask.
      * @return AsyncTask
      */
-    public static AsyncTask loadNativeLibraryAsync(final @Nullable NativeLibraryLoadCb readyCb) {
+    public static AsyncTask<Void, Void, Boolean> loadNativeLibraryAsync(final @Nullable NativeLibraryLoadCb readyCb) {
          class InitTask extends AsyncTask<Void, Void, Boolean> {
             @Override
             protected Boolean doInBackground(Void... voids) {

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/HttpHandler.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/networking/HttpHandler.java
@@ -11,7 +11,8 @@ import androidx.annotation.Nullable;
 /**
  * {@code HttpHandler} interface for handling network requests for map resources,
  * it can be implemented to provide non-default http network request or caching behavior.
- * To use client implemented HttpHandler provide one during map initialization {@link MapView#getMap(MapController.SceneLoadListener, HttpHandler)}
+ * To use client implemented HttpHandler provide one during map initialization
+ * {@link MapView#getMapAsync(MapView.MapReadyCallback, HttpHandler)}
  */
 public interface HttpHandler {
     /**


### PR DESCRIPTION
Javadoc task now finishes without errors (we don't need `failOnError = false`). I figured out the classpath fix from: https://github.com/square/leakcanary/blob/f5343aca6e019994f7e69a28fac14ca18e071b88/gradle/gradle-mvn-push.gradle#L82-L96. Should be easier to find and fix Javadoc syntax errors now.