### PR TITLE
Add iOS build to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ jobs:
             - ~/.ccache
       - store_artifacts:
           path: platforms/android/tangram/build/outputs/aar/tangram-release.aar
+          destination: tangram-android-${CIRCLE_SHA}.aar
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,13 +99,9 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      # Run on all pushes
+      # Run on pushes to all branches
       - build-test-linux
-      # Run on pushes to all branches except main
-      - build-android:
-          filters:
-            branches:
-              ignore: main
+      - build-android
       # Run on pushes to main
       - build-deploy-android:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,6 @@ executors:
       GRADLE_OPTS: -Xmx2048m
       CCACHE_MAXSIZE: 400M
       # The CircleCI android-ndk images export ANDROID_NDK_HOME with the location of the pre-installed NDK (https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images).
-  macos-executor:
-    macos:
-      xcode: "12.2.0"
-    environment: # Disable some unnecessary homebrew operations to save time.
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      HOMEBREW_NO_INSTALL_CLEANUP: 1
-      CCACHE_MAXSIZE: 400M
 jobs:
   build-test-linux:
     docker:
@@ -101,72 +94,6 @@ jobs:
             - ~/.ccache
       - store_artifacts:
           path: platforms/android/tangram/build/outputs/aar/tangram-release.aar
-  build-ios:
-    executor: macos-executor
-    steps:
-      # Check out repository with submodules.
-      - checkout
-      - run: git submodule update --init
-      # Install dependencies.
-      - run: brew install cmake ccache
-      - restore_cache:
-          keys:
-            - ios-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - ios-ccache-v1-{{ .Branch }}
-            - ios-ccache-v1
-      - run: ccache --zero-stats
-      # Build test app variants. Use simulator target to bypass codesigning.
-      - run: make ios-sim BUILD_TYPE=Debug CMAKE_OPTIONS="-DTANGRAM_XCODE_USE_CCACHE=1"
-      - run: make ios-static-sim BUILD_TYPE=Debug CMAKE_OPTIONS="-DTANGRAM_XCODE_USE_CCACHE=1"
-      - run: make ios-swift-sim BUILD_TYPE=Debug CMAKE_OPTIONS="-DTANGRAM_XCODE_USE_CCACHE=1"
-      - run: ccache --show-stats
-      - save_cache:
-          key: ios-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - ~/Library/Caches/ccache
-  build-deploy-ios:
-    executor: macos-executor
-    steps:
-      # Check out repository with submodules.
-      - checkout
-      - run: git submodule update --init
-      # Install dependencies.
-      - run: sudo gem install jazzy --no-document --version 0.10.0
-      - run: brew install cmake ccache
-      - restore_cache:
-          keys:
-            - ios-release-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - ios-release-ccache-v1-{{ .Branch }}
-            - ios-release-ccache-v1
-      - run: ccache --zero-stats
-      # Build the framework and package it into pod.zip.
-      - run: make ios-xcframework BUILD_TYPE=Release CMAKE_OPTIONS="-DTANGRAM_XCODE_USE_CCACHE=1"
-      # Check that bitcode is included for required archs.
-      - run: source scripts/check_bitcode.sh build/ios/Release/TangramMap.xcframework/ios-arm64_armv7/TangramMap.framework/TangramMap arm64 armv7
-      # Build the docs and package them into docs.zip.
-      - run: make ios-docs
-      - run: cd build/ios-docs && zip -r ~/docs.zip .
-      - store_artifacts:
-          path: ~/docs.zip
-      # To produce the intended structure within the zip archive, we must cd to each file's location.
-      - run: cd build/ios/Release && zip -r ~/pod.zip TangramMap.xcframework
-      # Add the readme and license files.
-      - run: cd platforms/ios/framework && zip ~/pod.zip README.md
-      - run: zip ~/pod.zip LICENSE
-      - store_artifacts:
-          path: ~/pod.zip
-      - when:
-          condition: << pipeline.git.tag >>
-          steps:
-            # Upload and publish the Cocoapods archive to GitHub. The download URL on GitHub uses the file name, labels have no effect.
-            - run: brew install gh
-            - run: mv ~/pod.zip ~/tangram-ios-<< pipeline.git.tag >>.zip
-            - run: gh release create << pipeline.git.tag >> --draft ~/tangram-ios-<< pipeline.git.tag >>.zip
-      - run: ccache --show-stats
-      - save_cache:
-          key: ios-release-ccache-v1-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - ~/Library/Caches/ccache
 workflows:
   version: 2
   build-and-deploy:
@@ -178,25 +105,8 @@ workflows:
           filters:
             branches:
               ignore: main
-      - build-ios:
-          filters:
-            branches:
-              ignore: main
       # Run on pushes to main
       - build-deploy-android:
           filters:
             branches:
               only: main
-      - build-deploy-ios:
-          filters:
-            branches:
-              only: main
-      # Run on tag pushes
-      - build-deploy-ios:
-          name: build-deploy-ios-tag
-          filters:
-            # For any tag of the form 1, 1.2.3, 1.4-beta2, etc. we will deploy a release build.
-            tags:
-              only: /[0-9]+(\.[0-9]+)*(-beta[0-9]*)?/
-            branches:
-              ignore: /.*/

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,3 +71,29 @@ jobs:
           name: macos-app
           path: build/*.app
           retention-days: 60
+  build-ios:
+    name: "Build for iOS"
+    runs-on: macos-10.15
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: "Install dependencies"
+        run: brew install ccache
+      - name: "Cache ccache directory"
+        uses: actions/cache@v2
+        with:
+          path: ~/Library/Caches/ccache
+          key: ios-ccache-v1-${{ github.sha }}
+          restore-keys: ios-ccache-v1-
+      - name: "Reset ccache stats"
+        run: ccache --zero-stats
+      - name: "Build iOS simulator app with framework"
+        run: make ios-sim BUILD_TYPE=Debug CMAKE_OPTIONS="-DTANGRAM_XCODE_USE_CCACHE=1"
+      - name: "Build iOS simulator app with static library"
+        run: make ios-static-sim BUILD_TYPE=Debug CMAKE_OPTIONS="-DTANGRAM_XCODE_USE_CCACHE=1"
+      - name: "Build iOS Swift app"
+        run: make ios-swift-sim BUILD_TYPE=Debug CMAKE_OPTIONS="-DTANGRAM_XCODE_USE_CCACHE=1"
+      - name: "Print ccache stats"
+        run: ccache --show-stats

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: "Release"
-on:
-  push:
-    tags: "[0-9]+.[0-9]+.[0-9]+"
+# on:
+#   push:
+#     tags: "[0-9]+.[0-9]+.[0-9]+"
+on: push
 jobs:
   build-deploy-ios:
     name: "Build and Deploy iOS Release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: "Release"
-# on:
-#   push:
-#     tags: "[0-9]+.[0-9]+.[0-9]+"
-on: push
+on:
+  push:
+    branches:
+      - main
 jobs:
   build-deploy-ios:
     name: "Build and Deploy iOS Release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           TANGRAM_VERSION=$(if [[ ${{ github.ref_type }} == "tag" ]]; then echo ${{ github.ref_name }}; else echo ${{ github.sha }}; fi)
           echo "TANGRAM_VERSION=$TANGRAM_VERSION" >> $GITHUB_ENV
       - name: "Install Jazzy"
-        run: sudo gem install jazzy --no-document --version 0.10.0
+        run: sudo gem install jazzy --no-document --version 0.14.1
       - name: "Install ccache"
         run: brew install ccache
       - name: "Cache ccache directory"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
       - name: "Upload pod"
         uses: actions/upload-artifact@v2
         with:
-          name: ios-pod
+          name: tangram-ios-${{ github.ref_name }}
           path: build/pod/
       - name: "Build docs"
         run: make ios-docs
       - name: "Upload docs"
         uses: actions/upload-artifact@v2
         with:
-          name: ios-docs
+          name: tangram-ios-docs-${{ github.ref_name }}
           path: build/ios-docs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: true
       - name: "Set version variable"
         run: |
-          TANGRAM_VERSION=$(if [[ ${{ github.ref_type }} == "tag" ]]; then echo ${{ github.ref_name }}; else echo ${{ github.sha }}; fi
+          TANGRAM_VERSION=$(if [[ ${{ github.ref_type }} == "tag" ]]; then echo ${{ github.ref_name }}; else echo ${{ github.sha }}; fi)
           echo "TANGRAM_VERSION=$TANGRAM_VERSION" >> $GITHUB_ENV
       - name: "Install Jazzy"
         run: sudo gem install jazzy --no-document --version 0.10.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Arrange pod contents"
         run: |
           mkdir build/pod
-          cp build/ios/Release/TangramMap.xcframework build/pod/TangramMap.xcframework
+          cp -r build/ios/Release/TangramMap.xcframework build/pod/TangramMap.xcframework
           cp platforms/ios/framework/README.md build/pod/README.md
           cp LICENSE build/pod/LICENSE
       - name: "Upload pod"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,26 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: "Install dependencies"
-        run: sudo gem install jazzy --no-document --version 0.10.0
       - name: "Set version variable"
         run: |
           TANGRAM_VERSION=$(if [[ ${{ github.ref_type }} == "tag" ]]; then echo ${{ github.ref_name }}; else echo ${{ github.sha }}; fi
           echo "TANGRAM_VERSION=$TANGRAM_VERSION" >> $GITHUB_ENV
+      - name: "Install Jazzy"
+        run: sudo gem install jazzy --no-document --version 0.10.0
+      - name: "Install ccache"
+        run: brew install ccache
+      - name: "Cache ccache directory"
+        uses: actions/cache@v2
+        with:
+          path: ~/Library/Caches/ccache
+          key: ios-release-ccache-v1-${{ github.sha }}
+          restore-keys: ios-release-ccache-v1-
+      - name: "Reset ccache stats"
+        run: ccache --zero-stats
       - name: "Build iOS XCFramework"
-        run: make ios-xcframework BUILD_TYPE=Release
+        run: make ios-xcframework BUILD_TYPE=Release CMAKE_OPTIONS="-DTANGRAM_XCODE_USE_CCACHE=1"
+      - name: "Print ccache stats"
+        run: ccache --show-stats
       - name: "Check bitcode"
         run: source scripts/check_bitcode.sh build/ios/Release/TangramMap.xcframework/ios-arm64_armv7/TangramMap.framework/TangramMap arm64 armv7
       - name: "Arrange pod contents"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
           submodules: true
       - name: "Install dependencies"
         run: sudo gem install jazzy --no-document --version 0.10.0
+      - name: "Set version variable"
+        run: |
+          TANGRAM_VERSION=$(if [[ ${{ github.ref_type }} == "tag" ]]; then echo ${{ github.ref_name }}; else echo ${{ github.sha }}; fi
+          echo "TANGRAM_VERSION=$TANGRAM_VERSION" >> $GITHUB_ENV
       - name: "Build iOS XCFramework"
         run: make ios-xcframework BUILD_TYPE=Release
       - name: "Check bitcode"
@@ -27,12 +31,12 @@ jobs:
       - name: "Upload pod"
         uses: actions/upload-artifact@v2
         with:
-          name: tangram-ios-${{ github.ref_name }}
+          name: tangram-ios-${{ env.TANGRAM_VERSION }}
           path: build/pod/
       - name: "Build docs"
         run: make ios-docs
       - name: "Upload docs"
         uses: actions/upload-artifact@v2
         with:
-          name: tangram-ios-docs-${{ github.ref_name }}
+          name: tangram-ios-docs-${{ env.TANGRAM_VERSION }}
           path: build/ios-docs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: "Release"
+on:
+  push:
+    tags: "[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  build-deploy-ios:
+    name: "Build and Deploy iOS Release"
+    runs-on: macos-10.15
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: "Install dependencies"
+        run: sudo gem install jazzy --no-document --version 0.10.0
+      - name: "Build iOS XCFramework"
+        run: make ios-xcframework BUILD_TYPE=Release
+      - name: "Check bitcode"
+        run: source scripts/check_bitcode.sh build/ios/Release/TangramMap.xcframework/ios-arm64_armv7/TangramMap.framework/TangramMap arm64 armv7
+      - name: "Arrange pod contents"
+        run: |
+          mkdir build/pod
+          cp build/ios/Release/TangramMap.xcframework build/pod/TangramMap.xcframework
+          cp platforms/ios/framework/README.md build/pod/README.md
+          cp LICENSE build/pod/LICENSE
+      - name: "Upload pod"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ios-pod
+          path: build/pod/
+      - name: "Build docs"
+        run: make ios-docs
+      - name: "Upload docs"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ios-docs
+          path: build/ios-docs/

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -43,8 +43,19 @@ $ git tag 1.0.0
 $ git push origin 1.0.0
 ```
 
+### 3. Create a Release on GitHub
+Draft a release for the new tag at [https://github.com/tangrams/tangram-es/releases][5]. 
+
+Document changes in the release notes.
+
+Once the iOS Release build completes on [GitHub Actions][6], download the artifact named `tangram-ios-<git revision>` containing the CocoaPod contents and then attach it to the GitHub release as `tangram-ios-<tag>.zip`. 
+
+Once the Android build completes on [CircleCI][1], download the artifact named `tangram-android-<git revision>.aar` and then attach it to the GitHub release as `tangram-android-<tag>.aar`.
+
+Publish the new release.
+
 ### 3. Push iOS framework to CocoaPods
-Once [CircleCI][1] completes the tag build, run `pod spec lint` in the directory containing `Tangram-es.podspec` to validate the Podspec.
+Run `pod spec lint` in the directory containing `Tangram-es.podspec` to validate the Podspec.
 
 Push the podspec to trunk:
 ```
@@ -52,7 +63,7 @@ pod trunk push Tangram-es.podspec
 ```
 
 ### 4. Promote Android artifact to production
-Once [CircleCI][1] completes the release build, log into [OSS Sonatype Nexus][2] and release to Central.
+Log into [OSS Sonatype Nexus][2] and release to Central.
 
 For details on this process see the [Sonatype OSS Repository Hosting Guide][3]
 
@@ -76,11 +87,9 @@ $ git commit -m "Prepare next development cycle"
 $ git push
 ```
 
-### 6. Document release
-Document release notes at [https://github.com/tangrams/tangram-es/releases][5].
-
 [1]: https://app.circleci.com/pipelines/github/tangrams/tangram-es
 [2]: https://oss.sonatype.org/
 [3]: https://central.sonatype.org/pages/ossrh-guide.html
 [4]: https://search.maven.org/artifact/com.mapzen.tangram/tangram
 [5]: https://github.com/tangrams/tangram-es/releases
+[6]: https://github.com/tangrams/tangram-es/actions/workflows/release.yml


### PR DESCRIPTION
CircleCI limits our builds to 1 macOS job at a time, which can make release deployments slow. I'm trying out iOS builds in GitHub Actions instead. 