### PR TITLE
Add 'visible' toggle for Android MapData and iOS TGMapData

### DIFF
--- a/core/include/tangram/data/tileSource.h
+++ b/core/include/tangram/data/tileSource.h
@@ -140,6 +140,9 @@ public:
         m_generateGeometry = _generateGeometry;
     }
 
+    bool isVisible() const { return m_isVisible; }
+    void setVisible(bool visible) { m_isVisible = visible; }
+
     /* Avoid RTTI by adding a boolean check on the data source object */
     virtual bool isRaster() const { return false; }
 
@@ -152,6 +155,8 @@ protected:
     // This datasource is used to generate actual tile geometry
     // Is set true for any source assigned in a Scene Layer and when the layer is not disabled
     bool m_generateGeometry = false;
+
+    bool m_isVisible = true;
 
     // Name used to identify this source in the style sheet
     std::string m_name;

--- a/core/src/tile/tileManager.cpp
+++ b/core/src/tile/tileManager.cpp
@@ -306,7 +306,7 @@ void TileManager::updateTileSets(const View& _view) {
 
     for (auto& tileSet : m_tileSets) {
         // check if tile set is active for zoom (zoom might be below min_zoom)
-        if (tileSet.source->isActiveForZoom(_view.getZoom())) {
+        if (tileSet.source->isActiveForZoom(_view.getZoom()) && tileSet.source->isVisible()) {
             updateTileSet(tileSet, _view.state());
         }
     }
@@ -599,9 +599,7 @@ void TileManager::removeTile(TileSet& _tileSet, std::map<TileID, TileEntry>::ite
     _tileIt = _tileSet.tiles.erase(_tileIt);
 }
 
-bool TileManager::updateProxyTile(TileSet& _tileSet, TileEntry& _tile,
-                                  const TileID& _proxyTileId,
-                                  const ProxyID _proxyId) {
+bool TileManager::updateProxyTile(TileSet& _tileSet, TileEntry& _tile, const TileID& _proxyTileId, ProxyID _proxyId) {
 
     if (!_proxyTileId.isValid()) { return false; }
 

--- a/core/src/tile/tileManager.h
+++ b/core/src/tile/tileManager.h
@@ -53,9 +53,9 @@ public:
     /* Returns the set of currently visible tiles */
     const auto& getVisibleTiles() const { return m_tiles; }
 
-    bool hasTileSetChanged() { return m_tileSetChanged; }
+    bool hasTileSetChanged() const { return m_tileSetChanged; }
 
-    bool hasLoadingTiles() {
+    bool hasLoadingTiles() const {
         return m_tilesInProgress > 0;
     }
 
@@ -118,7 +118,7 @@ protected:
      * Checks and updates m_tileSet with proxy tiles for every new visible tile
      *  @_tile: Tile, the new visible tile for which proxies needs to be added
      */
-    bool updateProxyTile(TileSet& _tileSet, TileEntry& _tile, const TileID& _proxy, const ProxyID _proxyID);
+    bool updateProxyTile(TileSet& _tileSet, TileEntry& _tile, const TileID& _proxy, ProxyID _proxyID);
     void updateProxyTiles(TileSet& _tileSet, const TileID& _tileID, TileEntry& _tile);
 
     /*

--- a/platforms/android/tangram/src/main/cpp/NativeMap.cpp
+++ b/platforms/android/tangram/src/main/cpp/NativeMap.cpp
@@ -593,6 +593,11 @@ void NATIVE_METHOD(setClientDataVisible)(JNIEnv* env, jobject obj, jlong javaSou
     source->setVisible(visible);
 }
 
+bool NATIVE_METHOD(getClientDataVisible)(JNIEnv* env, jobject obj, jlong javaSourcePtr) {
+    auto* source = reinterpret_cast<ClientDataSource*>(javaSourcePtr);
+    return source->isVisible();
+}
+
 } // extern "C"
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/cpp/NativeMap.cpp
+++ b/platforms/android/tangram/src/main/cpp/NativeMap.cpp
@@ -588,6 +588,11 @@ void NATIVE_METHOD(clearClientDataFeatures)(JNIEnv* env, jobject obj, jlong java
     source->clearFeatures();
 }
 
+void NATIVE_METHOD(setClientDataVisible)(JNIEnv* env, jobject obj, jlong javaSourcePtr, jboolean visible) {
+    auto* source = reinterpret_cast<ClientDataSource*>(javaSourcePtr);
+    source->setVisible(visible);
+}
+
 } // extern "C"
 
 } // namespace Tangram

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -67,6 +67,15 @@ public class MapData {
     }
 
     /**
+     * Get the current visibility of all the features in this {@code MapData}.
+     * @return If true, the features are currently drawn on the map. Otherwise, they are currently hidden.
+     */
+    public boolean getVisible() {
+        checkPointer(pointer);
+        return mapController.nativeMap.getClientDataVisible(pointer);
+    }
+
+    /**
      * Get the name of this {@code MapData}.
      * @return The name.
      */

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapData.java
@@ -58,6 +58,15 @@ public class MapData {
     }
 
     /**
+     * Set the visibility of all the features in this {@code MapData}.
+     * @param visible If true, the features are drawn on the map. Otherwise they are hidden.
+     */
+    public void setVisible(boolean visible) {
+        checkPointer(pointer);
+        mapController.nativeMap.setClientDataVisible(pointer, visible);
+    }
+
+    /**
      * Get the name of this {@code MapData}.
      * @return The name.
      */

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
@@ -84,6 +84,7 @@ class NativeMap {
     native synchronized void generateClientDataTiles(long sourcePtr);
     native synchronized void clearClientDataFeatures(long sourcePtr);
     native synchronized void setClientDataVisible(long sourcePtr, boolean visible);
+    native synchronized boolean getClientDataVisible(long sourcePtr);
 
     native synchronized void setDebugFlag(int flag, boolean on);
 

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/NativeMap.java
@@ -83,6 +83,7 @@ class NativeMap {
     native synchronized void addClientDataGeoJson(long sourcePtr, String geoJson);
     native synchronized void generateClientDataTiles(long sourcePtr);
     native synchronized void clearClientDataFeatures(long sourcePtr);
+    native synchronized void setClientDataVisible(long sourcePtr, boolean visible);
 
     native synchronized void setDebugFlag(int flag, boolean on);
 

--- a/platforms/ios/framework/src/TGMapData.h
+++ b/platforms/ios/framework/src/TGMapData.h
@@ -97,6 +97,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The name of the data source.
 @property (readonly, nonatomic) NSString* name;
 
+/// Whether this map data is drawn on the map.
+@property (nonatomic) BOOL visible;
+
 NS_ASSUME_NONNULL_END
 
 /// The map view that created this map data.

--- a/platforms/ios/framework/src/TGMapData.mm
+++ b/platforms/ios/framework/src/TGMapData.mm
@@ -126,4 +126,14 @@ static inline void TGFeaturePropertiesConvertToCoreProperties(TGFeaturePropertie
     return removed;
 }
 
+- (BOOL)visible
+{
+    return dataSource->isVisible();
+}
+
+- (void)setVisible:(BOOL)visible
+{
+    dataSource->setVisible(visible);
+}
+
 @end


### PR DESCRIPTION
Allows apps to temporarily hide a client data source without completely removing it.

Resolves https://github.com/tangrams/tangram-es/issues/2299