### PR TITLE
increase max zoom from 20.5 to 25

### DIFF
--- a/core/include/tangram/map.h
+++ b/core/include/tangram/map.h
@@ -261,8 +261,8 @@ public:
     // Get the minimum zoom level for the view.
     float getMinZoom() const;
 
-    // Set the maximum zoom level for the view; values greater than 20.5 will be
-    // clamped to 20.5; values less than the current minimum zoom level will set
+    // Set the maximum zoom level for the view; values greater than 25.0 will be
+    // clamped to 25.0; values less than the current minimum zoom level will set
     // the minimum zoom to this value.
     void setMaxZoom(float _maxZoom);
 

--- a/core/src/view/view.cpp
+++ b/core/src/view/view.cpp
@@ -161,7 +161,7 @@ void View::setMinZoom(float minZoom) {
 
 void View::setMaxZoom(float maxZoom) {
 
-    m_maxZoom = std::min(maxZoom, 20.5f);
+    m_maxZoom = std::min(maxZoom, 25.0f);
     m_minZoom = std::min(maxZoom, m_minZoom);
     // Set the current zoom again to validate it.
     setZoom(m_zoom);

--- a/core/src/view/view.h
+++ b/core/src/view/view.h
@@ -96,7 +96,7 @@ public:
     // Get the minimum zoom level.
     float getMinZoom() const { return m_minZoom; }
 
-    // Set the maximum zoom level. Clamped to <= 20.5.
+    // Set the maximum zoom level. Clamped to <= 25.0.
     void setMaxZoom(float maxZoom);
 
     // Get the maximum zoom level.

--- a/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
+++ b/platforms/android/tangram/src/main/java/com/mapzen/tangram/MapController.java
@@ -604,7 +604,7 @@ public class MapController {
     /**
      * Set the maximum zoom level of the map view.
      *
-     * Values greater than the default maximum zoom will be clamped. Assigning a value less than the
+     * Values greater than 25.0 will be clamped. Assigning a value less than the
      * current minimum zoom will set the minimum zoom to this value.
      * @param maximumZoom The zoom level
      */


### PR DESCRIPTION
25 seems to be about 2-5m for one phone width, probably higher than what anyone will ever need, but the capability is there now if map devs actually want to do this.

Defaults are left unchanged, will only have an effect in applications if users call `MapController.setMaximumZoomLevel`

fix #2264