### PR TITLE
Add default user agent string to requests in UrlClient

### DIFF
--- a/platforms/common/urlClient.cpp
+++ b/platforms/common/urlClient.cpp
@@ -63,6 +63,7 @@ struct UrlClient::Task {
         curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1);
         curl_easy_setopt(handle, CURLOPT_MAXREDIRS, 20);
         curl_easy_setopt(handle, CURLOPT_TCP_NODELAY, 1);
+        curl_easy_setopt(handle, CURLOPT_USERAGENT, _options.userAgentString);
     }
 
     void setup() {

--- a/platforms/common/urlClient.h
+++ b/platforms/common/urlClient.h
@@ -24,6 +24,7 @@ public:
         uint32_t maxActiveTasks = 20;
         uint32_t connectionTimeoutMs = 3000;
         uint32_t requestTimeoutMs = 30000;
+        const char* userAgentString = "tangram";
     };
 
     UrlClient(Options options);


### PR DESCRIPTION
Resolves an authentication issue with the nextzen.org tile endpoint.