### PR TITLE
Add shader defines for all blend modes

### DIFF
--- a/core/src/style/style.cpp
+++ b/core/src/style/style.cpp
@@ -41,11 +41,17 @@ void Style::build(const Scene& _scene) {
     constructVertexLayout();
     constructShaderProgram();
 
-    if (m_blend == Blending::inlay) {
-        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_BLEND_INLAY\n", false);
-    } else if (m_blend == Blending::overlay) {
-        m_shaderSource->addSourceBlock("defines", "#define TANGRAM_BLEND_OVERLAY\n", false);
+    const char* blendingDefine = "";
+    switch (m_blend) {
+    case Blending::opaque: blendingDefine = "#define TANGRAM_BLEND_OPAQUE\n"; break;
+    case Blending::add: blendingDefine = "#define TANGRAM_BLEND_ADD\n"; break;
+    case Blending::multiply: blendingDefine = "#define TANGRAM_BLEND_MULTIPLY\n"; break;
+    case Blending::inlay: blendingDefine = "#define TANGRAM_BLEND_INLAY\n"; break;
+    case Blending::translucent: blendingDefine = "#define TANGRAM_BLEND_TRANSLUCENT\n"; break;
+    case Blending::overlay: blendingDefine = "#define TANGRAM_BLEND_OVERLAY\n"; break;
     }
+
+    m_shaderSource->addSourceBlock("defines", blendingDefine, false);
 
     if (m_material.material) {
         m_material.uniforms = m_material.material->injectOnProgram(*m_shaderSource);


### PR DESCRIPTION
Fixes a bug with dashed polyline rendering introduced by https://github.com/tangrams/tangram-es/pull/2137. On [this line in polyline.fs](https://github.com/tangrams/tangram-es/blob/main/core/shaders/polyline.fs#L77) we checked `#if defined(TANGRAM_BLEND_OPAQUE)`, but `TANGRAM_BLEND_OPAQUE` was never injected! This change injects shader defines for all blending modes, to more closely match Tangram JS shaders.

Resolves #2256 