### PR TITLE
Android target sdk 30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
       - run: ccache --zero-stats
       - run: |
           cd platforms/android && ./gradlew demo:assembleDebug \
-          -Pandroid.ndkPath="$ANDROID_NDK_HOME" \
           -Ptangram.abis=arm64-v8a \
           -Ptangram.ccache=true
       - run: ccache --show-stats
@@ -88,7 +87,6 @@ jobs:
       # Build and upload snapshot.
       - run: |
           cd platforms/android && ./gradlew publish \
-          -Pandroid.ndkPath="$ANDROID_NDK_HOME" \
           -Psigning.keyId="$SIGNING_KEY_ID" \
           -Psigning.password="$SIGNING_PASSWORD" \
           -Psigning.secretKeyRingFile=secring.gpg \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run: ccache --zero-stats
       - run: |
           cd platforms/android && ./gradlew demo:assembleDebug \
-          -Pandroid.ndkPath=$ANDROID_NDK_HOME \
+          -Pandroid.ndkPath="$ANDROID_NDK_HOME" \
           -Ptangram.abis=arm64-v8a \
           -Ptangram.ccache=true
       - run: ccache --show-stats
@@ -88,7 +88,7 @@ jobs:
       # Build and upload snapshot.
       - run: |
           cd platforms/android && ./gradlew publish \
-          -Pandroid.ndkPath=$ANDROID_NDK_HOME \
+          -Pandroid.ndkPath="$ANDROID_NDK_HOME" \
           -Psigning.keyId="$SIGNING_KEY_ID" \
           -Psigning.password="$SIGNING_PASSWORD" \
           -Psigning.secretKeyRingFile=secring.gpg \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,8 @@ jobs:
             - android-ccache-v3-{{ .Branch }}
             - android-ccache-v3
       - run: ccache --zero-stats
+      # Tell gradle to use pre-installed NDK. This setting is deprecated, but android.ndkPath is ignored for some reason.
+      - run: echo "ndk.dir=$ANDROID_NDK_HOME" > platforms/android/local.properties
       - run: |
           cd platforms/android && ./gradlew demo:assembleDebug \
           -Ptangram.abis=arm64-v8a \
@@ -82,6 +84,8 @@ jobs:
             - android-release-ccache-v1-{{ .Branch }}
             - android-release-ccache-v1
       - run: ccache --zero-stats
+      # Tell gradle to use pre-installed NDK. This setting is deprecated, but android.ndkPath is ignored for some reason.
+      - run: echo "ndk.dir=$ANDROID_NDK_HOME" > platforms/android/local.properties
       # Configure publishing credentials.
       - run: echo "$SIGNING_SECRET_KEYRING_BASE64" | base64 --decode > platforms/android/tangram/secring.gpg
       # Build and upload snapshot.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,9 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y ccache
       - restore_cache:
           keys:
-            - android-ccache-v3-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - android-ccache-v3-{{ .Branch }}
-            - android-ccache-v3
+            - android-ccache-v4-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - android-ccache-v4-{{ .Branch }}
+            - android-ccache-v4
       - run: ccache --zero-stats
       # Tell gradle to use pre-installed NDK. This setting is deprecated, but android.ndkPath is ignored for some reason.
       - run: echo "ndk.dir=$ANDROID_NDK_HOME" > platforms/android/local.properties
@@ -68,7 +68,7 @@ jobs:
           -Ptangram.ccache=true
       - run: ccache --show-stats
       - save_cache:
-          key: android-ccache-v3-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          key: android-ccache-v4-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/.ccache
   build-deploy-android:
@@ -79,9 +79,9 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y ccache
       - restore_cache:
           keys:
-            - android-release-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - android-release-ccache-v1-{{ .Branch }}
-            - android-release-ccache-v1
+            - android-release-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - android-release-ccache-v2-{{ .Branch }}
+            - android-release-ccache-v2
       - run: ccache --zero-stats
       # Tell gradle to use pre-installed NDK. This setting is deprecated, but android.ndkPath is ignored for some reason.
       - run: echo "ndk.dir=$ANDROID_NDK_HOME" > platforms/android/local.properties
@@ -96,7 +96,7 @@ jobs:
           -Ptangram.ccache=true
       - run: ccache --show-stats
       - save_cache:
-          key: android-release-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+          key: android-release-ccache-v2-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/.ccache
   build-ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ executors:
     environment:
       GRADLE_OPTS: -Xmx2048m
       CCACHE_MAXSIZE: 400M
-      CCACHE_COMPILERCHECK: content # Default timestamp check fails because NDK compiler is installed for each job.
       # The CircleCI android-ndk images export ANDROID_NDK_HOME with the location of the pre-installed NDK (https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images).
   macos-executor:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,13 @@ version: 2.1
 executors:
   android-executor:
     docker:
-      - image: circleci/android:api-28-ndk
+      - image: circleci/android:api-30-ndk
     environment:
       GRADLE_OPTS: -Xmx2048m
       CCACHE_MAXSIZE: 400M
       CCACHE_COMPILERCHECK: content # Default timestamp check fails because NDK compiler is installed for each job.
+      NDK_VERSION: 20.0.5594570 # Use pre-installed NDK version, according to CircleCI dockerfile (https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images)
+      BUILD_TOOLS_VERSION: 30.0.2
   macos-executor:
     macos:
       xcode: "12.2.0"
@@ -60,7 +62,12 @@ jobs:
             - android-ccache-v3-{{ .Branch }}
             - android-ccache-v3
       - run: ccache --zero-stats
-      - run: cd platforms/android && ./gradlew demo:assembleDebug -Ptangram.abis=arm64-v8a -Ptangram.ccache=true
+      - run: |
+          cd platforms/android && ./gradlew demo:assembleDebug \
+          -Pandroid.ndkVersion=$NDK_VERSION \
+          -Pandroid.buildToolsVersion=$BUILD_TOOLS_VERSION \
+          -Ptangram.abis=arm64-v8a \
+          -Ptangram.ccache=true
       - run: ccache --show-stats
       - save_cache:
           key: android-ccache-v3-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
@@ -83,6 +90,8 @@ jobs:
       # Build and upload snapshot.
       - run: |
           cd platforms/android && ./gradlew publish \
+          -Pandroid.ndkVersion=$NDK_VERSION \
+          -Pandroid.buildToolsVersion=$BUILD_TOOLS_VERSION \
           -Psigning.keyId="$SIGNING_KEY_ID" \
           -Psigning.password="$SIGNING_PASSWORD" \
           -Psigning.secretKeyRingFile=secring.gpg \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ executors:
       GRADLE_OPTS: -Xmx2048m
       CCACHE_MAXSIZE: 400M
       CCACHE_COMPILERCHECK: content # Default timestamp check fails because NDK compiler is installed for each job.
-      NDK_VERSION: 20.0.5594570 # Use pre-installed NDK version, according to CircleCI dockerfile (https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images)
-      BUILD_TOOLS_VERSION: 30.0.2
+      # The CircleCI android-ndk images export ANDROID_NDK_HOME with the location of the pre-installed NDK (https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images).
   macos-executor:
     macos:
       xcode: "12.2.0"
@@ -64,8 +63,7 @@ jobs:
       - run: ccache --zero-stats
       - run: |
           cd platforms/android && ./gradlew demo:assembleDebug \
-          -Pandroid.ndkVersion=$NDK_VERSION \
-          -Pandroid.buildToolsVersion=$BUILD_TOOLS_VERSION \
+          -Pandroid.ndkPath=$ANDROID_NDK_HOME \
           -Ptangram.abis=arm64-v8a \
           -Ptangram.ccache=true
       - run: ccache --show-stats
@@ -90,8 +88,7 @@ jobs:
       # Build and upload snapshot.
       - run: |
           cd platforms/android && ./gradlew publish \
-          -Pandroid.ndkVersion=$NDK_VERSION \
-          -Pandroid.buildToolsVersion=$BUILD_TOOLS_VERSION \
+          -Pandroid.ndkPath=$ANDROID_NDK_HOME \
           -Psigning.keyId="$SIGNING_KEY_ID" \
           -Psigning.password="$SIGNING_PASSWORD" \
           -Psigning.secretKeyRingFile=secring.gpg \

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -5,7 +5,7 @@ allprojects {
       jcenter()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:4.1.2'
+      classpath 'com.android.tools.build:gradle:4.1.3'
     }
   }
 

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -7,6 +7,7 @@ apply from: 'versioning.gradle'
 
 android {
   compileSdkVersion 30
+  ndkVersion '20.0.5594570'
 
   // Specific ABI targets can be chosen with the 'abis' property as a comma-separated list of ABIs.
   // From the command line, add '-Ptangram.abis=armeabi-v7a,x86,...' to only build those ABIs.

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -6,7 +6,7 @@ version = VERSION_NAME
 apply from: 'versioning.gradle'
 
 android {
-  compileSdkVersion 28
+  compileSdkVersion 30
 
   // Specific ABI targets can be chosen with the 'abis' property as a comma-separated list of ABIs.
   // From the command line, add '-Ptangram.abis=armeabi-v7a,x86,...' to only build those ABIs.
@@ -18,7 +18,7 @@ android {
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 28
+    targetSdkVersion 30
     versionCode buildVersionCode()
     versionName VERSION_NAME
     consumerProguardFiles 'tangram-proguard-rules.txt'

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -7,6 +7,7 @@ apply from: 'versioning.gradle'
 
 android {
   compileSdkVersion 30
+  ndkPath "/opt/android/android-ndk-r20"
 
   // Specific ABI targets can be chosen with the 'abis' property as a comma-separated list of ABIs.
   // From the command line, add '-Ptangram.abis=armeabi-v7a,x86,...' to only build those ABIs.

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -7,7 +7,6 @@ apply from: 'versioning.gradle'
 
 android {
   compileSdkVersion 30
-  ndkVersion '20.0.5594570'
 
   // Specific ABI targets can be chosen with the 'abis' property as a comma-separated list of ABIs.
   // From the command line, add '-Ptangram.abis=armeabi-v7a,x86,...' to only build those ABIs.

--- a/platforms/android/tangram/build.gradle
+++ b/platforms/android/tangram/build.gradle
@@ -7,7 +7,6 @@ apply from: 'versioning.gradle'
 
 android {
   compileSdkVersion 30
-  ndkPath "/opt/android/android-ndk-r20"
 
   // Specific ABI targets can be chosen with the 'abis' property as a comma-separated list of ABIs.
   // From the command line, add '-Ptangram.abis=armeabi-v7a,x86,...' to only build those ABIs.


### PR DESCRIPTION
- Update Android target SDK version to 30
- Update Android Gradle plugin to 4.1.3
- Update CI configuration to use docker image with SDK 30 installed
- Configure CI builds to use pre-installed NDK version instead of installing default version