### PR TITLE
Use ccache caching on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
     environment:
       GRADLE_OPTS: -Xmx2048m
       CCACHE_MAXSIZE: 400M
-      CCACHE_COMPILERCHECK: content
+      CCACHE_COMPILERCHECK: content # Default timestamp check fails because NDK compiler is installed for each job.
   macos-executor:
     macos:
       xcode: "12.2.0"
@@ -76,6 +76,7 @@ jobs:
             - android-release-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - android-release-ccache-v1-{{ .Branch }}
             - android-release-ccache-v1
+      - run: ccache --zero-stats
       # Configure publishing credentials.
       - run: echo "$SIGNING_SECRET_KEYRING_BASE64" | base64 --decode > platforms/android/tangram/secring.gpg
       # Build and upload snapshot.
@@ -85,6 +86,7 @@ jobs:
           -Psigning.password="$SIGNING_PASSWORD" \
           -Psigning.secretKeyRingFile=secring.gpg \
           -Ptangram.ccache=true
+      - run: ccache --show-stats
       - save_cache:
           key: android-release-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
@@ -163,17 +165,17 @@ workflows:
   build-and-deploy:
     jobs:
       # Run on all pushes
-      # - build-test-linux
-      # - build-macos
+      - build-test-linux
+      - build-macos
       # Run on pushes to all branches except main
       - build-android:
           filters:
             branches:
               ignore: main
-      # - build-ios:
-      #     filters:
-      #       branches:
-      #         ignore: main
+      - build-ios:
+          filters:
+            branches:
+              ignore: main
       # Run on pushes to main
       - build-deploy-android:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,17 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=armeabi-v7a
+      - run: sudo apt-get update && sudo apt-get install -y ccache
+      - restore_cache:
+          keys:
+            - android-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - android-ccache-v1-{{ .Branch }}
+            - android-ccache-v1
+      - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=armeabi-v7a -Ptangram.ccache=true
+      - save_cache:
+          key: android-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/.ccache
   build-deploy-android:
     executor: android-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ executors:
     environment:
       GRADLE_OPTS: -Xmx2048m
       CCACHE_MAX_SIZE: 400M
+      CCACHE_DEBUG: 1
+      CCACHE_DEBUGDIR: /home/circleci/ccache-debug
   macos-executor:
     macos:
       xcode: "12.2.0"
@@ -64,6 +66,9 @@ jobs:
           key: android-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/.ccache
+      - run: zip -r ~/ccache-debug.zip $CCACHE_DEBUGDIR
+      - store_artifacts:
+          path: ~/ccache-debug.zip
   build-deploy-android:
     executor: android-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,22 +5,21 @@ executors:
       - image: circleci/android:api-28-ndk
     environment:
       GRADLE_OPTS: -Xmx2048m
-      CCACHE_MAX_SIZE: 400M
+      CCACHE_MAXSIZE: 400M
       CCACHE_DEBUG: 1
-      CCACHE_DEBUGDIR: /home/circleci/ccache-debug
   macos-executor:
     macos:
       xcode: "12.2.0"
     environment: # Disable some unnecessary homebrew operations to save time.
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-      CCACHE_MAX_SIZE: 400M
+      CCACHE_MAXSIZE: 400M
 jobs:
   build-test-linux:
     docker:
       - image: matteblair/docker-tangram-linux:0.2.0
     environment:
-      CCACHE_MAX_SIZE: 400M
+      CCACHE_MAXSIZE: 400M
     steps:
       - checkout
       - run: git submodule update --init
@@ -50,10 +49,6 @@ jobs:
       - run: source scripts/run_bench.sh build/linux
   build-android:
     executor: android-executor
-    environment:
-      CCACHE_MAX_SIZE: 400M
-      CCACHE_DEBUG: 1
-      CCACHE_DEBUGDIR: /home/circleci/ccache-debug
     steps:
       - checkout
       - run: git submodule update --init
@@ -70,7 +65,7 @@ jobs:
           key: android-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/.ccache
-      - run: zip -r ~/ccache-debug.zip $CCACHE_DEBUGDIR
+      - run: cd platforms/android/tangram/.cxx/cmake/debug && zip -r ~/ccache-debug.zip arm64-v8a
       - store_artifacts:
           path: ~/ccache-debug.zip
   build-deploy-android:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,17 +167,17 @@ workflows:
   build-and-deploy:
     jobs:
       # Run on all pushes
-      - build-test-linux
-      - build-macos
+      # - build-test-linux
+      # - build-macos
       # Run on pushes to all branches except main
       - build-android:
           filters:
             branches:
               ignore: main
-      - build-ios:
-          filters:
-            branches:
-              ignore: main
+      # - build-ios:
+      #     filters:
+      #       branches:
+      #         ignore: main
       # Run on pushes to main
       - build-deploy-android:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,25 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
+      - run: sudo apt-get update && sudo apt-get install -y ccache
+      - restore_cache:
+          keys:
+            - android-release-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - android-release-ccache-v1-{{ .Branch }}
+            - android-release-ccache-v1
       # Configure publishing credentials.
       - run: echo "$SIGNING_SECRET_KEYRING_BASE64" | base64 --decode > platforms/android/tangram/secring.gpg
       # Build and upload snapshot.
-      - run: cd platforms/android && ./gradlew publish -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password="$SIGNING_PASSWORD" -Psigning.secretKeyRingFile=secring.gpg
+      - run: |
+          cd platforms/android && ./gradlew publish \
+          -Psigning.keyId="$SIGNING_KEY_ID" \
+          -Psigning.password="$SIGNING_PASSWORD" \
+          -Psigning.secretKeyRingFile=secring.gpg \
+          -Ptangram.ccache=true
+      - save_cache:
+          key: android-release-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/.ccache
   build-ios:
     executor: macos-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs:
           -DTANGRAM_USE_SYSTEM_GLFW_LIBS=1 \
           -DTANGRAM_BUILD_TESTS=1 \
           -DTANGRAM_BUILD_BENCHMARKS=1 \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - run: ninja -C build/linux -j 4
       - run: ccache --show-stats
       - save_cache:
@@ -150,7 +151,7 @@ jobs:
             - macos-ccache-v1
       - run: ccache --zero-stats
       # Build the MacOS demo app and package it into demo.zip
-      - run: make osx MACOSX_DEPLOYMENT_TARGET=10.10.0 BUILD_TYPE=Debug CMAKE_OPTIONS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -GNinja"
+      - run: make osx MACOSX_DEPLOYMENT_TARGET=10.10.0 BUILD_TYPE=Debug CMAKE_OPTIONS="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -GNinja"
       - run: ccache --show-stats
       - save_cache:
           key: macos-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,10 @@ jobs:
       - run: source scripts/run_bench.sh build/linux
   build-android:
     executor: android-executor
+    environment:
+      CCACHE_MAX_SIZE: 400M
+      CCACHE_DEBUG: 1
+      CCACHE_DEBUGDIR: /home/circleci/ccache-debug
     steps:
       - checkout
       - run: git submodule update --init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ executors:
     environment:
       GRADLE_OPTS: -Xmx2048m
       CCACHE_MAXSIZE: 400M
-      CCACHE_DEBUG: 1
       CCACHE_COMPILERCHECK: content
   macos-executor:
     macos:
@@ -66,9 +65,6 @@ jobs:
           key: android-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/.ccache
-      - run: cd platforms/android/tangram/.cxx/cmake/debug && zip -r ~/ccache-debug.zip arm64-v8a
-      - store_artifacts:
-          path: ~/ccache-debug.zip
   build-deploy-android:
     executor: android-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,24 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: apt-get update && apt-get install -y wget
-      - run: make cmake-linux CMAKE_OPTIONS="-DTANGRAM_USE_SYSTEM_FONT_LIBS=1 -DTANGRAM_USE_SYSTEM_GLFW_LIBS=1 -DTANGRAM_BUILD_TESTS=1 -DTANGRAM_BUILD_BENCHMARKS=1 -GNinja"
+      - run: apt-get update && apt-get install -y ccache
+      - restore_cache:
+          keys:
+            - linux-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - linux-ccache-v1-{{ .Branch }}
+            - linux-ccache-v1
+      - run: |
+          cmake -H. -Bbuild/linux -GNinja \
+          -DTANGRAM_USE_SYSTEM_FONT_LIBS=1 \
+          -DTANGRAM_USE_SYSTEM_GLFW_LIBS=1 \
+          -DTANGRAM_BUILD_TESTS=1 \
+          -DTANGRAM_BUILD_BENCHMARKS=1 \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 
       - run: ninja -C build/linux -j 4
+      - save_cache:
+          key: linux-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/.ccache
       - run: source scripts/run_tests.sh build/linux ~/test-results/catch
       - store_test_results:
           path: ~/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ executors:
       GRADLE_OPTS: -Xmx2048m
       CCACHE_MAXSIZE: 400M
       CCACHE_DEBUG: 1
+      CCACHE_COMPILERCHECK: content
   macos-executor:
     macos:
       xcode: "12.2.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
             - android-ccache-v1-{{ .Branch }}
             - android-ccache-v1
       - run: ccache --zero-stats
-      - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=armeabi-v7a -Ptangram.ccache=true
+      - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=arm64-v8a -Ptangram.ccache=true
       - run: ccache --show-stats
       - save_cache:
           key: android-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
             - linux-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - linux-ccache-v1-{{ .Branch }}
             - linux-ccache-v1
+      - run: ccache --zero-stats
       - run: |
           cmake -H. -Bbuild/linux -GNinja \
           -DTANGRAM_USE_SYSTEM_FONT_LIBS=1 \
@@ -32,6 +33,7 @@ jobs:
           -DTANGRAM_BUILD_BENCHMARKS=1 \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 
       - run: ninja -C build/linux -j 4
+      - run: ccache --show-stats
       - save_cache:
           key: linux-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
@@ -51,7 +53,9 @@ jobs:
             - android-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - android-ccache-v1-{{ .Branch }}
             - android-ccache-v1
+      - run: ccache --zero-stats
       - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=armeabi-v7a -Ptangram.ccache=true
+      - run: ccache --show-stats
       - save_cache:
           key: android-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
@@ -137,8 +141,10 @@ jobs:
             - macos-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - macos-ccache-v1-{{ .Branch }}
             - macos-ccache-v1
+      - run: ccache --zero-stats
       # Build the MacOS demo app and package it into demo.zip
       - run: make osx MACOSX_DEPLOYMENT_TARGET=10.10.0 BUILD_TYPE=Debug CMAKE_OPTIONS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -GNinja"
+      - run: ccache --show-stats
       - save_cache:
           key: macos-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,14 +50,14 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y ccache
       - restore_cache:
           keys:
-            - android-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - android-ccache-v1-{{ .Branch }}
-            - android-ccache-v1
+            - android-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - android-ccache-v2-{{ .Branch }}
+            - android-ccache-v2
       - run: ccache --zero-stats
       - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=arm64-v8a -Ptangram.ccache=true
       - run: ccache --show-stats
       - save_cache:
-          key: android-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          key: android-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/.ccache
   build-deploy-android:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,20 @@ executors:
       - image: circleci/android:api-28-ndk
     environment:
       GRADLE_OPTS: -Xmx2048m
+      CCACHE_MAX_SIZE: 400M
   macos-executor:
     macos:
       xcode: "12.2.0"
     environment: # Disable some unnecessary homebrew operations to save time.
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      CCACHE_MAX_SIZE: 400M
 jobs:
   build-test-linux:
     docker:
       - image: matteblair/docker-tangram-linux:0.2.0
+    environment:
+      CCACHE_MAX_SIZE: 400M
     steps:
       - checkout
       - run: git submodule update --init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,14 +55,14 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y ccache
       - restore_cache:
           keys:
-            - android-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - android-ccache-v2-{{ .Branch }}
-            - android-ccache-v2
+            - android-ccache-v3-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - android-ccache-v3-{{ .Branch }}
+            - android-ccache-v3
       - run: ccache --zero-stats
       - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=arm64-v8a -Ptangram.ccache=true
       - run: ccache --show-stats
       - save_cache:
-          key: android-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          key: android-ccache-v3-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/.ccache
   build-deploy-android:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,6 @@ else()
   add_definitions(-DLOG_LEVEL=2)
 endif()
 
-if($ENV{CIRCLE_BUILD_NUM})
-  add_definitions(-DBUILD_NUM_STRING="\($ENV{CIRCLE_BUILD_NUM}\)")
-endif()
-
 include(cmake/utils.cmake)
 
 # If target platform isn't specified, use the local platform.

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -49,6 +49,7 @@ android {
                  '-Wno-unknown-warning-option'
         if (project.findProperty('tangram.ccache')) {
           arguments += '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
+          arguments += '-DCMAKE_C_COMPILER_LAUNCHER=ccache'
         }
         if (abi == 'all') {
           abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -47,7 +47,9 @@ android {
                  '-Wno-nested-anon-types',
                  '-Wno-unused-command-line-argument', // for -Wl linker flags..
                  '-Wno-unknown-warning-option'
-
+        if (project.findProperty('tangram.ccache')) {
+          arguments += '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
+        }
         if (abi == 'all') {
           abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
         } else {


### PR DESCRIPTION
Using CircleCI's [caching](https://circleci.com/docs/2.0/caching/?section=pipelines) functionality with [ccache](https://ccache.dev/) can greatly reduce the time spent re-compiling identical code in our CI checks. For the Android build job, this reduces CI run time by about 50%. 

Using ccache for the Android native build process was very straightforward thanks to CMake's `CMAKE_LANG_COMPILER_LAUNCHER` properties. I verified that caching worked locally, but on the Android CI jobs ccache was reporting a 100% miss rate. After much debugging, I found that ccache was detecting that the compiler binary file was different on each job. By default, ccache uses the timestamp of the compiler binary to check for changes. In the Android build jobs the compiler is installed fresh on each run, so it appears to be a different compiler each time. The solution to this was to change ccache's compiler check mode so that it hashes the compiler binary instead. Ideally, this shouldn't be necessary because the compiler should be pre-installed with the NDK in the Docker image, but I'm not going down that rabbit hole right now.

Using ccache with Xcode is [slightly trickier](https://crascit.com/2016/04/09/using-ccache-with-cmake/) so I have not implemented it for the iOS builds yet.