### PR TITLE
Decrease 'texture_scale' for polylines

### DIFF
--- a/core/shaders/polyline.vs
+++ b/core/shaders/polyline.vs
@@ -49,7 +49,7 @@ varying vec3 v_normal;
 #define UNPACK_POSITION(x) (x / 8192.0)
 #define UNPACK_EXTRUSION(x) (x / 4096.0)
 #define UNPACK_ORDER(x) (x / 2.0)
-#define UNPACK_TEXCOORD(x) (x / 8192.0)
+#define UNPACK_TEXCOORD(x) (x / 2048.0)
 
 vec4 modelPosition() {
     return vec4(UNPACK_POSITION(a_position.xyz) * exp2(u_tile_origin.z - u_tile_origin.w), 1.0);

--- a/core/src/style/polylineStyle.cpp
+++ b/core/src/style/polylineStyle.cpp
@@ -26,7 +26,7 @@
 
 constexpr float extrusion_scale = 4096.0f;
 constexpr float position_scale = 8192.0f;
-constexpr float texture_scale = 8192.0f;
+constexpr float texture_scale = 2048.0f;
 constexpr float order_scale = 2.0f;
 constexpr float dash_scale = 20.f;
 


### PR DESCRIPTION
Allows greater range of UV values, fixes numerical precision errors in tiles overzoomed up to 5 zoom levels

Resolves #2260 