### PR TITLE
Replace universal library/framework builds with xcframework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,16 +59,16 @@ jobs:
       - run: sudo gem install jazzy --no-document --version 0.10.0
       - run: brew install cmake
       # Build the framework and package it into pod.zip.
-      - run: make ios-framework-universal BUILD_TYPE=Release
+      - run: make ios-xcframework BUILD_TYPE=Release
       # Check that bitcode is included for required archs.
-      - run: source scripts/check_bitcode.sh build/ios/Release-universal/TangramMap.framework/TangramMap armv7 arm64
+      - run: source scripts/check_bitcode.sh build/ios/Release/TangramMap.xcframework/ios-arm64_armv7/TangramMap.framework/TangramMap arm64 armv7
       # Build the docs and package them into docs.zip.
       - run: make ios-docs
       - run: cd build/ios-docs && zip -r ~/docs.zip .
       - store_artifacts:
           path: ~/docs.zip
       # To produce the intended structure within the zip archive, we must cd to each file's location.
-      - run: cd build/ios/Release-universal && zip -r ~/pod.zip TangramMap.framework
+      - run: cd build/ios/Release && zip -r ~/pod.zip TangramMap.xcframework
       # Add the readme and license files.
       - run: cd platforms/ios/framework && zip ~/pod.zip README.md
       - run: zip ~/pod.zip LICENSE
@@ -98,15 +98,15 @@ jobs:
       - run: sudo gem install jazzy --no-document --version 0.10.0
       - run: brew install cmake jfrog-cli-go
       # Build the framework in release mode and package it into pod.zip
-      - run: make ios-framework-universal BUILD_TYPE=Release
+      - run: make ios-xcframework BUILD_TYPE=Release
       # Check that bitcode is included for required archs.
-      - run: source scripts/check_bitcode.sh build/ios/Release-universal/TangramMap.framework/TangramMap armv7 arm64
+      - run: source scripts/check_bitcode.sh build/ios/Release/TangramMap.xcframework/ios-arm64_armv7/TangramMap.framework/TangramMap arm64 armv7
       - run: make ios-docs
       - run: cd build/ios-docs && zip -r ~/docs.zip .
       - store_artifacts:
           path: ~/docs.zip
       # To produce the intended structure within the zip archive, we must cd to each file's location.
-      - run: cd build/ios/Release-universal && zip -r ~/pod.zip TangramMap.framework
+      - run: cd build/ios/Release && zip -r ~/pod.zip TangramMap.xcframework
       # Add the readme and license files.
       - run: cd platforms/ios/framework && zip ~/pod.zip README.md
       - run: zip ~/pod.zip LICENSE

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ endif
 # Default build type is Release
 BUILD_TYPE ?= Release
 
+IOS_SIM_ARCH ?= $(shell uname -m)
+
 BENCH_CMAKE_PARAMS = \
 	-DTANGRAM_BUILD_BENCHMARKS=1 \
 	-DCMAKE_BUILD_TYPE=Release \
@@ -189,13 +191,13 @@ ios: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch ${IOS_SIM_ARCH} ${XCPRETTY}
 
 ios-swift: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemoSwift -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-swift-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemoSwift -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemoSwift -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch ${IOS_SIM_ARCH} ${XCPRETTY}
 
 ios-xcode: cmake-ios
 	open platforms/ios/Tangram.xcworkspace
@@ -228,7 +230,7 @@ ios-static: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-static-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch ${IOS_SIM_ARCH} ${XCPRETTY}
 
 ios-static-lib: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}

--- a/Makefile
+++ b/Makefile
@@ -215,32 +215,35 @@ ios-framework: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramMap -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-framework-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramMap -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramMap -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
 
-ios-framework-universal: ios-framework ios-framework-sim
-	@mkdir -p ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal
-	@cp -r ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphoneos/TangramMap.framework ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal
-	lipo ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphoneos/TangramMap.framework/TangramMap \
-		${IOS_BUILD_DIR}/${BUILD_TYPE}-iphonesimulator/TangramMap.framework/TangramMap \
-		-create -output ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal/TangramMap.framework/TangramMap
+ios-xcframework: ios-framework ios-framework-sim
+	rm -rf ${IOS_BUILD_DIR}/${BUILD_TYPE}/TangramMap.xcframework
+	xcodebuild -create-xcframework \
+		-framework ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphoneos/TangramMap.framework \
+		-framework ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphonesimulator/TangramMap.framework \
+		-output ${IOS_BUILD_DIR}/${BUILD_TYPE}/TangramMap.xcframework
 
 ios-static: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-static-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme TangramDemo-static -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
 
 ios-static-lib: cmake-ios
 	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphoneos ${XCPRETTY}
 
 ios-static-lib-sim: cmake-ios
-	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphonesimulator -arch x86_64 ${XCPRETTY}
+	xcodebuild -workspace platforms/ios/Tangram.xcworkspace -scheme tangram-static -configuration ${BUILD_TYPE} -sdk iphonesimulator ${XCPRETTY}
 
-ios-static-lib-universal: ios-static-lib ios-static-lib-sim
-	@mkdir -p ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal
-	lipo ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphoneos/libtangram-static.a \
-		${IOS_BUILD_DIR}/${BUILD_TYPE}-iphonesimulator/libtangram-static.a \
-		-create -output ${IOS_BUILD_DIR}/${BUILD_TYPE}-universal/libtangram-static.a
+ios-static-xcframework: ios-static-lib ios-static-lib-sim
+	rm -rf ${IOS_BUILD_DIR}/${BUILD_TYPE}/TangramMapStatic.xcframework
+	xcodebuild -create-xcframework \
+		-library ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphoneos/libtangram-static.a \
+		-headers ${IOS_BUILD_DIR}/Headers \
+		-library ${IOS_BUILD_DIR}/${BUILD_TYPE}-iphonesimulator/libtangram-static.a \
+		-headers ${IOS_BUILD_DIR}/Headers \
+		-output ${IOS_BUILD_DIR}/${BUILD_TYPE}/TangramMapStatic.xcframework
 
 rpi: cmake-rpi
 	cmake --build ${RPI_BUILD_DIR}

--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -145,6 +145,8 @@ set_target_properties(TangramMap PROPERTIES
   # This ensures that the dynamic linker loads the framework from its embedded path in an app, not
   # from the location it was originally built.
   XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+  # Ensure that archives are built for distribution.
+  XCODE_ATTRIBUTE_BUILD_LIBRARY_FOR_DISTRIBUTION "YES"
 )
 # Other properties that are common to dynamic and static framework targets are set below.
 
@@ -229,9 +231,9 @@ set_target_properties(TangramMap tangram-static PROPERTIES
 add_custom_command(TARGET tangram-static POST_BUILD
   COMMAND
   ${CMAKE_COMMAND} -E make_directory
-  "${PROJECT_BINARY_DIR}/Include/TangramMap/"
+  "${PROJECT_BINARY_DIR}/Headers/"
   COMMAND
   ${CMAKE_COMMAND} -E copy_if_different
   ${TANGRAM_FRAMEWORK_HEADERS}
-  "${PROJECT_BINARY_DIR}/Include/TangramMap/"
+  "${PROJECT_BINARY_DIR}/Headers/"
 )

--- a/platforms/ios/config.cmake
+++ b/platforms/ios/config.cmake
@@ -224,6 +224,8 @@ set_target_properties(TangramMap tangram-static PROPERTIES
   XCODE_ATTRIBUTE_GCC_TREAT_WARNINGS_AS_ERRORS "YES"
   # Generate dsym for all build types to ensure symbols are available in profiling.
   XCODE_ATTRIBUTE_GCC_GENERATE_DEBUGGING_SYMBOLS "YES"
+  # Ensure that archives are built for distribution.
+  XCODE_ATTRIBUTE_BUILD_LIBRARY_FOR_DISTRIBUTION "YES"
 )
 
 # Copy the framework headers into a directory in the build folder, for use by

--- a/platforms/ios/demo/TangramDemo.xcodeproj/xcshareddata/xcschemes/TangramDemo-static.xcscheme
+++ b/platforms/ios/demo/TangramDemo.xcodeproj/xcshareddata/xcschemes/TangramDemo-static.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:TangramDemo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:TangramDemo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/platforms/ios/framework/Tangram-es.podspec
+++ b/platforms/ios/framework/Tangram-es.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.vendored_frameworks = 'TangramMap.framework'
+  s.vendored_frameworks = 'TangramMap.xcframework'
   s.module_name = 'TangramMap'
 
 end


### PR DESCRIPTION
Instead of combining iOS binaries for multiple architectures into a universal "fat" binary, we will now produce an XCFramework for distribution. An XCFramework encapsulates multiple architectures and multiple platforms (e.g. iOS and Simulator) in a structure that is easy to integrate in Xcode 11 and newer. 

Because an XCFramework is structured differently from the traditional Framework that we distributed previously, consumers of Tangram ES on iOS may need to make adjustments to their build configuration. Xcode versions 10 and earlier will not recognize the XCFramework structure, so consumers using those versions will need additional build configuration to link to the individual Frameworks within the XCFramework.

This incompatibility is regrettable, but I don't think there's any other practical way to support the new ARM-based Macs.

Resolves https://github.com/tangrams/tangram-es/issues/2229