### PR TITLE
Set up vcpkg binary caching via nuget on gh packages

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,8 +18,12 @@ jobs:
           ref: 2021.05.12
           path: vcpkg
       - name: "Setup NuGet Credentials"
-        run: nuget add source --username tangrams --password ${{ secrets.GITHUB_TOKEN }}
-          --store-password-in-clear-text --name GitHub "https://nuget.pkg.github.com/tangrams/index.json"
+        run: nuget sources add 
+          -source "https://nuget.pkg.github.com/tangrams/index.json"
+          -name GitHub
+          -username tangrams
+          -password ${{ secrets.GITHUB_TOKEN }}
+          -store-password-in-clear-text 
       - name: "Configure CMake"
         run: cmake -S . -B .\build -G "Visual Studio 16 2019"
           -DCMAKE_TOOLCHAIN_FILE=".\vcpkg\scripts\buildsystems\vcpkg.cmake"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
           -name GitHub
           -username tangrams
           -password ${{ secrets.GITHUB_TOKEN }}
-          -store-password-in-clear-text 
+          -storepasswordincleartext 
       - name: "Configure CMake"
         run: cmake -S . -B .\build -G "Visual Studio 16 2019"
           -DCMAKE_TOOLCHAIN_FILE=".\vcpkg\scripts\buildsystems\vcpkg.cmake"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,8 @@ jobs:
   build-test-windows:
     name: "Build and Test on Windows"
     runs-on: windows-2019
+    env:
+      VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v2
@@ -15,12 +17,9 @@ jobs:
           repository: microsoft/vcpkg
           ref: 2021.05.12
           path: vcpkg
-      - name: "Cache vcpkg binaries"
-        uses: actions/cache@v2
-        with:
-          path: ~\AppData\Local\vcpkg\archives
-          key: vcpkg-v2-${{ hashFiles('vcpkg.json') }}
-          restore-keys: vcpkg-v2-
+      - name: "Setup NuGet Credentials"
+        run: nuget add source --username tangrams --password ${{ secrets.GITHUB_TOKEN }}
+          --store-password-in-clear-text --name GitHub "https://nuget.pkg.github.com/tangrams/index.json"
       - name: "Configure CMake"
         run: cmake -S . -B .\build -G "Visual Studio 16 2019"
           -DCMAKE_TOOLCHAIN_FILE=".\vcpkg\scripts\buildsystems\vcpkg.cmake"

--- a/platforms/common/urlClient.cpp
+++ b/platforms/common/urlClient.cpp
@@ -192,8 +192,8 @@ UrlClient::UrlClient(Options options) : m_options(options) {
 
     // Start the curl thread
     m_curlHandle = curl_multi_init();
-    m_curlRunning = true;
     m_curlWorker = std::make_unique<std::thread>(&UrlClient::curlLoop, this);
+    m_curlRunning = true;
 
     // Init at least one task to avoid checking whether m_tasks is empty in
     // startPendingRequests()

--- a/platforms/common/urlClient.cpp
+++ b/platforms/common/urlClient.cpp
@@ -192,8 +192,8 @@ UrlClient::UrlClient(Options options) : m_options(options) {
 
     // Start the curl thread
     m_curlHandle = curl_multi_init();
-    m_curlWorker = std::make_unique<std::thread>(&UrlClient::curlLoop, this);
     m_curlRunning = true;
+    m_curlWorker = std::make_unique<std::thread>(&UrlClient::curlLoop, this);
 
     // Init at least one task to avoid checking whether m_tasks is empty in
     // startPendingRequests()


### PR DESCRIPTION
Setup following instructions on https://github.com/microsoft/vcpkg/blob/master/docs/users/binarycaching.md

The binary caching feature in vcpkg seems to be as fast as the GitHub Actions caching, but with more accurate hashing and longer retention (because it is hosted on GitHub Packages). Cache retention should be effectively unlimited now, versus just 7 days with GitHub Actions.