### PR TITLE
Fix texture URL resolution in scene zip bundles

### DIFF
--- a/core/src/scene/importer.cpp
+++ b/core/src/scene/importer.cpp
@@ -90,6 +90,9 @@ Node Importer::loadSceneData(Platform& _platform, const Url& _sceneUrl, const st
     Node textures = root["textures"];
     for (auto& sceneNode : m_sceneNodes) {
         auto sceneUrl = sceneNode.first;
+        if (isZipArchiveUrl(sceneUrl)) {
+            sceneUrl = getBaseUrlForZipArchive(sceneUrl);
+        }
         for (auto& node : sceneNode.second.pendingUrlNodes) {
             // If the node does not contain a named texture in the final scene, treat it as a URL relative to the scene
             // file where it was originally encountered.


### PR DESCRIPTION
Resolves https://github.com/tangrams/tangram-es/issues/2233

When we resolve texture URLs during the scene import process, we need to handle the case where the URL of the scene refers to a zip file. Relative URLs in a scene bundle refer to entries within the zip archive, so they need to be resolved as "zip URLs" instead of being resolved  relative to the scene bundle itself. In the linked issue, the image URLs were resolving to:
```
file:///path/to/walkabout-style.zip/images/walkabout-green1.jpg
```
Instead they should resolve to:
```
zip://file%3A%2F%2F%2Fpath%2Fto%2Fwalkabout-style.zip/images/walkabout-green1.jpg
```
