### PR TITLE
Fixes needed for Raspberry PI build on latest Raspbian

### DIFF
--- a/platforms/rpi/config.cmake
+++ b/platforms/rpi/config.cmake
@@ -40,6 +40,7 @@ target_link_libraries(tangram
   /opt/vc/lib/libbrcmGLESv2.so
   /opt/vc/lib/libvchiq_arm.so
   /opt/vc/lib/libvcos.so
+  /usr/lib/arm-linux-gnueabihf/libatomic.so.1
 )
 
 target_compile_options(tangram

--- a/platforms/rpi/src/main.cpp
+++ b/platforms/rpi/src/main.cpp
@@ -140,12 +140,12 @@ int main(int argc, char **argv) {
     Url baseUrl("file:///");
     char pathBuffer[PATH_MAX] = {0};
     if (getcwd(pathBuffer, PATH_MAX) != nullptr) {
-        baseUrl = Url(std::string(pathBuffer) + "/").resolved(baseUrl);
+        baseUrl = Url(std::string(pathBuffer) + "/").resolve(baseUrl);
     }
 
     LOG("Base URL: %s", baseUrl.string().c_str());
 
-    Url sceneUrl = Url(options.sceneFilePath).resolved(baseUrl);
+    Url sceneUrl = Url(options.sceneFilePath).resolve(baseUrl);
 
     map = std::make_unique<Map>(std::make_unique<RpiPlatform>(urlClientOptions));
     map->loadScene(sceneUrl.string(), !options.hasLocationSet, updates);


### PR DESCRIPTION
These updates are needed in order to build on the latest version of Raspberry PI O/S.